### PR TITLE
fix(scanner): make DNS pinning work with MCP SDK transports

### DIFF
--- a/cli/defenseclaw/registries/ssrf.py
+++ b/cli/defenseclaw/registries/ssrf.py
@@ -19,10 +19,10 @@ need to ingest from a private host must opt in with ``--allow-private``;
 the flag is plumbed all the way through the CLI surface so an
 "oops, my URL was internal" mistake stays explicit.
 
-This module is intentionally pure-Python and stdlib-only so it can be
-unit-tested without network access — :func:`guard_url` performs DNS
-resolution via :func:`socket.getaddrinfo`, but that lookup can be
-mocked in tests by passing a custom ``resolver`` callback.
+DNS resolution is dependency-injected so the guard can be unit-tested
+without network access. :func:`guard_url` uses
+:func:`socket.getaddrinfo` by default, but tests can pass a custom
+``resolver`` callback.
 """
 
 from __future__ import annotations
@@ -122,6 +122,37 @@ class SSRFError(ValueError):
 Resolver = Callable[[str], list[str]]
 
 
+def _canonical_dns_host(host: str | bytes | None) -> str:
+    """Return the ASCII hostname representation used by AnyIO."""
+    if isinstance(host, bytes):
+        try:
+            value = host.decode("ascii")
+        except UnicodeDecodeError as exc:
+            raise SSRFError("DNS host contains non-ASCII bytes") from exc
+    elif isinstance(host, str):
+        value = host
+    else:
+        raise SSRFError("DNS host must be text or ASCII bytes")
+
+    value = value.strip()
+    if not value:
+        raise SSRFError("DNS host is empty")
+    if any(ord(char) < 32 or ord(char) == 127 for char in value):
+        raise SSRFError("DNS host contains control characters")
+
+    try:
+        encoded = value.encode("ascii")
+    except UnicodeEncodeError:
+        import idna
+
+        try:
+            encoded = idna.encode(value, uts46=True)
+        except idna.IDNAError as exc:
+            raise SSRFError(f"invalid internationalized DNS host {value!r}") from exc
+
+    return encoded.decode("ascii").lower()
+
+
 def _default_resolver(host: str) -> list[str]:
     """Resolve *host* via getaddrinfo, returning a list of literal IPs.
 
@@ -196,9 +227,10 @@ def resolve_and_pin(
         raise SSRFError(
             f"unsupported URL scheme {scheme!r}; expected http or https"
         )
-    host = (parsed.hostname or "").strip().lower()
-    if not host:
+    parsed_host = parsed.hostname
+    if not parsed_host or not parsed_host.strip():
         raise SSRFError("URL is missing a host component")
+    host = _canonical_dns_host(parsed_host)
 
     if host in {"localhost", "ip6-localhost"} and not allow_private:
         raise SSRFError("refusing to fetch from localhost (use --allow-private to opt in)")
@@ -291,30 +323,48 @@ def pinned_getaddrinfo(host: str, port: int, ip: str) -> Iterator[None]:
     monkeypatches a module global; concurrent pinned fetches serialise on
     connect, matching the adapter ``_PinnedConnect`` contract.
     """
-    target_host = (host or "").strip().lower()
+    target_host = _canonical_dns_host(host)
     family_ip = ipaddress.ip_address(ip)
+    pinned_family = socket.AF_INET6 if family_ip.version == 6 else socket.AF_INET
     with _GETADDRINFO_PIN_LOCK:
         original = socket.getaddrinfo
 
-        def _pinned(node, service, *args, **kwargs):  # type: ignore[no-untyped-def]
-            asked = (str(node).strip().lower() if node is not None else "")
-            if asked == target_host:
-                # Resolve to the vetted IP literal. Preserve the requested
-                # service/port so a derived port still connects correctly;
-                # the Host header / TLS SNI continue to carry the hostname
-                # because those travel independently of the dial address.
-                fam = socket.AF_INET6 if family_ip.version == 6 else socket.AF_INET
-                return original(ip, service, fam, *args[1:], **kwargs)
-            # An IP literal that equals our pin is fine (some clients
-            # pre-resolve and re-call getaddrinfo with the IP).
+        def _pinned(  # type: ignore[no-untyped-def]
+            host,
+            port,
+            family=0,
+            type=0,
+            proto=0,
+            flags=0,
+        ):
+            asked = _canonical_dns_host(host)
+            matches_pin = asked == target_host
             try:
-                if ipaddress.ip_address(asked) == family_ip:
-                    return original(ip, service, *args, **kwargs)
+                matches_pin = matches_pin or ipaddress.ip_address(asked) == family_ip
             except ValueError:
                 pass
-            raise SSRFError(
-                f"unexpected DNS resolution for {asked!r} during pinned "
-                f"fetch of {target_host!r} (possible DNS rebinding)"
+            if not matches_pin:
+                raise SSRFError(
+                    f"unexpected DNS resolution for {asked!r} during pinned "
+                    f"fetch of {target_host!r} (possible DNS rebinding)"
+                )
+
+            requested_family = int(family)
+            if requested_family not in (socket.AF_UNSPEC, pinned_family):
+                raise socket.gaierror(
+                    socket.EAI_FAMILY,
+                    "address family does not match the pinned IP",
+                )
+
+            # The numeric address prevents a second DNS query. Host headers
+            # and TLS SNI are carried separately by the HTTP client.
+            return original(
+                str(family_ip),
+                port,
+                pinned_family,
+                type,
+                proto,
+                flags,
             )
 
         socket.getaddrinfo = _pinned  # type: ignore[assignment]

--- a/cli/defenseclaw/registries/ssrf.py
+++ b/cli/defenseclaw/registries/ssrf.py
@@ -27,12 +27,17 @@ without network access. :func:`guard_url` uses
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
+import contextvars
+import functools
 import ipaddress
 import os
 import socket
 import threading
-from collections.abc import Callable, Iterator
+import weakref
+from collections.abc import AsyncIterator, Callable, Iterator
+from dataclasses import dataclass
 from urllib.parse import urlparse
 
 # RFC 6598 carrier-grade NAT range. Python's ``ipaddress.is_private``
@@ -305,6 +310,85 @@ def resolve_and_pin(
 # :func:`socket.getaddrinfo`, so pinning there covers every client.
 
 _GETADDRINFO_PIN_LOCK = threading.Lock()
+_ANALYZER_DNS_ALLOWED: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "defenseclaw_analyzer_dns_allowed",
+    default=False,
+)
+_MISSING_LOOP_RESOLVER = object()
+
+
+@dataclass
+class _AsyncResolverPinState:
+    users: int
+    original_override: object
+
+
+_ASYNC_RESOLVER_STATES: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop, _AsyncResolverPinState
+] = weakref.WeakKeyDictionary()
+_ASYNC_RESOLVER_STATE_LOCK = threading.Lock()
+
+
+@contextlib.contextmanager
+def analyzer_dns_resolution() -> Iterator[None]:
+    """Let a configured scanner analyzer resolve its service endpoint."""
+    token = _ANALYZER_DNS_ALLOWED.set(True)
+    try:
+        yield
+    finally:
+        _ANALYZER_DNS_ALLOWED.reset(token)
+
+
+@contextlib.asynccontextmanager
+async def pinned_async_getaddrinfo() -> AsyncIterator[None]:
+    """Route the active event loop's resolver through the socket pin."""
+    loop = asyncio.get_running_loop()
+
+    async def _through_socket(
+        host,
+        port,
+        *,
+        family=0,
+        type=0,
+        proto=0,
+        flags=0,
+    ):
+        resolve = functools.partial(
+            socket.getaddrinfo,
+            host,
+            port,
+            family,
+            type,
+            proto,
+            flags,
+        )
+        return await asyncio.to_thread(resolve)
+
+    with _ASYNC_RESOLVER_STATE_LOCK:
+        state = _ASYNC_RESOLVER_STATES.get(loop)
+        if state is None:
+            original_override = vars(loop).get(
+                "getaddrinfo",
+                _MISSING_LOOP_RESOLVER,
+            )
+            loop.getaddrinfo = _through_socket  # type: ignore[method-assign]
+            state = _AsyncResolverPinState(1, original_override)
+            _ASYNC_RESOLVER_STATES[loop] = state
+        else:
+            state.users += 1
+
+    try:
+        yield
+    finally:
+        with _ASYNC_RESOLVER_STATE_LOCK:
+            state.users -= 1
+            if state.users == 0:
+                if state.original_override is _MISSING_LOOP_RESOLVER:
+                    if "getaddrinfo" in vars(loop):
+                        del loop.getaddrinfo
+                else:
+                    loop.getaddrinfo = state.original_override  # type: ignore[method-assign]
+                del _ASYNC_RESOLVER_STATES[loop]
 
 
 @contextlib.contextmanager
@@ -317,7 +401,9 @@ def pinned_getaddrinfo(host: str, port: int, ip: str) -> Iterator[None]:
     *different* port is also re-pointed at the vetted IP (clients may dial
     a derived port). A lookup for any *other* host raises :class:`SSRFError`
     so a library cannot side-channel a request to an unvetted destination
-    during the pinned operation.
+    during the pinned operation. Configured analyzers can opt into their
+    normal resolver in a task-local scope; MCP redirects and proxy lookups
+    stay pinned.
 
     Held under a process-wide lock for the duration of the block because it
     monkeypatches a module global; concurrent pinned fetches serialise on
@@ -344,6 +430,15 @@ def pinned_getaddrinfo(host: str, port: int, ip: str) -> Iterator[None]:
             except ValueError:
                 pass
             if not matches_pin:
+                if _ANALYZER_DNS_ALLOWED.get():
+                    return original(
+                        host,
+                        port,
+                        family,
+                        type,
+                        proto,
+                        flags,
+                    )
                 raise SSRFError(
                     f"unexpected DNS resolution for {asked!r} during pinned "
                     f"fetch of {target_host!r} (possible DNS rebinding)"

--- a/cli/defenseclaw/registries/ssrf.py
+++ b/cli/defenseclaw/registries/ssrf.py
@@ -393,6 +393,10 @@ async def pinned_async_getaddrinfo() -> AsyncIterator[None]:
         else:
             state.users += 1
 
+    # There is no await between registering this scope and yielding it, so
+    # cancellation cannot strand a registered-but-unentered user. Once the
+    # caller enters, normal task cancellation and BaseException paths unwind
+    # the scope through this finally block.
     try:
         yield
     finally:

--- a/cli/defenseclaw/registries/ssrf.py
+++ b/cli/defenseclaw/registries/ssrf.py
@@ -40,6 +40,8 @@ from collections.abc import AsyncIterator, Callable, Iterator
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
+import idna
+
 # RFC 6598 carrier-grade NAT range. Python's ``ipaddress.is_private``
 # does NOT include this block — it predates RFC 6598 — so we have to
 # match it explicitly to stay in lockstep with the Go-side gateway
@@ -148,8 +150,6 @@ def _canonical_dns_host(host: str | bytes | None) -> str:
     try:
         encoded = value.encode("ascii")
     except UnicodeEncodeError:
-        import idna
-
         try:
             encoded = idna.encode(value, uts46=True)
         except idna.IDNAError as exc:
@@ -310,11 +310,12 @@ def resolve_and_pin(
 # :func:`socket.getaddrinfo`, so pinning there covers every client.
 
 _GETADDRINFO_PIN_LOCK = threading.Lock()
-_ANALYZER_DNS_ALLOWED: contextvars.ContextVar[bool] = contextvars.ContextVar(
-    "defenseclaw_analyzer_dns_allowed",
-    default=False,
-)
 _MISSING_LOOP_RESOLVER = object()
+
+
+@dataclass(frozen=True)
+class _AnalyzerDNSPolicy:
+    trusted_hosts: frozenset[str]
 
 
 @dataclass
@@ -323,6 +324,12 @@ class _AsyncResolverPinState:
     original_override: object
 
 
+_ANALYZER_DNS_POLICY: contextvars.ContextVar[_AnalyzerDNSPolicy | None] = (
+    contextvars.ContextVar(
+        "defenseclaw_analyzer_dns_policy",
+        default=None,
+    )
+)
 _ASYNC_RESOLVER_STATES: weakref.WeakKeyDictionary[
     asyncio.AbstractEventLoop, _AsyncResolverPinState
 ] = weakref.WeakKeyDictionary()
@@ -330,13 +337,22 @@ _ASYNC_RESOLVER_STATE_LOCK = threading.Lock()
 
 
 @contextlib.contextmanager
-def analyzer_dns_resolution() -> Iterator[None]:
-    """Let a configured scanner analyzer resolve its service endpoint."""
-    token = _ANALYZER_DNS_ALLOWED.set(True)
+def analyzer_dns_resolution(*trusted_hosts: str | bytes) -> Iterator[None]:
+    """Allow analyzer DNS without opening a private-network bypass.
+
+    Explicitly configured analyzer endpoint hosts are trusted, including
+    private endpoints selected by the operator. Other hosts (for example a
+    provider default or redirect) may resolve only to public addresses. The
+    task-local policy keeps concurrent MCP transport lookups fail closed.
+    """
+    current = _ANALYZER_DNS_POLICY.get()
+    inherited = current.trusted_hosts if current is not None else frozenset()
+    trusted = inherited.union(_canonical_dns_host(host) for host in trusted_hosts)
+    token = _ANALYZER_DNS_POLICY.set(_AnalyzerDNSPolicy(trusted))
     try:
         yield
     finally:
-        _ANALYZER_DNS_ALLOWED.reset(token)
+        _ANALYZER_DNS_POLICY.reset(token)
 
 
 @contextlib.asynccontextmanager
@@ -430,8 +446,9 @@ def pinned_getaddrinfo(host: str, port: int, ip: str) -> Iterator[None]:
             except ValueError:
                 pass
             if not matches_pin:
-                if _ANALYZER_DNS_ALLOWED.get():
-                    return original(
+                analyzer_policy = _ANALYZER_DNS_POLICY.get()
+                if analyzer_policy is not None:
+                    results = original(
                         host,
                         port,
                         family,
@@ -439,6 +456,36 @@ def pinned_getaddrinfo(host: str, port: int, ip: str) -> Iterator[None]:
                         proto,
                         flags,
                     )
+                    if asked in analyzer_policy.trusted_hosts:
+                        return results
+
+                    for result in results:
+                        try:
+                            resolved = _normalize_ip(
+                                ipaddress.ip_address(str(result[4][0]))
+                            )
+                        except (IndexError, TypeError, ValueError) as exc:
+                            raise SSRFError(
+                                f"analyzer DNS for {asked!r} returned an invalid address"
+                            ) from exc
+                        if (
+                            resolved.is_loopback
+                            or resolved.is_link_local
+                            or resolved.is_private
+                            or resolved.is_multicast
+                            or resolved.is_unspecified
+                            or resolved.is_reserved
+                            or resolved in _CLOUD_METADATA_IPS
+                            or (
+                                resolved.version == 4
+                                and resolved in _CGNAT_NETWORK
+                            )
+                        ):
+                            raise SSRFError(
+                                f"analyzer DNS for unconfigured host {asked!r} "
+                                f"resolved to disallowed address {resolved}"
+                            )
+                    return results
                 raise SSRFError(
                     f"unexpected DNS resolution for {asked!r} during pinned "
                     f"fetch of {target_host!r} (possible DNS rebinding)"

--- a/cli/defenseclaw/registries/ssrf.py
+++ b/cli/defenseclaw/registries/ssrf.py
@@ -316,6 +316,7 @@ _MISSING_LOOP_RESOLVER = object()
 @dataclass(frozen=True)
 class _AnalyzerDNSPolicy:
     trusted_hosts: frozenset[str]
+    loopback_only_hosts: frozenset[str]
 
 
 @dataclass
@@ -337,18 +338,31 @@ _ASYNC_RESOLVER_STATE_LOCK = threading.Lock()
 
 
 @contextlib.contextmanager
-def analyzer_dns_resolution(*trusted_hosts: str | bytes) -> Iterator[None]:
+def analyzer_dns_resolution(
+    *trusted_hosts: str | bytes,
+    loopback_only_hosts: tuple[str | bytes, ...] = (),
+) -> Iterator[None]:
     """Allow analyzer DNS without opening a private-network bypass.
 
     Explicitly configured analyzer endpoint hosts are trusted, including
-    private endpoints selected by the operator. Other hosts (for example a
-    provider default or redirect) may resolve only to public addresses. The
-    task-local policy keeps concurrent MCP transport lookups fail closed.
+    private endpoints selected by the operator. Implicit local-provider hosts
+    may be marked loopback-only so poisoned ``localhost`` answers cannot reach
+    another private or metadata address. Other hosts (for example a redirect)
+    may resolve only to public addresses. The task-local policy keeps
+    concurrent MCP transport lookups fail closed.
     """
     current = _ANALYZER_DNS_POLICY.get()
     inherited = current.trusted_hosts if current is not None else frozenset()
     trusted = inherited.union(_canonical_dns_host(host) for host in trusted_hosts)
-    token = _ANALYZER_DNS_POLICY.set(_AnalyzerDNSPolicy(trusted))
+    inherited_loopback = (
+        current.loopback_only_hosts if current is not None else frozenset()
+    )
+    loopback_only = inherited_loopback.union(
+        _canonical_dns_host(host) for host in loopback_only_hosts
+    ).difference(trusted)
+    token = _ANALYZER_DNS_POLICY.set(
+        _AnalyzerDNSPolicy(trusted, loopback_only)
+    )
     try:
         yield
     finally:
@@ -472,6 +486,13 @@ def pinned_getaddrinfo(host: str, port: int, ip: str) -> Iterator[None]:
                             raise SSRFError(
                                 f"analyzer DNS for {asked!r} returned an invalid address"
                             ) from exc
+                        if asked in analyzer_policy.loopback_only_hosts:
+                            if not resolved.is_loopback:
+                                raise SSRFError(
+                                    f"implicit local analyzer host {asked!r} "
+                                    f"resolved to non-loopback address {resolved}"
+                                )
+                            continue
                         if (
                             resolved.is_loopback
                             or resolved.is_link_local

--- a/cli/defenseclaw/scanner/mcp.py
+++ b/cli/defenseclaw/scanner/mcp.py
@@ -38,11 +38,11 @@ import subprocess
 import sys
 import tempfile
 import threading
-from collections.abc import Iterator
+from collections.abc import Awaitable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 from defenseclaw.config import (
     CiscoAIDefenseConfig,
@@ -54,6 +54,8 @@ from defenseclaw.config import (
 from defenseclaw.models import Finding, ScanResult
 from defenseclaw.registries.ssrf import (
     SSRFError,
+    analyzer_dns_resolution,
+    pinned_async_getaddrinfo,
     pinned_getaddrinfo,
     resolve_and_pin,
 )
@@ -65,6 +67,8 @@ from defenseclaw.scanner._llm_env import (
 
 if TYPE_CHECKING:
     pass
+
+_T = TypeVar("_T")
 
 
 # env vars whose names contain any of these
@@ -837,6 +841,26 @@ def _inspect_to_llm(il: InspectLLMConfig) -> LLMConfig:
     )
 
 
+def _scope_network_analyzer_dns(scanner: object) -> None:
+    """Keep analyzer traffic separate from the pinned MCP transport."""
+    for attr_name in ("_api_analyzer", "_llm_analyzer"):
+        analyzer = getattr(scanner, attr_name, None)
+        analyze = getattr(analyzer, "analyze", None)
+        if not callable(analyze):
+            continue
+
+        async def run_analyzer(*args, _analyze=analyze, **kwargs):
+            with analyzer_dns_resolution():
+                return await _analyze(*args, **kwargs)
+
+        setattr(analyzer, "analyze", run_analyzer)
+
+
+async def _run_with_pinned_dns(scan: Awaitable[_T]) -> _T:
+    async with pinned_async_getaddrinfo():
+        return await scan
+
+
 class MCPScannerWrapper:
     """Wraps the cisco-ai-mcp-scanner SDK.
 
@@ -1000,6 +1024,7 @@ class MCPScannerWrapper:
         )
 
         scanner = MCPSDKScanner(sdk_config)
+        _scope_network_analyzer_dns(scanner)
         analyzers = self._parse_analyzers(AnalyzerEnum)
 
         start = time.monotonic()
@@ -1219,7 +1244,9 @@ class MCPScannerWrapper:
         all_findings: list[object] = []
 
         tool_results = asyncio.run(
-            scanner.scan_remote_server_tools(target, analyzers=analyzers)
+            _run_with_pinned_dns(
+                scanner.scan_remote_server_tools(target, analyzers=analyzers)
+            )
         )
         for tr in tool_results:
             entity_name = getattr(tr, "tool_name", "")
@@ -1230,7 +1257,9 @@ class MCPScannerWrapper:
 
         if cfg.scan_prompts:
             prompt_results = asyncio.run(
-                scanner.scan_remote_server_prompts(target, analyzers=analyzers)
+                _run_with_pinned_dns(
+                    scanner.scan_remote_server_prompts(target, analyzers=analyzers)
+                )
             )
             for pr in prompt_results:
                 entity_name = getattr(pr, "prompt_name", "")
@@ -1241,7 +1270,9 @@ class MCPScannerWrapper:
 
         if cfg.scan_resources:
             resource_results = asyncio.run(
-                scanner.scan_remote_server_resources(target, analyzers=analyzers)
+                _run_with_pinned_dns(
+                    scanner.scan_remote_server_resources(target, analyzers=analyzers)
+                )
             )
             for rr in resource_results:
                 entity_name = getattr(rr, "resource_name", "") or getattr(rr, "resource_uri", "")
@@ -1253,7 +1284,11 @@ class MCPScannerWrapper:
         if cfg.scan_instructions:
             try:
                 instr_results = asyncio.run(
-                    scanner.scan_remote_server_instructions(target, analyzers=analyzers)
+                    _run_with_pinned_dns(
+                        scanner.scan_remote_server_instructions(
+                            target, analyzers=analyzers
+                        )
+                    )
                 )
                 items = instr_results if isinstance(instr_results, list) else [instr_results]
                 for ir in items:

--- a/cli/defenseclaw/scanner/mcp.py
+++ b/cli/defenseclaw/scanner/mcp.py
@@ -43,6 +43,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, TypeVar
+from urllib.parse import urlparse
 
 from defenseclaw.config import (
     CiscoAIDefenseConfig,
@@ -841,19 +842,39 @@ def _inspect_to_llm(il: InspectLLMConfig) -> LLMConfig:
     )
 
 
-def _scope_network_analyzer_dns(scanner: object) -> None:
-    """Keep analyzer traffic separate from the pinned MCP transport."""
-    for attr_name in ("_api_analyzer", "_llm_analyzer"):
+def _scope_network_analyzer_dns(
+    scanner: object,
+    *,
+    api_endpoint: str,
+    llm_base_url: str,
+) -> None:
+    """Keep analyzer traffic separate without allowing private redirects."""
+    endpoint_by_analyzer = {
+        "_api_analyzer": api_endpoint,
+        "_llm_analyzer": llm_base_url,
+    }
+    for attr_name, endpoint in endpoint_by_analyzer.items():
         analyzer = getattr(scanner, attr_name, None)
         analyze = getattr(analyzer, "analyze", None)
         if not callable(analyze):
             continue
 
-        async def run_analyzer(*args, _analyze=analyze, **kwargs):
-            with analyzer_dns_resolution():
+        try:
+            endpoint_host = urlparse(endpoint).hostname if endpoint else None
+        except ValueError:
+            endpoint_host = None
+        trusted_hosts = (endpoint_host,) if endpoint_host else ()
+
+        async def run_analyzer(
+            *args,
+            _analyze=analyze,
+            _trusted_hosts=trusted_hosts,
+            **kwargs,
+        ):
+            with analyzer_dns_resolution(*_trusted_hosts):
                 return await _analyze(*args, **kwargs)
 
-        setattr(analyzer, "analyze", run_analyzer)
+        analyzer.analyze = run_analyzer
 
 
 async def _run_with_pinned_dns(scan: Awaitable[_T]) -> _T:
@@ -1024,7 +1045,11 @@ class MCPScannerWrapper:
         )
 
         scanner = MCPSDKScanner(sdk_config)
-        _scope_network_analyzer_dns(scanner)
+        _scope_network_analyzer_dns(
+            scanner,
+            api_endpoint=aid.endpoint,
+            llm_base_url=llm.base_url,
+        )
         analyzers = self._parse_analyzers(AnalyzerEnum)
 
         start = time.monotonic()

--- a/cli/defenseclaw/scanner/mcp.py
+++ b/cli/defenseclaw/scanner/mcp.py
@@ -38,7 +38,7 @@ import subprocess
 import sys
 import tempfile
 import threading
-from collections.abc import Awaitable, Iterator
+from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -847,6 +847,7 @@ def _scope_network_analyzer_dns(
     *,
     api_endpoint: str,
     llm_base_url: str,
+    llm_uses_local_default: bool,
 ) -> None:
     """Keep analyzer traffic separate without allowing private redirects."""
     endpoint_by_analyzer = {
@@ -863,7 +864,16 @@ def _scope_network_analyzer_dns(
             endpoint_host = urlparse(endpoint).hostname if endpoint else None
         except ValueError:
             endpoint_host = None
-        trusted_hosts = (endpoint_host,) if endpoint_host else ()
+        if endpoint_host:
+            trusted_hosts = (endpoint_host,)
+        elif attr_name == "_llm_analyzer" and llm_uses_local_default:
+            # LiteLLM's built-in local-provider endpoints use loopback when
+            # no explicit base URL is configured. Trust only those literal
+            # default host spellings; redirects and unrelated private names
+            # still pass through analyzer_dns_resolution's public-IP policy.
+            trusted_hosts = ("localhost", "127.0.0.1", "::1")
+        else:
+            trusted_hosts = ()
 
         async def run_analyzer(
             *args,
@@ -877,9 +887,9 @@ def _scope_network_analyzer_dns(
         analyzer.analyze = run_analyzer
 
 
-async def _run_with_pinned_dns(scan: Awaitable[_T]) -> _T:
+async def _run_with_pinned_dns(make_scan: Callable[[], Awaitable[_T]]) -> _T:
     async with pinned_async_getaddrinfo():
-        return await scan
+        return await make_scan()
 
 
 class MCPScannerWrapper:
@@ -1049,6 +1059,7 @@ class MCPScannerWrapper:
             scanner,
             api_endpoint=aid.endpoint,
             llm_base_url=llm.base_url,
+            llm_uses_local_default=llm.is_local_provider(),
         )
         analyzers = self._parse_analyzers(AnalyzerEnum)
 
@@ -1270,7 +1281,9 @@ class MCPScannerWrapper:
 
         tool_results = asyncio.run(
             _run_with_pinned_dns(
-                scanner.scan_remote_server_tools(target, analyzers=analyzers)
+                lambda: scanner.scan_remote_server_tools(
+                    target, analyzers=analyzers
+                )
             )
         )
         for tr in tool_results:
@@ -1283,7 +1296,9 @@ class MCPScannerWrapper:
         if cfg.scan_prompts:
             prompt_results = asyncio.run(
                 _run_with_pinned_dns(
-                    scanner.scan_remote_server_prompts(target, analyzers=analyzers)
+                    lambda: scanner.scan_remote_server_prompts(
+                        target, analyzers=analyzers
+                    )
                 )
             )
             for pr in prompt_results:
@@ -1296,7 +1311,9 @@ class MCPScannerWrapper:
         if cfg.scan_resources:
             resource_results = asyncio.run(
                 _run_with_pinned_dns(
-                    scanner.scan_remote_server_resources(target, analyzers=analyzers)
+                    lambda: scanner.scan_remote_server_resources(
+                        target, analyzers=analyzers
+                    )
                 )
             )
             for rr in resource_results:
@@ -1310,8 +1327,9 @@ class MCPScannerWrapper:
             try:
                 instr_results = asyncio.run(
                     _run_with_pinned_dns(
-                        scanner.scan_remote_server_instructions(
-                            target, analyzers=analyzers
+                        lambda: scanner.scan_remote_server_instructions(
+                            target,
+                            analyzers=analyzers,
                         )
                     )
                 )

--- a/cli/defenseclaw/scanner/mcp.py
+++ b/cli/defenseclaw/scanner/mcp.py
@@ -864,14 +864,16 @@ def _scope_network_analyzer_dns(
             endpoint_host = urlparse(endpoint).hostname if endpoint else None
         except ValueError:
             endpoint_host = None
+        loopback_only_hosts: tuple[str, ...] = ()
         if endpoint_host:
             trusted_hosts = (endpoint_host,)
         elif attr_name == "_llm_analyzer" and llm_uses_local_default:
-            # LiteLLM's built-in local-provider endpoints use loopback when
-            # no explicit base URL is configured. Trust only those literal
-            # default host spellings; redirects and unrelated private names
-            # still pass through analyzer_dns_resolution's public-IP policy.
-            trusted_hosts = ("localhost", "127.0.0.1", "::1")
+            # LiteLLM's built-in local-provider endpoints use these spellings
+            # when no explicit base URL is configured. Require their answers
+            # to remain loopback; redirects and unrelated private names still
+            # pass through analyzer_dns_resolution's public-IP policy.
+            trusted_hosts = ()
+            loopback_only_hosts = ("localhost", "127.0.0.1", "::1")
         else:
             trusted_hosts = ()
 
@@ -879,9 +881,13 @@ def _scope_network_analyzer_dns(
             *args,
             _analyze=analyze,
             _trusted_hosts=trusted_hosts,
+            _loopback_only_hosts=loopback_only_hosts,
             **kwargs,
         ):
-            with analyzer_dns_resolution(*_trusted_hosts):
+            with analyzer_dns_resolution(
+                *_trusted_hosts,
+                loopback_only_hosts=_loopback_only_hosts,
+            ):
                 return await _analyze(*args, **kwargs)
 
         analyzer.analyze = run_analyzer

--- a/cli/tests/test_mcp_dns_pinning.py
+++ b/cli/tests/test_mcp_dns_pinning.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration coverage for MCP transport DNS pinning."""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+import threading
+import time
+from contextlib import contextmanager
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+import uvicorn
+from defenseclaw.config import MCPScannerConfig
+from defenseclaw.scanner.mcp import MCPScannerWrapper
+from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="cisco-ai-mcp-scanner requires Python 3.11 or newer",
+)
+
+
+@contextmanager
+def _serve_mcp(transport: str):
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    port = listener.getsockname()[1]
+
+    app = FastMCP(
+        "dns-pin-test",
+        log_level="ERROR",
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=False,
+        ),
+    )
+
+    @app.tool()
+    def ping() -> str:
+        return "pong"
+
+    asgi = app.sse_app() if transport == "sse" else app.streamable_http_app()
+    server = uvicorn.Server(
+        uvicorn.Config(
+            asgi,
+            host="127.0.0.1",
+            port=port,
+            log_level="error",
+            access_log=False,
+            lifespan="on",
+            timeout_graceful_shutdown=1,
+            loop="asyncio",
+        )
+    )
+    thread = threading.Thread(
+        target=server.run,
+        kwargs={"sockets": [listener]},
+        daemon=True,
+    )
+    thread.start()
+    try:
+        deadline = time.monotonic() + 5
+        while not server.started:
+            if not thread.is_alive():
+                raise RuntimeError("MCP test server exited during startup")
+            if time.monotonic() >= deadline:
+                raise TimeoutError("MCP test server did not start")
+            time.sleep(0.01)
+        yield port
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
+        listener.close()
+        if thread.is_alive():
+            raise RuntimeError("MCP test server did not stop")
+
+
+@pytest.mark.parametrize(
+    ("transport", "path"),
+    [
+        pytest.param("streamable-http", "/mcp", id="streamable-http"),
+        pytest.param("sse", "/sse", id="sse"),
+    ],
+)
+def test_real_sdk_remote_scan_uses_pinned_dns(
+    monkeypatch,
+    transport,
+    path,
+):
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setenv("NO_PROXY", "*")
+    monkeypatch.setenv("no_proxy", "*")
+    for name in (
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+        "DEFENSECLAW_LLM_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    with _serve_mcp(transport) as port:
+        real_getaddrinfo = socket.getaddrinfo
+        target_calls: list[str] = []
+        pinned_calls: list[str] = []
+        unexpected_calls: list[str] = []
+
+        def rebinding_resolver(host, service, *args, **kwargs):
+            node = host.decode("ascii") if isinstance(host, bytes) else str(host)
+            if node == "rebind.invalid":
+                target_calls.append(node)
+                ip = "127.0.0.1" if len(target_calls) == 1 else "127.0.0.2"
+                return real_getaddrinfo(ip, service, *args, **kwargs)
+            if node == "127.0.0.1":
+                pinned_calls.append(node)
+                return real_getaddrinfo(node, service, *args, **kwargs)
+            unexpected_calls.append(node)
+            raise AssertionError(f"unexpected DNS lookup: {node}")
+
+        wrapper = MCPScannerWrapper(MCPScannerConfig(analyzers="readiness"))
+        url = f"http://rebind.invalid:{port}{path}"
+        with patch.object(socket, "getaddrinfo", rebinding_resolver):
+            result = wrapper.scan(url, allow_private=True)
+            assert socket.getaddrinfo is rebinding_resolver
+
+        assert result.target == url
+        assert target_calls == ["rebind.invalid"]
+        assert pinned_calls
+        assert unexpected_calls == []

--- a/cli/tests/test_mcp_dns_pinning.py
+++ b/cli/tests/test_mcp_dns_pinning.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import socket
 import sys
@@ -22,9 +23,10 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+import anyio
 import pytest
 import uvicorn
-from defenseclaw.config import MCPScannerConfig
+from defenseclaw.config import CiscoAIDefenseConfig, MCPScannerConfig
 from defenseclaw.scanner.mcp import MCPScannerWrapper
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
@@ -53,6 +55,10 @@ def _serve_mcp(transport: str):
     @app.tool()
     def ping() -> str:
         return "pong"
+
+    @app.tool()
+    def status() -> str:
+        return "ready"
 
     asgi = app.sse_app() if transport == "sse" else app.streamable_http_app()
     server = uvicorn.Server(
@@ -120,7 +126,10 @@ def test_real_sdk_remote_scan_uses_pinned_dns(
         real_getaddrinfo = socket.getaddrinfo
         target_calls: list[str] = []
         pinned_calls: list[str] = []
+        analyzer_calls: list[str] = []
         unexpected_calls: list[str] = []
+        analyzers_started = 0
+        both_analyzers_started = asyncio.Event()
 
         def rebinding_resolver(host, service, *args, **kwargs):
             node = host.decode("ascii") if isinstance(host, bytes) else str(host)
@@ -131,16 +140,39 @@ def test_real_sdk_remote_scan_uses_pinned_dns(
             if node == "127.0.0.1":
                 pinned_calls.append(node)
                 return real_getaddrinfo(node, service, *args, **kwargs)
+            if node == "analyzer.invalid":
+                analyzer_calls.append(node)
+                return real_getaddrinfo("8.8.8.8", service, *args, **kwargs)
             unexpected_calls.append(node)
             raise AssertionError(f"unexpected DNS lookup: {node}")
 
-        wrapper = MCPScannerWrapper(MCPScannerConfig(analyzers="readiness"))
+        async def analyze_with_public_dns(self, content, context=None):
+            nonlocal analyzers_started
+            analyzers_started += 1
+            if analyzers_started == 2:
+                both_analyzers_started.set()
+            await asyncio.wait_for(both_analyzers_started.wait(), timeout=5)
+            infos = await anyio.getaddrinfo("analyzer.invalid", 443)
+            assert {info[4][0] for info in infos} == {"8.8.8.8"}
+            return []
+
+        wrapper = MCPScannerWrapper(
+            MCPScannerConfig(analyzers="api"),
+            cisco_ai_defense=CiscoAIDefenseConfig(api_key="test-key"),
+        )
         url = f"http://rebind.invalid:{port}{path}"
-        with patch.object(socket, "getaddrinfo", rebinding_resolver):
+        with (
+            patch.object(socket, "getaddrinfo", rebinding_resolver),
+            patch(
+                "mcpscanner.core.analyzers.api_analyzer.ApiAnalyzer.analyze",
+                analyze_with_public_dns,
+            ),
+        ):
             result = wrapper.scan(url, allow_private=True)
             assert socket.getaddrinfo is rebinding_resolver
 
         assert result.target == url
         assert target_calls == ["rebind.invalid"]
         assert pinned_calls
+        assert analyzer_calls == ["analyzer.invalid", "analyzer.invalid"]
         assert unexpected_calls == []

--- a/cli/tests/test_mcp_dns_pinning.py
+++ b/cli/tests/test_mcp_dns_pinning.py
@@ -72,22 +72,42 @@ def test_pinned_dns_enters_before_scan_coroutine_is_created():
 
 
 @pytest.mark.parametrize(
-    ("provider", "allows_loopback_default"),
+    ("provider", "localhost_address", "allows_loopback_default"),
     [
-        pytest.param("ollama", True, id="local-provider"),
-        pytest.param("anthropic", False, id="cloud-provider"),
+        pytest.param(
+            "ollama",
+            "127.0.0.1",
+            True,
+            id="local-provider-loopback",
+        ),
+        pytest.param(
+            "ollama",
+            "169.254.169.254",
+            False,
+            id="local-provider-poisoned-localhost",
+        ),
+        pytest.param(
+            "anthropic",
+            "127.0.0.1",
+            False,
+            id="cloud-provider-loopback",
+        ),
     ],
 )
 def test_only_local_provider_default_can_resolve_loopback(
     provider,
+    localhost_address,
     allows_loopback_default,
 ):
     calls: list[str] = []
 
-    def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+    def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):  # noqa: A002
         node = host.decode("ascii") if isinstance(host, bytes) else str(host)
         calls.append(node)
-        address = "127.0.0.1" if node in {"localhost", "redirect.invalid"} else node
+        address = {
+            "localhost": localhost_address,
+            "redirect.invalid": "127.0.0.1",
+        }.get(node, node)
         return [
             (
                 socket.AF_INET,

--- a/cli/tests/test_mcp_dns_pinning.py
+++ b/cli/tests/test_mcp_dns_pinning.py
@@ -17,7 +17,8 @@ import socket
 import sys
 import threading
 import time
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
+from types import SimpleNamespace
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -25,9 +26,13 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import anyio
 import pytest
 import uvicorn
-from defenseclaw.config import CiscoAIDefenseConfig, MCPScannerConfig
-from defenseclaw.registries.ssrf import SSRFError
-from defenseclaw.scanner.mcp import MCPScannerWrapper
+from defenseclaw.config import CiscoAIDefenseConfig, LLMConfig, MCPScannerConfig
+from defenseclaw.registries.ssrf import SSRFError, pinned_getaddrinfo
+from defenseclaw.scanner.mcp import (
+    MCPScannerWrapper,
+    _run_with_pinned_dns,
+    _scope_network_analyzer_dns,
+)
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
@@ -35,6 +40,99 @@ pytestmark = pytest.mark.skipif(
     sys.version_info < (3, 11),
     reason="cisco-ai-mcp-scanner requires Python 3.11 or newer",
 )
+
+
+def test_pinned_dns_enters_before_scan_coroutine_is_created():
+    factory_called = False
+
+    def make_scan():
+        nonlocal factory_called
+        factory_called = True
+
+        async def scan():
+            return []
+
+        return scan()
+
+    @asynccontextmanager
+    async def fail_on_entry():
+        raise RuntimeError("pin entry failed")
+        yield  # pragma: no cover
+
+    with (
+        patch(
+            "defenseclaw.scanner.mcp.pinned_async_getaddrinfo",
+            fail_on_entry,
+        ),
+        pytest.raises(RuntimeError, match="pin entry failed"),
+    ):
+        anyio.run(_run_with_pinned_dns, make_scan)
+
+    assert not factory_called
+
+
+@pytest.mark.parametrize(
+    ("provider", "allows_loopback_default"),
+    [
+        pytest.param("ollama", True, id="local-provider"),
+        pytest.param("anthropic", False, id="cloud-provider"),
+    ],
+)
+def test_only_local_provider_default_can_resolve_loopback(
+    provider,
+    allows_loopback_default,
+):
+    calls: list[str] = []
+
+    def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+        node = host.decode("ascii") if isinstance(host, bytes) else str(host)
+        calls.append(node)
+        address = "127.0.0.1" if node in {"localhost", "redirect.invalid"} else node
+        return [
+            (
+                socket.AF_INET,
+                type or socket.SOCK_STREAM,
+                proto,
+                "",
+                (address, port),
+            )
+        ]
+
+    class LocalAnalyzer:
+        async def analyze(self):
+            with pytest.raises(SSRFError):
+                await anyio.getaddrinfo("redirect.invalid", 11434)
+            return await anyio.getaddrinfo("localhost", 11434)
+
+    scanner = SimpleNamespace(
+        _api_analyzer=None,
+        _llm_analyzer=LocalAnalyzer(),
+    )
+    llm = LLMConfig(provider=provider, model="test-model")
+    _scope_network_analyzer_dns(
+        scanner,
+        api_endpoint="",
+        llm_base_url=llm.base_url,
+        llm_uses_local_default=llm.is_local_provider(),
+    )
+
+    with patch.object(socket, "getaddrinfo", fake_getaddrinfo):
+        with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
+            if allows_loopback_default:
+                results = anyio.run(
+                    _run_with_pinned_dns,
+                    scanner._llm_analyzer.analyze,
+                )
+            else:
+                with pytest.raises(SSRFError):
+                    anyio.run(
+                        _run_with_pinned_dns,
+                        scanner._llm_analyzer.analyze,
+                    )
+
+    if allows_loopback_default:
+        assert {info[4][0] for info in results} == {"127.0.0.1"}
+    assert calls == ["redirect.invalid", "localhost"]
 
 
 @contextmanager

--- a/cli/tests/test_mcp_dns_pinning.py
+++ b/cli/tests/test_mcp_dns_pinning.py
@@ -12,7 +12,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import os
 import socket
 import sys
@@ -27,6 +26,7 @@ import anyio
 import pytest
 import uvicorn
 from defenseclaw.config import CiscoAIDefenseConfig, MCPScannerConfig
+from defenseclaw.registries.ssrf import SSRFError
 from defenseclaw.scanner.mcp import MCPScannerWrapper
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
@@ -93,7 +93,7 @@ def _serve_mcp(transport: str):
         thread.join(timeout=5)
         listener.close()
         if thread.is_alive():
-            raise RuntimeError("MCP test server did not stop")
+            print("warning: MCP test server did not stop", file=sys.stderr)
 
 
 @pytest.mark.parametrize(
@@ -127,9 +127,8 @@ def test_real_sdk_remote_scan_uses_pinned_dns(
         target_calls: list[str] = []
         pinned_calls: list[str] = []
         analyzer_calls: list[str] = []
+        analyzer_redirect_calls: list[str] = []
         unexpected_calls: list[str] = []
-        analyzers_started = 0
-        both_analyzers_started = asyncio.Event()
 
         def rebinding_resolver(host, service, *args, **kwargs):
             node = host.decode("ascii") if isinstance(host, bytes) else str(host)
@@ -142,23 +141,26 @@ def test_real_sdk_remote_scan_uses_pinned_dns(
                 return real_getaddrinfo(node, service, *args, **kwargs)
             if node == "analyzer.invalid":
                 analyzer_calls.append(node)
-                return real_getaddrinfo("8.8.8.8", service, *args, **kwargs)
+                return real_getaddrinfo("127.0.0.1", service, *args, **kwargs)
+            if node == "redirect.invalid":
+                analyzer_redirect_calls.append(node)
+                return real_getaddrinfo("127.0.0.1", service, *args, **kwargs)
             unexpected_calls.append(node)
             raise AssertionError(f"unexpected DNS lookup: {node}")
 
         async def analyze_with_public_dns(self, content, context=None):
-            nonlocal analyzers_started
-            analyzers_started += 1
-            if analyzers_started == 2:
-                both_analyzers_started.set()
-            await asyncio.wait_for(both_analyzers_started.wait(), timeout=5)
+            with pytest.raises(SSRFError):
+                await anyio.getaddrinfo("redirect.invalid", 443)
             infos = await anyio.getaddrinfo("analyzer.invalid", 443)
-            assert {info[4][0] for info in infos} == {"8.8.8.8"}
+            assert {info[4][0] for info in infos} == {"127.0.0.1"}
             return []
 
         wrapper = MCPScannerWrapper(
             MCPScannerConfig(analyzers="api"),
-            cisco_ai_defense=CiscoAIDefenseConfig(api_key="test-key"),
+            cisco_ai_defense=CiscoAIDefenseConfig(
+                endpoint="https://analyzer.invalid",
+                api_key="test-key",
+            ),
         )
         url = f"http://rebind.invalid:{port}{path}"
         with (
@@ -175,4 +177,5 @@ def test_real_sdk_remote_scan_uses_pinned_dns(
         assert target_calls == ["rebind.invalid"]
         assert pinned_calls
         assert analyzer_calls == ["analyzer.invalid", "analyzer.invalid"]
+        assert analyzer_redirect_calls == ["redirect.invalid", "redirect.invalid"]
         assert unexpected_calls == []

--- a/cli/tests/test_registry_ssrf.py
+++ b/cli/tests/test_registry_ssrf.py
@@ -19,9 +19,12 @@ so the suite never touches real DNS.
 from __future__ import annotations
 
 import os
+import socket
 import sys
 import unittest
 from unittest.mock import patch
+
+import anyio
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -314,8 +317,6 @@ class TestPinnedGetaddrinfo(unittest.TestCase):
     at connect time instead of honouring a urllib3-level connect pin."""
 
     def test_pinned_host_resolves_to_vetted_ip(self):
-        import socket
-
         # Inside the pin, a lookup for the vetted host returns the pinned
         # IP — NOT whatever a (rebinding) DNS would now answer.
         with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
@@ -323,27 +324,112 @@ class TestPinnedGetaddrinfo(unittest.TestCase):
         addrs = {info[4][0] for info in infos}
         self.assertEqual(addrs, {"93.184.216.34"})
 
-    def test_unexpected_host_is_refused(self):
-        import socket
+    def test_anyio_bytes_hostname_resolves_to_vetted_ip(self):
+        calls = []
 
+        def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+            calls.append((host, port, family, type, proto, flags))
+            return [
+                (
+                    family,
+                    type or socket.SOCK_STREAM,
+                    proto,
+                    "",
+                    (str(host), port),
+                )
+            ]
+
+        with patch.object(socket, "getaddrinfo", fake_getaddrinfo):
+            with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
+                infos = anyio.run(anyio.getaddrinfo, "rebind.example", 443)
+
+        self.assertEqual(infos[0][4][0], "93.184.216.34")
+        self.assertEqual(calls[0][0], "93.184.216.34")
+
+    def test_bytes_hostname_accepts_keyword_family(self):
+        calls = []
+
+        def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+            calls.append((host, port, family, type, proto, flags))
+            return [(family, type, proto, "", (str(host), port))]
+
+        with patch.object(socket, "getaddrinfo", fake_getaddrinfo):
+            with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
+                socket.getaddrinfo(
+                    b"rebind.example",
+                    8443,
+                    family=socket.AF_UNSPEC,
+                    type=socket.SOCK_STREAM,
+                    proto=socket.IPPROTO_TCP,
+                    flags=socket.AI_NUMERICHOST,
+                )
+
+        self.assertEqual(
+            calls,
+            [
+                (
+                    "93.184.216.34",
+                    8443,
+                    socket.AF_INET,
+                    socket.SOCK_STREAM,
+                    socket.IPPROTO_TCP,
+                    socket.AI_NUMERICHOST,
+                )
+            ],
+        )
+
+    def test_unicode_hostname_matches_anyio_alabel(self):
+        calls = []
+
+        def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+            calls.append(host)
+            return [(family, type, proto, "", (str(host), port))]
+
+        with patch.object(socket, "getaddrinfo", fake_getaddrinfo):
+            with pinned_getaddrinfo("faß.example", 443, "93.184.216.34"):
+                socket.getaddrinfo(b"xn--fa-hia.example", 443)
+
+        self.assertEqual(calls, ["93.184.216.34"])
+
+    def test_invalid_host_shapes_are_refused_before_resolving(self):
+        calls = []
+
+        def fake_getaddrinfo(*args, **kwargs):
+            calls.append((args, kwargs))
+            return []
+
+        bad_hosts = (
+            ("none", None),
+            ("non-ascii-bytes", b"\xff.example"),
+            ("nul", "bad\x00.example"),
+            ("surrogate", "\ud800.example"),
+        )
+        with patch.object(socket, "getaddrinfo", fake_getaddrinfo):
+            with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
+                for case, host in bad_hosts:
+                    with self.subTest(case=case):
+                        with self.assertRaises(SSRFError):
+                            socket.getaddrinfo(host, 443)
+
+        self.assertEqual(calls, [])
+
+    def test_unexpected_host_is_refused(self):
         # A side-channel lookup for a *different* host during the pinned
         # operation is refused, so a library cannot escape to an unvetted
         # (and possibly internal) destination mid-request.
         with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
-            with self.assertRaises(SSRFError):
-                socket.getaddrinfo("evil.internal", 443)
+            for host in ("evil.internal", b"evil.internal"):
+                with self.subTest(host=host):
+                    with self.assertRaises(SSRFError):
+                        socket.getaddrinfo(host, 443)
 
     def test_getaddrinfo_restored_after_block(self):
-        import socket
-
         original = socket.getaddrinfo
         with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
             pass
         self.assertIs(socket.getaddrinfo, original)
 
     def test_getaddrinfo_restored_on_exception(self):
-        import socket
-
         original = socket.getaddrinfo
         with self.assertRaises(RuntimeError):
             with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
@@ -351,14 +437,60 @@ class TestPinnedGetaddrinfo(unittest.TestCase):
         self.assertIs(socket.getaddrinfo, original)
 
     def test_ip_literal_matching_pin_is_allowed(self):
-        import socket
-
         # A client that pre-resolves and re-calls getaddrinfo with the IP
         # literal equal to the pin is allowed through.
         with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
-            infos = socket.getaddrinfo("93.184.216.34", 443)
-        self.assertTrue(infos)
+            for host in ("93.184.216.34", b"93.184.216.34"):
+                infos = socket.getaddrinfo(host, 443)
+                self.assertTrue(infos)
 
+    def test_different_ip_literal_is_refused(self):
+        with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
+            with self.assertRaises(SSRFError):
+                socket.getaddrinfo("127.0.0.1", 443)
+
+    def test_ipv6_pin_forces_ipv6_family(self):
+        calls = []
+
+        def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+            calls.append((host, port, family, type, proto, flags))
+            return [(family, type, proto, "", (str(host), port, 0, 0))]
+
+        with patch.object(socket, "getaddrinfo", fake_getaddrinfo):
+            with pinned_getaddrinfo("v6.example", 443, "2001:4860:4860::8888"):
+                socket.getaddrinfo(
+                    "v6.example",
+                    443,
+                    socket.AF_UNSPEC,
+                    socket.SOCK_STREAM,
+                    socket.IPPROTO_TCP,
+                )
+
+        self.assertEqual(calls[0][0], "2001:4860:4860::8888")
+        self.assertEqual(calls[0][2], socket.AF_INET6)
+
+    def test_incompatible_requested_family_is_refused(self):
+        with pinned_getaddrinfo("v6.example", 443, "2001:4860:4860::8888"):
+            with self.assertRaises(socket.gaierror):
+                socket.getaddrinfo("v6.example", 443, family=socket.AF_INET)
+
+    def test_unicode_url_uses_anyio_alabel_for_validation(self):
+        seen = []
+
+        def resolver(host):
+            seen.append(host)
+            return ["93.184.216.34"]
+
+        ip, host, port = resolve_and_pin(
+            "https://faß.example/mcp",
+            resolver=resolver,
+        )
+
+        self.assertEqual(
+            (ip, host, port),
+            ("93.184.216.34", "xn--fa-hia.example", 443),
+        )
+        self.assertEqual(seen, ["xn--fa-hia.example"])
 
     # --- Private upstream allowlist tests ---
 

--- a/cli/tests/test_registry_ssrf.py
+++ b/cli/tests/test_registry_ssrf.py
@@ -18,6 +18,7 @@ so the suite never touches real DNS.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import socket
 import sys
@@ -30,8 +31,10 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from defenseclaw.registries.ssrf import (
     SSRFError,
+    analyzer_dns_resolution,
     guard_git_url,
     guard_url,
+    pinned_async_getaddrinfo,
     pinned_getaddrinfo,
     resolve_and_pin,
 )
@@ -413,15 +416,97 @@ class TestPinnedGetaddrinfo(unittest.TestCase):
 
         self.assertEqual(calls, [])
 
-    def test_unexpected_host_is_refused(self):
-        # A side-channel lookup for a *different* host during the pinned
-        # operation is refused, so a library cannot escape to an unvetted
-        # (and possibly internal) destination mid-request.
+    def test_unexpected_public_host_is_refused(self):
+        calls = []
+
+        def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+            calls.append((host, port))
+            return [
+                (
+                    socket.AF_INET,
+                    type or socket.SOCK_STREAM,
+                    proto,
+                    "",
+                    ("8.8.8.8", port),
+                )
+            ]
+
+        with patch.object(socket, "getaddrinfo", fake_getaddrinfo):
+            with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
+                for host in ("proxy.example", b"proxy.example"):
+                    with self.subTest(host=host):
+                        with self.assertRaises(SSRFError):
+                            socket.getaddrinfo(host, 443)
+
+        self.assertEqual(calls, [])
+
+    def test_analyzer_dns_scope_allows_unrelated_host_and_resets(self):
+        calls = []
+
+        def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+            calls.append((host, port))
+            return [
+                (
+                    socket.AF_INET,
+                    type or socket.SOCK_STREAM,
+                    proto,
+                    "",
+                    ("8.8.8.8", port),
+                )
+            ]
+
+        with patch.object(socket, "getaddrinfo", fake_getaddrinfo):
+            with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
+                with analyzer_dns_resolution():
+                    infos = socket.getaddrinfo("analyzer.example", 443)
+                with self.assertRaises(SSRFError):
+                    socket.getaddrinfo("analyzer.example", 443)
+
+        self.assertEqual(calls, [("analyzer.example", 443)])
+        self.assertEqual({info[4][0] for info in infos}, {"8.8.8.8"})
+
+    def test_analyzer_dns_scope_resets_on_exception(self):
         with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
-            for host in ("evil.internal", b"evil.internal"):
-                with self.subTest(host=host):
-                    with self.assertRaises(SSRFError):
-                        socket.getaddrinfo(host, 443)
+            with self.assertRaises(RuntimeError):
+                with analyzer_dns_resolution():
+                    raise RuntimeError("boom")
+            with self.assertRaises(SSRFError):
+                socket.getaddrinfo("analyzer.example", 443)
+
+    def test_analyzer_dns_scope_is_task_local(self):
+        calls = []
+
+        def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+            node = host.decode("ascii") if isinstance(host, bytes) else str(host)
+            calls.append(node)
+            return [
+                (
+                    socket.AF_INET,
+                    type or socket.SOCK_STREAM,
+                    proto,
+                    "",
+                    ("8.8.8.8", port),
+                )
+            ]
+
+        async def run_lookups():
+            async def analyzer_lookup():
+                with analyzer_dns_resolution():
+                    return await anyio.getaddrinfo("analyzer.example", 443)
+
+            async def transport_lookup():
+                with self.assertRaises(SSRFError):
+                    await anyio.getaddrinfo("proxy.example", 443)
+
+            async with pinned_async_getaddrinfo():
+                return await asyncio.gather(analyzer_lookup(), transport_lookup())
+
+        with patch.object(socket, "getaddrinfo", fake_getaddrinfo):
+            with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
+                results = anyio.run(run_lookups)
+
+        self.assertEqual(calls, ["analyzer.example"])
+        self.assertEqual({info[4][0] for info in results[0]}, {"8.8.8.8"})
 
     def test_getaddrinfo_restored_after_block(self):
         original = socket.getaddrinfo
@@ -435,6 +520,106 @@ class TestPinnedGetaddrinfo(unittest.TestCase):
             with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
                 raise RuntimeError("boom")
         self.assertIs(socket.getaddrinfo, original)
+
+    def test_async_getaddrinfo_restored_after_block(self):
+        async def check_restoration():
+            loop = asyncio.get_running_loop()
+            original = loop.getaddrinfo
+            had_override = "getaddrinfo" in vars(loop)
+            async with pinned_async_getaddrinfo():
+                self.assertNotEqual(loop.getaddrinfo, original)
+            self.assertEqual(loop.getaddrinfo, original)
+            self.assertEqual("getaddrinfo" in vars(loop), had_override)
+
+        anyio.run(check_restoration)
+
+    def test_async_getaddrinfo_restored_on_exception(self):
+        async def check_restoration():
+            loop = asyncio.get_running_loop()
+            original = loop.getaddrinfo
+            with self.assertRaises(RuntimeError):
+                async with pinned_async_getaddrinfo():
+                    raise RuntimeError("boom")
+            self.assertEqual(loop.getaddrinfo, original)
+
+        anyio.run(check_restoration)
+
+    def test_overlapping_async_pin_scopes_restore_after_last_exit(self):
+        try:
+            __import__("uvloop")
+        except ImportError:
+            self.skipTest("uvloop is not installed")
+
+        async def check_overlap():
+            loop = asyncio.get_running_loop()
+            had_override = "getaddrinfo" in vars(loop)
+            first_entered = asyncio.Event()
+            second_entered = asyncio.Event()
+            first_exited = asyncio.Event()
+
+            async def first_scope():
+                async with pinned_async_getaddrinfo():
+                    first_entered.set()
+                    await second_entered.wait()
+                first_exited.set()
+
+            async def second_scope():
+                await first_entered.wait()
+                async with pinned_async_getaddrinfo():
+                    second_entered.set()
+                    await first_exited.wait()
+                    with self.assertRaises(SSRFError):
+                        await anyio.getaddrinfo("localhost", 443)
+
+            await asyncio.gather(first_scope(), second_scope())
+            self.assertEqual("getaddrinfo" in vars(loop), had_override)
+
+        with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
+            anyio.run(
+                check_overlap,
+                backend_options={"use_uvloop": True},
+            )
+
+    def test_async_pin_covers_uvloop(self):
+        try:
+            __import__("uvloop")
+        except ImportError:
+            self.skipTest("uvloop is not installed")
+        calls = []
+
+        def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+            node = host.decode("ascii") if isinstance(host, bytes) else str(host)
+            calls.append(node)
+            address = "8.8.8.8" if node == "analyzer.example" else node
+            return [
+                (
+                    socket.AF_INET,
+                    type or socket.SOCK_STREAM,
+                    proto,
+                    "",
+                    (address, port),
+                )
+            ]
+
+        async def run_lookups():
+            async with pinned_async_getaddrinfo():
+                target = await anyio.getaddrinfo("rebind.example", 443)
+                with analyzer_dns_resolution():
+                    analyzer = await anyio.getaddrinfo("analyzer.example", 443)
+                with self.assertRaises(SSRFError):
+                    await anyio.getaddrinfo("proxy.example", 443)
+                return target, analyzer
+
+        with patch.object(socket, "getaddrinfo", fake_getaddrinfo):
+            with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
+                target, analyzer = anyio.run(
+                    run_lookups,
+                    backend_options={"use_uvloop": True},
+                )
+
+        self.assertEqual(calls, ["93.184.216.34", "analyzer.example"])
+        self.assertEqual({info[4][0] for info in target}, {"93.184.216.34"})
+        self.assertEqual({info[4][0] for info in analyzer}, {"8.8.8.8"})
 
     def test_ip_literal_matching_pin_is_allowed(self):
         # A client that pre-resolves and re-calls getaddrinfo with the IP

--- a/cli/tests/test_registry_ssrf.py
+++ b/cli/tests/test_registry_ssrf.py
@@ -440,7 +440,7 @@ class TestPinnedGetaddrinfo(unittest.TestCase):
 
         self.assertEqual(calls, [])
 
-    def test_analyzer_dns_scope_allows_unrelated_host_and_resets(self):
+    def test_analyzer_dns_scope_allows_public_host_and_resets(self):
         calls = []
 
         def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
@@ -464,6 +464,73 @@ class TestPinnedGetaddrinfo(unittest.TestCase):
 
         self.assertEqual(calls, [("analyzer.example", 443)])
         self.assertEqual({info[4][0] for info in infos}, {"8.8.8.8"})
+
+    def test_analyzer_dns_scope_rejects_unconfigured_private_host(self):
+        for address in (
+            "127.0.0.1",
+            "10.0.0.1",
+            "169.254.169.254",
+            "100.64.0.1",
+            "::ffff:127.0.0.1",
+        ):
+            with self.subTest(address=address):
+                calls = []
+
+                def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+                    calls.append((host, port))
+                    return [
+                        (
+                            socket.AF_INET,
+                            type or socket.SOCK_STREAM,
+                            proto,
+                            "",
+                            (address, port),
+                        )
+                    ]
+
+                with patch.object(socket, "getaddrinfo", fake_getaddrinfo):
+                    with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
+                        with analyzer_dns_resolution("trusted.internal"):
+                            with self.assertRaises(SSRFError):
+                                socket.getaddrinfo("redirect.example", 443)
+
+                self.assertEqual(calls, [("redirect.example", 443)])
+
+    def test_analyzer_dns_scope_allows_configured_private_host_only(self):
+        calls = []
+
+        def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+            calls.append((host, port))
+            return [
+                (
+                    socket.AF_INET,
+                    type or socket.SOCK_STREAM,
+                    proto,
+                    "",
+                    ("127.0.0.1", port),
+                )
+            ]
+
+        with patch.object(socket, "getaddrinfo", fake_getaddrinfo):
+            with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
+                with analyzer_dns_resolution("analyzer.internal"):
+                    infos = socket.getaddrinfo("analyzer.internal", 443)
+
+        self.assertEqual(calls, [("analyzer.internal", 443)])
+        self.assertEqual({info[4][0] for info in infos}, {"127.0.0.1"})
+
+    def test_analyzer_dns_scope_rejects_mixed_public_private_answers(self):
+        def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+            return [
+                (socket.AF_INET, socket.SOCK_STREAM, proto, "", ("8.8.8.8", port)),
+                (socket.AF_INET, socket.SOCK_STREAM, proto, "", ("127.0.0.1", port)),
+            ]
+
+        with patch.object(socket, "getaddrinfo", fake_getaddrinfo):
+            with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
+                with analyzer_dns_resolution():
+                    with self.assertRaises(SSRFError):
+                        socket.getaddrinfo("redirect.example", 443)
 
     def test_analyzer_dns_scope_resets_on_exception(self):
         with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
@@ -545,11 +612,6 @@ class TestPinnedGetaddrinfo(unittest.TestCase):
         anyio.run(check_restoration)
 
     def test_overlapping_async_pin_scopes_restore_after_last_exit(self):
-        try:
-            __import__("uvloop")
-        except ImportError:
-            self.skipTest("uvloop is not installed")
-
         async def check_overlap():
             loop = asyncio.get_running_loop()
             had_override = "getaddrinfo" in vars(loop)
@@ -575,10 +637,12 @@ class TestPinnedGetaddrinfo(unittest.TestCase):
             self.assertEqual("getaddrinfo" in vars(loop), had_override)
 
         with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
-            anyio.run(
-                check_overlap,
-                backend_options={"use_uvloop": True},
-            )
+            anyio.run(check_overlap)
+            try:
+                __import__("uvloop")
+            except ImportError:
+                return
+            anyio.run(check_overlap, backend_options={"use_uvloop": True})
 
     def test_async_pin_covers_uvloop(self):
         try:

--- a/cli/tests/test_registry_ssrf.py
+++ b/cli/tests/test_registry_ssrf.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import platform
 import socket
 import sys
 import unittest
@@ -37,6 +38,11 @@ from defenseclaw.registries.ssrf import (
     pinned_async_getaddrinfo,
     pinned_getaddrinfo,
     resolve_and_pin,
+)
+
+_UVLOOP_SUPPORTED = (
+    sys.platform not in {"win32", "cygwin"}
+    and platform.python_implementation() != "PyPy"
 )
 
 
@@ -611,6 +617,59 @@ class TestPinnedGetaddrinfo(unittest.TestCase):
 
         anyio.run(check_restoration)
 
+    def test_async_getaddrinfo_restored_on_cancellation(self):
+        async def check_restoration():
+            loop = asyncio.get_running_loop()
+            original = loop.getaddrinfo
+            had_override = "getaddrinfo" in vars(loop)
+            entered = asyncio.Event()
+
+            async def hold_scope():
+                async with pinned_async_getaddrinfo():
+                    entered.set()
+                    await asyncio.Event().wait()
+
+            task = asyncio.create_task(hold_scope())
+            await entered.wait()
+            self.assertNotEqual(loop.getaddrinfo, original)
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+            self.assertEqual(loop.getaddrinfo, original)
+            self.assertEqual("getaddrinfo" in vars(loop), had_override)
+
+        with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
+            anyio.run(check_restoration)
+            if _UVLOOP_SUPPORTED:
+                anyio.run(
+                    check_restoration,
+                    backend_options={"use_uvloop": True},
+                )
+
+    def test_async_pin_preserves_instance_resolver_override(self):
+        async def check_restoration():
+            loop = asyncio.get_running_loop()
+
+            async def previous_resolver(*_args, **_kwargs):
+                return []
+
+            loop.getaddrinfo = previous_resolver
+            try:
+                self.assertIs(vars(loop)["getaddrinfo"], previous_resolver)
+                async with pinned_async_getaddrinfo():
+                    self.assertIsNot(loop.getaddrinfo, previous_resolver)
+                self.assertIs(loop.getaddrinfo, previous_resolver)
+            finally:
+                del loop.getaddrinfo
+
+        with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
+            anyio.run(check_restoration)
+            if _UVLOOP_SUPPORTED:
+                anyio.run(
+                    check_restoration,
+                    backend_options={"use_uvloop": True},
+                )
+
     def test_overlapping_async_pin_scopes_restore_after_last_exit(self):
         async def check_overlap():
             loop = asyncio.get_running_loop()
@@ -638,17 +697,14 @@ class TestPinnedGetaddrinfo(unittest.TestCase):
 
         with pinned_getaddrinfo("rebind.example", 443, "93.184.216.34"):
             anyio.run(check_overlap)
-            try:
-                __import__("uvloop")
-            except ImportError:
-                return
-            anyio.run(check_overlap, backend_options={"use_uvloop": True})
+            if _UVLOOP_SUPPORTED:
+                anyio.run(check_overlap, backend_options={"use_uvloop": True})
 
+    @unittest.skipUnless(
+        _UVLOOP_SUPPORTED,
+        "uvloop does not support Windows, Cygwin, or PyPy",
+    )
     def test_async_pin_covers_uvloop(self):
-        try:
-            __import__("uvloop")
-        except ImportError:
-            self.skipTest("uvloop is not installed")
         calls = []
 
         def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):


### PR DESCRIPTION
> Base note: This existing cross-repository PR was rebased onto `main` at `c2236353f32e50f5c3c770f2fca16fca8c1cfca2` on 2026-08-11. The current head is `f20bf80e3111c31a75619b95daa32350d4d5b61c`.

## Problem

Remote MCP scans validate a hostname and pin its approved IP before invoking the MCP Scanner SDK, but the SDK's HTTPX/AnyIO transports resolve through the active event loop. On uvloop and other cached resolver paths, changing only `socket.getaddrinfo()` does not reliably reach that transport resolver.

AnyIO also passes an IDNA-encoded `bytes` hostname. The old pin compared it using `str(node)`, turning `b"host"` into the literal string `"b'host'"` and rejecting the already-vetted target. The wrapper could additionally pass a forced address family positionally while retaining a caller-supplied `family=` keyword, producing `TypeError`.

The first analyzer isolation fix then created a second security boundary problem: every DNS lookup made under an analyzer task bypassed the pin without validating its returned addresses. A redirect, proxy, or provider-side lookup could therefore resolve an unconfigured hostname to loopback, RFC1918, link-local, CGNAT, cloud metadata, or another non-public address.

Fixes #359.

## Current Situation

Both MCP SDK transports exercise the affected async resolver path:

- streamable HTTP (`/mcp`)
- server-sent events (`/sse`)

On the rebased pre-review head (`8a12e920`), a focused source-to-sink harness entered the analyzer scope, resolved `redirect.example` to `127.0.0.1`, and observed `VULNERABLE_PRE_FIX_RESULT 127.0.0.1`. On the repaired head, the same lookup raises `SSRFError`.

## Solution

### Pin the real async transport resolver

- Canonicalize validation-time and connect-time hostnames to the same ASCII representation AnyIO uses.
- Decode resolver `bytes` strictly as ASCII and encode Unicode hostnames with IDNA/UTS46.
- Override the active event loop's `getaddrinfo()` while an SDK transport runs, routing it through the process-wide socket pin.
- Reference-count overlapping async pin scopes per event loop and restore the exact previous resolver after the last scope exits, including cancellation and exception paths.
- Create each SDK coroutine only after the async resolver scope enters, so a failed context entry cannot leave an un-awaited coroutine behind.
- Preserve requested port, socket type, protocol, and flags while forcing the family that matches the vetted IP.

### Keep analyzer networking usable without reopening SSRF

- Give each analyzer a task-local DNS policy.
- Treat only the operator-configured API or LLM endpoint hostname as trusted; this preserves explicitly configured private analyzer endpoints.
- When a local LiteLLM provider has no explicit base URL, mark its default spellings (`localhost`, `127.0.0.1`, and `::1`) loopback-only and reject every non-loopback answer; cloud-provider defaults remain public-only.
- Resolve other analyzer hosts once at the connection-time resolver boundary and reject every answer that is loopback, private, link-local, multicast, unspecified, reserved, CGNAT, cloud metadata, or IPv4-mapped unsafe space.
- Keep concurrent MCP transport lookups outside the analyzer context fail closed.

```mermaid
flowchart LR
    A[Remote MCP URL] --> B[Resolve and validate target]
    B --> C[Vetted numeric IP]
    C --> D[Event-loop resolver override]
    D --> E[MCP SDK SSE / streamable HTTP]
    E --> F[Dial vetted IP only]

    E --> G[Analyzer task-local DNS policy]
    G --> H{Explicitly configured endpoint?}
    H -->|Yes| I[Allow exact operator-selected host]
    H -->|No| M{Implicit local default?}
    M -->|Yes| N[Require every answer to be loopback]
    M -->|No| J[Resolve and validate every address]
    J -->|Public only| K[Allow]
    J -->|Private / metadata / unsafe| L[Raise SSRFError]
```

## What Changed (Where & How)

| Path | Change |
|---|---|
| `cli/defenseclaw/registries/ssrf.py` | Added AnyIO-compatible hostname canonicalization, event-loop resolver pinning with overlap-safe restoration, module-scope IDNA import, and task-local analyzer DNS policies that distinguish explicit trust, loopback-only defaults, and public-only unconfigured destinations. |
| `cli/defenseclaw/scanner/mcp.py` | Routed all four remote SDK scan phases through lazily created coroutines inside the async pin and wrapped API/LLM analyzers with their configured endpoint policy plus loopback-only local-provider defaults. |
| `cli/tests/test_registry_ssrf.py` | Added byte-host, IDNA, argument-shape, IPv4/IPv6, malformed-host, task-isolation, default-asyncio/uvloop overlap, cancellation, pre-existing resolver restoration, public analyzer, configured-private analyzer, and unsafe/mixed-answer regressions. |
| `cli/tests/test_mcp_dns_pinning.py` | Added real SDK tests for SSE and streamable HTTP with a rebinding resolver; removed cross-event-loop rendezvous; made teardown preserve the primary test failure; covered context-entry failure without an un-awaited coroutine; proved real loopback defaults remain usable while poisoned localhost, cloud defaults, and unconfigured private redirects fail closed. |

## Breaking Changes

None. Explicitly configured private analyzer endpoints remain supported. Unconfigured analyzer redirects or proxy/provider lookups that resolve to non-public address space now fail closed by design.

## Open Issues / Follow-ups

None.

## Test Plan

- `make py-lint`
  - Passed: Ruff reported `All checks passed!` for `cli/defenseclaw/`.
- `uv run --frozen pytest -q cli/tests/test_registry_ssrf.py cli/tests/test_mcp_dns_pinning.py`
  - Passed: `69 passed, 23 subtests passed in 4.01s`.
- `uv run --frozen pytest -q cli/tests/test_cmd_mcp.py cli/tests/test_cmd_mcp_scan_ux.py cli/tests/test_connector_mcp_writers.py cli/tests/test_mcp_dns_pinning.py cli/tests/test_mcp_llm_lane.py cli/tests/test_mcp_scanner_env.py cli/tests/test_mcp_windows_launchers.py cli/tests/test_registry_ssrf.py cli/tests/test_remediation_mcp_registry.py cli/tests/tui/test_mcp_set_form_screen.py`
  - Passed: `405 passed, 23 skipped, 82 subtests passed in 13.75s`.
- Pre-fix/repaired focused analyzer-DNS harness against `8a12e920` and `4757974a`
  - Pre-fix: `VULNERABLE_PRE_FIX_RESULT 127.0.0.1`.
  - Repaired: `FIXED_CURRENT_RESULT SSRFError`.
- `git diff --check origin/main...HEAD`
  - Passed with no output.
