### PR TITLE
fix(training): escape generated script literals

### DIFF
--- a/internal/training/runner.go
+++ b/internal/training/runner.go
@@ -2,6 +2,7 @@ package training
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -165,22 +166,28 @@ func generateUnslothScript(cfg RunConfig) (string, error) {
 		return "", fmt.Errorf("unknown algorithm for unsloth: %s", cfg.Algorithm)
 	}
 
+	baseModel := pythonStringLiteral(cfg.BaseModel)
+	datasetPath := pythonStringLiteral(cfg.DatasetPath)
+	outputDir := pythonStringLiteral(cfg.OutputDir)
+
 	script := fmt.Sprintf(`#!/usr/bin/env python3
-"""
-Auto-generated training script for Unsloth
-Backend: unsloth
-Algorithm: %s
-Base Model: %s
-"""
+# Auto-generated training script for Unsloth.
+# Backend: unsloth
+# Algorithm: %s
+# Base Model: %s
 
 from unsloth import FastLanguageModel
 from trl import %s
 from datasets import load_dataset
 
+BASE_MODEL = %s
+DATASET_PATH = %s
+OUTPUT_DIR = %s
+
 # Load model
-print("Loading model: %s")
+print("Loading model: " + BASE_MODEL)
 model, tokenizer = FastLanguageModel.from_pretrained(
-    model_name="%s",
+    model_name=BASE_MODEL,
     load_in_4bit=True,
     max_seq_length=4096
 )
@@ -198,8 +205,8 @@ model = FastLanguageModel.get_peft_model(
 )
 
 # Load dataset
-print("Loading dataset: %s")
-dataset = load_dataset("json", data_files="%s")
+print("Loading dataset: " + DATASET_PATH)
+dataset = load_dataset("json", data_files=DATASET_PATH)
 
 # Configure trainer
 print("Initializing trainer")
@@ -208,7 +215,7 @@ trainer = %s(
     tokenizer=tokenizer,
     train_dataset=dataset["train"],
     args=%s(
-        output_dir="%s",
+        output_dir=OUTPUT_DIR,
         num_train_epochs=3,
         per_device_train_batch_size=2,
         gradient_accumulation_steps=4,
@@ -226,13 +233,13 @@ trainer.train()
 # Save GGUF
 print("Exporting to GGUF format")
 model.save_pretrained_gguf(
-    "%s",
+    OUTPUT_DIR,
     tokenizer,
     quantization_method="q4_k_m"
 )
 
 print("Training complete!")
-`, cfg.Algorithm, cfg.BaseModel, importExtra, cfg.BaseModel, cfg.BaseModel, cfg.DatasetPath, cfg.DatasetPath, trainerClass, configClass, cfg.OutputDir, cfg.OutputDir)
+`, cfg.Algorithm, scriptCommentValue(cfg.BaseModel), importExtra, baseModel, datasetPath, outputDir, trainerClass, configClass)
 
 	return script, nil
 }
@@ -244,6 +251,11 @@ func generateMLXScript(cfg RunConfig) (string, error) {
 		return "", fmt.Errorf("unknown algorithm for mlx-lm-lora: %s", cfg.Algorithm)
 	}
 
+	algorithm := strings.ToLower(cfg.Algorithm)
+	baseModel := shellSingleQuote(cfg.BaseModel)
+	datasetPath := shellSingleQuote(cfg.DatasetPath)
+	outputDir := shellSingleQuote(cfg.OutputDir)
+
 	script := fmt.Sprintf(`#!/usr/bin/env bash
 # Auto-generated training script for MLX
 # Backend: mlx-lm-lora
@@ -252,18 +264,23 @@ func generateMLXScript(cfg RunConfig) (string, error) {
 
 set -e
 
+TRAIN_MODE=%s
+BASE_MODEL=%s
+DATASET_PATH=%s
+OUTPUT_DIR=%s
+
 echo "Starting MLX training"
-echo "Algorithm: %s"
-echo "Model: %s"
-echo "Dataset: %s"
-echo "Output: %s"
+echo "Algorithm: ${TRAIN_MODE}"
+echo "Model: ${BASE_MODEL}"
+echo "Dataset: ${DATASET_PATH}"
+echo "Output: ${OUTPUT_DIR}"
 
 # Train
 mlx-lm-lora \
-  --train-mode %s \
-  --model %s \
-  --data %s \
-  --output %s \
+  --train-mode "${TRAIN_MODE}" \
+  --model "${BASE_MODEL}" \
+  --data "${DATASET_PATH}" \
+  --output "${OUTPUT_DIR}" \
   --batch-size 2 \
   --epochs 3 \
   --learning-rate 2e-4
@@ -272,16 +289,37 @@ mlx-lm-lora \
 echo "Exporting to GGUF format"
 mlx-lm-lora \
   --export-gguf \
-  --model %s \
-  --output %s/model.gguf \
+  --model "${OUTPUT_DIR}" \
+  --output "${OUTPUT_DIR}/model.gguf" \
   --quantize q4_k_m
 
 echo "Training complete!"
-`, cfg.Algorithm, cfg.BaseModel, cfg.Algorithm, cfg.BaseModel, cfg.DatasetPath, cfg.OutputDir,
-		cfg.Algorithm, cfg.BaseModel, cfg.DatasetPath, cfg.OutputDir,
-		cfg.OutputDir, cfg.OutputDir)
+`, algorithm, scriptCommentValue(cfg.BaseModel), shellSingleQuote(algorithm), baseModel, datasetPath, outputDir)
 
 	return script, nil
+}
+
+func pythonStringLiteral(value string) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		// json.Marshal only fails for unsupported types or invalid numbers; string
+		// input is always encodable. Keep a defensive fallback for future edits.
+		return `""`
+	}
+	return string(encoded)
+}
+
+func shellSingleQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}
+
+func scriptCommentValue(value string) string {
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, "\n", " ")
+	return strings.TrimSpace(value)
 }
 
 // findGGUF searches for a .gguf file in the output directory

--- a/internal/training/runner_test.go
+++ b/internal/training/runner_test.go
@@ -138,8 +138,8 @@ func TestGenerateScript_MLX(t *testing.T) {
 	if !strings.Contains(script, "mlx-lm-lora") {
 		t.Errorf("script does not contain mlx-lm-lora")
 	}
-	if !strings.Contains(script, "--train-mode dpo") {
-		t.Errorf("script does not contain --train-mode dpo")
+	if !strings.Contains(script, `--train-mode "${TRAIN_MODE}"`) {
+		t.Errorf("script does not contain quoted --train-mode variable")
 	}
 	if !strings.Contains(script, "mlx-community/Mistral-7B-v0.1-4bit") {
 		t.Errorf("script does not contain base model name")
@@ -152,6 +152,71 @@ func TestGenerateScript_MLX(t *testing.T) {
 	}
 	if !strings.Contains(script, "#!/usr/bin/env bash") {
 		t.Errorf("script does not contain bash shebang")
+	}
+}
+
+func TestGenerateScript_UnslothEscapesConfigValues(t *testing.T) {
+	cfg := RunConfig{
+		Backend:     "unsloth",
+		Algorithm:   "sft",
+		BaseModel:   "model\"; __import__('os').system('touch /tmp/pwned') #",
+		DatasetPath: "/data/train.jsonl\"\nprint('pwned')\n#",
+		OutputDir:   "/output/\" + __import__('os').getcwd() + \"",
+	}
+
+	script, err := generateTrainingScript(cfg)
+	if err != nil {
+		t.Fatalf("generateTrainingScript failed: %v", err)
+	}
+
+	for _, want := range []string{
+		`BASE_MODEL = "model\"; __import__('os').system('touch /tmp/pwned') #"`,
+		`DATASET_PATH = "/data/train.jsonl\"\nprint('pwned')\n#"`,
+		`OUTPUT_DIR = "/output/\" + __import__('os').getcwd() + \""`,
+		`model_name=BASE_MODEL`,
+		`data_files=DATASET_PATH`,
+		`output_dir=OUTPUT_DIR`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("script missing escaped literal or variable use %q:\n%s", want, script)
+		}
+	}
+	if strings.Contains(script, `model_name="model";`) ||
+		strings.Contains(script, "\nprint('pwned')\n") ||
+		strings.Contains(script, `output_dir="/output/" +`) {
+		t.Fatalf("script contains executable interpolation:\n%s", script)
+	}
+}
+
+func TestGenerateScript_MLXQuotesConfigValues(t *testing.T) {
+	cfg := RunConfig{
+		Backend:     "mlx-lm-lora",
+		Algorithm:   "dpo",
+		BaseModel:   "model'; touch /tmp/pwned; echo '",
+		DatasetPath: "/data/train.jsonl\nuname -a",
+		OutputDir:   "/output/$(touch /tmp/pwned)",
+	}
+
+	script, err := generateTrainingScript(cfg)
+	if err != nil {
+		t.Fatalf("generateTrainingScript failed: %v", err)
+	}
+
+	for _, want := range []string{
+		`BASE_MODEL='model'\''; touch /tmp/pwned; echo '\''`,
+		"DATASET_PATH='/data/train.jsonl\nuname -a'",
+		`OUTPUT_DIR='/output/$(touch /tmp/pwned)'`,
+		`--model "${BASE_MODEL}"`,
+		`--data "${DATASET_PATH}"`,
+		`--output "${OUTPUT_DIR}"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("script missing shell-quoted literal or variable use %q:\n%s", want, script)
+		}
+	}
+	if strings.Contains(script, "--model model'; touch") ||
+		strings.Contains(script, "--output /output/$(touch") {
+		t.Fatalf("script contains unquoted shell interpolation:\n%s", script)
 	}
 }
 


### PR DESCRIPTION
## Problem

PR #424 generated training scripts interpolate config/category-derived values directly into executable Python and Bash. Malformed model/path values can break out of quoted script literals and execute code during training.

Related review comment: https://github.com/cisco-ai-defense/defenseclaw/pull/424#issuecomment-5150339108

## Current Situation

`internal/training/runner.go` builds the Unsloth Python and MLX shell scripts with `fmt.Sprintf`, inserting `BaseModel`, `DatasetPath`, and `OutputDir` into docstrings, comments, string literals, and shell arguments before executing the generated script.

## Solution

- Emit Python values through JSON string literals and use variables in executable calls.
- Emit MLX shell values through single-quoted assignments and quoted argv expansions.
- Sanitize comment-only metadata so newlines cannot become executable lines.
- Add regression tests using quotes, newlines, Python code fragments, and shell substitutions.

## Architecture Diagram

N/A

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `internal/training/runner.go` | Escapes generated Python/Bash literals and routes executable calls through data variables. |
| `internal/training/runner_test.go` | Adds injection-shaped regression coverage for both Unsloth and MLX script generation. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

- `go test ./internal/training` -> `ok   github.com/defenseclaw/defenseclaw/internal/training 2.569s`
- `git diff --check` -> no output

CI status: pending after PR creation.