### PR TITLE
fix(ci): stop passing llm key to windows live cells

### DIFF
--- a/.github/workflows/connector-live-e2e.yml
+++ b/.github/workflows/connector-live-e2e.yml
@@ -588,7 +588,6 @@ jobs:
           OPENAI_API_KEY: ${{ contains(fromJSON('["codex","opencode"]'), matrix.connector) && secrets.OPENAI_API_KEY || '' }}
           ANTHROPIC_API_KEY: ${{ matrix.connector == 'claudecode' && secrets.ANTHROPIC_API_KEY || '' }}
           CURSOR_API_KEY: ${{ matrix.connector == 'cursor' && secrets.CURSOR_API_KEY || '' }}
-          LLM_API_KEY: ${{ contains(fromJSON('["codex","claudecode","opencode"]'), matrix.connector) && secrets.LLM_API_KEY || '' }}
         run: |
           ./scripts/live-connector-e2e/run-windows.ps1 `
             -Layer live `


### PR DESCRIPTION
## Problem

PR #662 still passes `LLM_API_KEY` into manually dispatched Windows live cells for `codex`, `claudecode`, and `opencode`.

Linked finding: https://github.com/cisco-ai-defense/defenseclaw/pull/662#discussion_r3694942114

## Current Situation

The Windows live harness receives connector-specific `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `CURSOR_API_KEY`, but it also receives the generic `LLM_API_KEY` for several agent cells. The harness writes non-empty model keys into the DefenseClaw `.env`, so unrelated downloaded upstream agent installers/runtimes can still inherit the generic fallback secret.

## Solution

Remove `LLM_API_KEY` from the Windows live harness step env. The Windows live cells now receive only the connector-specific provider keys already needed by their selected connector.

## Architecture Diagram

N/A

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `.github/workflows/connector-live-e2e.yml` | Removes `LLM_API_KEY` from the Windows live harness step environment. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/connector-live-e2e.yml"); puts "yaml ok"'` -> `yaml ok`\n- `git diff --check` -> no output\n- Manual inspection of `.github/workflows/connector-live-e2e.yml` lines 584-593 confirmed the Windows live step now passes only `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `CURSOR_API_KEY`.\n\nCI status: green on PR #665; 80 checks passed and 9 were intentionally skipped.