### PR TITLE
fix audit SQLite lock guard lifetime

### DIFF
--- a/docs-site/content/docs/reference/env-vars.mdx
+++ b/docs-site/content/docs/reference/env-vars.mdx
@@ -217,6 +217,7 @@ scope at each such row.
 
 | Env var | Impact | Default | Accepted values | Purpose | Security concern | Consumers |
 | --- | --- | --- | --- | --- | --- | --- |
+| `DEFENSECLAW_AUDIT_DB_LOCK_HELPER_PATH` | — | `unset` | `absolute temporary database path`, `unset` | Passes the temporary audit database path to isolated subprocesses that verify SQLite kernel-lock and WAL lifecycle behavior. | — | `internal/audit/audit_db_lock_unix_test.go` — Peer-process lock and SQLite-close fixtures; never read by production runtime paths |
 | `DEFENSECLAW_AUTHENTICODE_HELPER` | — | `unset` | `test-defined absolute path`, `unset` | Carries the Authenticode PowerShell helper path to the native unsigned-PE regression fixture. | — | `cli/tests/test_windows_installer_artifacts.py` — Native Windows test fixture; never read by production runtime paths |
 | `DEFENSECLAW_CODEX_POLICY_ENTRY_PATH` | — | `unset` | `absolute test marker path`, `unset` | Test-only marker path used by the Codex effective-policy subprocess fixture to record helper entry. | — | `internal/gateway/connector/codex_policy_test.go` — Codex policy timeout/process-tree test fixture; never read by production runtime paths |
 | `DEFENSECLAW_CODEX_POLICY_GRANDCHILD_HELPER` | — | `unset` | `1`, `unset` | Selects the Codex policy grandchild fixture used to verify process-tree containment. | — | `internal/gateway/connector/codex_policy_test.go` — Test-only Codex policy grandchild helper |

--- a/internal/audit/audit_db_lock_unix_test.go
+++ b/internal/audit/audit_db_lock_unix_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
 
 // Copyright 2026 Cisco Systems, Inc. and its affiliates
 // SPDX-License-Identifier: Apache-2.0
@@ -6,11 +6,15 @@
 package audit
 
 import (
+	"context"
+	"database/sql"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
 
 const auditDBLockHelperPathEnv = "DEFENSECLAW_AUDIT_DB_LOCK_HELPER_PATH"
@@ -26,11 +30,18 @@ func TestHardenedAuditSQLiteRetainsLocksUntilClose(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer store.Close() //nolint:errcheck
+	closed := false
+	t.Cleanup(func() {
+		if !closed {
+			_ = store.Close()
+		}
+	})
 	if err := store.Init(); err != nil {
 		t.Fatal(err)
 	}
+	assertSQLiteWALMode(t, store.db)
 	assertAuditDBLockedByPeerProcess(t, path)
+	assertAuditSidecarPinsReused(t, store)
 
 	if _, err := store.db.Exec(`CREATE TABLE lock_probe (id INTEGER PRIMARY KEY, value TEXT)`); err != nil {
 		t.Fatal(err)
@@ -47,11 +58,7 @@ func TestHardenedAuditSQLiteRetainsLocksUntilClose(t *testing.T) {
 		before[suffix] = info
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=^TestAuditDBLockHelperProcess$")
-	cmd.Env = append(os.Environ(), auditDBLockHelperPathEnv+"="+path)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("run second SQLite process: %v\n%s", err, output)
-	}
+	runAuditDBHelperProcess(t, path, "TestAuditDBLockHelperProcess")
 
 	for _, suffix := range []string{"-wal", "-shm"} {
 		after, err := os.Stat(path + suffix)
@@ -65,6 +72,12 @@ func TestHardenedAuditSQLiteRetainsLocksUntilClose(t *testing.T) {
 	if _, err := store.db.Exec(`INSERT INTO lock_probe(value) VALUES ('parent-after-peer')`); err != nil {
 		t.Fatalf("write after peer close: %v", err)
 	}
+	closeErr := store.Close()
+	closed = true
+	if closeErr != nil {
+		t.Fatalf("close audit store: %v", closeErr)
+	}
+	assertAuditDBUnlockedByPeerProcess(t, path)
 }
 
 func TestJudgeBodySQLiteRetainsLocksUntilClose(t *testing.T) {
@@ -73,20 +86,104 @@ func TestJudgeBodySQLiteRetainsLocksUntilClose(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer store.Close() //nolint:errcheck
+	closed := false
+	t.Cleanup(func() {
+		if !closed {
+			_ = store.Close()
+		}
+	})
+	assertSQLiteWALMode(t, store.db)
 	assertAuditDBLockedByPeerProcess(t, path)
+
+	const closeCalls = 8
+	start := make(chan struct{})
+	errs := make(chan error, closeCalls)
+	for range closeCalls {
+		go func() {
+			<-start
+			errs <- store.Close()
+		}()
+	}
+	close(start)
+	for range closeCalls {
+		if err := <-errs; err != nil {
+			t.Fatalf("concurrent judge-body close: %v", err)
+		}
+	}
+	closed = true
+	assertAuditDBUnlockedByPeerProcess(t, path)
 }
 
 func assertAuditDBLockedByPeerProcess(t *testing.T, path string) {
 	t.Helper()
-	cmd := exec.Command(os.Args[0], "-test.run=^TestAuditDBLockProbeHelperProcess$")
+	runAuditDBHelperProcess(t, path, "TestAuditDBLockProbeHelperProcess")
+}
+
+func assertAuditDBUnlockedByPeerProcess(t *testing.T, path string) {
+	t.Helper()
+	runAuditDBHelperProcess(t, path, "TestAuditDBUnlockProbeHelperProcess")
+}
+
+func assertSQLiteWALMode(t *testing.T, db *sql.DB) {
+	t.Helper()
+	var mode string
+	if err := db.QueryRow(`PRAGMA journal_mode`).Scan(&mode); err != nil {
+		t.Fatalf("read SQLite journal mode: %v", err)
+	}
+	if !strings.EqualFold(mode, "wal") {
+		t.Fatalf("SQLite journal mode = %q, want WAL", mode)
+	}
+}
+
+func assertAuditSidecarPinsReused(t *testing.T, store *Store) {
+	t.Helper()
+	before := make(map[string]*os.File, len(store.dbPathGuard.sidecars))
+	for suffix, pinned := range store.dbPathGuard.sidecars {
+		before[suffix] = pinned
+	}
+	if len(before) == 0 {
+		t.Fatal("audit path guard retained no live SQLite sidecars")
+	}
+	for attempt := 0; attempt < 3; attempt++ {
+		if err := revalidateHardenedAuditSQLite(store.dbPathGuard); err != nil {
+			t.Fatalf("repeat audit path revalidation %d: %v", attempt+1, err)
+		}
+		if len(store.dbPathGuard.sidecars) != len(before) {
+			t.Fatalf("repeat revalidation retained %d sidecars, want %d", len(store.dbPathGuard.sidecars), len(before))
+		}
+		for suffix, pinned := range before {
+			if store.dbPathGuard.sidecars[suffix] != pinned {
+				t.Fatalf("repeat revalidation replaced retained %s descriptor", suffix)
+			}
+		}
+	}
+}
+
+func runAuditDBHelperProcess(t *testing.T, path, testName string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^"+testName+"$")
 	cmd.Env = append(os.Environ(), auditDBLockHelperPathEnv+"="+path)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("probe SQLite lock from peer process: %v\n%s", err, output)
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("run %s: %v\n%s", testName, ctx.Err(), output)
+	}
+	if err != nil {
+		t.Fatalf("run %s: %v\n%s", testName, err, output)
 	}
 }
 
 func TestAuditDBLockProbeHelperProcess(t *testing.T) {
+	probeAuditDBLockHelperProcess(t, true)
+}
+
+func TestAuditDBUnlockProbeHelperProcess(t *testing.T) {
+	probeAuditDBLockHelperProcess(t, false)
+}
+
+func probeAuditDBLockHelperProcess(t *testing.T, wantLocked bool) {
+	t.Helper()
 	path := os.Getenv(auditDBLockHelperPathEnv)
 	if path == "" {
 		return
@@ -105,8 +202,11 @@ func TestAuditDBLockProbeHelperProcess(t *testing.T) {
 	if err := syscall.FcntlFlock(file.Fd(), syscall.F_GETLK, &lock); err != nil {
 		t.Fatal(err)
 	}
-	if lock.Type == syscall.F_UNLCK {
+	if wantLocked && lock.Type == syscall.F_UNLCK {
 		t.Fatal("live SQLite connection holds no kernel lock on the database")
+	}
+	if !wantLocked && lock.Type != syscall.F_UNLCK {
+		t.Fatal("closed SQLite connection still holds a kernel lock on the database")
 	}
 }
 

--- a/internal/audit/audit_db_lock_unix_test.go
+++ b/internal/audit/audit_db_lock_unix_test.go
@@ -1,0 +1,138 @@
+//go:build !windows
+
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package audit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+const auditDBLockHelperPathEnv = "DEFENSECLAW_AUDIT_DB_LOCK_HELPER_PATH"
+
+const (
+	sqlitePendingByte = int64(0x40000000)
+	sqliteLockByteLen = int64(512)
+)
+
+func TestHardenedAuditSQLiteRetainsLocksUntilClose(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.db")
+	store, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close() //nolint:errcheck
+	if err := store.Init(); err != nil {
+		t.Fatal(err)
+	}
+	assertAuditDBLockedByPeerProcess(t, path)
+
+	if _, err := store.db.Exec(`CREATE TABLE lock_probe (id INTEGER PRIMARY KEY, value TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`INSERT INTO lock_probe(value) VALUES ('parent')`); err != nil {
+		t.Fatal(err)
+	}
+	before := make(map[string]os.FileInfo, 2)
+	for _, suffix := range []string{"-wal", "-shm"} {
+		info, err := os.Stat(path + suffix)
+		if err != nil {
+			t.Fatalf("stat live SQLite sidecar %s: %v", suffix, err)
+		}
+		before[suffix] = info
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestAuditDBLockHelperProcess$")
+	cmd.Env = append(os.Environ(), auditDBLockHelperPathEnv+"="+path)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run second SQLite process: %v\n%s", err, output)
+	}
+
+	for _, suffix := range []string{"-wal", "-shm"} {
+		after, err := os.Stat(path + suffix)
+		if err != nil {
+			t.Fatalf("live SQLite sidecar %s disappeared after peer close: %v", suffix, err)
+		}
+		if !os.SameFile(before[suffix], after) {
+			t.Fatalf("live SQLite sidecar %s was replaced after peer close", suffix)
+		}
+	}
+	if _, err := store.db.Exec(`INSERT INTO lock_probe(value) VALUES ('parent-after-peer')`); err != nil {
+		t.Fatalf("write after peer close: %v", err)
+	}
+}
+
+func TestJudgeBodySQLiteRetainsLocksUntilClose(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "judge_bodies.db")
+	store, err := NewJudgeBodyStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close() //nolint:errcheck
+	assertAuditDBLockedByPeerProcess(t, path)
+}
+
+func assertAuditDBLockedByPeerProcess(t *testing.T, path string) {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestAuditDBLockProbeHelperProcess$")
+	cmd.Env = append(os.Environ(), auditDBLockHelperPathEnv+"="+path)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("probe SQLite lock from peer process: %v\n%s", err, output)
+	}
+}
+
+func TestAuditDBLockProbeHelperProcess(t *testing.T) {
+	path := os.Getenv(auditDBLockHelperPathEnv)
+	if path == "" {
+		return
+	}
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close() //nolint:errcheck
+	lock := syscall.Flock_t{
+		Type:   syscall.F_WRLCK,
+		Whence: 0,
+		Start:  sqlitePendingByte,
+		Len:    sqliteLockByteLen,
+	}
+	if err := syscall.FcntlFlock(file.Fd(), syscall.F_GETLK, &lock); err != nil {
+		t.Fatal(err)
+	}
+	if lock.Type == syscall.F_UNLCK {
+		t.Fatal("live SQLite connection holds no kernel lock on the database")
+	}
+}
+
+func TestAuditDBLockHelperProcess(t *testing.T) {
+	path := os.Getenv(auditDBLockHelperPathEnv)
+	if path == "" {
+		return
+	}
+	db, err := openSQLite(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM lock_probe`).Scan(&count); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if count != 1 {
+		_ = db.Close()
+		t.Fatalf("lock probe rows = %d, want 1", count)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/audit/audit_db_path.go
+++ b/internal/audit/audit_db_path.go
@@ -42,77 +42,115 @@ func (hooks auditDBPathHooks) withDefaults() auditDBPathHooks {
 type preparedAuditDatabasePath struct {
 	path        string
 	pinned      *os.File
+	sidecars    []*os.File
 	securedMode os.FileMode
 	hooks       auditDBPathHooks
 	inMemory    bool
 }
 
 func (prepared *preparedAuditDatabasePath) close() {
-	if prepared != nil && prepared.pinned != nil {
-		_ = prepared.pinned.Close()
-		prepared.pinned = nil
+	if prepared == nil {
+		return
 	}
+	for index := len(prepared.sidecars) - 1; index >= 0; index-- {
+		_ = prepared.sidecars[index].Close()
+	}
+	prepared.sidecars = nil
+	if prepared.pinned == nil {
+		return
+	}
+	_ = prepared.pinned.Close()
+	prepared.pinned = nil
+}
+
+// hardenedAuditSQLite owns the out-of-band handles that pin the validated
+// database identity. POSIX closes on those files must happen only after
+// SQLite releases its locks, so callers close the SQL pool through this
+// wrapper instead of closing the path guard independently.
+type hardenedAuditSQLite struct {
+	*sql.DB
+	prepared *preparedAuditDatabasePath
+}
+
+func (opened *hardenedAuditSQLite) Close() error {
+	if opened == nil {
+		return nil
+	}
+	var err error
+	if opened.DB != nil {
+		err = opened.DB.Close()
+		opened.DB = nil
+	}
+	opened.prepared.close()
+	opened.prepared = nil
+	return err
 }
 
 // openHardenedAuditSQLite is the intended NewStore integration seam. It
 // preserves the existing pool/pragma behavior in openSQLite while adding a
 // fail-closed filesystem trust boundary around the lazy database/sql open.
-func openHardenedAuditSQLite(dbPath string, hooks auditDBPathHooks) (*sql.DB, error) {
-	db, _, err := openHardenedAuditSQLiteWithIdentity(dbPath, hooks)
-	return db, err
+func openHardenedAuditSQLite(dbPath string, hooks auditDBPathHooks) (*hardenedAuditSQLite, error) {
+	db, _, prepared, err := openHardenedAuditSQLiteWithIdentity(dbPath, hooks)
+	if err != nil {
+		return nil, err
+	}
+	return &hardenedAuditSQLite{DB: db, prepared: prepared}, nil
 }
 
 // openHardenedAuditSQLiteWithIdentity also returns the exact normalized path
-// passed to SQLite. Store retains that immutable identity for post-migration
-// revalidation and runtime-plan binding instead of reinterpreting a relative
-// constructor path after the process working directory changes.
+// passed to SQLite and the path guard that must outlive the SQL pool. Store
+// retains that immutable identity for post-migration revalidation and
+// runtime-plan binding instead of reinterpreting a relative constructor path
+// after the process working directory changes.
 func openHardenedAuditSQLiteWithIdentity(
 	dbPath string,
 	hooks auditDBPathHooks,
-) (*sql.DB, string, error) {
+) (*sql.DB, string, *preparedAuditDatabasePath, error) {
 	prepared, err := prepareAuditDatabasePath(dbPath, hooks)
 	if err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
-	defer prepared.close()
 
 	if prepared.inMemory {
 		db, err := openSQLite(prepared.path)
-		return db, prepared.path, err
+		if err != nil {
+			prepared.close()
+			return nil, "", nil, err
+		}
+		return db, prepared.path, prepared, nil
 	}
 	if hooks.beforeSQLiteOpen != nil {
 		if err := hooks.beforeSQLiteOpen(prepared.path); err != nil {
-			return nil, "", fmt.Errorf("audit: pre-open path check: %w", err)
+			prepared.close()
+			return nil, "", nil, fmt.Errorf("audit: pre-open path check: %w", err)
 		}
 	}
 	db, err := openSQLite(prepared.path)
 	if err != nil {
-		return nil, "", err
+		prepared.close()
+		return nil, "", nil, err
 	}
 	// sql.Open is lazy. Ping forces SQLite's DSN pragmas and filesystem open
 	// while the validated leaf remains pinned, making permission/open errors a
 	// constructor failure instead of a later write-path surprise.
 	if err := db.Ping(); err != nil {
 		_ = db.Close()
-		return nil, "", fmt.Errorf("audit: verify database open %s: %w", prepared.path, err)
+		prepared.close()
+		return nil, "", nil, fmt.Errorf("audit: verify database open %s: %w", prepared.path, err)
 	}
 	if err := prepared.validateAfterOpen(); err != nil {
 		_ = db.Close()
-		return nil, "", err
+		prepared.close()
+		return nil, "", nil, err
 	}
-	return db, prepared.path, nil
+	return db, prepared.path, prepared, nil
 }
 
 // revalidateHardenedAuditSQLite repeats the filesystem trust checks after
 // migrations and the readiness write have created or reused WAL/SHM files.
-// The SQLite connection remains open while the main leaf is pinned and every
-// auxiliary path is checked.
-func revalidateHardenedAuditSQLite(dbPath string, hooks auditDBPathHooks) error {
-	prepared, err := prepareAuditDatabasePath(dbPath, hooks)
-	if err != nil {
-		return err
-	}
-	defer prepared.close()
+// It reuses the original path guard so no database-related descriptor is
+// opened and then closed while SQLite owns POSIX locks for the same file.
+func revalidateHardenedAuditSQLite(prepared *preparedAuditDatabasePath) error {
 	return prepared.validateAfterOpen()
 }
 
@@ -199,8 +237,25 @@ var auditDBSQLiteSidecarSuffixes = [...]string{"-wal", "-shm", "-journal"}
 
 // secureAuditDBSQLiteSidecars handles leftovers from crashes and older
 // constructors before SQLite is allowed to recover/reuse their raw pages.
+// It must only run while no SQLite connection for databasePath is live.
 func secureAuditDBSQLiteSidecars(databasePath string, hooks auditDBPathHooks) error {
+	pinned, err := pinAndSecureAuditDBSQLiteSidecars(databasePath, hooks)
+	for index := len(pinned) - 1; index >= 0; index-- {
+		_ = pinned[index].Close()
+	}
+	return err
+}
+
+// pinAndSecureAuditDBSQLiteSidecars returns every handle it opens, including
+// on failure. Once SQLite is live, its caller must retain those descriptors
+// until after the SQL pool closes: POSIX close semantics would otherwise
+// discard SQLite's process-wide locks for the same WAL or SHM inode.
+func pinAndSecureAuditDBSQLiteSidecars(
+	databasePath string,
+	hooks auditDBPathHooks,
+) ([]*os.File, error) {
 	hooks = hooks.withDefaults()
+	pinnedFiles := make([]*os.File, 0, len(auditDBSQLiteSidecarSuffixes))
 	for _, suffix := range auditDBSQLiteSidecarSuffixes {
 		path := databasePath + suffix
 		before, err := os.Lstat(path)
@@ -208,66 +263,55 @@ func secureAuditDBSQLiteSidecars(databasePath string, hooks auditDBPathHooks) er
 			continue
 		}
 		if err != nil {
-			return fmt.Errorf("audit: inspect SQLite sidecar %s: %w", suffix, err)
+			return pinnedFiles, fmt.Errorf("audit: inspect SQLite sidecar %s: %w", suffix, err)
 		}
 		if err := validateAuditDBLeaf(path, before); err != nil {
-			return fmt.Errorf("audit: unsafe SQLite sidecar %s: %w", suffix, err)
+			return pinnedFiles, fmt.Errorf("audit: unsafe SQLite sidecar %s: %w", suffix, err)
 		}
 		pinned, err := openAuditDBFileNoFollow(path, false)
 		if err != nil {
-			return fmt.Errorf("audit: open SQLite sidecar %s safely: %w", suffix, err)
+			return pinnedFiles, fmt.Errorf("audit: open SQLite sidecar %s safely: %w", suffix, err)
 		}
-		closePinned := func() { _ = pinned.Close() }
+		pinnedFiles = append(pinnedFiles, pinned)
 		pinnedBefore, err := pinned.Stat()
 		if err != nil {
-			closePinned()
-			return fmt.Errorf("audit: inspect pinned SQLite sidecar %s: %w", suffix, err)
+			return pinnedFiles, fmt.Errorf("audit: inspect pinned SQLite sidecar %s: %w", suffix, err)
 		}
 		if !os.SameFile(before, pinnedBefore) {
-			closePinned()
-			return fmt.Errorf("audit: SQLite sidecar %s changed before secure open", suffix)
+			return pinnedFiles, fmt.Errorf("audit: SQLite sidecar %s changed before secure open", suffix)
 		}
 		if err := validateAuditDBLeaf(path, pinnedBefore); err != nil {
-			closePinned()
-			return fmt.Errorf("audit: unsafe pinned SQLite sidecar %s: %w", suffix, err)
+			return pinnedFiles, fmt.Errorf("audit: unsafe pinned SQLite sidecar %s: %w", suffix, err)
 		}
 
 		targetMode := tightenedAuditDBFileMode(pinnedBefore.Mode().Perm())
 		if targetMode != pinnedBefore.Mode().Perm() {
 			if err := hooks.chmodFile(pinned, targetMode); err != nil {
-				closePinned()
-				return fmt.Errorf("audit: secure SQLite sidecar %s permissions: %w", suffix, err)
+				return pinnedFiles, fmt.Errorf("audit: secure SQLite sidecar %s permissions: %w", suffix, err)
 			}
 		}
 		if err := hooks.securePlatformFile(pinned, false); err != nil {
-			closePinned()
-			return fmt.Errorf("audit: secure SQLite sidecar %s platform ACL: %w", suffix, err)
+			return pinnedFiles, fmt.Errorf("audit: secure SQLite sidecar %s platform ACL: %w", suffix, err)
 		}
 		pinnedAfter, err := pinned.Stat()
 		if err != nil {
-			closePinned()
-			return fmt.Errorf("audit: re-inspect pinned SQLite sidecar %s: %w", suffix, err)
+			return pinnedFiles, fmt.Errorf("audit: re-inspect pinned SQLite sidecar %s: %w", suffix, err)
 		}
 		after, err := os.Lstat(path)
 		if err != nil {
-			closePinned()
-			return fmt.Errorf("audit: re-inspect SQLite sidecar %s: %w", suffix, err)
+			return pinnedFiles, fmt.Errorf("audit: re-inspect SQLite sidecar %s: %w", suffix, err)
 		}
 		if !os.SameFile(pinnedAfter, after) {
-			closePinned()
-			return fmt.Errorf("audit: SQLite sidecar %s changed during secure open", suffix)
+			return pinnedFiles, fmt.Errorf("audit: SQLite sidecar %s changed during secure open", suffix)
 		}
 		if err := validateAuditDBLeaf(path, after); err != nil {
-			closePinned()
-			return fmt.Errorf("audit: unsafe SQLite sidecar %s after securing: %w", suffix, err)
+			return pinnedFiles, fmt.Errorf("audit: unsafe SQLite sidecar %s after securing: %w", suffix, err)
 		}
 		if !auditDBModeMatches(pinnedAfter, targetMode) {
-			closePinned()
-			return fmt.Errorf("audit: SQLite sidecar %s permissions could not be secured", suffix)
+			return pinnedFiles, fmt.Errorf("audit: SQLite sidecar %s permissions could not be secured", suffix)
 		}
-		closePinned()
 	}
-	return nil
+	return pinnedFiles, nil
 }
 
 func openPinnedAuditDBLeaf(path string) (*os.File, bool, error) {
@@ -451,7 +495,11 @@ func (prepared *preparedAuditDatabasePath) validateAfterOpen() error {
 	if !auditDBModeMatches(info, prepared.securedMode) {
 		return errors.New("audit: database file permissions changed during secure open")
 	}
-	return secureAuditDBSQLiteSidecars(prepared.path, prepared.hooks)
+	pinned, err := pinAndSecureAuditDBSQLiteSidecars(prepared.path, prepared.hooks)
+	// Retain handles even when validation fails. The open SQL pool must release
+	// its locks before any of these descriptors are closed.
+	prepared.sidecars = append(prepared.sidecars, pinned...)
+	return err
 }
 
 func tightenedAuditDBFileMode(mode os.FileMode) os.FileMode {

--- a/internal/audit/audit_db_path.go
+++ b/internal/audit/audit_db_path.go
@@ -42,7 +42,7 @@ func (hooks auditDBPathHooks) withDefaults() auditDBPathHooks {
 type preparedAuditDatabasePath struct {
 	path        string
 	pinned      *os.File
-	sidecars    []*os.File
+	sidecars    map[string]*os.File
 	securedMode os.FileMode
 	hooks       auditDBPathHooks
 	inMemory    bool
@@ -52,9 +52,7 @@ func (prepared *preparedAuditDatabasePath) close() {
 	if prepared == nil {
 		return
 	}
-	for index := len(prepared.sidecars) - 1; index >= 0; index-- {
-		_ = prepared.sidecars[index].Close()
-	}
+	closeAuditDBSQLiteSidecars(prepared.sidecars)
 	prepared.sidecars = nil
 	if prepared.pinned == nil {
 		return
@@ -148,8 +146,9 @@ func openHardenedAuditSQLiteWithIdentity(
 
 // revalidateHardenedAuditSQLite repeats the filesystem trust checks after
 // migrations and the readiness write have created or reused WAL/SHM files.
-// It reuses the original path guard so no database-related descriptor is
-// opened and then closed while SQLite owns POSIX locks for the same file.
+// It reuses existing sidecar pins and retains any newly discovered descriptor
+// until after SQLite closes, so revalidation never closes a database-related
+// descriptor while SQLite owns POSIX locks for the same file.
 func revalidateHardenedAuditSQLite(prepared *preparedAuditDatabasePath) error {
 	return prepared.validateAfterOpen()
 }
@@ -239,79 +238,96 @@ var auditDBSQLiteSidecarSuffixes = [...]string{"-wal", "-shm", "-journal"}
 // constructors before SQLite is allowed to recover/reuse their raw pages.
 // It must only run while no SQLite connection for databasePath is live.
 func secureAuditDBSQLiteSidecars(databasePath string, hooks auditDBPathHooks) error {
-	pinned, err := pinAndSecureAuditDBSQLiteSidecars(databasePath, hooks)
-	for index := len(pinned) - 1; index >= 0; index-- {
-		_ = pinned[index].Close()
-	}
+	pinned, err := pinAndSecureAuditDBSQLiteSidecars(databasePath, hooks, nil)
+	closeAuditDBSQLiteSidecars(pinned)
 	return err
 }
 
-// pinAndSecureAuditDBSQLiteSidecars returns every handle it opens, including
-// on failure. Once SQLite is live, its caller must retain those descriptors
-// until after the SQL pool closes: POSIX close semantics would otherwise
-// discard SQLite's process-wide locks for the same WAL or SHM inode.
+func closeAuditDBSQLiteSidecars(sidecars map[string]*os.File) {
+	for index := len(auditDBSQLiteSidecarSuffixes) - 1; index >= 0; index-- {
+		if pinned := sidecars[auditDBSQLiteSidecarSuffixes[index]]; pinned != nil {
+			_ = pinned.Close()
+		}
+	}
+}
+
+// pinAndSecureAuditDBSQLiteSidecars revalidates retained handles by suffix and
+// opens only sidecars that have appeared since the previous check. It returns
+// every handle it owns, including on failure. Once SQLite is live, its caller
+// must retain those descriptors until after the SQL pool closes: POSIX close
+// semantics would otherwise discard SQLite's process-wide locks for the same
+// WAL or SHM inode.
 func pinAndSecureAuditDBSQLiteSidecars(
 	databasePath string,
 	hooks auditDBPathHooks,
-) ([]*os.File, error) {
+	retained map[string]*os.File,
+) (map[string]*os.File, error) {
 	hooks = hooks.withDefaults()
-	pinnedFiles := make([]*os.File, 0, len(auditDBSQLiteSidecarSuffixes))
+	if retained == nil {
+		retained = make(map[string]*os.File, len(auditDBSQLiteSidecarSuffixes))
+	}
 	for _, suffix := range auditDBSQLiteSidecarSuffixes {
 		path := databasePath + suffix
 		before, err := os.Lstat(path)
 		if os.IsNotExist(err) {
+			if retained[suffix] != nil {
+				return retained, fmt.Errorf("audit: retained SQLite sidecar %s disappeared during secure open", suffix)
+			}
 			continue
 		}
 		if err != nil {
-			return pinnedFiles, fmt.Errorf("audit: inspect SQLite sidecar %s: %w", suffix, err)
+			return retained, fmt.Errorf("audit: inspect SQLite sidecar %s: %w", suffix, err)
 		}
 		if err := validateAuditDBLeaf(path, before); err != nil {
-			return pinnedFiles, fmt.Errorf("audit: unsafe SQLite sidecar %s: %w", suffix, err)
+			return retained, fmt.Errorf("audit: unsafe SQLite sidecar %s: %w", suffix, err)
 		}
-		pinned, err := openAuditDBFileNoFollow(path, false)
-		if err != nil {
-			return pinnedFiles, fmt.Errorf("audit: open SQLite sidecar %s safely: %w", suffix, err)
+		pinned := retained[suffix]
+		if pinned == nil {
+			pinned, err = openAuditDBFileNoFollow(path, false)
+			if err != nil {
+				return retained, fmt.Errorf("audit: open SQLite sidecar %s safely: %w", suffix, err)
+			}
+			retained[suffix] = pinned
 		}
-		pinnedFiles = append(pinnedFiles, pinned)
 		pinnedBefore, err := pinned.Stat()
 		if err != nil {
-			return pinnedFiles, fmt.Errorf("audit: inspect pinned SQLite sidecar %s: %w", suffix, err)
+			return retained, fmt.Errorf("audit: inspect pinned SQLite sidecar %s: %w", suffix, err)
 		}
 		if !os.SameFile(before, pinnedBefore) {
-			return pinnedFiles, fmt.Errorf("audit: SQLite sidecar %s changed before secure open", suffix)
+			return retained, fmt.Errorf("audit: SQLite sidecar %s changed before secure open", suffix)
 		}
 		if err := validateAuditDBLeaf(path, pinnedBefore); err != nil {
-			return pinnedFiles, fmt.Errorf("audit: unsafe pinned SQLite sidecar %s: %w", suffix, err)
+			return retained, fmt.Errorf("audit: unsafe pinned SQLite sidecar %s: %w", suffix, err)
 		}
 
 		targetMode := tightenedAuditDBFileMode(pinnedBefore.Mode().Perm())
 		if targetMode != pinnedBefore.Mode().Perm() {
 			if err := hooks.chmodFile(pinned, targetMode); err != nil {
-				return pinnedFiles, fmt.Errorf("audit: secure SQLite sidecar %s permissions: %w", suffix, err)
+				return retained, fmt.Errorf("audit: secure SQLite sidecar %s permissions: %w", suffix, err)
 			}
 		}
 		if err := hooks.securePlatformFile(pinned, false); err != nil {
-			return pinnedFiles, fmt.Errorf("audit: secure SQLite sidecar %s platform ACL: %w", suffix, err)
+			return retained, fmt.Errorf("audit: secure SQLite sidecar %s platform ACL: %w", suffix, err)
 		}
 		pinnedAfter, err := pinned.Stat()
 		if err != nil {
-			return pinnedFiles, fmt.Errorf("audit: re-inspect pinned SQLite sidecar %s: %w", suffix, err)
+			return retained, fmt.Errorf("audit: re-inspect pinned SQLite sidecar %s: %w", suffix, err)
 		}
 		after, err := os.Lstat(path)
 		if err != nil {
-			return pinnedFiles, fmt.Errorf("audit: re-inspect SQLite sidecar %s: %w", suffix, err)
+			return retained, fmt.Errorf("audit: re-inspect SQLite sidecar %s: %w", suffix, err)
 		}
 		if !os.SameFile(pinnedAfter, after) {
-			return pinnedFiles, fmt.Errorf("audit: SQLite sidecar %s changed during secure open", suffix)
+			return retained, fmt.Errorf("audit: SQLite sidecar %s changed during secure open", suffix)
 		}
 		if err := validateAuditDBLeaf(path, after); err != nil {
-			return pinnedFiles, fmt.Errorf("audit: unsafe SQLite sidecar %s after securing: %w", suffix, err)
+			return retained, fmt.Errorf("audit: unsafe SQLite sidecar %s after securing: %w", suffix, err)
 		}
 		if !auditDBModeMatches(pinnedAfter, targetMode) {
-			return pinnedFiles, fmt.Errorf("audit: SQLite sidecar %s permissions could not be secured", suffix)
+			return retained, fmt.Errorf("audit: SQLite sidecar %s permissions could not be secured", suffix)
 		}
 	}
-	return pinnedFiles, nil
+	return retained, nil
 }
 
 func openPinnedAuditDBLeaf(path string) (*os.File, bool, error) {
@@ -495,10 +511,10 @@ func (prepared *preparedAuditDatabasePath) validateAfterOpen() error {
 	if !auditDBModeMatches(info, prepared.securedMode) {
 		return errors.New("audit: database file permissions changed during secure open")
 	}
-	pinned, err := pinAndSecureAuditDBSQLiteSidecars(prepared.path, prepared.hooks)
+	pinned, err := pinAndSecureAuditDBSQLiteSidecars(prepared.path, prepared.hooks, prepared.sidecars)
 	// Retain handles even when validation fails. The open SQL pool must release
 	// its locks before any of these descriptors are closed.
-	prepared.sidecars = append(prepared.sidecars, pinned...)
+	prepared.sidecars = pinned
 	return err
 }
 

--- a/internal/audit/audit_db_path_test.go
+++ b/internal/audit/audit_db_path_test.go
@@ -346,9 +346,6 @@ func TestHardenedAuditSQLiteCreatesOwnerOnlyWALAndSHM(t *testing.T) {
 	if _, err := db.Exec(`INSERT INTO sidecar_probe(value) VALUES ('confidential')`); err != nil {
 		t.Fatal(err)
 	}
-	if err := secureAuditDBSQLiteSidecars(path, auditDBPathHooks{}); err != nil {
-		t.Fatal(err)
-	}
 	for _, suffix := range []string{"-wal", "-shm"} {
 		info, err := os.Stat(path + suffix)
 		if os.IsNotExist(err) {

--- a/internal/audit/judge_body_store.go
+++ b/internal/audit/judge_body_store.go
@@ -55,6 +55,8 @@ type JudgeBodyStore struct {
 	db        *sql.DB
 	path      string
 	pathGuard *preparedJudgeBodyPath
+	closeMu   sync.Mutex
+	closed    bool
 
 	// cutoverReady gates the runtime writer and compatibility reader when
 	// the store was opened by NewJudgeBodyStoreForCutover. The gateway uses
@@ -177,12 +179,24 @@ func unwrapOpenSQLiteErr(err error) error {
 
 // Close releases the underlying connection pool. Idempotent.
 func (s *JudgeBodyStore) Close() error {
-	if s == nil || s.db == nil {
+	if s == nil {
 		return nil
 	}
-	err := s.db.Close()
-	s.pathGuard.close()
+	s.closeMu.Lock()
+	defer s.closeMu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	db := s.db
+	s.db = nil
+	pathGuard := s.pathGuard
 	s.pathGuard = nil
+	var err error
+	if db != nil {
+		err = db.Close()
+	}
+	pathGuard.close()
 	return err
 }
 

--- a/internal/audit/judge_body_store.go
+++ b/internal/audit/judge_body_store.go
@@ -52,8 +52,9 @@ import (
 // verified cutover in judge_body_cutover.go and remain there only as a
 // read-only compatibility source until retention or authorized purge.
 type JudgeBodyStore struct {
-	db   *sql.DB
-	path string
+	db        *sql.DB
+	path      string
+	pathGuard *preparedJudgeBodyPath
 
 	// cutoverReady gates the runtime writer and compatibility reader when
 	// the store was opened by NewJudgeBodyStoreForCutover. The gateway uses
@@ -130,22 +131,23 @@ func newJudgeBodyStoreWithPathHooks(
 	if err != nil {
 		return nil, err
 	}
-	defer prepared.close()
 	dbPath = prepared.path
 	if hooks.beforeSQLiteOpen != nil {
 		if err := hooks.beforeSQLiteOpen(dbPath); err != nil {
+			prepared.close()
 			return nil, fmt.Errorf("judge_body: pre-open path check: %w", err)
 		}
 	}
 	db, err := openSQLite(dbPath)
 	if err != nil {
+		prepared.close()
 		// Strip the leading "audit:" tier that openSQLite stamps so
 		// the operator sees the correct subsystem in the wrapped
 		// error chain. openSQLite is shared across both DBs, so the
 		// tier disambiguation happens at the caller boundary.
 		return nil, fmt.Errorf("judge_body: open db %s: %w", dbPath, unwrapOpenSQLiteErr(err))
 	}
-	st := &JudgeBodyStore{db: db, path: dbPath}
+	st := &JudgeBodyStore{db: db, path: dbPath, pathGuard: prepared}
 	st.cutoverReady.Store(!requireCutover)
 	if err := st.init(); err != nil {
 		_ = st.Close()
@@ -178,7 +180,10 @@ func (s *JudgeBodyStore) Close() error {
 	if s == nil || s.db == nil {
 		return nil
 	}
-	return s.db.Close()
+	err := s.db.Close()
+	s.pathGuard.close()
+	s.pathGuard = nil
+	return err
 }
 
 // retry helpers reuse the audit-package retryBusy under the hood;

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -204,8 +204,9 @@ type ActionEntry struct {
 }
 
 type Store struct {
-	db     *sql.DB
-	dbPath string
+	db          *sql.DB
+	dbPath      string
+	dbPathGuard *preparedAuditDatabasePath
 
 	// lifecycleMu serializes initialization/close and lets mandatory v8
 	// event-history transactions pin a ready store until commit or rollback.
@@ -328,11 +329,11 @@ func openSQLite(dbPath string) (*sql.DB, error) {
 }
 
 func NewStore(dbPath string) (*Store, error) {
-	db, identity, err := openHardenedAuditSQLiteWithIdentity(dbPath, auditDBPathHooks{})
+	db, identity, pathGuard, err := openHardenedAuditSQLiteWithIdentity(dbPath, auditDBPathHooks{})
 	if err != nil {
 		return nil, err
 	}
-	return &Store{db: db, dbPath: identity}, nil
+	return &Store{db: db, dbPath: identity, dbPathGuard: pathGuard}, nil
 }
 
 // sqliteCoded is the structural interface implemented by the
@@ -1853,7 +1854,7 @@ func (s *Store) Init() error {
 	if err := s.proveDurableWrite(context.Background()); err != nil {
 		return err
 	}
-	if err := revalidateHardenedAuditSQLite(s.dbPath, auditDBPathHooks{}); err != nil {
+	if err := revalidateHardenedAuditSQLite(s.dbPathGuard); err != nil {
 		return fmt.Errorf("audit: revalidate database paths after initialization: %w", err)
 	}
 
@@ -4039,7 +4040,10 @@ func (s *Store) Close() error {
 	// transactions to release the lifecycle read lock.
 	s.ready.Store(false)
 	s.closed = true
-	return s.db.Close()
+	err := s.db.Close()
+	s.dbPathGuard.close()
+	s.dbPathGuard = nil
+	return err
 }
 
 // currentRunID resolves the per-process run id used to stamp audit

--- a/internal/envvars/registry.json
+++ b/internal/envvars/registry.json
@@ -2946,6 +2946,22 @@
       ],
       "since": "0.8.11",
       "security_note": "Bypassing the env_config file trust check lets a group-writable file at the canonical path retarget bearer-authenticated inspection POSTs. Test-only."
+    },
+    {
+      "name": "DEFENSECLAW_AUDIT_DB_LOCK_HELPER_PATH",
+      "category": "test_fixture",
+      "purpose": "Passes the temporary audit database path to isolated subprocesses that verify SQLite kernel-lock and WAL lifecycle behavior.",
+      "default": "unset",
+      "accepted_values": ["absolute temporary database path", "unset"],
+      "security_impact": "none",
+      "surface_in_doctor": false,
+      "consumers": [
+        {
+          "location": "internal/audit/audit_db_lock_unix_test.go",
+          "description": "Peer-process lock and SQLite-close fixtures; never read by production runtime paths"
+        }
+      ],
+      "since": "0.8.11"
     }
   ]
 }


### PR DESCRIPTION
Base: `main`. This PR has no stacked dependency.

## Problem

DefenseClaw's audit SQLite path hardening opened the database, WAL, and SHM through out-of-band `os.File` descriptors, then closed those descriptors while SQLite connections were still live.

On POSIX systems, closing any descriptor for an inode can discard all advisory locks held by that process for the inode. That bypasses SQLite's internal descriptor bookkeeping. A peer process can consequently misidentify itself as the final WAL connection, unlink the named WAL/SHM files, and leave the gateway writing through orphaned descriptors. A later CLI or TUI connection can create a second WAL/SHM history for the same main database, leading to index and B-tree corruption.

This was reproduced from a brand-new database and surfaced as `database disk image is malformed`.

## Current Situation

The affected lifecycle had three lock-invalidating close paths:

1. `openHardenedAuditSQLiteWithIdentity` closed the pinned main database descriptor after SQLite was opened and pinged.
2. Post-initialization revalidation repeatedly opened and closed live WAL/SHM pins.
3. The judge-body store used the same early main-database pin cleanup pattern.

The filesystem identity and permission checks were correct, but their descriptor ownership ended too early.

## Solution

### Keep path guards alive with SQLite

The audit store now owns its prepared database-path guard for the full SQL-pool lifetime. Live WAL/SHM descriptors discovered during post-open validation are retained by the same guard, including partial validation failures.

### Reuse pinned sidecars during revalidation

Retained sidecars are keyed by suffix. Revalidation uses the existing descriptor for identity and permission checks, opens only a newly discovered sidecar, and never accumulates duplicate descriptors across initialization retries.

### Preserve close ordering

Every success and error path now follows one ordering:

1. Close the SQLite pool and release SQLite locks.
2. Close retained sidecar pins.
3. Close the main database pin.

The standalone hardened-open test seam uses a managed wrapper with the same ordering.

### Apply the same lifetime rule to judge bodies

`JudgeBodyStore` retains its prepared path guard until after the SQLite pool closes. Its close sequence is serialized and single-shot, so concurrent or repeated callers cannot close the path guard twice.

```mermaid
flowchart LR
    H["Filesystem hardening"] -->|"pin validated DB/WAL/SHM identities"| G["Path guard"]
    S["SQLite connection pool"] --> L["SQLite POSIX locks"]
    G -. "retained for pool lifetime" .-> L
    S -->|"1. close pool"| R["SQLite releases locks"]
    R -->|"2. close retained pins"| G
```

## What Changed (Where & How)

| Path | Change |
|---|---|
| `internal/audit/audit_db_path.go` | Retains main/sidecar path handles until after SQLite closes, reuses sidecar pins by suffix during revalidation, and makes direct hardened opens lifecycle-managed. |
| `internal/audit/store.go` | Stores the audit path guard and closes it after the SQL pool. |
| `internal/audit/judge_body_store.go` | Stores the judge-body path guard and makes close ordering concurrent-safe and idempotent. |
| `internal/audit/audit_db_lock_unix_test.go` | Adds bounded peer-process kernel-lock, post-close unlock, repeated-revalidation, concurrent-close, WAL-mode, and WAL/SHM identity regression coverage. |
| `internal/audit/audit_db_path_test.go` | Removes a live-connection call to the pre-open-only sidecar helper. |
| `internal/envvars/registry.json` | Declares the subprocess-only lock-test path as a `test_fixture` variable. |
| `docs-site/content/docs/reference/env-vars.mdx` | Regenerates the canonical environment-variable catalog. |

## Breaking Changes

None. Database schemas, configuration, public APIs, and operator workflows are unchanged.

## Open Issues / Follow-ups

None.

## Test Plan

- `go test ./internal/audit -run 'Test(HardenedAuditSQLiteRetainsLocksUntilClose|JudgeBodySQLiteRetainsLocksUntilClose)$' -count=1 -v`
  - PASS
- `go test ./internal/audit -count=1`
  - PASS (`22.419s`)
- `go test -race -count=1 -timeout 45m ./internal/audit`
  - PASS (`656.752s`), no race reports
- `go vet ./internal/audit`
  - PASS
- `make go-lint`
  - PASS through the repository's documented `go vet ./...` fallback because `golangci-lint` was not installed locally
- `GOOS=linux GOARCH=amd64 go test -c ./internal/audit -o /tmp/defenseclaw-audit-linux.test`
  - PASS
- `GOOS=windows GOARCH=amd64 go test -c ./internal/audit -o /tmp/defenseclaw-audit-windows.test.exe`
  - PASS
- `PYTHONPATH=cli .venv/bin/python -m pytest -q cli/tests/test_envvars_codebase_coverage.py`
  - PASS (`7 passed, 10 subtests passed`)
- `go test ./internal/envvars -count=1`
  - PASS
- Fresh-install overlap replay with the fix-branch gateway:
  - Bootstrap Python Store closed while the gateway remained live: WAL/SHM inode identities unchanged
  - A second SQLite peer opened and closed: WAL/SHM inode identities unchanged
  - 20 hook requests: visible audit row count increased from 21 to 101; `PRAGMA quick_check = ok`
  - Two Python writers (1,000 events each) plus four hook workers (400 requests each): all six workers exited 0; 8,489 visible audit events; `PRAGMA integrity_check = ok`; WAL/SHM inode identities unchanged
