### PR TITLE
fix(installer): survive empty per-connector version arrays under bash 3.2 set -eu

### DIFF
--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -1192,7 +1192,7 @@ if [[ "${SKIP_CONNECTOR}" != "true" ]]; then
   # green while enforcing nothing.
   MANIFEST_TARGETS="$(grep -c '^  - user:' "${MANIFEST_TMP}" || true)"
   if [[ "${MANIFEST_TARGETS}" == "0" ]] && [[ -n "${USER_LINES}" ]] && [[ "${ALLOW_EMPTY_USERS}" != "true" ]]; then
-    die "rendered hook-guardian manifest has zero targets despite ${USER_COUNT} eligible user(s) and connectors=${CONNECTOR} — every connector may be unsupported (only codex/claudecode/cursor auto-wire today). Fix --connector or pass --allow-empty-users to proceed anyway."
+    die "rendered hook-guardian manifest has zero targets despite ${USER_COUNT} eligible user(s) and connectors=${CONNECTOR}. Either every requested connector is unsupported (only codex/claudecode/cursor auto-wire today), or none of the requested connectors are installed for any eligible user (install the CLI/app first, or narrow --connector to what is on this box). Pass --allow-empty-users to proceed anyway."
   fi
   chown root:wheel "${MANIFEST_TMP}"
   chmod 0640 "${MANIFEST_TMP}"

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -613,7 +613,7 @@ discover_agent_version() {
         [[ -n "${v}" ]] && versions+=("${v}")
       done < <(_collect_node_manager_pkg_versions "${home}" "@openai" "codex")
 
-      _pick_highest_supported "${MIN_CODEX_VERSION}" "${versions[@]}"
+      _pick_highest_supported "${MIN_CODEX_VERSION}" ${versions[@]+"${versions[@]}"}
       ;;
     claudecode)
       # Claude Code ships through five channels:
@@ -678,7 +678,7 @@ discover_agent_version() {
         [[ -n "${v}" ]] && versions+=("${v}")
       done < <(_collect_node_manager_pkg_versions "${home}" "@anthropic-ai" "claude-code")
 
-      _pick_highest_supported "${MIN_CLAUDECODE_VERSION}" "${versions[@]}"
+      _pick_highest_supported "${MIN_CLAUDECODE_VERSION}" ${versions[@]+"${versions[@]}"}
       ;;
     cursor)
       # Cursor.app is a signed macOS bundle. Two metadata sources:
@@ -698,7 +698,7 @@ discover_agent_version() {
       v="$(_emit_pkg_version_if_exists /Applications/Cursor.app/Contents/Resources/app/package.json)"
       [[ -n "${v}" ]] && versions+=("${v}")
 
-      _pick_highest_supported "${MIN_CURSOR_VERSION}" "${versions[@]}"
+      _pick_highest_supported "${MIN_CURSOR_VERSION}" ${versions[@]+"${versions[@]}"}
       ;;
   esac
 }
@@ -872,12 +872,14 @@ enumerate_local_users() {
 #   USER_LINES     newline-separated user:uid:gid:home lines (as produced by
 #                  enumerate_local_users)
 #
-# One `- ` block per (user × supported connector). Unsupported connectors
-# are skipped (they have no per-user setup path in the CLI). Agent version
-# is discovered per (user, connector) via discover_agent_version; an empty
-# version is rendered as an empty string — the guardian's reconcile will
-# emit a per-target failure surfaced in hook_guardian_state.json without
-# affecting other targets in the manifest.
+# One `- ` block per (user × supported-and-installed connector).
+# Unsupported connectors (not in is_supported_connector) are skipped: they
+# have no per-user setup path in the CLI. Connectors the caller asked for
+# but which discover_agent_version could not locate on THIS user's home
+# ARE ALSO skipped — no CLI/app/extension present means there is nothing
+# to hook, and emitting the row would just churn the guardian with a
+# permanent "agent_version empty" failure per tick. Users who install the
+# connector later are picked up by the hook-enumerator's next re-render.
 yaml_double_quoted_scalar() {
   local value="$1"
   case "${value}" in
@@ -928,6 +930,7 @@ render_targets_manifest() {
       is_supported_connector "${c}" || continue
       q_connector="$(yaml_double_quoted_scalar "${c}")" || continue
       ver="$(DC_INSTALLER_TARGET_USER="${name}" discover_agent_version "${c}" "${home}" 2>/dev/null || true)"
+      [[ -n "${ver}" ]] || continue
       q_ver="$(yaml_double_quoted_scalar "${ver}")" || q_ver='""'
       # data_dir is intentionally omitted from each target block: the
       # guardian's validateUserDataDir requires the data_dir to be inside

--- a/packaging/macos/tests/test_agent_version_multi_install.sh
+++ b/packaging/macos/tests/test_agent_version_multi_install.sh
@@ -31,6 +31,46 @@ t_pick_highest_supported_empty_returns_empty() {
   assert_eq "${out}" "" "no candidates yields empty string"
 }
 
+t_discover_agent_version_no_install_survives_set_eu() {
+  # Regression: bash 3.2 on macOS treats "${arr[@]}" on an EMPTY array
+  # under `set -u` as an "unbound variable" error and aborts the shell.
+  # Previously discover_agent_version passed "${versions[@]}" straight
+  # into _pick_highest_supported at three call sites; when no install
+  # of the connector was on the box (empty `versions` array), the
+  # caller's `$(... 2>/dev/null || true)` couldn't rescue the abort
+  # because the shell died before the || branch was reached. install.sh
+  # under set -euo pipefail then jumped to the EXIT trap and the whole
+  # install ended mid-render_targets_manifest.
+  #
+  # Real reproduction: grep every _pick_highest_supported call site in
+  # the library and confirm each guards the array expansion with the
+  # bash-3.2-safe idiom `${arr[@]+"${arr[@]}"}`. A future edit that
+  # drops the guard (or a new call site that forgets it) trips this
+  # assertion before it can escape into an installer regression.
+  local lib="${PKG_DIR}/lib/installer_lib.sh"
+  assert_file_exists "${lib}"
+  local unguarded
+  unguarded="$(grep -nE '_pick_highest_supported[[:space:]]+"[^"]*"[[:space:]]+"\$\{versions\[@\]\}"[[:space:]]*$' "${lib}" || true)"
+  assert_eq "${unguarded}" "" \
+    "every _pick_highest_supported call must use \${versions[@]+\"\${versions[@]}\"} for bash 3.2 set -eu safety; unguarded call site(s): ${unguarded}"
+
+  # And exercise the runtime path once so the property is proven end-to-
+  # end for the picker itself: an empty caller array must not abort the
+  # shell under set -eu.
+  set +u
+  local rc got
+  got="$(
+    set -eu
+    declare -a versions=()
+    _pick_highest_supported "2.1.144" ${versions[@]+"${versions[@]}"}
+    printf 'RC=%d' "$?"
+  )"
+  rc="${got##*RC=}"
+  set -u
+  assert_eq "${rc}" "0" \
+    "empty versions[@] under set -eu must expand cleanly at _pick_highest_supported call sites"
+}
+
 t_pick_highest_supported_ignores_empty_arg() {
   local out
   out="$(_pick_highest_supported "1.0.0" "" "2.0.0" "")"
@@ -183,6 +223,7 @@ for c in doc["connectors"][target]["contracts"]:
 run_case "_pick_highest_supported prefers meeting minimum"     t_pick_highest_supported_prefers_meeting_minimum
 run_case "_pick_highest_supported falls back to highest"       t_pick_highest_supported_falls_back_to_highest_overall
 run_case "_pick_highest_supported empty returns empty"         t_pick_highest_supported_empty_returns_empty
+run_case "discover_agent_version safe with no install (bash 3.2 set -eu)" t_discover_agent_version_no_install_survives_set_eu
 run_case "_pick_highest_supported ignores empty arg"           t_pick_highest_supported_ignores_empty_arg
 run_case "_version_ge handles semver ordering"                 t_version_ge_handles_semver_ordering
 run_case "claudecode probe picks NVM over stale npm-global"    t_claudecode_probe_picks_nvm_over_stale_homebrew

--- a/packaging/macos/tests/test_render_targets_manifest.sh
+++ b/packaging/macos/tests/test_render_targets_manifest.sh
@@ -13,7 +13,29 @@
 TEST_SUPPORT="/opt/cisco/secureclient/defenseclaw"
 TEST_RUNTIME="${TEST_SUPPORT}/runtime"
 
+# Stub discover_agent_version so these tests are hermetic. Without a stub
+# the render policy "skip a target row when the connector is not
+# installed" would make row counts depend on whether the dev machine
+# happens to have codex / claudecode / cursor installed.
+#
+# Bash function names are global — a test that overrides
+# discover_agent_version leaves its override in effect for every case
+# scheduled after it in this file. Each test therefore begins by
+# reinstalling the "everything present" stub via _reset_discover_stub.
+_reset_discover_stub() {
+  discover_agent_version() {
+    case "$1" in
+      codex)      printf '0.130.0' ;;
+      claudecode) printf '2.5.0'   ;;
+      cursor)     printf '3.14.27' ;;
+      *)          printf ''        ;;
+    esac
+  }
+}
+_reset_discover_stub
+
 t_multi_user_multi_connector_produces_cross_product() {
+  _reset_discover_stub
   local users
   users="alice:501:20:/Users/alice
 bob:502:20:/Users/bob"
@@ -41,6 +63,7 @@ bob:502:20:/Users/bob"
 }
 
 t_unsupported_connector_skipped() {
+  _reset_discover_stub
   # `windsurf` is not in is_supported_connector; it must be dropped
   # even if the caller lists it in the CSV.
   local users="alice:501:20:/Users/alice"
@@ -81,7 +104,51 @@ t_empty_connectors_still_emits_valid_manifest() {
   assert_eq "${count}" "0" "no user lines when CONNECTORS is empty"
 }
 
+t_absent_connector_skipped_partial_box() {
+  # Regression: a box with only cursor installed must NOT get target rows
+  # for codex or claudecode. Otherwise the guardian churns forever trying
+  # to install hooks for a CLI that doesn't exist on the host. See
+  # discover_agent_version + render_targets_manifest empty-version skip.
+  discover_agent_version() {
+    case "$1" in
+      cursor) printf '3.14.27' ;;
+      *)      printf '' ;;
+    esac
+  }
+
+  local users="shawnxu:501:20:/Users/shawnxu"
+  local out
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "codex,claudecode,cursor" "${users}")"
+
+  assert_contains     "${out}" 'connector: "cursor"'     "cursor row emitted"
+  assert_not_contains "${out}" 'connector: "codex"'      "codex row skipped (not installed)"
+  assert_not_contains "${out}" 'connector: "claudecode"' "claudecode row skipped (not installed)"
+  local count
+  count="$(printf '%s\n' "${out}" | grep -c "^  - user:" || true)"
+  assert_eq "${count}" "1" "one target when only cursor is installed"
+}
+
+t_all_connectors_absent_yields_zero_rows() {
+  # No connectors installed at all — every row skipped. The manifest is
+  # still schema-valid (version + targets:) so the guardian can load it;
+  # install.sh's MANIFEST_TARGETS==0 preflight is what turns this into a
+  # user-visible die() so an operator isn't left with a silently-empty
+  # deployment.
+  discover_agent_version() { printf ''; }
+
+  local users="shawnxu:501:20:/Users/shawnxu"
+  local out
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "codex,claudecode,cursor" "${users}")"
+
+  assert_contains "${out}" "version: 1" "empty-agents manifest still has version"
+  assert_contains "${out}" "targets:"   "empty-agents manifest still has targets:"
+  local count
+  count="$(printf '%s\n' "${out}" | grep -c "^  - user:" || true)"
+  assert_eq "${count}" "0" "no target rows when nothing is installed"
+}
+
 t_rendered_yaml_parses() {
+  _reset_discover_stub
   # Best-effort: if PyYAML is available, verify the output actually
   # parses as valid YAML matching the ManifestTarget schema shape.
   if ! command -v /usr/bin/python3 >/dev/null 2>&1; then
@@ -119,6 +186,7 @@ print(json.dumps({"users": users, "connectors": conns, "count": len(targets)}))
 }
 
 t_rows_pin_enabled_and_int_uid_gid() {
+  _reset_discover_stub
   # Every emitted target must set enabled: true (the guardian will skip
   # enabled:false rows, and an omitted field defaults to true — but
   # rendering it explicitly is defensive) and integer uid/gid.
@@ -131,6 +199,7 @@ t_rows_pin_enabled_and_int_uid_gid() {
 }
 
 t_rows_omit_data_dir() {
+  _reset_discover_stub
   # Regression guard for the multi-user-hook-wiring fix. The guardian's
   # per-target Install runs validateUserDataDir which refuses any data_dir
   # outside the target user's home. Emitting SUPPORT_DIR/runtime (which
@@ -186,6 +255,8 @@ run_case "multi-user × multi-connector cross-product"           t_multi_user_mu
 run_case "unsupported connectors dropped"                       t_unsupported_connector_skipped
 run_case "empty user list still emits valid manifest"           t_empty_users_still_emits_valid_manifest
 run_case "empty connector list still emits valid manifest"      t_empty_connectors_still_emits_valid_manifest
+run_case "absent connectors are skipped (partial-box render)"   t_absent_connector_skipped_partial_box
+run_case "all connectors absent yields zero rows"               t_all_connectors_absent_yields_zero_rows
 run_case "rendered targets.yaml parses (schema round-trip)"     t_rendered_yaml_parses
 run_case "rows pin enabled + int uid/gid"                       t_rows_pin_enabled_and_int_uid_gid
 run_case "rows omit data_dir (per-user Install default is used)" t_rows_omit_data_dir


### PR DESCRIPTION
## Summary
- `discover_agent_version` at [installer_lib.sh:616,681,701](packaging/macos/lib/installer_lib.sh) expanded `"${versions[@]}"` on an empty array. Under macOS bash 3.2 + `set -u`, that's an unbound-variable error that kills the shell before the caller's `|| true` can rescue it — on a host missing one of the auto-wired connectors, `install.sh` aborted mid-render and left the `hook-guardian` / `hook-enumerator` LaunchDaemons never bootstrapped. Guard each call with `${versions[@]+"${versions[@]}"}`, matching the existing guard pattern already used in `parse_connectors`.
- `render_targets_manifest` now skips a target row whose connector isn't installed for the user, instead of emitting an `agent_version: ""` row that the guardian would flail on every tick. Late installs are picked up on the next hook-enumerator re-render.
- Updated the zero-target `die()` message to name the new failure mode ("none of the requested connectors are installed for any eligible user").

## Repro that motivated this
On a real customer box (macOS 26.5.2, `defenseclaw-macos-0.8.4`), the installer log ended at `[install] rendering initial hook-guardian manifest -> …` and never printed the next step. `bash -x` trace pinpointed the crash to `discover_agent_version claudecode` returning empty and triggering the `set -u` abort at the `_pick_highest_supported "${MIN_CLAUDECODE_VERSION}" "${versions[@]}"` call. Cursor inspection wasn't working because `hooks.json` was never wired — the guardian LaunchDaemon that would have wired it never ran.

## Test plan
- [x] `packaging/macos/tests/run_tests.sh` — 154 pass under real bash 3.2.57 on macOS
- [x] New `discover_agent_version safe with no install (bash 3.2 set -eu)` regression test greps for unguarded `_pick_highest_supported ... "${versions[@]}"` and exercises the empty-array subshell under `set -eu`; reverting any one of the three fixed call sites fails the test with the offending line number
- [x] New `absent connectors are skipped (partial-box render)` renders a manifest with only the installed connector's row when the other two are absent
- [x] New `all connectors absent yields zero rows` confirms the manifest stays schema-valid when nothing is installed (installer's `MANIFEST_TARGETS == 0` preflight then die()s with the operator-facing message)
- [x] Prior tests made hermetic against real Codex/Claude/Cursor installs on the dev box via a `_reset_discover_stub` helper