### PR TITLE
fix: detect Cursor and observe new connectors during quickstart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,9 @@ path: _source-install-preflight
 # Run the freshly-installed CLI binary directly so a stale shell PATH
 # doesn't invoke an older `defenseclaw` still sitting earlier in PATH.
 # The CLI handles its own idempotence, so repeated `make all` is safe.
+# When no TTY is available, the follow-up additive setup observes only newly
+# detected hook connectors, preserves existing modes, and restarts the gateway
+# only when it actually adds a connector.
 quickstart: _source-install-preflight
 	@profile="$${PROFILE:-observe}"; \
 	if [ "$${NO_QUICKSTART:-0}" = "1" ]; then \
@@ -241,6 +244,10 @@ quickstart: _source-install-preflight
 				--scanner-mode "$${SCANNER_MODE:-local}" \
 				--no-start-gateway --verify; then \
 				echo "  Quickstart reported errors — run 'defenseclaw doctor' to investigate"; \
+				exit 1; \
+			fi; \
+			if ! "$$dc_bin" setup --add-detected --yes --restart; then \
+				echo "  Could not add newly detected connectors — run 'defenseclaw agent discover --refresh' to investigate"; \
 				exit 1; \
 			fi; \
 		fi; \

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -232,6 +232,15 @@ def _safe_mtime(path: str | None) -> float | None:
     help="(no subcommand) Add every locally-detected hook connector to the batch.",
 )
 @click.option(
+    "--add-detected",
+    "batch_add_detected",
+    is_flag=True,
+    help=(
+        "(no subcommand) Add newly detected hook connectors without removing or "
+        "changing existing connectors. New connectors use --mode."
+    ),
+)
+@click.option(
     "--all",
     "batch_all",
     is_flag=True,
@@ -264,6 +273,7 @@ def setup(
     ctx: click.Context,
     batch_connectors: tuple[str, ...],
     batch_detected: bool,
+    batch_add_detected: bool,
     batch_all: bool,
     batch_mode: str,
     batch_restart: bool,
@@ -288,6 +298,8 @@ def setup(
       batch mode / optional judge connector pickers. For scripting, select
       connectors with repeatable '-c/--connector', '--detected', and/or
       '--all' (e.g. 'defenseclaw setup -c hermes -c codex --mode action').
+      Use '--add-detected --yes' to add newly installed connectors in observe
+      mode without changing the existing active roster or its modes.
     """
     # Snapshot config.yaml's mtime before the subcommand runs. The
     # result callback below (``_auto_restart_sidecar_after_setup``)
@@ -299,9 +311,9 @@ def setup(
     if ctx.invoked_subcommand is not None:
         # A subcommand (setup codex, setup guardrail, …) will run; the
         # group-level batch flags only apply to the bare `setup` form.
-        if batch_connectors or batch_detected or batch_all:
+        if batch_connectors or batch_detected or batch_add_detected or batch_all:
             click.echo(
-                "  ⚠ --connector/--detected/--all are ignored when a setup "
+                "  ⚠ --connector/--detected/--add-detected/--all are ignored when a setup "
                 "subcommand is given; use them with bare `defenseclaw setup`.",
                 err=True,
             )
@@ -314,6 +326,7 @@ def setup(
         ctx.find_object(AppContext),
         connectors=list(batch_connectors),
         detected=batch_detected,
+        add_detected=batch_add_detected,
         all_connectors=batch_all,
         mode=batch_mode,
         restart=batch_restart,
@@ -6431,6 +6444,7 @@ def _dispatch_bare_setup(
     *,
     connectors: list[str],
     detected: bool,
+    add_detected: bool,
     all_connectors: bool,
     mode: str,
     restart: bool,
@@ -6438,15 +6452,19 @@ def _dispatch_bare_setup(
 ) -> None:
     """Resolve and apply the bare-``setup`` target set (SU-11, Hybrid C).
 
-    Scripting flags (``-c/--connector``, ``--detected``, ``--all``) select the
-    batch non-interactively; with no flags and a TTY this launches the
-    interactive picker. With no flags on a non-interactive stream it falls back
-    to printing the group help — preserving the pre-SU-11 bare-``setup``
-    behavior in CI / pipelines so nothing hangs on stdin.
+    Scripting flags (``-c/--connector``, ``--detected``, ``--add-detected``,
+    ``--all``) select the batch non-interactively; with no flags and a TTY this
+    launches the interactive picker. With no flags on a non-interactive stream
+    it falls back to printing the group help — preserving the pre-SU-11
+    bare-``setup`` behavior in CI / pipelines so nothing hangs on stdin.
     """
     if app is None or getattr(app, "cfg", None) is None:
         click.echo(ctx.get_help())
         return
+    if add_detected and (connectors or detected or all_connectors):
+        raise click.UsageError(
+            "--add-detected cannot be combined with --connector, --detected, or --all"
+        )
 
     targets: list[str] = []
 
@@ -6468,6 +6486,29 @@ def _dispatch_bare_setup(
 
     for raw in connectors:
         _add(raw)
+    if add_detected:
+        active = {
+            normalize_connector(str(name))
+            for name in app.cfg.active_connectors()
+            if str(name).strip()
+        }
+        for c in _detect_installed_connectors():
+            if (
+                c not in active
+                and c in _HOOK_ENFORCED_CONNECTORS
+                and platform_support.connector_supported_on_os(c)
+            ):
+                _add(c)
+        if not targets:
+            click.echo("  No newly detected hook connectors to add.")
+            return
+        active_proxies = sorted(name for name in active if platform_support.is_proxy_connector(name))
+        if active_proxies:
+            click.echo(
+                "  Detected hook connectors were not added because the active proxy connector "
+                f"({', '.join(active_proxies)}) cannot share the multi-connector hook path."
+            )
+            return
     if detected:
         for c in _detect_installed_connectors():
             if c in _HOOK_ENFORCED_CONNECTORS and platform_support.connector_supported_on_os(c):
@@ -6509,7 +6550,8 @@ def _dispatch_bare_setup(
             if configure_model:
                 _prompt_judge_model_config(app, gc)
 
-    _reconcile_batch_active_connectors(app.cfg, targets)
+    if not add_detected:
+        _reconcile_batch_active_connectors(app.cfg, targets)
     _apply_setup_batch(
         ctx,
         app,

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -119,6 +119,11 @@ _SETUP_RESTART_HANDLED_KEY = SETUP_RESTART_HANDLED_META_KEY
 # default restart a synchronous readiness gate, without changing restart
 # policy for unrelated setup subcommands that merely share the same config.
 _SETUP_BATCH_READINESS_KEY = "defenseclaw._setup_batch_readiness_connectors"
+# Deferred per-connector audit records for a restarting bare batch. The result
+# callback emits these only after the gateway is healthy, so a fresh quickstart
+# can retain fail-closed canonical admission without trying to audit through a
+# sidecar that ``init --no-start-gateway`` deliberately left stopped.
+_SETUP_BATCH_AUDIT_KEY = "defenseclaw._setup_batch_audits"
 _CONNECTOR_RUNTIME_READY_TIMEOUT_SECONDS = 60.0
 _GATEWAY_API_READY_TIMEOUT_SECONDS = 45.0
 _DEFENSE_GATEWAY_LIFECYCLE_TIMEOUT_SECONDS = 60
@@ -5187,8 +5192,10 @@ def _apply_hook_connector_setup(
     mode: str = "observe",
     restart: bool,
     allow_offline_audit: bool = False,
+    defer_audit: bool = False,
     workspace_dir: str | None = None,
     write_mode: str = "replace",
+    preserve_global_settings: bool = False,
     rule_pack: str | None = None,
     rule_pack_dir: str | None = None,
     block_message: str | None = None,
@@ -5364,7 +5371,8 @@ def _apply_hook_connector_setup(
     # a stale gate on disk that the restarted gateway immediately reloads.
     _prune_judge_gate_to_action_scope(gc, [connector])
 
-    gc.scanner_mode = "local"
+    if not preserve_global_settings:
+        gc.scanner_mode = "local"
     gc.port = gc.port or 4000
     # SU-02/J1/J2: preserve the operator's detection strategy + judge state
     # across re-runs. setup used to unconditionally re-pin detection_strategy =
@@ -5379,12 +5387,13 @@ def _apply_hook_connector_setup(
         gc.detection_strategy = "regex_only"
     if not gc.detection_strategy_completion:
         gc.detection_strategy_completion = "regex_only"
-    cfg.ai_discovery.enabled = True
-    cfg.ai_discovery.mode = cfg.ai_discovery.mode or "enhanced"
-    cfg.ai_discovery.include_shell_history = True
-    cfg.ai_discovery.include_package_manifests = True
-    cfg.ai_discovery.include_env_var_names = True
-    cfg.ai_discovery.include_network_domains = True
+    if not preserve_global_settings:
+        cfg.ai_discovery.enabled = True
+        cfg.ai_discovery.mode = cfg.ai_discovery.mode or "enhanced"
+        cfg.ai_discovery.include_shell_history = True
+        cfg.ai_discovery.include_package_manifests = True
+        cfg.ai_discovery.include_env_var_names = True
+        cfg.ai_discovery.include_network_domains = True
 
     try:
         cfg.save()
@@ -5422,12 +5431,13 @@ def _apply_hook_connector_setup(
         )
         click.echo(f"  ✓ {_CONNECTOR_META[connector]['label']} connector setup complete")
 
-    _log_setup_action(
-        app,
-        ACTION_SETUP_HOOK_CONNECTOR,
-        f"connector={connector} mode={desired_mode} surface=hook",
-        allow_offline=allow_offline_audit,
-    )
+    if not defer_audit:
+        _log_setup_action(
+            app,
+            ACTION_SETUP_HOOK_CONNECTOR,
+            f"connector={connector} mode={desired_mode} surface=hook",
+            allow_offline=allow_offline_audit,
+        )
 
     return True
 
@@ -6363,6 +6373,7 @@ def _apply_setup_batch(
     restart: bool,
     prompt_per_connector: bool,
     connector_modes: dict[str, str] | None = None,
+    preserve_global_settings: bool = False,
     allow_trusted_path_prompt: bool = True,
     trusted_prompt_cache: dict[str, bool] | None = None,
 ) -> None:
@@ -6380,12 +6391,14 @@ def _apply_setup_batch(
     click.echo(f"  Configuring {len(connectors)} connector(s): {', '.join(connectors)}")
 
     applied: list[str] = []
+    deferred_audits: list[tuple[str, str]] = []
     if allow_trusted_path_prompt:
         trusted_prompt_cache = trusted_prompt_cache if trusted_prompt_cache is not None else {}
     else:
         trusted_prompt_cache = None
     for c in connectors:
         connector_mode = (connector_modes or {}).get(c, default_mode)
+        applied_mode = "action" if (connector_mode or "").strip().lower() == "action" else "observe"
         enable_judge: bool | None = None
         if prompt_per_connector:
             connector_mode = _prompt_connector_mode(c, default_mode=connector_mode)
@@ -6397,7 +6410,9 @@ def _apply_setup_batch(
             mode=connector_mode,
             restart=False,
             allow_offline_audit=not restart,
+            defer_audit=restart,
             write_mode="add",
+            preserve_global_settings=preserve_global_settings,
             enable_judge=enable_judge,
             judge_hook_connectors=None,
             allow_trusted_path_prompt=allow_trusted_path_prompt,
@@ -6406,20 +6421,26 @@ def _apply_setup_batch(
         if not ok and (connector_mode or "").strip().lower() == "action":
             label = _CONNECTOR_META.get(c, {}).get("label", c)
             ux.warn(f"{label}: requested action mode was refused; configuring observe mode instead.")
+            applied_mode = "observe"
             ok = _apply_hook_connector_setup(
                 app,
                 connector=c,
                 mode="observe",
                 restart=False,
                 allow_offline_audit=not restart,
+                defer_audit=restart,
                 write_mode="add",
+                preserve_global_settings=preserve_global_settings,
                 enable_judge=enable_judge,
                 judge_hook_connectors=None,
                 allow_trusted_path_prompt=allow_trusted_path_prompt,
                 trusted_prompt_cache=trusted_prompt_cache,
             )
         if ok:
-            applied.append(c)
+            normalized = normalize_connector(c)
+            applied.append(normalized)
+            if restart:
+                deferred_audits.append((normalized, applied_mode))
 
     if not applied:
         raise click.ClickException("no connectors were configured — see errors above")
@@ -6432,7 +6453,8 @@ def _apply_setup_batch(
     # selected target, even when the gateway was stopped or the config bytes
     # were already current. Unrelated setup subcommands never set this marker.
     if restart:
-        ctx.meta[_SETUP_BATCH_READINESS_KEY] = tuple(sorted({normalize_connector(name) for name in connectors if name}))
+        ctx.meta[_SETUP_BATCH_READINESS_KEY] = tuple(sorted(set(applied)))
+        ctx.meta[_SETUP_BATCH_AUDIT_KEY] = tuple(sorted(deferred_audits))
     else:
         ctx.meta[_SETUP_RESTART_HANDLED_KEY] = True
         click.echo("  --no-restart: config updated; restart defenseclaw-gateway to wire the connector hooks.")
@@ -6458,13 +6480,13 @@ def _dispatch_bare_setup(
     it falls back to printing the group help — preserving the pre-SU-11
     bare-``setup`` behavior in CI / pipelines so nothing hangs on stdin.
     """
-    if app is None or getattr(app, "cfg", None) is None:
-        click.echo(ctx.get_help())
-        return
     if add_detected and (connectors or detected or all_connectors):
         raise click.UsageError(
             "--add-detected cannot be combined with --connector, --detected, or --all"
         )
+    if app is None or getattr(app, "cfg", None) is None:
+        click.echo(ctx.get_help())
+        return
 
     targets: list[str] = []
 
@@ -6560,6 +6582,7 @@ def _dispatch_bare_setup(
         restart=restart,
         prompt_per_connector=False,
         connector_modes=connector_modes,
+        preserve_global_settings=add_detected,
         allow_trusted_path_prompt=prompt_batch,
         trusted_prompt_cache=trusted_prompt_cache,
     )
@@ -9448,6 +9471,17 @@ def _auto_restart_sidecar_after_setup(ctx: click.Context, *_args, **_kwargs) -> 
         if isinstance(batch_targets_raw, (list, tuple))
         else []
     )
+    batch_audits_raw = ctx.meta.get(_SETUP_BATCH_AUDIT_KEY)
+    batch_audits = (
+        [
+            (normalize_connector(connector), mode)
+            for connector, mode in batch_audits_raw
+            if isinstance(connector, str) and connector and mode in ("observe", "action")
+        ]
+        if isinstance(batch_audits_raw, (list, tuple))
+        and all(isinstance(item, (list, tuple)) and len(item) == 2 for item in batch_audits_raw)
+        else []
+    )
     if not batch_targets and (cfg_path is None or after is None or before == after):
         return
 
@@ -9469,6 +9503,13 @@ def _auto_restart_sidecar_after_setup(ctx: click.Context, *_args, **_kwargs) -> 
             wait_for_connector_ready=True,
             start_if_stopped=True,
         )
+        for connector, audit_mode in batch_audits:
+            _log_setup_action(
+                app,
+                ACTION_SETUP_HOOK_CONNECTOR,
+                f"connector={connector} mode={audit_mode} surface=hook",
+                allow_offline=False,
+            )
         return
 
     pid_file = os.path.join(data_dir, "gateway.pid")

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -5042,7 +5042,13 @@ def _prompt_add_replace_cancel(connector: str, others: list[str]) -> str | None:
     return {"a": "add", "r": "replace", "c": None}[choice]
 
 
-def _write_connector_identity(cfg, connector: str, write_mode: str) -> None:
+def _write_connector_identity(
+    cfg,
+    connector: str,
+    write_mode: str,
+    *,
+    preserve_primary: bool = False,
+) -> None:
     """Persist the active-connector identity honoring the WU7 write mode.
 
     ``replace`` (default, legacy behavior): this connector becomes the sole
@@ -5051,12 +5057,15 @@ def _write_connector_identity(cfg, connector: str, write_mode: str) -> None:
 
     ``add`` (WU7 D2=A): merge this connector into ``guardrail.connectors``
     alongside the existing one(s). On the first add the existing singular
-    connector is seeded into the map so BOTH are represented. The singular
-    ``guardrail.connector`` and ``claw.mode`` fields are kept pointing at the
-    primary (sorted-first) connector so backward-compat readers — older Go
-    binaries and the Python single-connector paths — keep working.
+    connector is seeded into the map so BOTH are represented. By default the
+    singular ``guardrail.connector`` and ``claw.mode`` fields point at the
+    sorted-first connector for backward compatibility. ``preserve_primary``
+    retains an already active primary for non-destructive additive discovery.
     """
     gc = cfg.guardrail
+    existing_primary = normalize_connector(
+        (getattr(gc, "connector", "") or getattr(cfg.claw, "mode", "") or "").strip()
+    )
     if write_mode == "add":
         if not getattr(gc, "connectors", None):
             gc.connectors = {}
@@ -5075,7 +5084,11 @@ def _write_connector_identity(cfg, connector: str, write_mode: str) -> None:
             )
         if connector not in gc.connectors:
             gc.connectors[connector] = PerConnectorGuardrailConfig()
-        primary = sorted(gc.connectors)[0]
+        primary = (
+            existing_primary
+            if preserve_primary and existing_primary in gc.connectors
+            else sorted(gc.connectors)[0]
+        )
         gc.connector = primary
         cfg.claw.mode = primary
     else:  # replace
@@ -5280,7 +5293,12 @@ def _apply_hook_connector_setup(
     # connector (legacy behavior); "add" merges it into guardrail.connectors
     # alongside the existing one(s) while keeping the singular field as a
     # backward-compatible primary mirror.
-    _write_connector_identity(cfg, connector, write_mode)
+    _write_connector_identity(
+        cfg,
+        connector,
+        write_mode,
+        preserve_primary=preserve_global_settings,
+    )
     # Per-connector rule pack (parity with single-connector --rule-pack).
     # Each connector scans against its own EffectiveRulePackDir at boot, so
     # this lets one connector run strict while a peer runs permissive.

--- a/cli/defenseclaw/inventory/agent_discovery.py
+++ b/cli/defenseclaw/inventory/agent_discovery.py
@@ -22,9 +22,11 @@ import json
 import locale
 import ntpath
 import os
+import plistlib
 import shutil
 import stat
 import subprocess
+import sys
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass
@@ -63,10 +65,11 @@ from defenseclaw.file_permissions import atomic_write_private_bytes
 # sides — if the wording ever changes, the consumer can't silently drift.
 UNTRUSTED_PREFIX_ERROR = "binary path is not in a trusted install prefix"
 
-# Version 3 separates a connector's on-disk configuration from a verified
-# application installation.  Version 2 caches treated either signal as
-# ``installed``, which produced false positives for observe-only connectors.
-CACHE_SCHEMA_VERSION = 3
+# Version 4 adds passive macOS application-bundle discovery. Version 3
+# separates a connector's on-disk configuration from a verified application
+# installation; older caches therefore cannot represent every current install
+# signal faithfully.
+CACHE_SCHEMA_VERSION = 4
 CACHE_TTL_SECONDS = 86_400
 CACHE_FILENAME = "agent_discovery.json"
 VERSION_TIMEOUT_SECONDS = 2.0
@@ -1680,6 +1683,8 @@ def _version_for_agent_binary(
 ) -> tuple[str, str]:
     """Probe a CLI, or read metadata for a GUI that must not be launched."""
 
+    if name == "cursor" and _macos_app_bundle_for_binary(binary_path) is not None:
+        return _macos_app_version_for_binary(binary_path)
     if name == "antigravity" and _binary_command_name(binary_path) == "antigravity":
         return _windows_file_version_for_binary(
             binary_path,
@@ -1692,6 +1697,26 @@ def _version_for_agent_binary(
         require_trusted_binary_paths=require_trusted_binary_paths,
         data_dir=data_dir,
     )
+
+
+def _macos_app_version_for_binary(binary_path: str) -> tuple[str, str]:
+    """Read a Cursor app bundle's version without launching its executable."""
+
+    bundle = _macos_app_bundle_for_binary(binary_path)
+    if bundle is None:
+        return "", "macOS application bundle is unavailable"
+    info_path = bundle / "Contents" / "Info.plist"
+    try:
+        with info_path.open("rb") as stream:
+            info = plistlib.load(stream)
+    except (OSError, plistlib.InvalidFileException, ValueError) as exc:
+        return "", f"application metadata probe failed: {exc}"
+    if not isinstance(info, dict):
+        return "", "application metadata is invalid"
+    version = str(info.get("CFBundleShortVersionString") or info.get("CFBundleVersion") or "").strip()
+    if not version:
+        return "", "application metadata has no version"
+    return version, ""
 
 
 def _windows_file_version_for_binary(
@@ -1824,15 +1849,26 @@ def _binary_candidates_for_agent(name: str, spec: _AgentSpec) -> tuple[str, ...]
     if not spec.binary_name:
         return ()
     candidates: list[str] = []
-    path = _which(spec.binary_name)
-    if path:
-        candidates.append(path)
+    binary_names = (spec.binary_name,)
+    if name == "cursor":
+        # Cursor's standalone/headless installer exposes ``cursor-agent``;
+        # the desktop application's optional shell command remains ``cursor``.
+        binary_names = ("cursor-agent", spec.binary_name)
+    for binary_name in dict.fromkeys(binary_names):
+        path = _which(binary_name)
+        if path:
+            candidates.append(path)
+    if not _is_windows_host() and _is_macos_host():
+        for candidate in _macos_binary_candidates(name):
+            if os.path.isfile(candidate):
+                candidates.append(os.path.abspath(candidate))
     if not _is_windows_host():
-        return tuple(candidates)
+        return _deduplicate_paths(candidates)
 
-    for candidate in _windows_binary_candidates(name, spec.binary_name):
-        if os.path.isfile(candidate):
-            candidates.append(os.path.abspath(candidate))
+    for binary_name in dict.fromkeys(binary_names):
+        for candidate in _windows_binary_candidates(name, binary_name):
+            if os.path.isfile(candidate):
+                candidates.append(os.path.abspath(candidate))
 
     if name == "codex":
         for local_app_data in _windows_current_user_local_app_data_roots():
@@ -1854,6 +1890,12 @@ def _binary_candidates_for_agent(name: str, spec: _AgentSpec) -> tuple[str, ...]
                 if os.path.isfile(candidate):
                     candidates.append(os.path.abspath(candidate))
 
+    return _deduplicate_paths(candidates)
+
+
+def _deduplicate_paths(candidates: list[str]) -> tuple[str, ...]:
+    """Return path candidates once, using host-appropriate comparisons."""
+
     deduplicated: list[str] = []
     seen: set[str] = set()
     for candidate in candidates:
@@ -1863,6 +1905,44 @@ def _binary_candidates_for_agent(name: str, spec: _AgentSpec) -> tuple[str, ...]
         seen.add(key)
         deduplicated.append(candidate)
     return tuple(deduplicated)
+
+
+def _is_macos_host() -> bool:
+    """Return whether documented macOS application locations apply."""
+
+    return sys.platform == "darwin"
+
+
+def _macos_application_roots() -> tuple[Path, ...]:
+    """Return the standard system and per-user macOS application roots."""
+
+    return (Path("/Applications"), Path(os.path.expanduser("~/Applications")))
+
+
+def _macos_binary_candidates(connector: str) -> tuple[str, ...]:
+    """Return embedded CLIs from documented macOS application bundles."""
+
+    if connector != "cursor":
+        return ()
+    relative = Path("Cursor.app") / "Contents" / "Resources" / "app" / "bin" / "cursor"
+    return tuple(os.fspath(root / relative) for root in _macos_application_roots())
+
+
+def _macos_app_bundle_for_binary(binary_path: str) -> Path | None:
+    """Resolve a known embedded Cursor CLI back to its application bundle."""
+
+    if not _is_macos_host() or not binary_path:
+        return None
+    try:
+        candidate = Path(binary_path).absolute()
+    except (OSError, ValueError):
+        return None
+    for root in _macos_application_roots():
+        bundle = (root / "Cursor.app").absolute()
+        expected = bundle / "Contents" / "Resources" / "app" / "bin" / "cursor"
+        if _path_key(os.fspath(candidate)) == _path_key(os.fspath(expected)):
+            return bundle
+    return None
 
 
 def _is_windows_host() -> bool:

--- a/cli/defenseclaw/inventory/agent_discovery.py
+++ b/cli/defenseclaw/inventory/agent_discovery.py
@@ -35,6 +35,7 @@ from functools import lru_cache
 from io import StringIO
 from pathlib import Path
 from typing import Any, NamedTuple
+from xml.parsers.expat import ExpatError
 
 import yaml
 
@@ -1709,7 +1710,7 @@ def _macos_app_version_for_binary(binary_path: str) -> tuple[str, str]:
     try:
         with info_path.open("rb") as stream:
             info = plistlib.load(stream)
-    except (OSError, plistlib.InvalidFileException, ValueError) as exc:
+    except (OSError, plistlib.InvalidFileException, ExpatError, ValueError) as exc:
         return "", f"application metadata probe failed: {exc}"
     if not isinstance(info, dict):
         return "", "application metadata is invalid"
@@ -1860,7 +1861,7 @@ def _binary_candidates_for_agent(name: str, spec: _AgentSpec) -> tuple[str, ...]
             candidates.append(path)
     if not _is_windows_host() and _is_macos_host():
         for candidate in _macos_binary_candidates(name):
-            if os.path.isfile(candidate):
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
                 candidates.append(os.path.abspath(candidate))
     if not _is_windows_host():
         return _deduplicate_paths(candidates)
@@ -1934,14 +1935,26 @@ def _macos_app_bundle_for_binary(binary_path: str) -> Path | None:
     if not _is_macos_host() or not binary_path:
         return None
     try:
-        candidate = Path(binary_path).absolute()
+        candidate = os.path.realpath(os.path.abspath(binary_path))
     except (OSError, ValueError):
         return None
-    for root in _macos_application_roots():
-        bundle = (root / "Cursor.app").absolute()
-        expected = bundle / "Contents" / "Resources" / "app" / "bin" / "cursor"
-        if _path_key(os.fspath(candidate)) == _path_key(os.fspath(expected)):
-            return bundle
+    for application_root in _macos_application_roots():
+        try:
+            root = os.path.realpath(os.path.abspath(os.fspath(application_root)))
+            bundle = os.path.realpath(os.path.join(root, "Cursor.app"))
+            expected = os.path.realpath(
+                os.path.join(bundle, "Contents", "Resources", "app", "bin", "cursor")
+            )
+        except (OSError, ValueError):
+            continue
+        # A symlinked bundle or embedded CLI must remain inside the resolved
+        # application root. This is the bundle equivalent of trusted-prefix
+        # validation and prevents passive metadata from blessing an app that
+        # escapes to an attacker-controlled location.
+        if not _path_is_within(bundle, root) or not _path_is_within(expected, bundle):
+            continue
+        if _path_key(candidate) == _path_key(expected):
+            return Path(bundle)
     return None
 
 

--- a/cli/tests/test_agent_discovery.py
+++ b/cli/tests/test_agent_discovery.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import os
+import plistlib
 import stat
 import subprocess
 import sys
@@ -63,6 +64,20 @@ def _pin_home(monkeypatch, tmp_path: Path) -> None:
 def windows_host_no_path(monkeypatch) -> None:
     monkeypatch.setattr(ad.shutil, "which", lambda _name: None)
     monkeypatch.setattr(ad, "_is_windows_host", lambda: True)
+
+
+@pytest.fixture
+def macos_host_no_path(monkeypatch, isolate_macos_application_discovery) -> None:
+    monkeypatch.setattr(ad.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(ad, "_is_macos_host", lambda: True)
+    monkeypatch.setattr(ad, "_is_windows_host", lambda: False)
+
+
+@pytest.fixture(autouse=True)
+def isolate_macos_application_discovery(monkeypatch) -> None:
+    """Keep unit scans independent of applications installed on the test Mac."""
+
+    monkeypatch.setattr(ad, "_is_macos_host", lambda: False)
 
 
 @pytest.fixture(autouse=True)
@@ -480,6 +495,66 @@ def test_antigravity_gui_fallback_reads_metadata_without_launch(
     assert signal.binary_path == str(gui)
     assert signal.config_path == ""
     assert signal.version == "2.2.1"
+
+
+def test_cursor_macos_app_fallback_reads_metadata_without_launch(
+    monkeypatch,
+    tmp_path,
+    macos_host_no_path,
+):
+    _pin_home(monkeypatch, tmp_path)
+    applications = tmp_path / "Applications"
+    bundle = applications / "Cursor.app"
+    binary = bundle / "Contents" / "Resources" / "app" / "bin" / "cursor"
+    binary.parent.mkdir(parents=True)
+    binary.write_bytes(b"test executable")
+    info_path = bundle / "Contents" / "Info.plist"
+    with info_path.open("wb") as stream:
+        plistlib.dump(
+            {
+                "CFBundleName": "Cursor",
+                "CFBundleShortVersionString": "3.13.25",
+            },
+            stream,
+        )
+    monkeypatch.setattr(ad, "_macos_application_roots", lambda: (applications,))
+    monkeypatch.setattr(
+        ad.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("Cursor was launched")),
+    )
+
+    signal = ad._scan_agent("cursor", require_trusted_binary_paths=True)
+
+    assert signal.installed is True
+    assert signal.binary_path == str(binary)
+    assert signal.version == "3.13.25"
+    assert signal.error == ""
+
+
+def test_cursor_standalone_agent_alias_is_detected(monkeypatch, tmp_path):
+    _pin_home(monkeypatch, tmp_path)
+    binary = tmp_path / "bin" / "cursor-agent"
+    binary.parent.mkdir()
+    binary.write_bytes(b"test executable")
+    monkeypatch.setattr(
+        ad.shutil,
+        "which",
+        lambda name: str(binary) if name == "cursor-agent" else None,
+    )
+    monkeypatch.setattr(
+        ad,
+        "_version_for_agent_binary",
+        lambda name, path, _args, **_kwargs: (
+            ("3.13.25", "") if name == "cursor" and path == str(binary) else ("", "bad")
+        ),
+    )
+
+    signal = ad._scan_agent("cursor")
+
+    assert signal.installed is True
+    assert signal.binary_path == str(binary)
+    assert signal.version == "3.13.25"
 
 
 def test_antigravity_windows_roots_are_narrow_trusted_prefixes(monkeypatch, tmp_path):

--- a/cli/tests/test_agent_discovery.py
+++ b/cli/tests/test_agent_discovery.py
@@ -71,6 +71,7 @@ def macos_host_no_path(monkeypatch, isolate_macos_application_discovery) -> None
     monkeypatch.setattr(ad.shutil, "which", lambda _name: None)
     monkeypatch.setattr(ad, "_is_macos_host", lambda: True)
     monkeypatch.setattr(ad, "_is_windows_host", lambda: False)
+    monkeypatch.setattr(ad, "_macos_application_roots", lambda: ())
 
 
 @pytest.fixture(autouse=True)
@@ -508,6 +509,7 @@ def test_cursor_macos_app_fallback_reads_metadata_without_launch(
     binary = bundle / "Contents" / "Resources" / "app" / "bin" / "cursor"
     binary.parent.mkdir(parents=True)
     binary.write_bytes(b"test executable")
+    binary.chmod(0o755)
     info_path = bundle / "Contents" / "Info.plist"
     with info_path.open("wb") as stream:
         plistlib.dump(
@@ -530,6 +532,114 @@ def test_cursor_macos_app_fallback_reads_metadata_without_launch(
     assert signal.binary_path == str(binary)
     assert signal.version == "3.13.25"
     assert signal.error == ""
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX execute bits are not meaningful on Windows")
+def test_cursor_macos_app_non_executable_cli_is_ignored(
+    monkeypatch,
+    tmp_path,
+    macos_host_no_path,
+):
+    applications = tmp_path / "Applications"
+    bundle = applications / "Cursor.app"
+    binary = bundle / "Contents" / "Resources" / "app" / "bin" / "cursor"
+    binary.parent.mkdir(parents=True)
+    binary.write_bytes(b"not executable")
+    binary.chmod(0o644)
+    info_path = bundle / "Contents" / "Info.plist"
+    with info_path.open("wb") as stream:
+        plistlib.dump({"CFBundleShortVersionString": "3.13.25"}, stream)
+    monkeypatch.setattr(ad, "_macos_application_roots", lambda: (applications,))
+
+    signal = ad._scan_agent("cursor", require_trusted_binary_paths=True)
+
+    assert signal.installed is False
+    assert signal.binary_path == ""
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation is not generally available on Windows CI")
+def test_cursor_macos_app_symlink_escape_remains_untrusted(
+    monkeypatch,
+    tmp_path,
+    macos_host_no_path,
+):
+    applications = tmp_path / "Applications"
+    applications.mkdir()
+    outside_bundle = tmp_path / "Downloads" / "Cursor.app"
+    binary = outside_bundle / "Contents" / "Resources" / "app" / "bin" / "cursor"
+    binary.parent.mkdir(parents=True)
+    binary.write_bytes(b"test executable")
+    binary.chmod(0o755)
+    info_path = outside_bundle / "Contents" / "Info.plist"
+    with info_path.open("wb") as stream:
+        plistlib.dump({"CFBundleShortVersionString": "3.13.25"}, stream)
+    (applications / "Cursor.app").symlink_to(outside_bundle, target_is_directory=True)
+    monkeypatch.setattr(ad, "_macos_application_roots", lambda: (applications,))
+
+    signal = ad._scan_agent("cursor", require_trusted_binary_paths=True)
+
+    assert signal.installed is False
+    assert ad.UNTRUSTED_PREFIX_ERROR in signal.error
+
+
+def test_cursor_macos_app_outside_configured_roots_remains_untrusted(
+    monkeypatch,
+    tmp_path,
+    macos_host_no_path,
+):
+    _pin_home(monkeypatch, tmp_path)
+    applications = tmp_path / "Applications"
+    bundle = tmp_path / "Downloads" / "Cursor.app"
+    binary = bundle / "Contents" / "Resources" / "app" / "bin" / "cursor"
+    binary.parent.mkdir(parents=True)
+    binary.write_bytes(b"test executable")
+    binary.chmod(0o755)
+    info_path = bundle / "Contents" / "Info.plist"
+    with info_path.open("wb") as stream:
+        plistlib.dump(
+            {
+                "CFBundleName": "Cursor",
+                "CFBundleShortVersionString": "3.13.25",
+            },
+            stream,
+        )
+    monkeypatch.setattr(ad, "_macos_application_roots", lambda: (applications,))
+    monkeypatch.setattr(
+        ad.shutil,
+        "which",
+        lambda name: str(binary) if name == "cursor" else None,
+    )
+
+    signal = ad._scan_agent("cursor", require_trusted_binary_paths=True)
+
+    assert signal.installed is False
+    assert signal.binary_path == str(binary)
+    assert ad.UNTRUSTED_PREFIX_ERROR in signal.error
+
+
+def test_cursor_macos_app_metadata_parser_errors_are_reported(
+    monkeypatch,
+    tmp_path,
+    macos_host_no_path,
+):
+    applications = tmp_path / "Applications"
+    bundle = applications / "Cursor.app"
+    binary = bundle / "Contents" / "Resources" / "app" / "bin" / "cursor"
+    binary.parent.mkdir(parents=True)
+    binary.write_bytes(b"test executable")
+    info_path = bundle / "Contents" / "Info.plist"
+    info_path.write_bytes(b"not a plist")
+    monkeypatch.setattr(ad, "_macos_application_roots", lambda: (applications,))
+    monkeypatch.setattr(
+        ad.plistlib,
+        "load",
+        lambda _stream: (_ for _ in ()).throw(ad.ExpatError("malformed metadata")),
+    )
+
+    version, error = ad._macos_app_version_for_binary(str(binary))
+
+    assert version == ""
+    assert error == "application metadata probe failed: malformed metadata"
 
 
 def test_cursor_standalone_agent_alias_is_detected(monkeypatch, tmp_path):

--- a/cli/tests/test_cmd_setup_fu_phase2.py
+++ b/cli/tests/test_cmd_setup_fu_phase2.py
@@ -741,6 +741,64 @@ class TestBareSetupBatch(_BaseSetup):
         self.assertEqual(res.exit_code, 0, msg=res.output)
         self.assertEqual(set(self.app.cfg.guardrail.connectors), {"hermes"})
 
+    def test_add_detected_preserves_existing_roster_and_modes(self):
+        self._seed_map("codex", "hermes")
+        gc = self.app.cfg.guardrail
+        gc.connectors["codex"].mode = "action"
+        gc.connectors["hermes"].mode = "observe"
+
+        with _stub_side_effects(), patch(
+            "defenseclaw.commands.cmd_setup._detect_installed_connectors",
+            return_value=["codex", "cursor"],
+        ):
+            res = _invoke(["--add-detected", "--yes", "--no-restart"], self.app)
+
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        self.assertEqual(set(gc.connectors), {"codex", "cursor", "hermes"})
+        self.assertEqual(gc.connectors["codex"].mode, "action")
+        self.assertEqual(gc.connectors["hermes"].mode, "observe")
+        self.assertEqual(gc.connectors["cursor"].mode, "observe")
+
+    def test_add_detected_is_a_noop_when_every_detected_connector_is_active(self):
+        self._seed_map("codex")
+
+        with patch(
+            "defenseclaw.commands.cmd_setup._detect_installed_connectors",
+            return_value=["codex"],
+        ), patch("defenseclaw.commands.cmd_setup._apply_setup_batch") as apply_batch:
+            res = _invoke(["--add-detected", "--yes", "--no-restart"], self.app)
+
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        self.assertIn("No newly detected hook connectors", res.output)
+        apply_batch.assert_not_called()
+
+    def test_add_detected_rejects_exact_batch_flags(self):
+        res = _invoke(
+            ["--add-detected", "--detected", "--yes", "--no-restart"],
+            self.app,
+            catch=True,
+        )
+
+        self.assertNotEqual(res.exit_code, 0)
+        self.assertIn("cannot be combined", res.output)
+
+    def test_add_detected_preserves_an_active_proxy_connector(self):
+        gc = self.app.cfg.guardrail
+        gc.connectors = {}
+        gc.connector = "openclaw"
+        self.app.cfg.claw.mode = "openclaw"
+
+        with patch(
+            "defenseclaw.commands.cmd_setup._detect_installed_connectors",
+            return_value=["cursor"],
+        ), patch("defenseclaw.commands.cmd_setup._apply_setup_batch") as apply_batch:
+            res = _invoke(["--add-detected", "--yes", "--no-restart"], self.app)
+
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        self.assertIn("active proxy connector", res.output)
+        self.assertEqual(self.app.cfg.active_connectors(), ["openclaw"])
+        apply_batch.assert_not_called()
+
     def test_all_selects_every_hook_connector(self):
         with _stub_side_effects():
             res = _invoke(["--all", "--no-restart"], self.app)

--- a/cli/tests/test_cmd_setup_fu_phase2.py
+++ b/cli/tests/test_cmd_setup_fu_phase2.py
@@ -772,6 +772,21 @@ class TestBareSetupBatch(_BaseSetup):
         self.assertEqual(gc.scanner_mode, "both")
         self.assertEqual(ai_discovery, ai_discovery_before)
 
+    def test_add_detected_preserves_primary_when_new_connector_sorts_first(self):
+        self._seed_map("hermes")
+        gc = self.app.cfg.guardrail
+
+        with _stub_side_effects(), patch(
+            "defenseclaw.commands.cmd_setup._detect_installed_connectors",
+            return_value=["codex"],
+        ):
+            res = _invoke(["--add-detected", "--yes", "--no-restart"], self.app)
+
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        self.assertEqual(set(gc.connectors), {"codex", "hermes"})
+        self.assertEqual(gc.connector, "hermes")
+        self.assertEqual(self.app.cfg.claw.mode, "hermes")
+
     def test_add_detected_restarting_batch_audits_after_gateway_is_ready(self):
         self._seed_map("codex")
         gateway_ready = False

--- a/cli/tests/test_cmd_setup_fu_phase2.py
+++ b/cli/tests/test_cmd_setup_fu_phase2.py
@@ -34,12 +34,14 @@ Covers:
 from __future__ import annotations
 
 import contextlib
+import copy
 import os
 import sys
 import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import click
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -746,6 +748,15 @@ class TestBareSetupBatch(_BaseSetup):
         gc = self.app.cfg.guardrail
         gc.connectors["codex"].mode = "action"
         gc.connectors["hermes"].mode = "observe"
+        gc.scanner_mode = "both"
+        ai_discovery = self.app.cfg.ai_discovery
+        ai_discovery.enabled = False
+        ai_discovery.mode = "operator-managed"
+        ai_discovery.include_shell_history = False
+        ai_discovery.include_package_manifests = False
+        ai_discovery.include_env_var_names = False
+        ai_discovery.include_network_domains = False
+        ai_discovery_before = copy.deepcopy(ai_discovery)
 
         with _stub_side_effects(), patch(
             "defenseclaw.commands.cmd_setup._detect_installed_connectors",
@@ -758,9 +769,40 @@ class TestBareSetupBatch(_BaseSetup):
         self.assertEqual(gc.connectors["codex"].mode, "action")
         self.assertEqual(gc.connectors["hermes"].mode, "observe")
         self.assertEqual(gc.connectors["cursor"].mode, "observe")
+        self.assertEqual(gc.scanner_mode, "both")
+        self.assertEqual(ai_discovery, ai_discovery_before)
+
+    def test_add_detected_restarting_batch_audits_after_gateway_is_ready(self):
+        self._seed_map("codex")
+        gateway_ready = False
+
+        def restart_gateway(*_args, **_kwargs):
+            nonlocal gateway_ready
+            gateway_ready = True
+
+        def require_running_gateway(*_args, **_kwargs):
+            if not gateway_ready:
+                raise CanonicalObservabilityUnavailableError("offline")
+
+        self.app.logger = MagicMock()
+        self.app.logger.log_action.side_effect = require_running_gateway
+        with _stub_side_effects(), patch(
+            "defenseclaw.commands.cmd_setup._restart_services",
+            side_effect=restart_gateway,
+        ), patch(
+            "defenseclaw.commands.cmd_setup._detect_installed_connectors",
+            return_value=["codex", "cursor"],
+        ):
+            res = _invoke(["--add-detected", "--yes", "--restart"], self.app)
+
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        self.assertTrue(gateway_ready)
+        self.app.logger.log_action.assert_called_once()
 
     def test_add_detected_is_a_noop_when_every_detected_connector_is_active(self):
         self._seed_map("codex")
+        gc = self.app.cfg.guardrail
+        before = (copy.deepcopy(gc.connectors), gc.connector, self.app.cfg.claw.mode)
 
         with patch(
             "defenseclaw.commands.cmd_setup._detect_installed_connectors",
@@ -770,6 +812,10 @@ class TestBareSetupBatch(_BaseSetup):
 
         self.assertEqual(res.exit_code, 0, msg=res.output)
         self.assertIn("No newly detected hook connectors", res.output)
+        self.assertEqual(
+            (gc.connectors, gc.connector, self.app.cfg.claw.mode),
+            before,
+        )
         apply_batch.assert_not_called()
 
     def test_add_detected_rejects_exact_batch_flags(self):
@@ -782,11 +828,28 @@ class TestBareSetupBatch(_BaseSetup):
         self.assertNotEqual(res.exit_code, 0)
         self.assertIn("cannot be combined", res.output)
 
+    def test_add_detected_rejects_conflicts_without_loaded_config(self):
+        ctx = click.Context(setup_group)
+
+        with ctx, self.assertRaises(click.UsageError):
+            cmd_setup._dispatch_bare_setup(
+                ctx,
+                None,
+                connectors=["codex"],
+                detected=False,
+                add_detected=True,
+                all_connectors=False,
+                mode="observe",
+                restart=False,
+                yes=True,
+            )
+
     def test_add_detected_preserves_an_active_proxy_connector(self):
         gc = self.app.cfg.guardrail
         gc.connectors = {}
         gc.connector = "openclaw"
         self.app.cfg.claw.mode = "openclaw"
+        before = (copy.deepcopy(gc.connectors), gc.connector, self.app.cfg.claw.mode)
 
         with patch(
             "defenseclaw.commands.cmd_setup._detect_installed_connectors",
@@ -796,6 +859,10 @@ class TestBareSetupBatch(_BaseSetup):
 
         self.assertEqual(res.exit_code, 0, msg=res.output)
         self.assertIn("active proxy connector", res.output)
+        self.assertEqual(
+            (gc.connectors, gc.connector, self.app.cfg.claw.mode),
+            before,
+        )
         self.assertEqual(self.app.cfg.active_connectors(), ["openclaw"])
         apply_batch.assert_not_called()
 

--- a/cli/tests/test_install_dev_static.py
+++ b/cli/tests/test_install_dev_static.py
@@ -92,8 +92,17 @@ def test_make_python_recipes_use_cross_platform_venv_path() -> None:
 def test_noninteractive_quickstart_adds_newly_detected_connectors_safely() -> None:
     text = MAKEFILE.read_text(encoding="utf-8")
     quickstart = text[text.index("\nquickstart:") : text.index("\n# Post-install interactive prompt")]
+    init_command = '"$$dc_bin" init --non-interactive --yes'
+    setup_guard = 'if ! "$$dc_bin" setup --add-detected --yes --restart; then'
 
-    assert '"$$dc_bin" setup --add-detected --yes --restart' in quickstart
+    first_init = quickstart.index(init_command)
+    no_tty_init = quickstart.index(init_command, first_init + len(init_command))
+    assert no_tty_init < quickstart.index(setup_guard)
+    setup_failure = quickstart[
+        quickstart.index(setup_guard) : quickstart.index("\n\t\t\tfi; \\", quickstart.index(setup_guard))
+    ]
+    assert "Could not add newly detected connectors" in setup_failure
+    assert "exit 1;" in setup_failure
 
 
 def test_local_make_workflow_uses_one_test_ready_python_environment() -> None:

--- a/cli/tests/test_install_dev_static.py
+++ b/cli/tests/test_install_dev_static.py
@@ -89,6 +89,13 @@ def test_make_python_recipes_use_cross_platform_venv_path() -> None:
     assert "$(VENV_BIN)/python$(EXE) -m pytest cli/tests -q" in text
 
 
+def test_noninteractive_quickstart_adds_newly_detected_connectors_safely() -> None:
+    text = MAKEFILE.read_text(encoding="utf-8")
+    quickstart = text[text.index("\nquickstart:") : text.index("\n# Post-install interactive prompt")]
+
+    assert '"$$dc_bin" setup --add-detected --yes --restart' in quickstart
+
+
 def test_local_make_workflow_uses_one_test_ready_python_environment() -> None:
     text = MAKEFILE.read_text(encoding="utf-8")
     pycli = text[text.index("\npycli:") : text.index("\ndev-pycli:")]


### PR DESCRIPTION
Base: `main` (standalone; no stacked dependency).

## Problem

DefenseClaw can miss Cursor on macOS when the desktop application is installed but the optional `cursor` shell command is not on `PATH`. As a result, `make all` does not include Cursor in first-run connector setup, so Cursor is neither shown as installed nor automatically brought up in observe mode.

## Current Situation

- Agent discovery only treats a successfully version-probed CLI as installation evidence.
- Cursor's macOS desktop bundle contains an embedded CLI and trustworthy read-only version metadata, but discovery does not inspect either.
- Cursor's standalone installer exposes `cursor-agent`, while the discovery spec only probes `cursor`.
- Non-interactive `make all` initializes one connector. Existing `--observe-all` behavior is unsuitable for reruns because it rebuilds the selected connector map and can change existing modes.

## Solution

### Passive Cursor discovery

- Discover both `cursor-agent` and `cursor` command aliases.
- On macOS, inspect standard system and per-user `Cursor.app` locations.
- Read `CFBundleShortVersionString` (falling back to `CFBundleVersion`) from `Info.plist` without launching the application or its embedded CLI.
- Require the embedded CLI to be a regular executable and resolve bundle/root paths before admission so symlink escapes are rejected.
- Bump the discovery cache schema so cached Cursor false negatives are invalidated.

### Additive quickstart activation

- Add `defenseclaw setup --add-detected`, which selects only detected hook connectors that are not already active.
- Preserve the complete existing connector roster, legacy primary connector, per-connector modes, shared scanner mode, and operator-configured AI discovery inputs.
- Default newly added connectors to observe mode.
- Leave active proxy connectors unchanged because proxy and multi-hook paths cannot be combined.
- Have the non-interactive `make all` path run additive setup and restart the gateway only when a connector is actually added, ensuring hooks are wired immediately.

### Fail-closed restart and audit ordering

- Persist the additive connector change first.
- Start or restart the gateway and verify every added connector's runtime readiness.
- Admit canonical setup audit events only after the gateway is healthy, avoiding a fresh quickstart failure caused by `init --no-start-gateway` while retaining fail-closed audit behavior.

## Architecture Diagram

```mermaid
flowchart LR
    A["make all (no TTY)"] --> B["init --non-interactive --no-start-gateway"]
    C["PATH: cursor-agent / cursor"] --> D["Shared agent discovery"]
    E["Resolved Cursor.app bundle + executable CLI"] --> D
    B --> F["setup --add-detected --yes --restart"]
    D --> F
    F --> G{"New inactive hook connector found?"}
    G -- "No" --> H["No-op; preserve config and gateway state"]
    G -- "Yes" --> I["Add connector in observe mode"]
    I --> J["Preserve primary, roster, modes, scanner, and discovery settings"]
    J --> K["Persist config"]
    K --> L["Start/restart gateway + verify connector readiness"]
    L --> M["Emit deferred canonical setup audit"]
```

Security boundary: app metadata is read passively only from a resolved bundle that remains inside a configured macOS application root. Runtime mutation remains fail-closed: a restart/readiness or canonical-audit failure exits non-zero.

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `Makefile` | Runs additive detected-connector setup in the non-interactive quickstart path and restarts the gateway when a connector is added. |
| `cli/defenseclaw/inventory/agent_discovery.py` | Adds Cursor CLI aliases, passive macOS bundle/version discovery, executable and symlink-boundary checks, path de-duplication, and discovery cache invalidation. |
| `cli/defenseclaw/commands/cmd_setup.py` | Adds the additive `--add-detected` workflow, preserves the existing primary plus global/per-connector settings, and defers fail-closed audit admission until after gateway readiness. |
| `cli/tests/test_agent_discovery.py` | Covers passive bundle discovery, untrusted and symlink-escaped bundles, non-executable embedded CLIs, malformed metadata, the `cursor-agent` alias, and host isolation. |
| `cli/tests/test_cmd_setup_fu_phase2.py` | Covers additive setup, no-op behavior, flag conflicts, mode/global-setting preservation, active proxy preservation, and restart-before-audit ordering. |
| `cli/tests/test_install_dev_static.py` | Pins the no-TTY quickstart branch ordering and complete failure path. |

## Breaking Changes

- Non-interactive `make all` now adds newly detected hook connectors in observe mode and restarts the gateway when additions occur.
- Existing primary and active connectors, modes, scanner configuration, AI discovery inputs, and proxy configurations remain unchanged.
- The discovery cache schema advances from v3 to v4, causing one fresh discovery scan after upgrade.

## Open Issues / Follow-ups

None.

## Test Plan

1. Focused setup/init/discovery regression suite:

   ```sh
   .venv/bin/python -m pytest cli/tests/test_cmd_setup*.py cli/tests/test_cmd_init.py cli/tests/test_agent_discovery.py cli/tests/test_install_dev_static.py -q
   ```

   Observed: `684 passed, 7 skipped, 50 subtests passed in 39.95s`.

2. Python lint on every changed Python file:

   ```sh
   .venv/bin/ruff check cli/defenseclaw/inventory/agent_discovery.py cli/defenseclaw/commands/cmd_setup.py cli/tests/test_agent_discovery.py cli/tests/test_cmd_setup_fu_phase2.py cli/tests/test_install_dev_static.py
   ```

   Observed: `All checks passed!`.

3. Commit whitespace validation:

   ```sh
   git show --format= --check HEAD
   ```

   Observed: exit code `0` with no output.

4. Live Cursor discovery on macOS:

   ```sh
   .venv/bin/defenseclaw agent discover --refresh --json
   ```

   Observed: Cursor reported `installed: true`, version `3.13.25`, at `/Applications/Cursor.app/Contents/Resources/app/bin/cursor`.

5. Connected-device SSH validation of commit `8cc2b2c55`:

   ```sh
   ssh defenseclaw-macos 'cd /tmp/defenseclaw-pr683.sXDgoF/source && .venv/bin/python -m pytest cli/tests/test_agent_discovery.py cli/tests/test_cmd_setup_fu_phase2.py::TestBareSetupBatch cli/tests/test_cmd_setup_multi_connector.py::TestWriteConnectorIdentityUnit cli/tests/test_install_dev_static.py::test_noninteractive_quickstart_adds_newly_detected_connectors_safely -q'
   ssh openclaw-vineeth 'cd /tmp/defenseclaw-pr683.zqQiMm/source && .venv/bin/python -m pytest cli/tests/test_agent_discovery.py cli/tests/test_cmd_setup_fu_phase2.py::TestBareSetupBatch cli/tests/test_cmd_setup_multi_connector.py::TestWriteConnectorIdentityUnit cli/tests/test_install_dev_static.py::test_noninteractive_quickstart_adds_newly_detected_connectors_safely -q'
   ssh defenseclaw-windows 'powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "& { Set-Location C:\Users\Administrator\AppData\Local\Temp\defenseclaw-pr683-8cc2b2c55\source; $content = Get-Content .\scripts\windows-native-ci.ps1; Invoke-Expression (($content[304..396]) -join [Environment]::NewLine); Set-CurrentUserAsDefaultOwner; & .\.venv\Scripts\python.exe -m pytest cli/tests/test_agent_discovery.py cli/tests/test_cmd_setup_fu_phase2.py::TestBareSetupBatch cli/tests/test_cmd_setup_multi_connector.py::TestWriteConnectorIdentityUnit cli/tests/test_install_dev_static.py::test_noninteractive_quickstart_adds_newly_detected_connectors_safely -q; exit $LASTEXITCODE }"'
   ```

   Observed:
   - `defenseclaw-macos`: `140 passed, 5 skipped in 4.06s`.
   - `openclaw-vineeth` (Linux): `140 passed, 5 skipped in 7.72s`.
   - `defenseclaw-windows`: `134 passed, 11 skipped in 5.89s`. The repository's `Set-CurrentUserAsDefaultOwner` preparation was applied because this elevated SSH account otherwise creates temporary directories owned by `BUILTIN\\Administrators`.

6. Hosted CodeRabbit review of the latest commit:

   Observed: review completed with `APPROVED`; all 5 CodeRabbit pre-merge checks passed and no new actionable comments remained.

7. GitHub PR checks:

   ```sh
   gh pr checks 683 --repo cisco-ai-defense/defenseclaw
   python3 /Users/vnarajal/.codex/plugins/cache/openai-curated-remote/github/0.1.8-2841cf9749ae/skills/gh-fix-ci/scripts/inspect_pr_checks.py --repo . --pr 683 --json
   ```

   Observed: both commands exited `0`; `89` checks passed, `4` conditional jobs were intentionally skipped, and `0` checks failed or remained pending. The independent inspector reported `PR #683: no failing checks detected`.
