### PR TITLE
Reject reparse points in Windows native capture

### DIFF
--- a/cli/tests/test_windows_release_certification.py
+++ b/cli/tests/test_windows_release_certification.py
@@ -28,6 +28,7 @@ SMOKE_PATH = ROOT / ".github" / "workflows" / "release-candidate-smoke.yml"
 WINDOWS_NATIVE_PATH = ROOT / ".github" / "workflows" / "windows-native.yml"
 FRESH_INSTALL = (ROOT / "scripts" / "test-fresh-install-release-windows.ps1").read_text(encoding="utf-8")
 DISPOSABLE_LAUNCHER = (ROOT / "scripts" / "invoke-windows-setup-standard-user-ci.ps1").read_text(encoding="utf-8")
+DISPOSABLE_FILE_GUARD = (ROOT / "scripts" / "windows-disposable-file-guard.cs").read_text(encoding="utf-8")
 STANDARD_USER_PROCESS_LAUNCHER = (ROOT / "scripts" / "windows-disposable-standard-user-launcher.cs").read_text(
     encoding="utf-8"
 )
@@ -643,6 +644,30 @@ def test_disposable_setup_failure_preserves_bounded_native_log_before_profile_cl
     assert "Copy-Item" not in DISPOSABLE_LAUNCHER
 
 
+def test_native_diagnostic_capture_is_bound_to_verified_file_handles() -> None:
+    selection = _function("Get-WindowsNativeCaptureFiles")
+    capture = _function("Invoke-Capture")
+
+    assert "SortedDictionary[string, IO.FileInfo]" in selection
+    assert "$selectionLimit = 30" in selection
+    assert "$matches" not in selection.casefold()
+    assert "$visited" not in selection
+    assert "OpenRootedReader($root)" in capture
+    assert "ReadBoundedUtf8($file.FullName, 1048576)" in capture
+    assert "ReadAllText($file.FullName)" not in capture
+
+    for contract in (
+        "FILE_FLAG_OPEN_REPARSE_POINT",
+        "GetFileInformationByHandle",
+        "GetFinalPathNameByHandleW",
+        "sealed class RootedReader",
+        "guarded file resolved outside its retained root",
+    ):
+        assert contract in DISPOSABLE_FILE_GUARD
+    assert "leaf replaced by a reparse point after enumeration" in HARNESS
+    assert "replaced ancestor outside its retained root" in HARNESS
+
+
 def test_publish_includes_windows_binaries_without_an_omission_mode() -> None:
     workflow = _workflow(RELEASE_PATH)
     jobs = workflow["jobs"]
@@ -823,7 +848,7 @@ def test_amp_windows_live_prompts_invoke_native_pwsh_explicitly() -> None:
     assert result_gate is not None
     assert live_run is not None
     assert "(Get-Process -Id $PID).Path.Replace('\\', '/')" in helper.group(0)
-    assert '-NoLogo -NoProfile -NonInteractive -Command' in helper.group(0)
+    assert "-NoLogo -NoProfile -NonInteractive -Command" in helper.group(0)
     assert "cannot contain double quotes" in helper.group(0)
     assert "Get-AmpWindowsPowerShellToolCommand(" in result_gate.group(0)
     assert result_gate.group(0).count("Get-Content -Raw -LiteralPath") == 1

--- a/scripts/live-connector-e2e/test-windows.ps1
+++ b/scripts/live-connector-e2e/test-windows.ps1
@@ -1501,6 +1501,27 @@ private-secret-name = "DefenseClaw must remain redacted"
         $standardUserFileGuardText -match 'NumberOfLinks != 1' -and
         $standardUserFileGuardText -match 'FileMode\.CreateNew') `
         'diagnostic/result handoff validates and consumes one no-follow, single-link regular-file handle'
+    $captureSelectionFunction = [regex]::Match(
+        $nativeHarnessText,
+        '(?s)function Get-WindowsNativeCaptureFiles\b.*?(?=\r?\nfunction )'
+    ).Value
+    $captureFunction = [regex]::Match(
+        $nativeHarnessText,
+        '(?s)function Invoke-Capture\b.*?(?=\r?\nfunction )'
+    ).Value
+    Assert-True ($captureSelectionFunction -match 'SortedDictionary\[string, IO\.FileInfo\]' -and
+        $captureSelectionFunction -match '\$selectionLimit = 30' -and
+        $captureSelectionFunction -notmatch '\$matches\b' -and
+        $captureSelectionFunction -notmatch '\$visited\b' -and
+        $captureFunction -match 'DisposableFileGuard\]::OpenRootedReader\(\$root\)' -and
+        $captureFunction -match 'ReadBoundedUtf8\(\$file\.FullName, 1048576\)' -and
+        $captureFunction -notmatch 'ReadAllText\(\$file\.FullName\)' -and
+        $standardUserFileGuardText -match 'sealed class RootedReader' -and
+        $standardUserFileGuardText -match 'GetFinalPathNameByHandleW' -and
+        $standardUserFileGuardText -match 'guarded file resolved outside its retained root' -and
+        $nativeHarnessText -match 'leaf replaced by a reparse point after enumeration' -and
+        $nativeHarnessText -match 'replaced ancestor outside its retained root') `
+        'native capture exhaustively selects priority logs and reads only retained-root no-follow handles'
     Assert-True ($standardUserSafetyText -match 'function Grant-DisposableAncestorReadLease' -and
         $standardUserSafetyText -match 'function Restore-DisposableAncestorReadLease' -and
         $standardUserSafetyText -match '(?s)Grant-DisposableAncestorReadLease.*?FileSystemRights\]::ReadAndExecute.*?InheritanceFlags\]::None.*?PropagationFlags\]::None' -and

--- a/scripts/windows-disposable-file-guard.cs
+++ b/scripts/windows-disposable-file-guard.cs
@@ -17,9 +17,12 @@ namespace DefenseClaw
     public static class DisposableFileGuard
     {
         private const uint GENERIC_READ = 0x80000000;
+        private const uint FILE_READ_ATTRIBUTES = 0x00000080;
         private const uint FILE_SHARE_READ = 0x00000001;
+        private const uint FILE_SHARE_WRITE = 0x00000002;
         private const uint OPEN_EXISTING = 3;
         private const uint FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000;
+        private const uint FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
         private const uint FILE_ATTRIBUTE_DIRECTORY = 0x00000010;
         private const uint FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400;
         private const uint FILE_TYPE_DISK = 0x0001;
@@ -70,6 +73,18 @@ namespace DefenseClaw
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern uint GetFileType(SafeFileHandle file);
 
+        [DllImport(
+            "kernel32.dll",
+            EntryPoint = "GetFinalPathNameByHandleW",
+            CharSet = CharSet.Unicode,
+            ExactSpelling = true,
+            SetLastError = true)]
+        private static extern uint GetFinalPathNameByHandle(
+            SafeFileHandle file,
+            [Out] StringBuilder path,
+            uint pathLength,
+            uint flags);
+
         private static SafeFileHandle OpenNoFollow(string path)
         {
             if (String.IsNullOrWhiteSpace(path) || !Path.IsPathRooted(path))
@@ -97,15 +112,40 @@ namespace DefenseClaw
             return handle;
         }
 
-        private static long ValidateRegularSingleLink(
+        private static SafeFileHandle OpenRootNoFollow(string path)
+        {
+            if (String.IsNullOrWhiteSpace(path) || !Path.IsPathRooted(path))
+            {
+                throw new ArgumentException("guarded root path must be absolute", "path");
+            }
+            if (path.IndexOf('\0') >= 0)
+            {
+                throw new ArgumentException("guarded root path contains NUL", "path");
+            }
+            SafeFileHandle handle = CreateFile(
+                path,
+                FILE_READ_ATTRIBUTES,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                IntPtr.Zero,
+                OPEN_EXISTING,
+                FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
+                IntPtr.Zero);
+            if (handle.IsInvalid)
+            {
+                int error = Marshal.GetLastWin32Error();
+                handle.Dispose();
+                throw new Win32Exception(error, "CreateFileW no-follow root open failed for " + path);
+            }
+            return handle;
+        }
+
+        private static BY_HANDLE_FILE_INFORMATION ReadHandleInformation(
             SafeFileHandle handle,
-            long maximumBytes,
             string path)
         {
-            if (maximumBytes < 0) throw new ArgumentOutOfRangeException("maximumBytes");
             if (GetFileType(handle) != FILE_TYPE_DISK)
             {
-                throw new InvalidOperationException("guarded handoff is not a disk file: " + path);
+                throw new InvalidOperationException("guarded object is not on disk: " + path);
             }
             BY_HANDLE_FILE_INFORMATION information;
             if (!GetFileInformationByHandle(handle, out information))
@@ -114,6 +154,16 @@ namespace DefenseClaw
                     Marshal.GetLastWin32Error(),
                     "GetFileInformationByHandle failed for " + path);
             }
+            return information;
+        }
+
+        private static long ValidateRegularSingleLink(
+            SafeFileHandle handle,
+            long maximumBytes,
+            string path)
+        {
+            if (maximumBytes < 0) throw new ArgumentOutOfRangeException("maximumBytes");
+            BY_HANDLE_FILE_INFORMATION information = ReadHandleInformation(handle, path);
             if ((information.FileAttributes &
                 (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT)) != 0)
             {
@@ -133,6 +183,83 @@ namespace DefenseClaw
                     "guarded handoff exceeds its byte bound: " + path);
             }
             return (long)unsignedSize;
+        }
+
+        private static void ValidateRootDirectory(SafeFileHandle handle, string path)
+        {
+            BY_HANDLE_FILE_INFORMATION information = ReadHandleInformation(handle, path);
+            if ((information.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0 ||
+                (information.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0)
+            {
+                throw new InvalidOperationException(
+                    "guarded root is not a real directory: " + path);
+            }
+        }
+
+        private static string GetFinalPath(SafeFileHandle handle, string path)
+        {
+            int capacity = 512;
+            while (capacity <= 65536)
+            {
+                StringBuilder value = new StringBuilder(capacity);
+                uint length = GetFinalPathNameByHandle(
+                    handle,
+                    value,
+                    (uint)value.Capacity,
+                    0);
+                if (length == 0)
+                {
+                    throw new Win32Exception(
+                        Marshal.GetLastWin32Error(),
+                        "GetFinalPathNameByHandleW failed for " + path);
+                }
+                if (length < (uint)value.Capacity)
+                {
+                    return TrimTrailingSeparators(value.ToString());
+                }
+                capacity = checked((int)length + 1);
+            }
+            throw new InvalidOperationException("guarded final path is too long: " + path);
+        }
+
+        private static string TrimTrailingSeparators(string path)
+        {
+            string root = Path.GetPathRoot(path);
+            int minimum = String.IsNullOrEmpty(root) ? 0 : root.Length;
+            int length = path.Length;
+            while (length > minimum &&
+                (path[length - 1] == Path.DirectorySeparatorChar ||
+                 path[length - 1] == Path.AltDirectorySeparatorChar))
+            {
+                length--;
+            }
+            return path.Substring(0, length);
+        }
+
+        private static string NormalizeLexicalPath(string path)
+        {
+            return TrimTrailingSeparators(Path.GetFullPath(path));
+        }
+
+        private static string ToExtendedDosPath(string path)
+        {
+            string full = NormalizeLexicalPath(path);
+            if (full.StartsWith(@"\\?\", StringComparison.Ordinal))
+            {
+                return full;
+            }
+            if (full.StartsWith(@"\\", StringComparison.Ordinal))
+            {
+                return @"\\?\UNC\" + full.Substring(2);
+            }
+            return @"\\?\" + full;
+        }
+
+        private static bool IsStrictChildPath(string child, string root)
+        {
+            return child.Length > root.Length &&
+                child.StartsWith(root, StringComparison.OrdinalIgnoreCase) &&
+                child[root.Length] == Path.DirectorySeparatorChar;
         }
 
         private static byte[] ReadExact(SafeFileHandle handle, long size, string path)
@@ -177,6 +304,96 @@ namespace DefenseClaw
         {
             return new UTF8Encoding(false, true).GetString(
                 ReadBoundedBytes(path, maximumBytes));
+        }
+
+        // Holds the verified state root open while capture enumerates and reads.
+        // Each selected file is opened no-follow, validated by that same handle,
+        // and required to resolve below the retained root before any bytes are read.
+        public sealed class RootedReader : IDisposable
+        {
+            private readonly string lexicalRoot;
+            private readonly string finalRoot;
+            private SafeFileHandle rootHandle;
+
+            internal RootedReader(string rootPath)
+            {
+                lexicalRoot = NormalizeLexicalPath(rootPath);
+                rootHandle = OpenRootNoFollow(lexicalRoot);
+                try
+                {
+                    ValidateRootDirectory(rootHandle, lexicalRoot);
+                    finalRoot = GetFinalPath(rootHandle, lexicalRoot);
+                    string expectedRoot = ToExtendedDosPath(lexicalRoot);
+                    if (!String.Equals(
+                        finalRoot,
+                        expectedRoot,
+                        StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException(
+                            "guarded root resolved through a different filesystem object: " +
+                            lexicalRoot);
+                    }
+                }
+                catch
+                {
+                    rootHandle.Dispose();
+                    rootHandle = null;
+                    throw;
+                }
+            }
+
+            public string ReadBoundedUtf8(string path, long maximumBytes)
+            {
+                if (rootHandle == null || rootHandle.IsClosed || rootHandle.IsInvalid)
+                {
+                    throw new ObjectDisposedException("RootedReader");
+                }
+                string lexicalPath = NormalizeLexicalPath(path);
+                if (!IsStrictChildPath(lexicalPath, lexicalRoot))
+                {
+                    throw new InvalidOperationException(
+                        "guarded file escaped its lexical root: " + path);
+                }
+
+                ValidateRootDirectory(rootHandle, lexicalRoot);
+                string currentRoot = GetFinalPath(rootHandle, lexicalRoot);
+                if (!String.Equals(
+                    currentRoot,
+                    finalRoot,
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(
+                        "guarded root identity changed during capture: " + lexicalRoot);
+                }
+
+                using (SafeFileHandle handle = OpenNoFollow(lexicalPath))
+                {
+                    long size = ValidateRegularSingleLink(handle, maximumBytes, lexicalPath);
+                    string finalPath = GetFinalPath(handle, lexicalPath);
+                    if (!IsStrictChildPath(finalPath, finalRoot))
+                    {
+                        throw new InvalidOperationException(
+                            "guarded file resolved outside its retained root: " + lexicalPath);
+                    }
+                    return new UTF8Encoding(false, true).GetString(
+                        ReadExact(handle, size, lexicalPath));
+                }
+            }
+
+            public void Dispose()
+            {
+                if (rootHandle != null)
+                {
+                    rootHandle.Dispose();
+                    rootHandle = null;
+                }
+                GC.SuppressFinalize(this);
+            }
+        }
+
+        public static RootedReader OpenRootedReader(string rootPath)
+        {
+            return new RootedReader(rootPath);
         }
 
         public static string ComputeSha256Hex(string path, long maximumBytes)

--- a/scripts/windows-native-ci.ps1
+++ b/scripts/windows-native-ci.ps1
@@ -41,6 +41,14 @@ if (-not ('DefenseClaw.SetupStandardUserLauncher' -as [type])) {
     Add-Type -Path $setupStandardUserLauncherSource
 }
 
+$disposableFileGuardSource = Join-Path $PSScriptRoot 'windows-disposable-file-guard.cs'
+if (-not ('DefenseClaw.DisposableFileGuard' -as [type])) {
+    if (-not (Test-Path -LiteralPath $disposableFileGuardSource -PathType Leaf)) {
+        throw "Windows disposable file guard source is missing: $disposableFileGuardSource"
+    }
+    Add-Type -Path $disposableFileGuardSource
+}
+
 function Get-RedactionValues {
     $names = @(
         'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'AMP_API_KEY', 'AZURE_OPENAI_API_KEY',
@@ -5830,9 +5838,11 @@ function Get-WindowsNativeCaptureFiles([string]$Root) {
 
     $pending = [Collections.Generic.Queue[IO.DirectoryInfo]]::new()
     $pending.Enqueue($rootItem)
-    $matches = [Collections.Generic.List[IO.FileInfo]]::new()
-    $visited = 0
-    while ($pending.Count -gt 0 -and $visited -lt 4096) {
+    $selected = [Collections.Generic.SortedDictionary[string, IO.FileInfo]]::new(
+        [StringComparer]::OrdinalIgnoreCase
+    )
+    $selectionLimit = 30
+    while ($pending.Count -gt 0) {
         $directory = $pending.Dequeue()
         if (Test-WindowsNativeReparsePoint $directory) { continue }
         try {
@@ -5841,30 +5851,26 @@ function Get-WindowsNativeCaptureFiles([string]$Root) {
             continue
         }
         foreach ($child in $children) {
-            $visited++
             if (Test-WindowsNativeReparsePoint $child) { continue }
             if ($child.PSIsContainer) {
                 $pending.Enqueue([IO.DirectoryInfo]$child)
             } elseif ($child -is [IO.FileInfo] -and
                 $child.Name -match '^(gateway|watchdog|results|doctor|.*\.log)' -and
                 $child.Length -le 1048576) {
-                $matches.Add([IO.FileInfo]$child)
+                $priority = if ($child.Name -eq 'wizard-driver.log') { 0 }
+                    elseif ($child.Name -in @('go-test-failure-summary.log', 'go-test.log')) { 1 }
+                    else { 2 }
+                $selectionKey = '{0}|{1}' -f $priority, $child.FullName
+                $selected[$selectionKey] = [IO.FileInfo]$child
+                if ($selected.Count -gt $selectionLimit) {
+                    $lastKey = @($selected.Keys)[-1]
+                    [void]$selected.Remove($lastKey)
+                }
             }
-            if ($visited -ge 4096) { break }
         }
     }
 
-    return @(
-        $matches |
-            Sort-Object @{
-                Expression = {
-                    if ($_.Name -eq 'wizard-driver.log') { 0 }
-                    elseif ($_.Name -in @('go-test-failure-summary.log', 'go-test.log')) { 1 }
-                    else { 2 }
-                }
-            }, FullName |
-            Select-Object -First 30
-    )
+    return @($selected.Values)
 }
 
 function Invoke-Capture {
@@ -5888,9 +5894,26 @@ function Invoke-Capture {
     }
     Write-BoundedText (Join-Path $destination 'listeners.txt') ($listeners -join [Environment]::NewLine)
     if (Test-Path -LiteralPath $root) {
-        foreach ($file in @(Get-WindowsNativeCaptureFiles $root)) {
-            $relative = [IO.Path]::GetRelativePath($root, $file.FullName) -replace '[\\/:*?"<>|]', '_'
-            Write-BoundedText (Join-Path $destination $relative) ([IO.File]::ReadAllText($file.FullName))
+        $captureReader = $null
+        try {
+            $captureReader = [DefenseClaw.DisposableFileGuard]::OpenRootedReader($root)
+        } catch {
+            $captureReader = $null
+        }
+        if ($null -ne $captureReader) {
+            try {
+                foreach ($file in @(Get-WindowsNativeCaptureFiles $root)) {
+                    try {
+                        $capturedText = $captureReader.ReadBoundedUtf8($file.FullName, 1048576)
+                    } catch {
+                        continue
+                    }
+                    $relative = [IO.Path]::GetRelativePath($root, $file.FullName) -replace '[\\/:*?"<>|]', '_'
+                    Write-BoundedText (Join-Path $destination $relative) $capturedText
+                }
+            } finally {
+                $captureReader.Dispose()
+            }
         }
     }
 }
@@ -5943,6 +5966,8 @@ function Invoke-SelfTest {
     $boundedSecret = 'bounded-secret-value'
     $captureFixture = Join-Path $root 'bounded-capture-selection'
     $symlinkTarget = $null
+    $outsideCaptureRoot = $null
+    $captureReader = $null
     $originalBoundedSecret = [Environment]::GetEnvironmentVariable('DC_E2E_TEST_SECRET')
     try {
         $env:DC_E2E_TEST_SECRET = $boundedSecret
@@ -6128,7 +6153,11 @@ function Invoke-SelfTest {
             [IO.FileShare]::None
         )
         try { $oversized.SetLength(1048577) } finally { $oversized.Dispose() }
-        $symlinkTarget = Join-Path $root 'outside-capture-secret.bin'
+        $outsideCaptureRoot = Join-Path ([IO.Path]::GetTempPath()) (
+            'defenseclaw-native-capture-outside-' + [guid]::NewGuid().ToString('N')
+        )
+        [IO.Directory]::CreateDirectory($outsideCaptureRoot) | Out-Null
+        $symlinkTarget = Join-Path $outsideCaptureRoot 'outside-capture-secret.bin'
         $symlinkPath = Join-Path $captureFixture 'doctor.log'
         Set-Content -LiteralPath $symlinkTarget -Value 'sensitive diagnostic fixture' -NoNewline
         New-Item -ItemType SymbolicLink -Path $symlinkPath -Target $symlinkTarget -ErrorAction Stop | Out-Null
@@ -6154,13 +6183,71 @@ function Invoke-SelfTest {
         }) {
             throw 'reparse-point diagnostic bypassed the native capture symlink guard'
         }
+
+        $captureReader = [DefenseClaw.DisposableFileGuard]::OpenRootedReader($captureFixture)
+        $guardedBoundedText = $captureReader.ReadBoundedUtf8($boundedPath, 1048576)
+        if ($guardedBoundedText -cne [IO.File]::ReadAllText($boundedPath)) {
+            throw 'capture retained-root reader changed a verified regular diagnostic'
+        }
+        $leafSwapRoot = Join-Path $captureFixture 'leaf-swap'
+        [IO.Directory]::CreateDirectory($leafSwapRoot) | Out-Null
+        $leafSwapPath = Join-Path $leafSwapRoot 'wizard-driver.log'
+        Set-Content -LiteralPath $leafSwapPath -Value 'safe diagnostic fixture' -NoNewline
+        $leafCandidate = @(Get-WindowsNativeCaptureFiles $leafSwapRoot) |
+            Where-Object {
+                $_.FullName.Equals($leafSwapPath, [StringComparison]::OrdinalIgnoreCase)
+            } |
+            Select-Object -First 1
+        if ($null -eq $leafCandidate) {
+            throw 'capture leaf-swap fixture was not selected before replacement'
+        }
+        [IO.File]::Delete($leafSwapPath)
+        New-Item -ItemType SymbolicLink -Path $leafSwapPath -Target $symlinkTarget -ErrorAction Stop | Out-Null
+        $leafSwapRejected = $false
+        try {
+            $null = $captureReader.ReadBoundedUtf8($leafCandidate.FullName, 1048576)
+        } catch {
+            $leafSwapRejected = $true
+        }
+        if (-not $leafSwapRejected) {
+            throw 'capture followed a leaf replaced by a reparse point after enumeration'
+        }
+
+        $ancestorSwapRoot = Join-Path $captureFixture 'ancestor-swap'
+        [IO.Directory]::CreateDirectory($ancestorSwapRoot) | Out-Null
+        $ancestorSwapPath = Join-Path $ancestorSwapRoot 'doctor.log'
+        Set-Content -LiteralPath $ancestorSwapPath -Value 'safe diagnostic fixture' -NoNewline
+        $ancestorCandidate = @(Get-WindowsNativeCaptureFiles $ancestorSwapRoot) |
+            Where-Object {
+                $_.FullName.Equals($ancestorSwapPath, [StringComparison]::OrdinalIgnoreCase)
+            } |
+            Select-Object -First 1
+        if ($null -eq $ancestorCandidate) {
+            throw 'capture ancestor-swap fixture was not selected before replacement'
+        }
+        Set-Content -LiteralPath (Join-Path $outsideCaptureRoot 'doctor.log') `
+            -Value 'outside diagnostic fixture' -NoNewline
+        Remove-SafeDisposableTree -Path $ancestorSwapRoot -Root $captureFixture
+        New-Item -ItemType Junction -Path $ancestorSwapRoot -Target $outsideCaptureRoot -ErrorAction Stop | Out-Null
+        $ancestorSwapRejected = $false
+        try {
+            $null = $captureReader.ReadBoundedUtf8($ancestorCandidate.FullName, 1048576)
+        } catch {
+            $ancestorSwapRejected = $true
+        }
+        if (-not $ancestorSwapRejected) {
+            throw 'capture followed a replaced ancestor outside its retained root'
+        }
     } finally {
         [Environment]::SetEnvironmentVariable('DC_E2E_TEST_SECRET', $originalBoundedSecret)
+        if ($null -ne $captureReader) {
+            $captureReader.Dispose()
+        }
         if (Test-Path -LiteralPath $captureFixture) {
             Remove-SafeDisposableTree -Path $captureFixture -Root $root
         }
-        if ($symlinkTarget -and (Test-Path -LiteralPath $symlinkTarget)) {
-            Remove-Item -LiteralPath $symlinkTarget -Force
+        if ($outsideCaptureRoot -and (Test-Path -LiteralPath $outsideCaptureRoot)) {
+            Remove-SafeDisposableTree -Path $outsideCaptureRoot -Root $outsideCaptureRoot
         }
     }
 

--- a/scripts/windows-native-ci.ps1
+++ b/scripts/windows-native-ci.ps1
@@ -5815,14 +5815,47 @@ function Stop-StateProcesses([string]$Root) {
     if ($remaining.Count) { throw "isolated process cleanup timed out: $($remaining -join ', ')" }
 }
 
+function Test-WindowsNativeReparsePoint([IO.FileSystemInfo]$Item) {
+    return (($Item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0)
+}
+
 function Get-WindowsNativeCaptureFiles([string]$Root) {
     if (-not (Test-Path -LiteralPath $Root)) { return @() }
+    try {
+        $rootItem = [IO.DirectoryInfo](Get-Item -LiteralPath $Root -Force -ErrorAction Stop)
+    } catch {
+        return @()
+    }
+    if (Test-WindowsNativeReparsePoint $rootItem) { return @() }
+
+    $pending = [Collections.Generic.Queue[IO.DirectoryInfo]]::new()
+    $pending.Enqueue($rootItem)
+    $matches = [Collections.Generic.List[IO.FileInfo]]::new()
+    $visited = 0
+    while ($pending.Count -gt 0 -and $visited -lt 4096) {
+        $directory = $pending.Dequeue()
+        if (Test-WindowsNativeReparsePoint $directory) { continue }
+        try {
+            $children = @(Get-ChildItem -LiteralPath $directory.FullName -Force -ErrorAction SilentlyContinue)
+        } catch {
+            continue
+        }
+        foreach ($child in $children) {
+            $visited++
+            if (Test-WindowsNativeReparsePoint $child) { continue }
+            if ($child.PSIsContainer) {
+                $pending.Enqueue([IO.DirectoryInfo]$child)
+            } elseif ($child -is [IO.FileInfo] -and
+                $child.Name -match '^(gateway|watchdog|results|doctor|.*\.log)' -and
+                $child.Length -le 1048576) {
+                $matches.Add([IO.FileInfo]$child)
+            }
+            if ($visited -ge 4096) { break }
+        }
+    }
+
     return @(
-        Get-ChildItem -LiteralPath $Root -Recurse -File -ErrorAction SilentlyContinue |
-            Where-Object {
-                $_.Name -match '^(gateway|watchdog|results|doctor|.*\.log)' -and
-                    $_.Length -le 1048576
-            } |
+        $matches |
             Sort-Object @{
                 Expression = {
                     if ($_.Name -eq 'wizard-driver.log') { 0 }
@@ -5909,6 +5942,7 @@ function Invoke-SelfTest {
     $boundedLimit = 256
     $boundedSecret = 'bounded-secret-value'
     $captureFixture = Join-Path $root 'bounded-capture-selection'
+    $symlinkTarget = $null
     $originalBoundedSecret = [Environment]::GetEnvironmentVariable('DC_E2E_TEST_SECRET')
     try {
         $env:DC_E2E_TEST_SECRET = $boundedSecret
@@ -6094,6 +6128,10 @@ function Invoke-SelfTest {
             [IO.FileShare]::None
         )
         try { $oversized.SetLength(1048577) } finally { $oversized.Dispose() }
+        $symlinkTarget = Join-Path $root 'outside-capture-secret.bin'
+        $symlinkPath = Join-Path $captureFixture 'doctor.log'
+        Set-Content -LiteralPath $symlinkTarget -Value 'sensitive diagnostic fixture' -NoNewline
+        New-Item -ItemType SymbolicLink -Path $symlinkPath -Target $symlinkTarget -ErrorAction Stop | Out-Null
 
         $captureFiles = @(Get-WindowsNativeCaptureFiles $root)
         if (-not ($captureFiles | Where-Object {
@@ -6111,10 +6149,18 @@ function Invoke-SelfTest {
         }) {
             throw 'oversized diagnostic bypassed the native capture size guard'
         }
+        if ($captureFiles | Where-Object {
+            $_.FullName.Equals($symlinkPath, [StringComparison]::OrdinalIgnoreCase)
+        }) {
+            throw 'reparse-point diagnostic bypassed the native capture symlink guard'
+        }
     } finally {
         [Environment]::SetEnvironmentVariable('DC_E2E_TEST_SECRET', $originalBoundedSecret)
         if (Test-Path -LiteralPath $captureFixture) {
             Remove-SafeDisposableTree -Path $captureFixture -Root $root
+        }
+        if ($symlinkTarget -and (Test-Path -LiteralPath $symlinkTarget)) {
+            Remove-Item -LiteralPath $symlinkTarget -Force
         }
     }
 

--- a/scripts/windows-native-ci.ps1
+++ b/scripts/windows-native-ci.ps1
@@ -5388,14 +5388,47 @@ function Stop-StateProcesses([string]$Root) {
     if ($remaining.Count) { throw "isolated process cleanup timed out: $($remaining -join ', ')" }
 }
 
+function Test-WindowsNativeReparsePoint([IO.FileSystemInfo]$Item) {
+    return (($Item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0)
+}
+
 function Get-WindowsNativeCaptureFiles([string]$Root) {
     if (-not (Test-Path -LiteralPath $Root)) { return @() }
+    try {
+        $rootItem = [IO.DirectoryInfo](Get-Item -LiteralPath $Root -Force -ErrorAction Stop)
+    } catch {
+        return @()
+    }
+    if (Test-WindowsNativeReparsePoint $rootItem) { return @() }
+
+    $pending = [Collections.Generic.Queue[IO.DirectoryInfo]]::new()
+    $pending.Enqueue($rootItem)
+    $matches = [Collections.Generic.List[IO.FileInfo]]::new()
+    $visited = 0
+    while ($pending.Count -gt 0 -and $visited -lt 4096) {
+        $directory = $pending.Dequeue()
+        if (Test-WindowsNativeReparsePoint $directory) { continue }
+        try {
+            $children = @(Get-ChildItem -LiteralPath $directory.FullName -Force -ErrorAction SilentlyContinue)
+        } catch {
+            continue
+        }
+        foreach ($child in $children) {
+            $visited++
+            if (Test-WindowsNativeReparsePoint $child) { continue }
+            if ($child.PSIsContainer) {
+                $pending.Enqueue([IO.DirectoryInfo]$child)
+            } elseif ($child -is [IO.FileInfo] -and
+                $child.Name -match '^(gateway|watchdog|results|doctor|.*\.log)' -and
+                $child.Length -le 1048576) {
+                $matches.Add([IO.FileInfo]$child)
+            }
+            if ($visited -ge 4096) { break }
+        }
+    }
+
     return @(
-        Get-ChildItem -LiteralPath $Root -Recurse -File -ErrorAction SilentlyContinue |
-            Where-Object {
-                $_.Name -match '^(gateway|watchdog|results|doctor|.*\.log)' -and
-                    $_.Length -le 1048576
-            } |
+        $matches |
             Sort-Object @{
                 Expression = {
                     if ($_.Name -eq 'wizard-driver.log') { 0 }
@@ -5482,6 +5515,7 @@ function Invoke-SelfTest {
     $boundedLimit = 256
     $boundedSecret = 'bounded-secret-value'
     $captureFixture = Join-Path $root 'bounded-capture-selection'
+    $symlinkTarget = $null
     $originalBoundedSecret = [Environment]::GetEnvironmentVariable('DC_E2E_TEST_SECRET')
     try {
         $env:DC_E2E_TEST_SECRET = $boundedSecret
@@ -5667,6 +5701,10 @@ function Invoke-SelfTest {
             [IO.FileShare]::None
         )
         try { $oversized.SetLength(1048577) } finally { $oversized.Dispose() }
+        $symlinkTarget = Join-Path $root 'outside-capture-secret.bin'
+        $symlinkPath = Join-Path $captureFixture 'doctor.log'
+        Set-Content -LiteralPath $symlinkTarget -Value 'sensitive diagnostic fixture' -NoNewline
+        New-Item -ItemType SymbolicLink -Path $symlinkPath -Target $symlinkTarget -ErrorAction Stop | Out-Null
 
         $captureFiles = @(Get-WindowsNativeCaptureFiles $root)
         if (-not ($captureFiles | Where-Object {
@@ -5684,10 +5722,18 @@ function Invoke-SelfTest {
         }) {
             throw 'oversized diagnostic bypassed the native capture size guard'
         }
+        if ($captureFiles | Where-Object {
+            $_.FullName.Equals($symlinkPath, [StringComparison]::OrdinalIgnoreCase)
+        }) {
+            throw 'reparse-point diagnostic bypassed the native capture symlink guard'
+        }
     } finally {
         [Environment]::SetEnvironmentVariable('DC_E2E_TEST_SECRET', $originalBoundedSecret)
         if (Test-Path -LiteralPath $captureFixture) {
             Remove-SafeDisposableTree -Path $captureFixture -Root $root
+        }
+        if ($symlinkTarget -and (Test-Path -LiteralPath $symlinkTarget)) {
+            Remove-Item -LiteralPath $symlinkTarget -Force
         }
     }
 


### PR DESCRIPTION
**Stack/base:** Standalone security fix rebased directly onto `main` at `c2236353f32e50f5c3c770f2fca16fca8c1cfca2`; no dependent pull requests.

## Problem

Windows native diagnostic capture enumerated candidate log files, rejected reparse points during discovery, and later reopened each selected pathname with `[IO.File]::ReadAllText(...)`. An attacker able to modify the state tree could replace a selected file or one of its ancestors between those operations and make capture read a different filesystem object. The candidate traversal also stopped globally after 4,096 entries, so sufficiently many decoys could prevent priority diagnostics from being considered, and its `$matches` local collided case-insensitively with PowerShell's automatic `$Matches` variable.

Fixes #645.

## Current Situation

The original PR rejected reparse points visible during enumeration, but review and the first Windows CI run exposed three remaining gaps:

1. `$matches` became the automatic regex-result hashtable after `-match`, so the harness failed at `.Add(...)`.
2. The global traversal cap could discard later `wizard-driver.log`, `go-test-failure-summary.log`, or `go-test.log` files before priority selection.
3. `ReadAllText(path)` performed a fresh path resolution after discovery, leaving a swap/reparse TOCTOU window.

## Solution

### Exhaustive traversal with bounded retention

The capture walker now examines the complete non-reparse tree while retaining only the best 30 candidates in an ordinal-ignore-case `SortedDictionary`. Priority diagnostics therefore remain selectable regardless of earlier decoys, without retaining an unbounded result list. The conflicting `$matches` and obsolete `$visited` variables are gone.

### Handle-bound, retained-root reads

`DisposableFileGuard.RootedReader` retains a validated no-follow handle to the capture root. For every selected file it:

1. verifies the candidate is lexically beneath that root;
2. opens the leaf with `FILE_FLAG_OPEN_REPARSE_POINT`;
3. validates disk-file type, attributes, single-link identity, and byte bound from that same handle;
4. obtains the final path from that same handle and requires it to remain beneath the retained root; and
5. reads the exact validated byte count through that handle.

Any disappeared file, reparse replacement, outside-root ancestor swap, size mutation, or other validation failure is skipped rather than captured.

```mermaid
flowchart LR
    A["Exhaustive non-reparse enumeration"] --> B["Bounded priority set: 30 files"]
    B --> C["Retained verified root handle"]
    C --> D["Open candidate no-follow"]
    D --> E["Same-handle attributes, link count, size, and final path"]
    E -->|"valid child"| F["Same-handle bounded read"]
    E -->|"swap, reparse, or escape"| G["Reject and skip"]
    F --> H["Redact and write diagnostics"]
```

### Deterministic race regressions

The Windows native self-test now selects a legitimate diagnostic and then deterministically replaces (a) the leaf with a symbolic link and (b) an ancestor directory with a junction to an outside directory. Both reads must be rejected. Static certification tests lock in the handle-bound contracts and the bounded priority selector.

## What Changed (Where & How)

| Area | Path | Change |
|---|---|---|
| Native capture | `scripts/windows-native-ci.ps1` | Replaced the conflicting/unbounded traversal state, routed reads through one retained-root reader, and added deterministic leaf/ancestor swap self-tests. |
| Windows file guard | `scripts/windows-disposable-file-guard.cs` | Added retained-root/no-follow file reads with same-handle identity, attribute, final-path, size, and exact-read validation. |
| Live connector harness | `scripts/live-connector-e2e/test-windows.ps1` | Added static contracts for bounded selection, no pathname reopen, retained-root enforcement, and swap regressions. |
| Release certification | `cli/tests/test_windows_release_certification.py` | Added cross-platform source assertions covering the security invariants and test fixtures. |

## Breaking Changes

None. Ordinary in-root UTF-8 diagnostic files retain the existing 1 MiB per-file and 30-file bounds. Files that cannot be proven to be regular, single-link children of the retained state root are now skipped.

## Open Issues / Follow-ups

None.

## Test Plan

- `uv run --frozen pytest -q cli/tests/test_windows_release_certification.py cli/tests/test_connector_live_e2e_path_policy.py cli/tests/test_windows_installer_artifacts.py`
  - Passed: `102 passed, 61 skipped in 3.69s`.
- `uv run --frozen ruff check cli/tests/test_windows_release_certification.py`
  - Passed: `All checks passed!`
- `uv run --frozen ruff format --check cli/tests/test_windows_release_certification.py`
  - Passed: `1 file already formatted`.
- `actionlint .github/workflows/windows-native.yml`
  - Passed with no findings.
- `git diff --check`
  - Passed with no whitespace errors.
- Native Windows PowerShell self-test
  - Not runnable in the local macOS worktree because neither Windows PowerShell nor `pwsh` is installed.
  - GitHub Actions [`Windows PowerShell harness validation`](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/31457851987/job/93675255485) passed, including C# compilation and the deterministic capture self-tests.
  - GitHub Actions [`Windows Native Required`](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/31457851987/job/93681052339) passed.
- Full PR check set at commit `4fc57ccadae1b8482fd5d10afcd1868ba941bf78`
  - Terminal result: `87 passed`, `4 intentionally skipped`, `0 failed`, `0 pending`.
