### PR TITLE
docs: reorganize CEL policy guidance and stabilize Windows CI

### DIFF
--- a/cli/tests/test_track9_v7.py
+++ b/cli/tests/test_track9_v7.py
@@ -310,7 +310,11 @@ class TestGoScanCodeJSONSchema(unittest.TestCase):
                 cwd=str(ROOT),
                 capture_output=True,
                 text=True,
-                timeout=180,
+                # The hosted Windows Python shard cold-compiles the complete
+                # Go CLI without the setup-go cache used by the Go matrix.
+                # Keep the tighter local/POSIX bound while allowing runner
+                # image and scheduling variance on Windows.
+                timeout=300 if os.name == "nt" else 180,
                 env={
                     **os.environ,
                     "HOME": str(isolated_home),

--- a/docs-site/app/(docs)/docs/connectors/tool-call-state/page.tsx
+++ b/docs-site/app/(docs)/docs/connectors/tool-call-state/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next';
+import Script from 'next/script';
+import { canonicalUrl } from '@/lib/site';
+
+const destinationPath = `${process.env.NEXT_PUBLIC_BASE_PATH ?? ''}/docs/policies/cel/tool-call-state/`;
+
+const redirectScript = `
+(function () {
+  var target = new URL(${JSON.stringify(destinationPath)}, window.location.origin);
+  target.search = window.location.search;
+  target.hash = window.location.hash;
+  window.location.replace(target.href);
+})();
+`;
+
+export const metadata: Metadata = {
+  title: 'Documentation moved',
+  robots: { index: false, follow: true },
+  alternates: {
+    canonical: canonicalUrl('/docs/policies/cel/tool-call-state/'),
+  },
+};
+
+export default function LegacyToolCallStatePage() {
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-16">
+      <Script
+        id="legacy-tool-call-state-redirect"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{ __html: redirectScript }}
+      />
+      <h1 className="text-3xl font-semibold">Documentation moved</h1>
+      <p className="mt-4 text-fd-muted-foreground">
+        The tool-call state contract now lives under CEL policies.
+      </p>
+      <a
+        className="mt-6 inline-flex text-fd-primary underline underline-offset-4"
+        href={destinationPath}
+      >
+        Open the stateful connector lifecycle
+      </a>
+    </main>
+  );
+}

--- a/docs-site/content/docs/connectors/compatibility.mdx
+++ b/docs-site/content/docs/connectors/compatibility.mdx
@@ -18,14 +18,13 @@ certifies Codex, Claude Code, and Amp; see the
 [native Windows connector matrix](/docs/get-started/windows#certified-connector-scope).
 </Callout>
 
-<Callout type="info" title="Experimental tool-call state contract">
+<Callout type="info" title="CEL policy and tool-call state contract">
 The version gate below proves that DefenseClaw understands a connector's hook
 schema; it does not by itself prove that pre/post tool calls can be paired or
 that a post event means success. See the
-[experimental tool-call state contract](/docs/connectors/tool-call-state) for
-exclusive ActionFacts/CEL routing, tool-surface coverage, outcome and identity
-tiers, and the connector-specific rollout holds. Existing policy defaults are
-unchanged.
+[stateful connector lifecycle](/docs/policies/cel/tool-call-state#connector-outcome-and-identity-matrix)
+for tool-surface coverage, outcome and identity tiers, and connector-specific
+rollout holds. Existing policy defaults are unchanged.
 </Callout>
 
 ## Current contracts

--- a/docs-site/content/docs/policies/cel/authoring.mdx
+++ b/docs-site/content/docs/policies/cel/authoring.mdx
@@ -1,0 +1,253 @@
+---
+title: Authoring CEL rules
+description: Write portable DefenseClaw CEL expressions against typed ActionFacts, validate them, and test their connector coverage safely.
+keywords:
+  - CEL authoring
+  - DefenseClaw ActionFacts
+  - CEL rule examples
+  - guardrail rule packs
+  - validate-pack
+---
+
+CEL rules are Boolean matchers inside guardrail rule packs. A rule combines a
+typed `expression` for authoritative tool-call facts with a required Go/RE2
+`pattern` for compatible fallback detection.
+
+Start with the [complete rule on the CEL overview](/docs/policies/cel#start-with-a-complete-rule),
+then use this page to adapt it to your command, path, network, or data-flow
+case. The [CEL engine reference](/docs/policies/cel/engine) is normative for
+field types, admitted syntax, costs, and runtime behavior.
+
+## Rule-file contract
+
+Put additive organization rules in a file with a unique `category`. A category
+that matches a bundled category replaces that entire category; a unique name
+adds rules without shadowing shipped groups such as `command` or
+`sensitive-path`.
+
+Every field has a distinct job:
+
+| Field | Contract |
+| --- | --- |
+| `version` | Rule-file schema version. Use `1`. |
+| `category` | File-level catalog group. Use a unique organization category unless replacing a complete bundled category intentionally. |
+| `id` | Stable finding and semantic-owner ID. Custom rules claim their own ID; keep IDs unique. |
+| `expression` | Boolean CEL expression with no surrounding whitespace. It is compiled even when the rule is disabled. |
+| `pattern` | Required Go/RE2 fallback. It preserves detection when the connector cannot supply authoritative structured facts. |
+| `tool_call_only` | Restricts the regex fallback to trusted tool calls. CEL is always tool-call-only whether this is `true` or omitted. |
+| `title`, `severity`, `confidence`, `tags` | Finding metadata. Severity is `LOW`, `MEDIUM`, `HIGH`, or `CRITICAL`; confidence is from `0` to `1`; tags must be non-empty. |
+
+CEL returns only `true` or `false`; it does not return a verdict. A `true`
+result creates the YAML-defined finding. Connector mode, severity thresholds,
+HITL, and enforcement evidence determine the resulting action.
+
+For fallback-pattern design and counterexamples, use the
+[RE2 regex cookbook](/docs/policies/regex-cookbook).
+
+## Authoring patterns
+
+Prefer semantic operations and joined facts over connector-specific tool
+names. Use `c.program` for normalized program identity; `c.executable` preserves
+the invocation token or path. `f.tool` can vary across connectors.
+
+<Tabs items={['Command', 'Path', 'Network', 'Data flow']}>
+
+<Tab value="Command">
+
+Require a complete argument vector before making an argument-sensitive claim:
+
+```text title="CEL expression"
+f.commands.exists(c,
+  c.argv_complete &&
+  c.program in ['curl', 'curl.exe', 'wget', 'wget.exe'] &&
+  defenseclaw.guardrail.semantic.v1.OperationKind.OPERATION_KIND_FETCH
+    in c.operations)
+```
+
+</Tab>
+
+<Tab value="Path">
+
+Join the path to its command and use a boundary-safe directory check:
+
+```text title="CEL expression"
+f.commands.exists(c,
+  f.paths.exists(p,
+    p.command_id == c.id &&
+    p.access == defenseclaw.guardrail.semantic.v1.PathAccess.PATH_ACCESS_WRITE &&
+    (p.resolved == '/etc/systemd/system' ||
+     p.resolved.startsWith('/etc/systemd/system/'))))
+```
+
+`resolved` and `active_home` may be empty when the connector cannot prove host
+context. Use `normalized` or `absolute` deliberately when resolution is not a
+requirement; never assume an empty value means a safe value.
+
+</Tab>
+
+<Tab value="Network">
+
+Match an upload to a public or unresolved hostname:
+
+```text title="CEL expression"
+f.commands.exists(c,
+  defenseclaw.guardrail.semantic.v1.OperationKind.OPERATION_KIND_UPLOAD
+    in c.operations &&
+  f.network.exists(n,
+    n.command_id == c.id &&
+    n.action == defenseclaw.guardrail.semantic.v1.NetworkAction.NETWORK_ACTION_UPLOAD &&
+    n.scope in [
+      defenseclaw.guardrail.semantic.v1.NetworkScope.NETWORK_SCOPE_PUBLIC,
+      defenseclaw.guardrail.semantic.v1.NetworkScope.NETWORK_SCOPE_UNKNOWN
+    ]))
+```
+
+DefenseClaw does not perform DNS resolution while building facts. A hostname
+can therefore remain `UNKNOWN`; include that scope when the rule should cover
+external hostnames that are not literal public IP addresses.
+
+</Tab>
+
+<Tab value="Data flow">
+
+Join the command to both edges of a file-to-network flow:
+
+```text title="CEL expression"
+f.commands.exists(c,
+  f.data_flows.exists(read,
+    read.to_command_id == c.id &&
+    read.from == defenseclaw.guardrail.semantic.v1.DataKind.DATA_KIND_FILE &&
+    read.to == defenseclaw.guardrail.semantic.v1.DataKind.DATA_KIND_PROCESS) &&
+  f.data_flows.exists(send,
+    send.from_command_id == c.id &&
+    send.from == defenseclaw.guardrail.semantic.v1.DataKind.DATA_KIND_PROCESS &&
+    send.to == defenseclaw.guardrail.semantic.v1.DataKind.DATA_KIND_NETWORK))
+```
+
+The classifier models the file read and network send as separate edges through
+the process. Joining both edges to `c.id` avoids combining unrelated commands.
+
+</Tab>
+
+</Tabs>
+
+## ActionFacts authoring reference
+
+The only CEL variable is `f`, typed as
+`defenseclaw.guardrail.semantic.v1.Facts`. Field names use protobuf snake case;
+for example, write `f.active_home`, not `f.activeHome`.
+
+| Value | Type | Important fields and use |
+| --- | --- | --- |
+| `f.tool` | `string` | Connector-reported tool identity. Prefer semantic facts when a rule should be portable. |
+| `f.cwd` | `string` | Trusted invocation working directory when known. |
+| `f.active_home` | `string` | Trusted same-host active home when known; never accepted from an untrusted payload claim. |
+| `f.parse` | `ParseResult` | `status`, `dialect`, and bounded `issues`. CEL runs only after an authoritative complete parse, so partial or ambiguous inputs take the regex fallback before evaluation. |
+| `f.commands` | `list<CommandFact>` | IDs, parent/pipeline links, program identity, argv, operations, redirects, wrappers, dialect, effect, and completeness. |
+| `f.paths` | `list<PathFact>` | `command_id`, access, flavor, raw `value`, lexical `normalized`, `absolute`, and context-resolved `resolved`. |
+| `f.network` | `list<NetworkFact>` | `command_id`, action, scheme, host, port, normalized host, scope, target kind, and prefix length. |
+| `f.data_flows` | `list<DataFlowFact>` | Source and destination command IDs plus typed `from` and `to` data kinds. An endpoint ID of `0` represents a non-command file or network boundary. |
+
+### Command facts
+
+| Field | Meaning |
+| --- | --- |
+| `id`, `parent_command_id`, `pipeline_id` | Deterministic links between commands, nested wrappers, pipelines, and other fact collections. |
+| `kind` | Process or shell redirect. |
+| `dialect` | Argv, POSIX, PowerShell, `cmd.exe`, mixed, or none. |
+| `effect` | Execute, preview, or uncertain. Uncertain analysis takes fallback before CEL; preview facts can support detection but not enforcement evidence. |
+| `executable` | Original executable token or path. |
+| `program` | Normalized lowercase program identity; prefer this for portable command matching. |
+| `argv`, `arguments`, `argv_complete` | Parsed vector plus quote/expansion metadata and a proof that the vector is complete. |
+| `operations` | Typed behaviors such as read, write, delete, upload, privilege change, or container execution. |
+| `redirects`, `wrappers` | File-descriptor targets and wrapper executable/argv chains. |
+
+### Common enum families
+
+Use fully qualified constants. Numeric enum comparisons and comparisons across
+different enum families are rejected.
+
+| Family | Values available to rules |
+| --- | --- |
+| `OperationKind` | `EXECUTE`, `READ`, `WRITE`, `APPEND`, `DELETE`, `COPY`, `MOVE`, `LIST`, `SEARCH`, `FETCH`, `UPLOAD`, `CONNECT`, `LISTEN`, `TUNNEL`, `NETWORK_SCAN`, `DECODE`, `PROCESS_KILL`, `DISK_WRITE`, `PRIVILEGE`, `PERMISSION_CHANGE`, `CONFIG_CHANGE`, `ACCOUNT_CHANGE`, `SCHEDULE`, `CONTAINER_RUN`, `WORKLOAD_EXEC`, `NAMESPACE_ENTER`, `ROOT_CHANGE`, `ENVIRONMENT_READ`, `CREDENTIAL_READ`, `POLICY_BYPASS` |
+| `PathAccess` | `READ`, `WRITE`, `APPEND`, `DELETE`, `EXECUTE`, `LIST`, `METADATA`, `CONNECT` |
+| `PathFlavor` | `UNKNOWN`, `POSIX`, `WINDOWS`, `DEVICE`, `REGISTRY` |
+| `NetworkAction` | `CONNECT`, `LISTEN`, `DOWNLOAD`, `UPLOAD`, `DNS`, `TUNNEL`, `SCAN` |
+| `NetworkScope` | `UNKNOWN`, `LOOPBACK`, `LINK_LOCAL`, `PRIVATE`, `PUBLIC` |
+| `NetworkTargetKind` | `UNKNOWN`, `SINGLE_HOST`, `SINGLE_ADDRESS_CIDR`, `MULTI_ADDRESS_CIDR`, `RANGE`, `LIST`, `GENERATED` |
+| `DataKind` | `STDIN`, `STDOUT`, `FILE`, `NETWORK`, `PROCESS` |
+| `CommandEffect` | `EXECUTE`, `PREVIEW`, `UNCERTAIN` |
+| `ParseStatus` | `COMPLETE`, `PARTIAL`, `UNSUPPORTED`, `INVALID`, `LIMIT_EXCEEDED`, `AMBIGUOUS`, `NOT_APPLICABLE` |
+
+Prefix each value with its generated enum name, for example:
+
+```text title="CEL enum constant"
+defenseclaw.guardrail.semantic.v1.PathAccess.PATH_ACCESS_DELETE
+```
+
+The authoritative schema is
+[`internal/guardrail/semanticpb/facts.proto`](https://github.com/cisco-ai-defense/defenseclaw/blob/main/internal/guardrail/semanticpb/facts.proto).
+
+## Validate what you author
+
+<Steps>
+
+<Step>
+
+**Keep additions isolated.** Store organization rules in a uniquely named
+category so omitted bundled components continue to inherit the compiled
+baseline.
+
+```text
+~/.defenseclaw/policies/guardrail/my-org/
+  rules/
+    my-org.yaml
+```
+
+</Step>
+
+<Step>
+
+**Compile the complete candidate.** The authoritative loader checks schema,
+required metadata, regex fallback, CEL typing and admission, and cost limits.
+
+```bash
+defenseclaw guardrail validate-pack \
+  ~/.defenseclaw/policies/guardrail/my-org
+```
+
+See [Validate rule packs](/docs/policies/rulepack-validation) for JSON output,
+exit semantics, partial-pack inheritance, and activation.
+
+</Step>
+
+<Step>
+
+**Exercise representative calls in observe mode.** Compilation does not prove
+that every connector projects the facts your expression expects. Run positive
+and negative cases through each target connector, inspect the finding ID, and
+check the [tool-surface matrix](/docs/policies/cel/tool-call-state#tool-surface-matrix)
+before enabling action mode.
+
+</Step>
+
+</Steps>
+
+<Callout type="info" title="Validation is not a CEL fixture runner">
+There is no public CLI that injects synthetic `ActionFacts` into one CEL
+expression. Repository contributors should add focused Go fixtures and run
+`go test ./internal/guardrail/semantic ./internal/guardrail ./internal/gateway`.
+When the compiled default catalog changes, also run `make generate-guardrail-catalog` and
+`make check-guardrail-catalog`.
+</Callout>
+
+## Authoring checklist
+
+- Use a unique category unless replacing a whole bundled category deliberately.
+- Use a unique rule ID and treat it as stable finding metadata.
+- Join related facts with command IDs; never rely on list position.
+- Prefer `c.program` and typed operations over connector-specific tool names.
+- Treat empty context-derived fields as unknown, not safe.
+- Keep the required fallback scoped to the same security intent as the CEL rule.
+- Validate the complete pack, then test both matches and near misses per connector.
+- Review [CEL engine behavior](/docs/policies/cel/engine) before relying on detection or enforcement semantics.

--- a/docs-site/content/docs/policies/cel/engine.mdx
+++ b/docs-site/content/docs/policies/cel/engine.mdx
@@ -1,0 +1,161 @@
+---
+title: CEL engine
+description: Understand DefenseClaw's typed ActionFacts projection, CEL admission rules, bounded evaluation, semantic ownership, and fallback behavior.
+keywords:
+  - DefenseClaw CEL engine
+  - CEL runtime limits
+  - ActionFacts engine
+  - semantic rule owners
+  - CEL regex fallback
+---
+
+DefenseClaw embeds CEL as a bounded semantic matcher, not as a general-purpose
+policy runtime. The server establishes a trusted tool-action boundary,
+normalizes the action into typed `ActionFacts`, and evaluates one immutable
+Boolean program per semantic rule owner.
+
+Use [Authoring CEL rules](/docs/policies/cel/authoring) for the rule schema,
+field reference, enums, and examples. This page defines what the compiler and
+runtime accept and how a match becomes detection or enforcement evidence.
+
+## Evaluation pipeline
+
+<Flow
+  direction="TB"
+  caption="Only authoritative facts enter CEL. Full facts detect the security intent; an execute-only projection determines whether that evidence can support synchronous enforcement."
+>
+  <Node id="boundary" kind="connector">Server-established trusted action boundary</Node>
+  <Node id="analyze" kind="gateway">Parse and normalize tool arguments</Node>
+  <Node id="facts" kind="policy">Authoritative full ActionFacts</Node>
+  <Node id="full" kind="policy">Evaluate owner on full facts</Node>
+  <Node id="execute" kind="policy">Evaluate execute-only projection</Node>
+  <Node id="fallback" kind="policy">Owner-local regex fallback</Node>
+  <Node id="detect" kind="decision">Detection-only finding</Node>
+  <Node id="enforce" kind="decision">Enforcement-eligible finding</Node>
+  <Node id="none" kind="decision">No owner finding</Node>
+  <Node id="action" kind="decision">Policy profile resolves action</Node>
+  <Edge from="boundary" to="analyze" />
+  <Edge from="analyze" to="facts" label="authoritative" />
+  <Edge from="analyze" to="fallback" label="unsupported or ambiguous" variant="dashed" />
+  <Edge from="facts" to="full" />
+  <Edge from="full" to="none" label="false" />
+  <Edge from="full" to="fallback" label="error or budget" variant="dashed" />
+  <Edge from="full" to="execute" label="true" />
+  <Edge from="execute" to="enforce" label="true + eligible surface" />
+  <Edge from="execute" to="detect" label="false or ineligible surface" />
+  <Edge from="fallback" to="detect" label="pattern matched" />
+  <Edge from="fallback" to="none" label="no match" />
+  <Edge from="detect" to="action" />
+  <Edge from="enforce" to="action" />
+</Flow>
+
+`ActionFacts` and raw tool arguments stay private to the in-process analysis
+path. They are not exposed as a public CEL endpoint, logged as CEL input, or
+written to the durable ordered-state ledger.
+
+## Admission and activation
+
+The rule-pack loader compiles every supplied `expression`, including disabled
+rules. Each expression must be Boolean, contain no surrounding whitespace, and
+use only the admitted surface below. Its rule must also contain a valid bounded
+`pattern` fallback.
+
+Catalog categories merge before compilation:
+
+- A unique custom category adds to the compiled baseline.
+- A category with the same name as a bundled category replaces that entire
+  category.
+- Any schema, regex, type, admission, enum, or cost failure rejects the complete
+  candidate generation.
+
+A rejected candidate is not published. If the gateway already has an active
+in-process generation, that generation remains unchanged; offline validation
+simply reports the candidate failure.
+
+## Supported CEL subset
+
+DefenseClaw admits a small, reviewable CEL surface.
+
+| Supported | Examples and constraints |
+| --- | --- |
+| Boolean logic | `&&`, `||`, `!` |
+| Scalar comparison | `==`, `!=`, and `in` for bounded Boolean, integer, and string values |
+| Collection predicates | Boolean `exists` comprehensions; nesting is limited to two levels |
+| String predicates | `startsWith`, `endsWith`, `contains`, and member-form `matches` |
+| Literals | Boolean, integer, string, and scalar lists |
+| Field selection | Typed fields reachable from `f` using protobuf snake-case names |
+
+Arithmetic, ordering comparisons, indexing, ternaries, maps, `has`, null,
+floating-point/unsigned/byte literals, arbitrary functions, message equality,
+and list equality are rejected. DefenseClaw adds no custom CEL helper
+functions. `matches` must use a literal Go/RE2 pattern of at most 512 bytes;
+dynamic regexes and global-form `matches(value, pattern)` are rejected.
+
+## Resource limits
+
+| Limit | Maximum |
+| --- | --- |
+| Expression size | 16 KiB in bytes and runes |
+| Checked AST | 4,096 nodes; depth 64 |
+| Comprehension nesting | 2 |
+| CEL regex literal | 512 bytes |
+| Fallback regex | 2,048 bytes |
+| Static cost per rule | 6,000,000 |
+| Runtime cost per rule | 1,250,000 |
+| Semantic rules per effective catalog | 256 |
+| Enabled catalog static cost | 32,000,000 |
+| Trusted dispatch budget | 50 ms and 24,000,000 total cost |
+
+These bounds apply before connector action mapping. Exceeding an admission
+limit rejects the candidate; exceeding a runtime limit takes that owner to its
+fallback without stopping unrelated rules.
+
+## Runtime results
+
+| Result | Owner behavior |
+| --- | --- |
+| Compile or admission failure | Reject the candidate generation; do not publish it. |
+| Projection is unsupported, partial, ambiguous, invalid, or uncertain | Run this owner's required regex fallback. |
+| CEL evaluates `false` | Produce no owner finding and suppress only this owner's claimed fallback IDs on the structured route. |
+| CEL matches full facts but not the execute-only projection | Create detection-only evidence; preview behavior cannot synchronously block. |
+| CEL matches both projections on an enforcement-eligible, synchronous surface | Create an enforcement-eligible finding from the YAML metadata. |
+| CEL matches but the connector surface is not block-capable or enforcement-eligible | Create detection-only evidence. |
+| CEL errors, times out, or exceeds runtime cost | Run this owner's regex fallback; unrelated rules continue. |
+
+Custom rules own their own rule ID. DefenseClaw may define internal alias,
+prerequisite, and safe-negative contracts for bundled owners, but those maps
+are not configurable through CEL or YAML. A fallback match and authoritative
+CEL result never produce duplicate findings for the same owner.
+
+The [stateful connector lifecycle](/docs/policies/cel/tool-call-state)
+determines which native events are synchronous, block-capable, outcome-paired,
+or eligible to advance durable ordered state.
+
+## Single-call CEL and ordered state
+
+Single-call CEL findings can run on trusted inspect calls and authenticated
+native pre-tool hooks. Durable chains are narrower: only authenticated native
+connector hook events with the required session and invocation identity can
+advance the SQLite state ledger. Inspect, proxy, router, and OTLP traffic never
+advance a chain.
+
+The six ordered chains are a fixed compiled catalog. Adding a CEL/YAML rule
+does not define a new sequence; custom CEL rules remain single-action matchers.
+See [Stateful connector lifecycle](/docs/policies/cel/tool-call-state) for the
+pending-to-success contract and connector matrix.
+
+## Test engine behavior
+
+`defenseclaw guardrail validate-pack` is the public authority for schema,
+regex, CEL typing and admission, and aggregate-cost checks. It does not inject
+synthetic facts or prove that a connector projects the fields an expression
+expects.
+
+Repository contributors should add focused Go fixtures and run:
+
+```bash
+go test ./internal/guardrail/semantic ./internal/guardrail ./internal/gateway
+```
+
+When the compiled default catalog changes, also run
+`make generate-guardrail-catalog` and `make check-guardrail-catalog`.

--- a/docs-site/content/docs/policies/cel/index.mdx
+++ b/docs-site/content/docs/policies/cel/index.mdx
@@ -1,0 +1,145 @@
+---
+title: CEL policies
+description: Match authenticated, structured tool calls with bounded CEL expressions and turn matches into DefenseClaw findings.
+keywords:
+  - DefenseClaw CEL
+  - CEL policy
+  - ActionFacts
+  - guardrail rule packs
+  - structured tool calls
+---
+
+DefenseClaw uses a deliberately narrow CEL engine to match authenticated,
+structured tool calls. CEL sees normalized command, path, network, and data-flow
+facts—not raw connector payloads—and returns a Boolean match. The rule supplies
+the finding metadata, while the active policy profile maps that finding to
+`allow`, `alert`, `confirm`, or `block`.
+
+<Callout type="info" title="CEL complements OPA/Rego">
+CEL performs semantic matching inside a trusted tool-call boundary. OPA/Rego
+continues to own admission, firewall, sandbox, audit, and policy-domain
+decisions. CEL does not scan prompts or ordinary tool-result text and does not
+expose a separate policy endpoint.
+</Callout>
+
+<Cards>
+  <Card
+    title="Author CEL rules"
+    href="/docs/policies/cel/authoring"
+    description="Learn the rule schema, ActionFacts model, enum constants, portable predicates, and validation workflow."
+  />
+  <Card
+    title="Understand the CEL engine"
+    href="/docs/policies/cel/engine"
+    description="Review the admitted language subset, compiler and runtime limits, ownership, fallback, and evaluation behavior."
+  />
+  <Card
+    title="Stateful connector lifecycle"
+    href="/docs/policies/cel/tool-call-state"
+    description="See connector outcome guarantees, ordered-state behavior, tool-surface matrices, and rollout holds."
+  />
+  <Card
+    title="Validate rule packs"
+    href="/docs/policies/rulepack-validation"
+    description="Use the authoritative loader locally or in CI before activating a candidate pack."
+  />
+</Cards>
+
+## Where CEL fits
+
+<Flow
+  direction="TB"
+  caption="The connector contract establishes trust. CEL never trusts a payload to declare itself structured, and an uncertain projection stays on that rule owner's regex fallback."
+>
+  <Node id="hook" kind="connector">Authenticated tool-action route</Node>
+  <Node id="contract" kind="gateway">Server-resolved action contract</Node>
+  <Node id="analyze" kind="gateway">Analyze tool arguments</Node>
+  <Node id="facts" kind="policy">Bounded ActionFacts</Node>
+  <Node id="cel" kind="policy">CEL Boolean owner</Node>
+  <Node id="fallback" kind="policy">Owner-local regex fallback</Node>
+  <Node id="finding" kind="decision">Finding metadata</Node>
+  <Node id="action" kind="decision">allow / alert / confirm / block</Node>
+  <Node id="reply" kind="connector">Caller or connector response</Node>
+  <Edge from="hook" to="contract" />
+  <Edge from="contract" to="analyze" />
+  <Edge from="analyze" to="facts" label="authoritative" />
+  <Edge from="analyze" to="fallback" label="unsupported or ambiguous" variant="dashed" />
+  <Edge from="facts" to="cel" />
+  <Edge from="cel" to="fallback" label="evaluation error" variant="dashed" />
+  <Edge from="cel" to="finding" label="true" />
+  <Edge from="fallback" to="finding" label="pattern matched" />
+  <Edge from="finding" to="action" />
+  <Edge from="action" to="reply" />
+</Flow>
+
+The authenticated route and its server-resolved action contract establish the
+tool-call boundary. This includes trusted single-call inspection and supported
+native pre-tool hooks; only the latter can participate in durable ordered
+state. DefenseClaw normalizes the action into private `ActionFacts` and exposes
+one typed variable, `f`, to CEL. A semantic rule owner takes exactly one route:
+authoritative facts plus CEL, or that same owner's compatible regex fallback.
+
+## Start with a complete rule
+
+Add organization rules in a file with a unique `category`. This example finds
+a command that reads a protected directory and joins the command to its path by
+ID so facts from different commands cannot accidentally satisfy the rule.
+
+```yaml title="rules/my-org.yaml"
+version: 1
+category: my-org
+rules:
+  - id: ORG-PAYMENTS-SECRETS
+    tool_call_only: true
+    expression: >-
+      f.commands.exists(c,
+      defenseclaw.guardrail.semantic.v1.OperationKind.OPERATION_KIND_READ in c.operations &&
+      f.paths.exists(p, p.command_id == c.id &&
+      p.access == defenseclaw.guardrail.semantic.v1.PathAccess.PATH_ACCESS_READ &&
+      (p.resolved == '/srv/payments/secrets' ||
+      p.resolved.startsWith('/srv/payments/secrets/'))))
+    pattern: '(?i)(?:^|\s)/srv/payments/secrets(?:/|\s|$)'
+    title: "Payments secret directory read"
+    severity: CRITICAL
+    confidence: 0.95
+    tags: [credential, payments, file-sensitive]
+```
+
+The expression only decides whether the action matches. A `true` result creates
+the YAML-defined finding; connector mode, severity thresholds, HITL, and
+enforcement evidence determine the runtime action. The required `pattern`
+preserves compatible detection when structured facts are not authoritative.
+
+Continue with [Authoring CEL rules](/docs/policies/cel/authoring) to adapt this
+rule to command, path, network, and data-flow cases.
+
+## Validate and activate
+
+Compile the candidate with the same Go loader used by the gateway, then restart
+with the exact directory. Rule-pack files are not live-watched.
+
+```bash
+defenseclaw guardrail validate-pack \
+  ~/.defenseclaw/policies/guardrail/my-org
+
+defenseclaw setup guardrail \
+  --rule-pack-dir ~/.defenseclaw/policies/guardrail/my-org \
+  --restart
+
+defenseclaw doctor
+```
+
+Exit `0` means the candidate is valid, `1` means it is invalid, and `2` means
+the authoritative validator was unavailable. Validation proves that the pack
+is admissible; exercise representative positive and negative calls in observe
+mode before enabling action mode. See [Validate rule packs](/docs/policies/rulepack-validation)
+for CI output and partial-pack behavior.
+
+## Choose the next page
+
+| If you need to… | Continue with… |
+| --- | --- |
+| Write or review expressions | [Authoring CEL rules](/docs/policies/cel/authoring) |
+| Understand admission, limits, fallback, or enforcement evidence | [CEL engine](/docs/policies/cel/engine) |
+| Check connector pairing, ordered chains, or artifact promotion | [Stateful connector lifecycle](/docs/policies/cel/tool-call-state) |
+| Validate a complete pack locally or in CI | [Validate rule packs](/docs/policies/rulepack-validation) |

--- a/docs-site/content/docs/policies/cel/meta.json
+++ b/docs-site/content/docs/policies/cel/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "CEL policies",
+  "pages": ["index", "authoring", "engine", "tool-call-state"]
+}

--- a/docs-site/content/docs/policies/cel/tool-call-state.mdx
+++ b/docs-site/content/docs/policies/cel/tool-call-state.mdx
@@ -1,13 +1,31 @@
 ---
-title: Experimental Tool-Call State Contract
-description: How DefenseClaw routes structured tool calls, proves successful execution, and correlates dangerous actions across turns without broadening false-positive behavior.
+title: Stateful connector lifecycle
+description: How authenticated connector hooks prove outcomes, commit ordered tool-call state, and preserve conservative enforcement guarantees.
 keywords:
-  - DefenseClaw ActionFacts
-  - DefenseClaw CEL
+  - DefenseClaw connector lifecycle
   - stateful tool-call guardrails
   - dangerous tool-call chains
   - connector hook outcomes
+  - tool-call state
 ---
+
+This page defines the experimental connector contract behind ordered tool-call
+state. For single-call matching, rule fields, and runtime fallback, start with
+[CEL policies](/docs/policies/cel), [Authoring CEL rules](/docs/policies/cel/authoring),
+and the [CEL engine](/docs/policies/cel/engine).
+
+<Cards>
+  <Card
+    title="CEL engine"
+    href="/docs/policies/cel/engine"
+    description="Understand ActionFacts, semantic ownership, fallback, and detection-versus-enforcement behavior."
+  />
+  <Card
+    title="Author CEL rules"
+    href="/docs/policies/cel/authoring"
+    description="Write portable single-action matchers and validate their connector coverage."
+  />
+</Cards>
 
 <Callout type="warning" title="Experimental contract">
 This is the rollout contract for experimental stateful tool-call protection.
@@ -40,12 +58,11 @@ flag.
 | Prompt, model, stop, session, and subagent lifecycle | Existing prompt/result or audit route | Preserve the current connector behavior; these events are neither tool proposals nor typed state transitions. |
 | Unsupported, partial, ambiguous, or malformed action schema | Owner-local regex fallback | Preserve compatible detection without granting the payload semantic authority it did not prove. |
 
-This is exclusive at the semantic-rule-owner boundary: a CEL-owned rule and its
-legacy regex do not both produce decisions for the same action. CEL owns a rule
-when the connector supplied a trusted tool boundary and `ActionFacts` produced
-an authoritative projection. The regex fallback owns that rule when the parser
-or schema cannot do so. Unrelated legacy rules can still run from the same
-immutable rule-pack generation.
+Structured action routing uses the [CEL engine's exclusive semantic-owner
+contract](/docs/policies/cel/engine#runtime-results). Authoritative facts use
+CEL; unsupported or ambiguous projection and evaluation errors use that
+owner's compatible regex fallback. The two routes do not produce duplicate
+owner findings, and unrelated rules continue normally.
 
 The state-transition route is a closed, versioned extension point, and its list
 is currently empty for every connector. It can be populated only when an
@@ -84,6 +101,28 @@ proposal on a connector with authoritative pairing, it stores a bounded,
 content-free pending marker or predecessor projection keyed by the connector
 instance, authenticated session, and strongest invocation identity.
 
+<Sequence
+  caption="Intent becomes durable history only after the same connector contract proves identity and success. Failure, cancellation, ambiguity, expiry, and turn cutoffs discard the pending proposal."
+  participants={[
+    { id: 'agent', label: 'Agent runtime', kind: 'agent' },
+    { id: 'hook', label: 'Connector hooks', kind: 'connector' },
+    { id: 'gateway', label: 'DefenseClaw gateway', kind: 'gateway' },
+    { id: 'ledger', label: 'State ledger', kind: 'datastore' },
+  ]}
+>
+  <Message from="agent" to="hook" label="tool proposal" />
+  <Message from="hook" to="gateway" label="authenticated pre-tool event + call ID" />
+  <Message from="gateway" to="ledger" label="store content-free pending marker" />
+  <Message from="gateway" to="hook" kind="return" label="allow / alert / confirm / block" />
+  <Message from="agent" to="hook" label="tool outcome" />
+  <Message from="hook" to="gateway" label="matching authoritative result" />
+  <Message from="gateway" to="ledger" label="commit successful predecessor" />
+</Sequence>
+
+Only authenticated native `/api/v1/{connector}/hook` events can advance this
+ledger. Inspect, proxy, router, and OTLP traffic may produce single-call
+findings but never create or commit ordered state.
+
 ```text
 pre-tool proposal -> standalone/chain decision -> pending
 pending + matching successful post-tool result -> durable successful step
@@ -97,6 +136,9 @@ window, mismatched session, conflicting ID, or ambiguous join cannot promote
 the proposal. Successful steps and deduplication receipts live in DefenseClaw's
 SQLite store so reviewed chains can span turns and gateway restarts while still
 respecting wall-clock and event-count windows.
+
+The six ordered chains are a fixed compiled catalog; CEL/YAML rule authoring
+does not define new sequences. Custom CEL rules remain single-action matchers.
 
 The fixed catalog contains six ordered chain definitions: guardrails-off then
 egress, permission denial then bypass, privilege discovery then elevation,
@@ -184,6 +226,11 @@ is available on Windows. DefenseClaw enables and tests only the connectors in
 the [native Windows connector matrix](/docs/get-started/windows#certified-connector-scope)
 and does not create hook integrations for clients that are not installed or
 supported there.
+
+A `yes` in this matrix means the connector emits a reviewed event for that
+surface. It does not guarantee paired outcome identity, every `ActionFacts`
+field, or enforcement eligibility; use the outcome matrix above for those
+claims.
 
 | Connector | Generic | Shell | File read | File write/edit | MCP | Skills | Mail / SaaS |
 | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/docs-site/content/docs/policies/creator.mdx
+++ b/docs-site/content/docs/policies/creator.mdx
@@ -132,7 +132,7 @@ defenseclaw policy activate my-policy
 | Severity matrix  | `skill_actions.<sev>` (runtime/file/install) plus per-scanner `scanner_overrides.<scanner>.<sev>`.                                     |
 | Admission        | `admission.scan_on_install`, `admission.allow_list_bypass_scan`, and `first_party_allow_list` entries.                                 |
 | Guardrail        | `guardrail.block_threshold` / `alert_threshold`, `guardrail.hilt`, `guardrail.patterns`, `severity_mappings`, Cisco trust level.       |
-| Rule pack        | Per-file regex rules (`policies/guardrail/<pack>/rules/<filename>.yaml`).                                                              |
+| Rule pack        | Per-file CEL expressions with required regex fallback, plus regex-only rules (`policies/guardrail/<pack>/rules/<filename>.yaml`).       |
 | Suppressions     | The three layers: `pre_judge_strips`, `finding_suppressions`, `tool_suppressions`.                                                     |
 | Sensitive tools  | `sensitive_tools` array — per-tool result inspection and judge-result toggles.                                                         |
 | LLM judges       | `judges.<name>` (pii / injection / tool-injection / exfil) — system prompts and category mappings.                                     |

--- a/docs-site/content/docs/policies/index.mdx
+++ b/docs-site/content/docs/policies/index.mdx
@@ -21,6 +21,11 @@ The guided trace normalizes a connector event, matches a deterministic rule, che
 
 <Cards>
   <Card
+    title="CEL tool-call policies"
+    href="/docs/policies/cel"
+    description="Author bounded CEL rules against trusted ActionFacts, understand the engine and regex fallback, and review connector lifecycle guarantees."
+  />
+  <Card
     title="Policy creator"
     href="/docs/policies/creator"
     description="Build a complete policy from a preset, see live OPA-WASM verdicts in your browser, and export every YAML / data.json / Rego file ready to paste into ~/.defenseclaw/policies/."
@@ -152,8 +157,8 @@ Guardrail scanner and hook events separately preserve matching rule IDs, evaluat
 ## Layer 2 — Guardrail rule packs
 
 The guardrail rule pack is the *content* the gateway evaluates against — the
-tool-call CEL expressions and bounded regex fallbacks, judge prompts, and
-category taxonomies. Three packs ship out of the box:
+[tool-call CEL expressions](/docs/policies/cel/authoring) and bounded regex fallbacks,
+judge prompts, and category taxonomies. Three packs ship out of the box:
 
 <Cards>
   <Card title="permissive" href="/docs/defaults" description="Permissive runtime posture: CRITICAL blocks, HIGH alerts, and lower severities allow. Pair with observe mode for a non-enforcing pilot." />
@@ -434,7 +439,13 @@ Ways to act on correlations without changing the gateway runtime:
 
 ## Authoring custom rule packs
 
-The path of least resistance is to extend rather than replace. Custom rule packs live on disk and are pointed at via the `guardrail.rule_pack_dir` config key — there is no built-in linter or fixture-runner today, so the workflow is git-driven.
+The path of least resistance is to extend rather than replace. Custom rule
+packs live on disk and are selected through `guardrail.rule_pack_dir`. Before
+switching the gateway, run the built-in offline validator: it uses the same Go
+loader as the gateway, compiles every CEL expression, and rejects the complete
+candidate on any invalid component. See [Validate rule packs](/docs/policies/rulepack-validation)
+for the command contract and [CEL rule authoring](/docs/policies/cel/authoring) for
+the expression schema and authoring examples.
 
 <Steps>
   <Step>
@@ -453,32 +464,39 @@ The path of least resistance is to extend rather than replace. Custom rule packs
     ```
   </Step>
   <Step>
-    **Add a rules file alongside `local-patterns.yaml`.** Keep your custom rules in their own file so updates to the bundled patterns don't conflict.
+    **Add a rules file alongside `local-patterns.yaml`.** Keep custom rules in
+    their own file so updates to bundled patterns do not conflict. A CEL rule
+    still carries its bounded regex fallback; follow the
+    [CEL authoring guide](/docs/policies/cel/authoring) for the full rule shape.
   </Step>
   <Step>
-    **Validate the surrounding config.** There is no rule-pack-specific CLI linter today. `defenseclaw config validate` checks `config.yaml` itself (including the `rule_pack_dir` value), but it does not parse every YAML file inside that directory:
+    **Validate the complete candidate pack.** This is an offline preflight and
+    does not modify the active gateway:
 
     ```bash
-    defenseclaw config validate
+    defenseclaw guardrail validate-pack \
+      ~/.defenseclaw/policies/guardrail/my-org
     ```
+
+    Exit `0` means the same authoritative loader accepted the pack. Use
+    `--json` in CI; exits `1` and `2` distinguish an invalid pack from an
+    unavailable validator.
   </Step>
   <Step>
-    **Point the gateway at the new directory.** Edit `~/.defenseclaw/config.yaml` and set:
-
-    ```yaml
-    guardrail:
-      rule_pack_dir: ~/.defenseclaw/policies/guardrail/my-org
-    ```
-
-    Then restart the gateway so it rebuilds the local rule set and judge from the new directory:
+    **Apply the validated directory and verify the effective connector packs.**
+    The setup command writes `rule_pack_dir` and restarts the gateway so it
+    rebuilds the local rules and judge:
 
     ```bash
-    defenseclaw-gateway restart
+    defenseclaw setup guardrail \
+      --rule-pack-dir ~/.defenseclaw/policies/guardrail/my-org \
+      --restart
+    defenseclaw doctor
     ```
 
-    `defenseclaw-gateway policy reload` is narrower: it recompiles the OPA modules under `policy_dir`; it is not the rule-pack reload command.
-
-    `defenseclaw setup guardrail --rule-pack <name>` is for switching between the three bundled packs (`default`, `strict`, `permissive`); custom directories go through `rule_pack_dir`.
+    DefenseClaw does not watch rule-pack files for live changes.
+    `defenseclaw-gateway policy reload` recompiles OPA modules under
+    `policy_dir`; it does not reload guardrail rule packs.
   </Step>
 </Steps>
 

--- a/docs-site/content/docs/policies/meta.json
+++ b/docs-site/content/docs/policies/meta.json
@@ -2,6 +2,7 @@
   "title": "Policies",
   "pages": [
     "index",
+    "cel",
     "rulepack-validation",
     "creator",
     "verify-locally",

--- a/docs-site/content/docs/policies/rulepack-validation.mdx
+++ b/docs-site/content/docs/policies/rulepack-validation.mdx
@@ -47,7 +47,7 @@ Validation compiles every supplied `expression`, including expressions on
 disabled rules, and rejects the complete candidate if admission fails. It also
 enforces the semantic rule-count and aggregate-cost limits. Expressions must
 be non-empty, free of surrounding whitespace, and Boolean; a rule with an
-expression must still provide its required bounded `pattern` fallback.
+expression must still provide its required, bounded `pattern` fallback.
 
 `tool_call_only` does not bypass any of these checks or establish a trusted
 boundary. During validation it only controls the eventual eligibility of the

--- a/docs-site/content/docs/policies/rulepack-validation.mdx
+++ b/docs-site/content/docs/policies/rulepack-validation.mdx
@@ -36,32 +36,22 @@ version, or invalid replacement component fails the pack. DefenseClaw does not
 silently discard the bad file or keep only the entries that happened to parse.
 </Callout>
 
-## Tool-call semantic rules
+## CEL expression validation
 
-A rule may include an optional CEL `expression`. DefenseClaw compiles every
-supplied expression during validation, including expressions on disabled
-rules, and rejects the candidate pack if admission fails. Expressions run only
-inside authenticated trusted tool-call evaluation; the rule's
-regular-expression `pattern` remains required as its bounded fallback.
+For the rule schema, field reference, and examples, use
+[Authoring CEL rules](/docs/policies/cel/authoring). The
+[CEL engine](/docs/policies/cel/engine) defines the admitted language subset,
+limits, execution projections, ownership, and fallback behavior.
 
-`tool_call_only` controls where the regex is eligible. It is not a trust
-switch: expressions are always evaluated only after the server has established
-an authenticated tool-call boundary. With `tool_call_only: true`, the regex is
-also excluded from prompt, completion, tool-result, and static-artifact scans.
-A tool-call-only regex rule may omit `expression`.
+Validation compiles every supplied `expression`, including expressions on
+disabled rules, and rejects the complete candidate if admission fails. It also
+enforces the semantic rule-count and aggregate-cost limits. Expressions must
+be non-empty, free of surrounding whitespace, and Boolean; a rule with an
+expression must still provide its required bounded `pattern` fallback.
 
-For an authoritative structured action, the CEL owner and its equivalent
-legacy IDs are evaluated as one exclusive route: a semantic match emits one
-canonical finding, and a semantic negative suppresses only the legacy patterns
-that owner can safely disprove. Unsupported, malformed, ambiguous, or
-unprojected actions retain the bounded regex fallback. DefenseClaw does not run
-CEL and the owned fallback as two independent detectors, so migrating a rule
-does not create duplicate findings.
-
-CEL is intentionally narrow. It adds operation, argument, path, endpoint, and
-data-flow predicates to trusted tool calls; it does not replace OPA/Rego
-policy, scan prompts or completions, or create a second general policy
-endpoint.
+`tool_call_only` does not bypass any of these checks or establish a trusted
+boundary. During validation it only controls the eventual eligibility of the
+rule's regex fallback outside tool-call inspection.
 
 ## Partial packs and fallback
 

--- a/docs-site/content/docs/reference/gateway-api.mdx
+++ b/docs-site/content/docs/reference/gateway-api.mdx
@@ -226,10 +226,11 @@ Single-call semantic findings are available on this inspect route and on
 native pre-tool hooks. Ordered tool chains are stricter: they use durable
 SQLite state only on authenticated `/api/v1/{connector}/hook` events with
 canonical connector and session correlation. Inspect, proxy, router, and OTLP
-traffic never advance a chain. Exact authenticated config-change and
-result-like hook events may supply an antecedent, but a chain can deny only
-its final step on an enforcement-safe synchronous pre-tool event. Post-tool
-and tool-result events never make the final blocking decision.
+traffic never advance a chain. Only a matching authoritative successful result
+can promote an existing pending proposal into a durable successful predecessor.
+A chain can deny only its final step on an enforcement-safe synchronous
+pre-tool event. Post-tool and tool-result events never make the final blocking
+decision.
 See the [stateful connector lifecycle](/docs/policies/cel/tool-call-state) for
 the pairing, state-level, and cutoff contracts.
 Chain matches are `HIGH` severity and retain the connector's effective action

--- a/docs-site/content/docs/reference/gateway-api.mdx
+++ b/docs-site/content/docs/reference/gateway-api.mdx
@@ -220,7 +220,7 @@ The `/api/v1/inspect/*` family is the hot path that connector hooks and the Open
 no client-supplied `is_tool_call` switch and no additional semantic endpoint.
 The authenticated route and its server-side connector identity establish the
 boundary. A request with `tool: "message"` stays in the message lane and is not
-eligible for structured tool-call CEL rules.
+eligible for [structured tool-call CEL rules](/docs/policies/cel/engine).
 
 Single-call semantic findings are available on this inspect route and on
 native pre-tool hooks. Ordered tool chains are stricter: they use durable
@@ -230,6 +230,8 @@ traffic never advance a chain. Exact authenticated config-change and
 result-like hook events may supply an antecedent, but a chain can deny only
 its final step on an enforcement-safe synchronous pre-tool event. Post-tool
 and tool-result events never make the final blocking decision.
+See the [stateful connector lifecycle](/docs/policies/cel/tool-call-state) for
+the pairing, state-level, and cutoff contracts.
 Chain matches are `HIGH` severity and retain the connector's effective action
 matrix: default and permissive profiles alert, strict blocks, and eligible
 human-in-the-loop configurations confirm. A durable deny receipt is created

--- a/docs-site/public/docs/connectors/tool-call-state/llms.md
+++ b/docs-site/public/docs/connectors/tool-call-state/llms.md
@@ -1,0 +1,5 @@
+# Documentation moved
+
+The stateful tool-call contract now lives under Policies:
+
+<https://cisco-ai-defense.github.io/defenseclaw/docs/policies/cel/tool-call-state/llms.md>

--- a/docs/GUARDRAIL_RULE_PACKS.md
+++ b/docs/GUARDRAIL_RULE_PACKS.md
@@ -1,7 +1,10 @@
 # Guardrail rule-pack engineering contract
 
-Operator recipes, suppressions, and verification steps are maintained in the
-published [policies documentation](https://cisco-ai-defense.github.io/defenseclaw/docs/policies/).
+Operator CEL authoring and engine behavior are maintained in the published
+[CEL authoring guide](https://cisco-ai-defense.github.io/defenseclaw/docs/policies/cel/authoring/)
+and [CEL engine reference](https://cisco-ai-defense.github.io/defenseclaw/docs/policies/cel/engine/).
+Recipes, suppressions, and verification steps remain in the broader
+[policies documentation](https://cisco-ai-defense.github.io/defenseclaw/docs/policies/).
 
 ## Two policy layers
 


### PR DESCRIPTION
> Base: `main`. This PR is not stacked and can be reviewed and merged independently.

## Problem

CEL documentation was published as one dense tool-call state page under Connectors, even though CEL authoring, engine behavior, fallback semantics, and connector lifecycle are policy concerns. The core tables were useful, but developers had no focused path from a first rule to the engine contract and connector guarantees.

Separately, the hosted Windows Python CI shard failed while running `TestGoScanCodeJSONSchema.test_go_scan_code_json_validates_schema`. That test invokes `go run ./cmd/defenseclaw scan code`, which cold-compiles the complete Go CLI without the `setup-go` cache used by the dedicated Go matrix. Both the original job and its rerun reached the shared 180-second timeout even though the other 1,961 tests passed and the dedicated Windows Go suite was green.

## Current Situation

- The old `/docs/connectors/tool-call-state/` page mixed introductory material, authoring guidance, engine constraints, stateful lifecycle behavior, and large compatibility matrices.
- CEL content was outside the Policies navigation hierarchy and lacked a clear overview → authoring → engine → lifecycle learning path.
- Existing references linked directly to the connector location.
- The CLI schema test used the same 180-second subprocess timeout on every operating system despite the substantially slower cold-build path on hosted Windows runners.
- No CEL runtime behavior, policy defaults, connector contracts, or production timeout behavior needed to change.

## Solution

### Policy-focused CEL documentation

Create a nested CEL section under Policies with four focused pages:

1. **CEL policies** — conceptual overview, evaluation flow, complete starter rule, validation, and activation.
2. **Authoring CEL rules** — rule-file contract, typed `ActionFacts`, enum reference, joined command/path/network/data-flow examples, validation, and authoring checklist.
3. **CEL engine** — admitted language subset, compiler/runtime limits, semantic ownership, regex fallback, enforcement evidence, and ordered-state boundaries.
4. **Stateful connector lifecycle** — existing outcome, identity, tool-surface, rollout, and artifact-promotion contracts.

The existing lifecycle tables and anchors remain available while the surrounding material becomes easier to navigate and review.

### Developer-oriented examples and diagrams

Add a complete validated YAML rule, command/path/network/data-flow CEL examples, typed fact and enum references, evaluation and lifecycle diagrams, and explicit validation/observe/activation guidance.

### Backward-compatible documentation migration

Keep the legacy connector URL working through a static redirect that preserves query strings and fragment identifiers, uses the production base path, publishes a canonical URL, marks the legacy route `noindex`, and provides both non-JavaScript and machine-readable moved notices.

### Windows CI stabilization

Keep the existing 180-second subprocess timeout on POSIX systems and allow 300 seconds only on Windows. This preserves the tighter local bound while accommodating hosted-runner image, scheduling, and cold-compilation variance in the Windows Python shard.

## Architecture Diagram

```mermaid
flowchart TD
    A["Authenticated tool-action route"] --> B["Server-resolved action contract"]
    B --> C["Parse and normalize arguments"]
    C -->|Authoritative projection| D["Typed ActionFacts"]
    C -->|Unsupported or ambiguous| E["Owner-local regex fallback"]
    D --> F["Bounded Boolean CEL owner"]
    F -->|True| G["YAML-defined finding"]
    F -->|False| H["No owner finding"]
    F -->|Runtime error or budget| E
    E -->|Pattern match| G
    G --> I["Policy profile resolves allow / alert / confirm / block"]
    I --> J["Connector response"]

    K["Native pre-tool hook with durable identity"] --> L["Stateful connector lifecycle"]
    L --> I
```

CEL remains an in-process semantic matcher over server-established trusted facts. OPA/Rego continues to own broader admission, sandbox, firewall, audit, and policy-domain decisions.

## What Changed (Where & How)

| File / Path | Summary |
| --- | --- |
| `docs-site/content/docs/policies/cel/{index,authoring,engine,tool-call-state}.mdx` | Adds the four-page CEL policy section, diagrams, examples, reference tables, and preserved lifecycle contracts. |
| `docs-site/content/docs/policies/cel/meta.json`, `docs-site/content/docs/policies/meta.json` | Defines the CEL subsection and places it in the Policies sidebar. |
| `docs-site/content/docs/connectors/tool-call-state.mdx` | Moves the misplaced connector page into the CEL policy section. |
| `docs-site/app/(docs)/docs/connectors/tool-call-state/page.tsx` | Adds the legacy static redirect with canonical/noindex metadata and query/fragment preservation. |
| `docs-site/public/docs/connectors/tool-call-state/llms.md` | Adds a machine-readable moved notice for the legacy path. |
| `docs-site/content/docs/{connectors/compatibility,policies/index,policies/creator,policies/rulepack-validation,reference/gateway-api}.mdx` | Updates navigation, terminology, authoring workflow, validation guidance, and cross-references. |
| `docs/GUARDRAIL_RULE_PACKS.md` | Points the engineering contract to the focused authoring and engine references. |
| `cli/tests/test_track9_v7.py` | Uses a 300-second timeout for the hosted Windows cold-build path while retaining 180 seconds elsewhere. |

## Breaking Changes

None.

The legacy documentation URL redirects to the new policy location while preserving query strings and anchors. This PR does not change CEL evaluation, rule-pack schemas, policy defaults, connector behavior, public APIs, or operator configuration. The CI change affects only a test subprocess timeout on Windows.

## Open Issues / Follow-ups

None.

## Test Plan

```sh
npm --prefix docs-site run validate-snippets
```

Observed result: PASS; 308 documentation code fences validated.

```sh
npm --prefix docs-site run validate-links
```

Observed result: PASS; zero link errors.

```sh
npm --prefix docs-site run build
```

Observed result: PASS; 171 static pages generated, 80 `llms.md` files written, 26 diagrams scanned, and 81 canonical pages validated.

```sh
TMPDIR=/private/tmp go run ./cmd/defenseclaw rulepack validate --dir .tmp-doc-cel-pack --json
```

Observed result: PASS; the CEL overview rule returned `"valid": true`.

```sh
uv run pytest -q cli/tests/test_track9_v7.py
```

Observed result: PASS; 9 tests and 2 subtests passed in 1.99 seconds.

```sh
uv run pytest -q cli/tests/test_track9_v7.py::TestGoScanCodeJSONSchema::test_go_scan_code_json_validates_schema
uv run ruff check cli/tests/test_track9_v7.py
git diff --check
```

Observed result: PASS; the focused schema test passed, Ruff reported no issues, and the diff contained no whitespace errors.

```sh
BASE_PATH= npm --prefix docs-site run dev -- --hostname 127.0.0.1 --port 4173
```

Observed result: PASS; manually verified the overview, authoring examples and tabs, engine reference, lifecycle tables, diagram lightbox, nested desktop/mobile navigation, and a clean browser console. Verified the legacy route preserves its query string and anchor while redirecting to the lifecycle matrix.

Case-insensitive documentation scan: PASS; zero prohibited-term matches in source or generated documentation.
