### PR TITLE
fix: show trusted rule titles without redaction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,6 +404,23 @@ jobs:
           name: python-coverage
           path: coverage-py.xml
 
+  make-test:
+    # Preserve the legacy required-check context without rerunning the corpus.
+    # The Go and Python aggregate jobs already require every underlying shard.
+    name: make test (unified)
+    needs: [go-test, python-lint-test]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require unified Go and Python test gates
+        env:
+          GO_TEST_RESULT: ${{ needs.go-test.result }}
+          PYTHON_TEST_RESULT: ${{ needs.python-lint-test.result }}
+        run: |
+          set -euo pipefail
+          test "$GO_TEST_RESULT" = success
+          test "$PYTHON_TEST_RESULT" = success
+
   python-wheel-install:
     name: Python Wheel Security Contract (${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/cli/defenseclaw/commands/cmd_setup_redaction.py
+++ b/cli/defenseclaw/commands/cmd_setup_redaction.py
@@ -1346,6 +1346,8 @@ def _render_buckets(buckets) -> None:
 
 def _render_preview(preview) -> None:
     click.echo("\nRedaction policy preview")
+    click.echo("  Scope: configurable observability log/trace projections only")
+    click.echo("  OS notifications and agent hook responses retain separate safety redaction")
     click.echo(f"  Effective legs changed: {len(preview.changes)}")
     click.echo(f"  Newly unredacted: {preview.newly_unredacted}")
     click.echo(f"  No longer unredacted: {preview.no_longer_unredacted}")

--- a/cli/tests/test_ci_workflow_efficiency.py
+++ b/cli/tests/test_ci_workflow_efficiency.py
@@ -54,7 +54,7 @@ def test_ci_shards_python_once_and_does_not_repeat_unified_corpus() -> None:
 
 def test_ci_preserves_make_test_context_without_repeating_test_work() -> None:
     workflow_text = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
-    jobs = yaml.load(workflow_text, Loader=yaml.BaseLoader)["jobs"]
+    jobs = yaml.safe_load(workflow_text)["jobs"]
 
     aggregate = jobs["make-test"]
     assert aggregate["name"] == "make test (unified)"
@@ -62,14 +62,26 @@ def test_ci_preserves_make_test_context_without_repeating_test_work() -> None:
     assert aggregate["if"] == "${{ always() }}"
     assert aggregate["runs-on"] == "ubuntu-latest"
     assert len(aggregate["steps"]) == 1
-    assert not any("uses" in step for step in aggregate["steps"])
+    step = aggregate["steps"][0]
+    assert set(step) == {"name", "env", "run"}
+    assert step["name"] == "Require unified Go and Python test gates"
+    assert step["env"] == {
+        "GO_TEST_RESULT": "${{ needs.go-test.result }}",
+        "PYTHON_TEST_RESULT": "${{ needs.python-lint-test.result }}",
+    }
+    assert step["run"].splitlines() == [
+        "set -euo pipefail",
+        'test "$GO_TEST_RESULT" = success',
+        'test "$PYTHON_TEST_RESULT" = success',
+    ]
 
-    rendered = str(aggregate)
-    assert "needs.go-test.result" in rendered
-    assert "needs.python-lint-test.result" in rendered
-    assert 'test "$GO_TEST_RESULT" = success' in rendered
-    assert 'test "$PYTHON_TEST_RESULT" = success' in rendered
-    assert "run: make test" not in workflow_text
+    run_steps = [
+        step["run"]
+        for job in jobs.values()
+        for step in job.get("steps", [])
+        if "run" in step
+    ]
+    assert all("make test" not in run for run in run_steps)
 
 
 def test_ci_shards_slow_gateway_package_and_combines_go_coverage() -> None:

--- a/cli/tests/test_ci_workflow_efficiency.py
+++ b/cli/tests/test_ci_workflow_efficiency.py
@@ -16,6 +16,8 @@
 
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -42,13 +44,32 @@ def test_ci_shards_python_once_and_does_not_repeat_unified_corpus() -> None:
     assert "pattern: python-coverage-part-*" in workflow
     assert 'test "${#coverage_parts[@]}" -eq 4' in workflow
     assert ".venv/bin/coverage combine" in workflow
-    assert "name: make test (unified)" not in workflow
     assert "run: make test" not in workflow
 
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
     lock = (ROOT / "uv.lock").read_text(encoding="utf-8")
     assert '"pytest-xdist==3.8.0"' in pyproject
     assert 'name = "pytest-xdist"' in lock
+
+
+def test_ci_preserves_make_test_context_without_repeating_test_work() -> None:
+    workflow_text = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    jobs = yaml.load(workflow_text, Loader=yaml.BaseLoader)["jobs"]
+
+    aggregate = jobs["make-test"]
+    assert aggregate["name"] == "make test (unified)"
+    assert aggregate["needs"] == ["go-test", "python-lint-test"]
+    assert aggregate["if"] == "${{ always() }}"
+    assert aggregate["runs-on"] == "ubuntu-latest"
+    assert len(aggregate["steps"]) == 1
+    assert not any("uses" in step for step in aggregate["steps"])
+
+    rendered = str(aggregate)
+    assert "needs.go-test.result" in rendered
+    assert "needs.python-lint-test.result" in rendered
+    assert 'test "$GO_TEST_RESULT" = success' in rendered
+    assert 'test "$PYTHON_TEST_RESULT" = success' in rendered
+    assert "run: make test" not in workflow_text
 
 
 def test_ci_shards_slow_gateway_package_and_combines_go_coverage() -> None:

--- a/cli/tests/test_cmd_setup_redaction.py
+++ b/cli/tests/test_cmd_setup_redaction.py
@@ -318,6 +318,8 @@ def test_execute_mutations_binds_write_to_preview_and_verifies_plan(
 
     assert result.exit_code == 0, result.output
     assert "newly unredacted: 14" in result.output.lower()
+    assert "configurable observability log/trace projections only" in result.output
+    assert "OS notifications and agent hook responses" in result.output
     assert "Managed policy remains locked" in result.output
     assert calls[0][2]["expected_before_sha256"] == preview.before_sha256
     backup_path = calls[0][2]["backup_path"]

--- a/docs-site/content/docs/reference/redaction.mdx
+++ b/docs-site/content/docs/reference/redaction.mdx
@@ -112,6 +112,12 @@ collection and routing unchanged. The generated local SQLite projection inherits
 `none`; the managed enterprise destination remains release-owned and locked to
 its managed profile. Existing stored or exported records are not rewritten.
 
+The command governs observability log and trace projections. It does not disable
+the separate safety scrub applied to OS notifications or agent hook responses.
+Those attended surfaces may show exact ship-authored rule IDs and titles, but
+continue to hide free-form reasons and matched literals that could contain PII,
+credentials, or prompt-injection content.
+
 <Callout type="warn" title="remove-all permits raw governed content">
 `remove-all` can expose prompts, responses, tool arguments/results, evidence,
 paths, and identifiers to every configurable destination. Use it only when local

--- a/internal/gateway/agent_hook.go
+++ b/internal/gateway/agent_hook.go
@@ -1853,8 +1853,9 @@ func (a *APIServer) dispatchAgentHookNotification(req agentHookRequest, action, 
 	}
 	// Honor the cloud-controlled per-inspection redaction policy
 	// (all-sinks scope, managed_enterprise only) when a caller passes
-	// one; otherwise default to the historical ForSinkReason behavior.
-	safeReason := redaction.ReasonForSink(reason, notificationSinkPolicy(policy))
+	// one; otherwise keep compatibility redaction while allowing exact
+	// compiled-in rule metadata through for operator triage.
+	safeReason := notificationDisplayReason(reason, notificationSinkPolicy(policy))
 	base := notifier.BlockEvent{
 		Source:       notifier.SourceHook,
 		Target:       target,
@@ -2033,7 +2034,7 @@ func agentHookResponseForProfile(profile connector.HookProfile, req agentHookReq
 	if rawAction == "" {
 		rawAction = action
 	}
-	safeReason := redaction.ReasonForAgent(reason)
+	safeReason := agentDisplayReason(reason)
 	additional := genericHookAdditionalContext(req.ConnectorName, rawAction, severity, safeReason, wouldBlock)
 	resp := agentHookResponse{
 		Action:            action,

--- a/internal/gateway/agent_hook.go
+++ b/internal/gateway/agent_hook.go
@@ -1749,7 +1749,10 @@ func (a *APIServer) evaluateAgentHook(ctx context.Context, req agentHookRequest)
 	// original verdict reason, so telemetry retains the "why" while the agent
 	// shows the operator's message. Resolved per connector.
 	responseReason := resolveHookBlockReasonForConfig(a.scannerCfg, req.ConnectorName, action, reason)
-	resp := agentHookResponseForProfile(profile, req, action, rawAction, severity, responseReason, findings, mode, wouldBlock, caps)
+	resp := agentHookResponseForProfile(
+		profile, req, action, rawAction, severity, responseReason, findings, mode, wouldBlock, caps,
+		sinkPolicyFor(ctx, verdict.RedactionEnabled),
+	)
 	// Stamp the unified-pipeline correlation keys so the HTTP
 	// response, the audit envelope (HookAuditEnvelope.EvaluationID
 	// / RuleIDs), and the scan_finding events all join on the same
@@ -2020,11 +2023,11 @@ func mapHookActionForProfile(rawAction, mode, event string, caps connector.HookC
 	}
 }
 
-func agentHookResponseFor(req agentHookRequest, action, rawAction, severity, reason string, findings []string, mode string, wouldBlock bool, caps connector.HookCapability) agentHookResponse {
-	return agentHookResponseForProfile(connector.HookProfile{}, req, action, rawAction, severity, reason, findings, mode, wouldBlock, caps)
+func agentHookResponseFor(req agentHookRequest, action, rawAction, severity, reason string, findings []string, mode string, wouldBlock bool, caps connector.HookCapability, policy ...redaction.SinkPolicy) agentHookResponse {
+	return agentHookResponseForProfile(connector.HookProfile{}, req, action, rawAction, severity, reason, findings, mode, wouldBlock, caps, policy...)
 }
 
-func agentHookResponseForProfile(profile connector.HookProfile, req agentHookRequest, action, rawAction, severity, reason string, findings []string, mode string, wouldBlock bool, caps connector.HookCapability) agentHookResponse {
+func agentHookResponseForProfile(profile connector.HookProfile, req agentHookRequest, action, rawAction, severity, reason string, findings []string, mode string, wouldBlock bool, caps connector.HookCapability, policy ...redaction.SinkPolicy) agentHookResponse {
 	if severity == "" {
 		severity = "NONE"
 	}
@@ -2034,7 +2037,7 @@ func agentHookResponseForProfile(profile connector.HookProfile, req agentHookReq
 	if rawAction == "" {
 		rawAction = action
 	}
-	safeReason := agentDisplayReason(reason)
+	safeReason := agentDisplayReason(reason, notificationSinkPolicy(policy))
 	additional := genericHookAdditionalContext(req.ConnectorName, rawAction, severity, safeReason, wouldBlock)
 	resp := agentHookResponse{
 		Action:            action,

--- a/internal/gateway/claude_code_hook.go
+++ b/internal/gateway/claude_code_hook.go
@@ -279,8 +279,9 @@ func (a *APIServer) dispatchClaudeCodeHookNotification(req claudeCodeHookRequest
 	}
 	// Honor the cloud-controlled per-inspection redaction policy
 	// (all-sinks scope, managed_enterprise only) when a caller passes
-	// one; otherwise default to the historical ForSinkReason behavior.
-	safeReason := redaction.ReasonForSink(reason, notificationSinkPolicy(policy))
+	// one; otherwise keep compatibility redaction while allowing exact
+	// compiled-in rule metadata through for operator triage.
+	safeReason := notificationDisplayReason(reason, notificationSinkPolicy(policy))
 	base := notifier.BlockEvent{
 		Source:       notifier.SourceHook,
 		Target:       target,
@@ -373,7 +374,7 @@ func claudeCodeResponseFor(req claudeCodeHookRequest, action, rawAction, severit
 	if rawAction == "" {
 		rawAction = action
 	}
-	safeReason := redaction.ReasonForAgent(reason)
+	safeReason := agentDisplayReason(reason)
 	additional := claudeCodeAdditionalContext(rawAction, severity, safeReason, wouldBlock)
 	resp := claudeCodeHookResponse{
 		Action:            action,

--- a/internal/gateway/claude_code_hook.go
+++ b/internal/gateway/claude_code_hook.go
@@ -235,7 +235,10 @@ func (a *APIServer) evaluateClaudeCodeHook(ctx context.Context, req claudeCodeHo
 		a.dispatchClaudeCodeHookNotification(req, action, rawAction, verdict.Severity, verdict.Reason, wouldBlock, evalCtx,
 			sinkPolicyFor(ctx, verdict.RedactionEnabled))
 	}
-	resp := claudeCodeResponseFor(req, action, rawAction, verdict.Severity, verdict.Reason, verdict.Findings, mode, wouldBlock)
+	resp := claudeCodeResponseFor(
+		req, action, rawAction, verdict.Severity, verdict.Reason, verdict.Findings, mode, wouldBlock,
+		sinkPolicyFor(ctx, verdict.RedactionEnabled),
+	)
 	// Stamp the unified-pipeline correlation keys so the agent-hook
 	// dispatch wrapper (claudeCodeResponseToAgentHookResponse) and
 	// the audit envelope (HookAuditEnvelope.EvaluationID / RuleIDs)
@@ -364,7 +367,7 @@ func (a *APIServer) claudeCodeMode() string {
 	return normalizeAgentHookMode(mode)
 }
 
-func claudeCodeResponseFor(req claudeCodeHookRequest, action, rawAction, severity, reason string, findings []string, mode string, wouldBlock bool) claudeCodeHookResponse {
+func claudeCodeResponseFor(req claudeCodeHookRequest, action, rawAction, severity, reason string, findings []string, mode string, wouldBlock bool, policy ...redaction.SinkPolicy) claudeCodeHookResponse {
 	if severity == "" {
 		severity = "NONE"
 	}
@@ -374,7 +377,7 @@ func claudeCodeResponseFor(req claudeCodeHookRequest, action, rawAction, severit
 	if rawAction == "" {
 		rawAction = action
 	}
-	safeReason := agentDisplayReason(reason)
+	safeReason := agentDisplayReason(reason, notificationSinkPolicy(policy))
 	additional := claudeCodeAdditionalContext(rawAction, severity, safeReason, wouldBlock)
 	resp := claudeCodeHookResponse{
 		Action:            action,

--- a/internal/gateway/codex_hook.go
+++ b/internal/gateway/codex_hook.go
@@ -292,8 +292,9 @@ func (a *APIServer) dispatchCodexHookNotification(req codexHookRequest, action, 
 	}
 	// Honor the cloud-controlled per-inspection redaction policy
 	// (all-sinks scope, managed_enterprise only) when a caller passes
-	// one; otherwise default to the historical ForSinkReason behavior.
-	safeReason := redaction.ReasonForSink(reason, notificationSinkPolicy(policy))
+	// one; otherwise keep compatibility redaction while allowing exact
+	// compiled-in rule metadata through for operator triage.
+	safeReason := notificationDisplayReason(reason, notificationSinkPolicy(policy))
 	base := notifier.BlockEvent{
 		Source:       notifier.SourceHook,
 		Target:       target,
@@ -385,7 +386,7 @@ func codexResponseFor(event, action, rawAction, severity, reason string, finding
 	if rawAction == "" {
 		rawAction = action
 	}
-	safeReason := redaction.ReasonForAgent(reason)
+	safeReason := agentDisplayReason(reason)
 	additional := codexAdditionalContext(rawAction, severity, safeReason, wouldBlock)
 	resp := codexHookResponse{
 		Action:            action,

--- a/internal/gateway/codex_hook.go
+++ b/internal/gateway/codex_hook.go
@@ -269,7 +269,10 @@ func (a *APIServer) evaluateCodexHook(ctx context.Context, req codexHookRequest)
 		a.dispatchCodexHookNotification(req, action, rawAction, verdict.Severity, verdict.Reason, wouldBlock, evalCtx,
 			sinkPolicyFor(ctx, verdict.RedactionEnabled))
 	}
-	resp := codexResponseFor(req.HookEventName, action, rawAction, verdict.Severity, verdict.Reason, verdict.Findings, mode, wouldBlock)
+	resp := codexResponseFor(
+		req.HookEventName, action, rawAction, verdict.Severity, verdict.Reason, verdict.Findings, mode, wouldBlock,
+		sinkPolicyFor(ctx, verdict.RedactionEnabled),
+	)
 	resp.EvaluationID = evalCtx.EvaluationID
 	resp.RuleIDs = evalCtx.RuleIDs
 	resp.RedactionEnabled = verdict.RedactionEnabled
@@ -376,7 +379,7 @@ func (a *APIServer) codexMode() string {
 	return normalizeAgentHookMode(mode)
 }
 
-func codexResponseFor(event, action, rawAction, severity, reason string, findings []string, mode string, wouldBlock bool) codexHookResponse {
+func codexResponseFor(event, action, rawAction, severity, reason string, findings []string, mode string, wouldBlock bool, policy ...redaction.SinkPolicy) codexHookResponse {
 	if severity == "" {
 		severity = "NONE"
 	}
@@ -386,7 +389,7 @@ func codexResponseFor(event, action, rawAction, severity, reason string, finding
 	if rawAction == "" {
 		rawAction = action
 	}
-	safeReason := agentDisplayReason(reason)
+	safeReason := agentDisplayReason(reason, notificationSinkPolicy(policy))
 	additional := codexAdditionalContext(rawAction, severity, safeReason, wouldBlock)
 	resp := codexHookResponse{
 		Action:            action,

--- a/internal/gateway/inspect.go
+++ b/internal/gateway/inspect.go
@@ -1040,12 +1040,10 @@ func (a *APIServer) handleInspectTool(w http.ResponseWriter, r *http.Request) {
 
 	elapsed := time.Since(t0)
 
-	// verdict.Reason is composed as "matched: <rule-id>:<title>"
-	// which is PII-safe by construction (rule metadata only).
-	// redaction.Reason is a no-op on it because every token passes
-	// the rule-id allow-list — we still route through the helper
-	// so any future reason-building logic that embeds literals
-	// picks up the scrub automatically.
+	// verdict.Reason is normally composed as "matched: <rule-id>:<title>".
+	// Exact compiled-in ID/title pairs are safe metadata, while titles from
+	// external scanners can contain matched literals. Display boundaries use
+	// the catalog-aware helpers in reason_display.go to distinguish the two.
 	safeFindings := make([]string, len(verdict.Findings))
 	for i, finding := range verdict.Findings {
 		safeFindings[i] = redaction.Reason(finding)
@@ -1196,9 +1194,9 @@ func appendVerdictReason(reason, suffix string) string {
 // field in DetailedFindings is replaced with the
 // "<redacted-evidence len=... sha=...>" placeholder AND Reason is
 // routed through ForSinkReason. The composed reason is normally
-// shaped as "matched: <rule-id>:<title>, …" — ForSinkReason is a
-// no-op on that metadata-only shape, but if a scanner ever embeds
-// a matched literal in f.Title the sink barrier scrubs it.
+// shaped as "matched: <rule-id>:<title>, …". Exact compiled-in pairs pass
+// through via defaultSinkDisplayReason; if a scanner embeds a matched literal
+// in f.Title, the sink barrier still scrubs it.
 //
 // The original verdict is left untouched so canonical observability producers
 // retain the full source data. The unified runtime applies the selected
@@ -1208,7 +1206,7 @@ func (v *ToolInspectVerdict) sanitizeForResponse(reveal bool) *ToolInspectVerdic
 		return v
 	}
 	cp := *v
-	cp.Reason = redaction.ForSinkReason(v.Reason)
+	cp.Reason = defaultSinkDisplayReason(v.Reason)
 	if len(v.DetailedFindings) == 0 {
 		return &cp
 	}

--- a/internal/gateway/inspect.go
+++ b/internal/gateway/inspect.go
@@ -56,7 +56,9 @@ const revealHeader = "X-DefenseClaw-Reveal-PII"
 // Destination projection is unaffected: canonical telemetry keeps the source
 // facts and the unified v8 router applies each destination's selected redaction
 // profile independently. The response header changes only this HTTP response;
-// it cannot make a configured destination more or less restrictive.
+// it cannot make a configured destination more or less restrictive. An
+// explicit managed-enterprise redact directive remains authoritative over the
+// response header.
 func wantsReveal(r *http.Request) bool {
 	return r.Header.Get(revealHeader) == "1"
 }
@@ -1195,18 +1197,20 @@ func appendVerdictReason(reason, suffix string) string {
 // "<redacted-evidence len=... sha=...>" placeholder AND Reason is
 // routed through ForSinkReason. The composed reason is normally
 // shaped as "matched: <rule-id>:<title>, …". Exact compiled-in pairs pass
-// through via defaultSinkDisplayReason; if a scanner embeds a matched literal
-// in f.Title, the sink barrier still scrubs it.
+// through via defaultSinkDisplayReason only when no managed override is
+// active; if a scanner embeds a matched literal in f.Title, the sink barrier
+// still scrubs it.
 //
 // The original verdict is left untouched so canonical observability producers
 // retain the full source data. The unified runtime applies the selected
 // redaction profile independently for each destination after routing.
 func (v *ToolInspectVerdict) sanitizeForResponse(reveal bool) *ToolInspectVerdict {
-	if reveal {
+	policy := sinkPolicyFor(context.Background(), v.RedactionEnabled)
+	if reveal && policy != redaction.SinkPolicyRedact {
 		return v
 	}
 	cp := *v
-	cp.Reason = defaultSinkDisplayReason(v.Reason)
+	cp.Reason = defaultSinkDisplayReason(v.Reason, policy)
 	if len(v.DetailedFindings) == 0 {
 		return &cp
 	}

--- a/internal/gateway/reason_display.go
+++ b/internal/gateway/reason_display.go
@@ -58,9 +58,13 @@ func trustedBuiltInFindingLabel(label string) bool {
 }
 
 // agentDisplayReason keeps exact, ship-authored catalog metadata readable on
-// agent surfaces while retaining the existing scrub for every free-form or
-// scanner-authored reason.
-func agentDisplayReason(reason string) string {
+// agent surfaces under the default compatibility policy while retaining the
+// existing scrub for every free-form or scanner-authored reason. Explicit
+// managed policies remain authoritative in both directions.
+func agentDisplayReason(reason string, policy redaction.SinkPolicy) string {
+	if policy != redaction.SinkPolicyDefault {
+		return redaction.ReasonForSink(reason, policy)
+	}
 	if trustedBuiltInMatchReason(reason) {
 		return reason
 	}
@@ -77,11 +81,11 @@ func notificationDisplayReason(reason string, policy redaction.SinkPolicy) strin
 	return redaction.ReasonForSink(reason, policy)
 }
 
-// defaultSinkDisplayReason is used by compatibility response bodies that do
-// not carry a request-scoped managed policy.
-func defaultSinkDisplayReason(reason string) string {
-	if trustedBuiltInMatchReason(reason) {
+// defaultSinkDisplayReason applies the catalog carve-out to compatibility
+// response bodies only when no managed override is active.
+func defaultSinkDisplayReason(reason string, policy redaction.SinkPolicy) string {
+	if policy == redaction.SinkPolicyDefault && trustedBuiltInMatchReason(reason) {
 		return reason
 	}
-	return redaction.ForSinkReason(reason)
+	return redaction.ReasonForSink(reason, policy)
 }

--- a/internal/gateway/reason_display.go
+++ b/internal/gateway/reason_display.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"strings"
+
+	"github.com/defenseclaw/defenseclaw/internal/redaction"
+)
+
+const builtInMatchReasonPrefix = "matched: "
+
+// trustedBuiltInMatchReason reports whether reason consists exclusively of
+// exact rule ID/title pairs from the compiled-in catalog. The equality check
+// is deliberately stricter than a character allow-list: scanner-provided
+// titles can contain matched literals that merely look like harmless metadata.
+func trustedBuiltInMatchReason(reason string) bool {
+	body, ok := strings.CutPrefix(reason, builtInMatchReasonPrefix)
+	if !ok || body == "" {
+		return false
+	}
+	labels := strings.Split(body, ", ")
+	if len(labels) == 0 || len(labels) > 5 {
+		return false
+	}
+	for _, label := range labels {
+		if !trustedBuiltInFindingLabel(label) {
+			return false
+		}
+	}
+	return true
+}
+
+func trustedBuiltInFindingLabel(label string) bool {
+	for _, category := range defaultRuleCategories {
+		for _, rule := range category.Rules {
+			base := rule.ID + ":" + rule.Title
+			if label == base || label == base+" (obfuscated)" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// agentDisplayReason keeps exact, ship-authored catalog metadata readable on
+// agent surfaces while retaining the existing scrub for every free-form or
+// scanner-authored reason.
+func agentDisplayReason(reason string) string {
+	if trustedBuiltInMatchReason(reason) {
+		return reason
+	}
+	return redaction.ReasonForAgent(reason)
+}
+
+// notificationDisplayReason applies the same narrow catalog carve-out to OS
+// notifications only under the default compatibility policy. An explicit
+// managed-enterprise redact directive remains authoritative.
+func notificationDisplayReason(reason string, policy redaction.SinkPolicy) string {
+	if policy == redaction.SinkPolicyDefault && trustedBuiltInMatchReason(reason) {
+		return reason
+	}
+	return redaction.ReasonForSink(reason, policy)
+}
+
+// defaultSinkDisplayReason is used by compatibility response bodies that do
+// not carry a request-scoped managed policy.
+func defaultSinkDisplayReason(reason string) string {
+	if trustedBuiltInMatchReason(reason) {
+		return reason
+	}
+	return redaction.ForSinkReason(reason)
+}

--- a/internal/gateway/reason_display_test.go
+++ b/internal/gateway/reason_display_test.go
@@ -17,9 +17,11 @@
 package gateway
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
 	"github.com/defenseclaw/defenseclaw/internal/redaction"
 )
 
@@ -97,18 +99,97 @@ func TestAgentAndDefaultSinkDisplayReasonUseTrustedMetadataCarveOut(t *testing.T
 	t.Cleanup(func() { redaction.SetAgentReasonRedactionDisabled(false) })
 
 	trusted := "matched: TRUST-SAFETY-OVERRIDE:Safety override attempt"
-	if got := agentDisplayReason(trusted); got != trusted {
+	if got := agentDisplayReason(trusted, redaction.SinkPolicyDefault); got != trusted {
 		t.Fatalf("agent display reason = %q, want trusted metadata", got)
 	}
-	if got := defaultSinkDisplayReason(trusted); got != trusted {
+	if got := defaultSinkDisplayReason(trusted, redaction.SinkPolicyDefault); got != trusted {
 		t.Fatalf("default sink display reason = %q, want trusted metadata", got)
+	}
+	for name, got := range map[string]string{
+		"agent":   agentDisplayReason(trusted, redaction.SinkPolicyRedact),
+		"default": defaultSinkDisplayReason(trusted, redaction.SinkPolicyRedact),
+	} {
+		if got == trusted || !strings.Contains(got, "<redacted") {
+			t.Fatalf("forced-redact %s reason = %q, want trusted title redacted", name, got)
+		}
 	}
 
 	untrusted := "matched: TRUST-SAFETY-OVERRIDE:scanner supplied value"
-	if got := agentDisplayReason(untrusted); got == untrusted || !strings.Contains(got, "<redacted") {
+	if got := agentDisplayReason(untrusted, redaction.SinkPolicyDefault); got == untrusted || !strings.Contains(got, "<redacted") {
 		t.Fatalf("agent display reason = %q, want scanner title redacted", got)
 	}
-	if got := defaultSinkDisplayReason(untrusted); got == untrusted || !strings.Contains(got, "<redacted") {
+	if got := defaultSinkDisplayReason(untrusted, redaction.SinkPolicyDefault); got == untrusted || !strings.Contains(got, "<redacted") {
 		t.Fatalf("default sink display reason = %q, want scanner title redacted", got)
+	}
+	if got := agentDisplayReason(untrusted, redaction.SinkPolicyRaw); got != untrusted {
+		t.Fatalf("raw agent display reason = %q, want %q", got, untrusted)
+	}
+	if got := defaultSinkDisplayReason(untrusted, redaction.SinkPolicyRaw); got != untrusted {
+		t.Fatalf("raw default sink display reason = %q, want %q", got, untrusted)
+	}
+}
+
+func TestHookResponseDisplayReasonHonorsManagedRedactionPolicy(t *testing.T) {
+	trusted := "matched: TRUST-SAFETY-OVERRIDE:Safety override attempt"
+	generic := agentHookResponseFor(
+		agentHookRequest{ConnectorName: "cursor", HookEventName: "PreToolUse"},
+		"block", "block", "HIGH", trusted, nil, "action", false,
+		connector.HookCapability{}, redaction.SinkPolicyRedact,
+	)
+	codex := codexResponseFor(
+		"PreToolUse", "block", "block", "HIGH", trusted, nil, "action", false,
+		redaction.SinkPolicyRedact,
+	)
+	claude := claudeCodeResponseFor(
+		claudeCodeHookRequest{HookEventName: "PreToolUse"},
+		"block", "block", "HIGH", trusted, nil, "action", false,
+		redaction.SinkPolicyRedact,
+	)
+
+	tests := []struct {
+		name   string
+		reason string
+		wire   interface{}
+	}{
+		{name: "generic", reason: generic.Reason, wire: generic},
+		{name: "codex", reason: codex.Reason, wire: codex},
+		{name: "claude-code", reason: claude.Reason, wire: claude},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !strings.Contains(test.reason, "<redacted") {
+				t.Fatalf("managed-redact response reason = %q, want redacted title", test.reason)
+			}
+			payload, err := json.Marshal(test.wire)
+			if err != nil {
+				t.Fatalf("marshal response: %v", err)
+			}
+			if strings.Contains(string(payload), "Safety override attempt") {
+				t.Fatalf("managed-redact response leaked trusted title: %s", payload)
+			}
+		})
+	}
+}
+
+func TestSanitizeForResponseHonorsManagedRedactionDirective(t *testing.T) {
+	previous := ManagedEnterpriseActive()
+	SetManagedEnterpriseActive(true)
+	t.Cleanup(func() { SetManagedEnterpriseActive(previous) })
+
+	trusted := "matched: TRUST-SAFETY-OVERRIDE:Safety override attempt"
+	redact := true
+	verdict := &ToolInspectVerdict{Reason: trusted, RedactionEnabled: &redact}
+	for _, reveal := range []bool{false, true} {
+		got := verdict.sanitizeForResponse(reveal)
+		if got.Reason == trusted || !strings.Contains(got.Reason, "<redacted") {
+			t.Fatalf("sanitizeForResponse(reveal=%t) reason = %q, want managed redaction", reveal, got.Reason)
+		}
+	}
+
+	untrusted := "matched: TRUST-SAFETY-OVERRIDE:scanner supplied value"
+	raw := false
+	got := (&ToolInspectVerdict{Reason: untrusted, RedactionEnabled: &raw}).sanitizeForResponse(false)
+	if got.Reason != untrusted {
+		t.Fatalf("managed-raw response reason = %q, want %q", got.Reason, untrusted)
 	}
 }

--- a/internal/gateway/reason_display_test.go
+++ b/internal/gateway/reason_display_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/redaction"
+)
+
+func TestTrustedBuiltInMatchReason(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason string
+		want   bool
+	}{
+		{
+			name:   "single compiled-in finding",
+			reason: "matched: TRUST-SAFETY-OVERRIDE:Safety override attempt",
+			want:   true,
+		},
+		{
+			name: "multiple compiled-in findings",
+			reason: "matched: TRUST-SAFETY-OVERRIDE:Safety override attempt, " +
+				"TRUST-JAILBREAK:Jailbreak attempt",
+			want: true,
+		},
+		{
+			name:   "normalized match suffix",
+			reason: "matched: TRUST-SAFETY-OVERRIDE:Safety override attempt (obfuscated)",
+			want:   true,
+		},
+		{
+			name:   "same rule with scanner-authored title",
+			reason: "matched: TRUST-SAFETY-OVERRIDE:not the catalog title",
+			want:   false,
+		},
+		{
+			name:   "unknown rule",
+			reason: "matched: CUSTOM-RULE:Operator supplied title",
+			want:   false,
+		},
+		{
+			name:   "trailing content",
+			reason: "matched: TRUST-SAFETY-OVERRIDE:Safety override attempt\nextra",
+			want:   false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := trustedBuiltInMatchReason(test.reason); got != test.want {
+				t.Fatalf("trustedBuiltInMatchReason(%q) = %t, want %t", test.reason, got, test.want)
+			}
+		})
+	}
+}
+
+func TestNotificationDisplayReasonPreservesOnlyTrustedCatalogMetadata(t *testing.T) {
+	trusted := "matched: TRUST-SAFETY-OVERRIDE:Safety override attempt"
+	if got := notificationDisplayReason(trusted, redaction.SinkPolicyDefault); got != trusted {
+		t.Fatalf("default notification reason = %q, want trusted metadata", got)
+	}
+
+	forced := notificationDisplayReason(trusted, redaction.SinkPolicyRedact)
+	if forced == trusted || !strings.Contains(forced, "<redacted") {
+		t.Fatalf("forced-redact notification reason = %q, want redacted title", forced)
+	}
+
+	untrusted := "matched: TRUST-SAFETY-OVERRIDE:scanner supplied value"
+	got := notificationDisplayReason(untrusted, redaction.SinkPolicyDefault)
+	if got == untrusted || !strings.Contains(got, "<redacted") {
+		t.Fatalf("untrusted notification reason = %q, want redacted suffix", got)
+	}
+	if raw := notificationDisplayReason(untrusted, redaction.SinkPolicyRaw); raw != untrusted {
+		t.Fatalf("raw managed notification reason = %q, want %q", raw, untrusted)
+	}
+}
+
+func TestAgentAndDefaultSinkDisplayReasonUseTrustedMetadataCarveOut(t *testing.T) {
+	redaction.SetAgentReasonRedactionDisabled(false)
+	t.Cleanup(func() { redaction.SetAgentReasonRedactionDisabled(false) })
+
+	trusted := "matched: TRUST-SAFETY-OVERRIDE:Safety override attempt"
+	if got := agentDisplayReason(trusted); got != trusted {
+		t.Fatalf("agent display reason = %q, want trusted metadata", got)
+	}
+	if got := defaultSinkDisplayReason(trusted); got != trusted {
+		t.Fatalf("default sink display reason = %q, want trusted metadata", got)
+	}
+
+	untrusted := "matched: TRUST-SAFETY-OVERRIDE:scanner supplied value"
+	if got := agentDisplayReason(untrusted); got == untrusted || !strings.Contains(got, "<redacted") {
+		t.Fatalf("agent display reason = %q, want scanner title redacted", got)
+	}
+	if got := defaultSinkDisplayReason(untrusted); got == untrusted || !strings.Contains(got, "<redacted") {
+		t.Fatalf("default sink display reason = %q, want scanner title redacted", got)
+	}
+}

--- a/scripts/live-connector-e2e/run-windows.ps1
+++ b/scripts/live-connector-e2e/run-windows.ps1
@@ -558,15 +558,21 @@ function Test-ConnectorEvent(
     [int]$Since,
     [string]$SessionID = '',
     [string]$HookEvent = '',
-    [string]$RequestID = ''
+    [string]$RequestID = '',
+    [string]$ToolInvocationID = ''
 ) {
     if (-not [string]::IsNullOrWhiteSpace($SessionID) -or
         -not [string]::IsNullOrWhiteSpace($HookEvent) -or
-        -not [string]::IsNullOrWhiteSpace($RequestID)) {
+        -not [string]::IsNullOrWhiteSpace($RequestID) -or
+        -not [string]::IsNullOrWhiteSpace($ToolInvocationID)) {
         $decision = Get-LatestHookDecision `
             -Path $Path -Name $Name -Since $Since `
-            -SessionID $SessionID -HookEvent $HookEvent
-        if ($null -eq $decision) { return $false }
+            -SessionID $SessionID -HookEvent $HookEvent `
+            -ToolInvocationID $ToolInvocationID
+        if ($null -eq $decision -or
+            [string]::IsNullOrWhiteSpace([string]$decision.request_id)) {
+            return $false
+        }
         return [string]::IsNullOrWhiteSpace($RequestID) -or
             [string]$decision.request_id -ceq $RequestID
     }
@@ -584,7 +590,9 @@ function Test-BlockVerdict(
     [string]$Path,
     [int]$Since,
     [string]$Name = '',
-    [string]$RequestID = ''
+    [string]$RequestID = '',
+    [string]$SessionID = '',
+    [string]$ToolInvocationID = ''
 ) {
     $lines = @(Get-EventLines $Path)
     if ($Since -ge $lines.Count) { return $false }
@@ -596,11 +604,18 @@ function Test-BlockVerdict(
                 -not (Test-CanonicalConnectorRecord $eventRecord $Name)) {
                 continue
             }
-            if (-not [string]::IsNullOrWhiteSpace($RequestID)) {
-                $correlation = Get-JsonPropertyValue $eventRecord 'correlation'
-                if ([string](Get-JsonPropertyValue $correlation 'request_id') -cne $RequestID) {
-                    continue
-                }
+            $correlation = Get-JsonPropertyValue $eventRecord 'correlation'
+            if (-not [string]::IsNullOrWhiteSpace($RequestID) -and
+                [string](Get-JsonPropertyValue $correlation 'request_id') -cne $RequestID) {
+                continue
+            }
+            if (-not [string]::IsNullOrWhiteSpace($SessionID) -and
+                [string](Get-JsonPropertyValue $correlation 'session_id') -cne $SessionID) {
+                continue
+            }
+            if (-not [string]::IsNullOrWhiteSpace($ToolInvocationID) -and
+                [string](Get-JsonPropertyValue $correlation 'tool_invocation_id') -cne $ToolInvocationID) {
+                continue
             }
             $eventName = [string](Get-JsonPropertyValue $eventRecord 'event_name')
             $bucket = [string](Get-JsonPropertyValue $eventRecord 'bucket')
@@ -616,7 +631,9 @@ function Test-BlockVerdict(
             }
             $blockedValues = if ($eventName -ceq 'scan.completed') { @('block') } else { @('block', 'deny') }
             foreach ($field in $fields) {
-                if ([string](Get-JsonPropertyValue $body $field) -cin $blockedValues) { return $true }
+                if ([string](Get-JsonPropertyValue $body $field) -cin $blockedValues) {
+                    return $true
+                }
             }
         } catch { continue }
     }
@@ -630,25 +647,29 @@ function Wait-GatewayEvidenceAfter(
     [bool]$RequireBlock,
     [int]$TimeoutMilliseconds = 5000,
     [string]$SessionID = '',
-    [string]$HookEvent = ''
+    [string]$HookEvent = '',
+    [string]$ToolInvocationID = ''
 ) {
     $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMilliseconds)
     $connectorEvent = $false
     $blockVerdict = $false
     $requestID = ''
     $hasHookIdentity = -not [string]::IsNullOrWhiteSpace($SessionID) -or
-        -not [string]::IsNullOrWhiteSpace($HookEvent)
+        -not [string]::IsNullOrWhiteSpace($HookEvent) -or
+        -not [string]::IsNullOrWhiteSpace($ToolInvocationID)
     do {
         $decision = $null
         if ($hasHookIdentity) {
             $decision = Get-LatestHookDecision `
                 -Path $Path -Name $Name -Since $Since `
-                -SessionID $SessionID -HookEvent $HookEvent
+                -SessionID $SessionID -HookEvent $HookEvent `
+                -ToolInvocationID $ToolInvocationID
             if ($null -ne $decision) {
                 $requestID = [string]$decision.request_id
                 $connectorEvent = Test-ConnectorEvent `
                     -Path $Path -Name $Name -Since $Since `
-                    -SessionID $SessionID -HookEvent $HookEvent -RequestID $requestID
+                    -SessionID $SessionID -HookEvent $HookEvent -RequestID $requestID `
+                    -ToolInvocationID $ToolInvocationID
             } else {
                 $connectorEvent = $false
             }
@@ -662,7 +683,8 @@ function Wait-GatewayEvidenceAfter(
                     ([bool]$decision.enforced -or [bool]$decision.would_block) -and
                     -not [string]::IsNullOrWhiteSpace($requestID)) {
                     $blockVerdict = Test-BlockVerdict `
-                        -Path $Path -Since $Since -Name $Name -RequestID $requestID
+                        -Path $Path -Since $Since -Name $Name -RequestID $requestID `
+                        -SessionID $SessionID -ToolInvocationID $ToolInvocationID
                 }
             } else {
                 $blockVerdict = Test-BlockVerdict -Path $Path -Since $Since -Name $Name
@@ -677,6 +699,7 @@ function Wait-GatewayEvidenceAfter(
         ConnectorEvent = $connectorEvent
         BlockVerdict = $blockVerdict
         RequestID = $requestID
+        ToolInvocationID = $ToolInvocationID
     }
 }
 
@@ -706,7 +729,8 @@ function Get-LatestHookDecision(
     [string]$Name,
     [int]$Since,
     [string]$SessionID = '',
-    [string]$HookEvent = ''
+    [string]$HookEvent = '',
+    [string]$ToolInvocationID = ''
 ) {
     $lines = @(Get-EventLines $Path)
     if ($Since -ge $lines.Count) { return $null }
@@ -730,6 +754,10 @@ function Get-LatestHookDecision(
                 [string](Get-JsonPropertyValue $body 'defenseclaw.hook.event') -cne $HookEvent) {
                 continue
             }
+            if (-not [string]::IsNullOrWhiteSpace($ToolInvocationID) -and
+                [string](Get-JsonPropertyValue $correlation 'tool_invocation_id') -cne $ToolInvocationID) {
+                continue
+            }
             $match = [pscustomobject][ordered]@{
                 connector = [string](Get-JsonPropertyValue $eventRecord 'connector')
                 action = [string](Get-JsonPropertyValue $body 'defenseclaw.guardrail.effective_action')
@@ -739,6 +767,7 @@ function Get-LatestHookDecision(
                 enforced = [bool]$enforced.Value
                 rule_ids = @(Get-JsonPropertyValue $body 'defenseclaw.guardrail.rule_ids')
                 request_id = [string](Get-JsonPropertyValue $correlation 'request_id')
+                tool_invocation_id = [string](Get-JsonPropertyValue $correlation 'tool_invocation_id')
                 record_id = [string](Get-JsonPropertyValue $eventRecord 'record_id')
             }
         } catch { continue }
@@ -1277,17 +1306,71 @@ function Invoke-Teardown {
     }
 }
 
-function Invoke-Hook([string]$EventName, [string]$Payload, [ValidateSet('allow', 'block')][string]$Expected, [bool]$RequireGatewayBlock = $false) {
-    $before = @(Get-EventLines $script:GatewayJsonl).Count
+function New-AmpHookPayloadOccurrence(
+    [string]$Payload,
+    [string]$IdentitySuffix,
+    [string]$OutputRoot
+) {
+    if ($IdentitySuffix -cnotmatch '^[a-z0-9][a-z0-9-]*$') {
+        throw "invalid Amp hook identity suffix: $IdentitySuffix"
+    }
     $payloadObject = [IO.File]::ReadAllText($Payload) | ConvertFrom-Json -ErrorAction Stop
+    $sourceEventID = [string](Get-JsonPropertyValue $payloadObject 'source_event_id')
+    if ([string]::IsNullOrWhiteSpace($sourceEventID)) {
+        throw 'Amp hook occurrence requires source_event_id'
+    }
+    $payloadObject.source_event_id = "$sourceEventID`:$IdentitySuffix"
+    $sourceSequenceText = [string](Get-JsonPropertyValue $payloadObject 'source_sequence')
+    [long]$sourceSequence = 0
+    if (-not [long]::TryParse($sourceSequenceText, [ref]$sourceSequence) -or
+        $sourceSequence -gt ([long]::MaxValue - 1000000)) {
+        throw 'Amp hook occurrence requires a bounded numeric source_sequence'
+    }
+    $payloadObject.source_sequence = [string]($sourceSequence + 1000000)
+    $toolCallID = [string](Get-JsonPropertyValue $payloadObject 'tool_call_id')
+    if (-not [string]::IsNullOrWhiteSpace($toolCallID)) {
+        $payloadObject.tool_call_id = "$toolCallID-$IdentitySuffix"
+    }
+    [IO.Directory]::CreateDirectory($OutputRoot) | Out-Null
+    $outputPath = Join-Path $OutputRoot "amp-$IdentitySuffix.json"
+    [IO.File]::WriteAllText(
+        $outputPath,
+        ($payloadObject | ConvertTo-Json -Depth 32 -Compress)
+    )
+    return $outputPath
+}
+
+function Invoke-Hook(
+    [string]$EventName,
+    [string]$Payload,
+    [ValidateSet('allow', 'block')][string]$Expected,
+    [bool]$RequireGatewayBlock = $false,
+    [string]$IdentitySuffix = ''
+) {
+    $before = @(Get-EventLines $script:GatewayJsonl).Count
+    $effectivePayload = $Payload
+    if ($Connector -eq 'amp' -and -not [string]::IsNullOrWhiteSpace($IdentitySuffix)) {
+        $effectivePayload = New-AmpHookPayloadOccurrence `
+            -Payload $Payload -IdentitySuffix $IdentitySuffix `
+            -OutputRoot (Join-Path $StateRoot 'hook-payloads')
+    }
+    $payloadObject = [IO.File]::ReadAllText($effectivePayload) | ConvertFrom-Json -ErrorAction Stop
     $sessionID = [string](Get-JsonPropertyValue $payloadObject 'session_id')
     $hookEvent = [string](Get-JsonPropertyValue $payloadObject 'hook_event_name')
     if ([string]::IsNullOrWhiteSpace($hookEvent)) { $hookEvent = $EventName }
-    $result = Invoke-Tool (Resolve-ContractHookTool) @('hook', '--connector', $Connector, '--event', $EventName) @(0, 2) -InputPath $Payload
+    $toolInvocationID = [string](Get-JsonPropertyValue $payloadObject 'tool_call_id')
+    if ([string]::IsNullOrWhiteSpace($toolInvocationID)) {
+        $toolInvocationID = [string](Get-JsonPropertyValue $payloadObject 'tool_use_id')
+    }
+    if ([string]::IsNullOrWhiteSpace($toolInvocationID)) {
+        $toolInvocationID = [string](Get-JsonPropertyValue $payloadObject 'toolUseId')
+    }
+    $result = Invoke-Tool (Resolve-ContractHookTool) @('hook', '--connector', $Connector, '--event', $EventName) @(0, 2) -InputPath $effectivePayload
     $requireBlockEvidence = $Expected -eq 'block' -or $RequireGatewayBlock
     $evidence = Wait-GatewayEvidenceAfter `
         -Path $script:GatewayJsonl -Name $Connector -Since $before `
-        -RequireBlock $requireBlockEvidence -SessionID $sessionID -HookEvent $hookEvent
+        -RequireBlock $requireBlockEvidence -SessionID $sessionID -HookEvent $hookEvent `
+        -ToolInvocationID $toolInvocationID
     if (-not $evidence.ConnectorEvent) { throw "$EventName did not reach the gateway" }
     if ($Expected -eq 'allow' -and $result.ExitCode -ne 0) { throw "$EventName should allow but exited $($result.ExitCode)" }
     if ($Expected -eq 'block' -and $result.ExitCode -ne 2 -and $result.StdOut -notmatch '(?i)block|deny') { throw "$EventName did not shape a block decision" }
@@ -2231,7 +2314,9 @@ function Invoke-ContractRun {
         Invoke-Hook 'tool.call' (Join-Path $golden 'subagent_tool_call.json') allow
     }
     Invoke-DangerousCommandCorpus action
-    Invoke-Hook $blockEvent (Join-Path $golden 'pre_tool_block.json') block
+    $blockIdentitySuffix = if ($Connector -eq 'amp') { 'action-block' } else { '' }
+    Invoke-Hook $blockEvent (Join-Path $golden 'pre_tool_block.json') block `
+        -IdentitySuffix $blockIdentitySuffix
     if ($Connector -eq 'amp') {
         Invoke-Hook 'agent.end' (Join-Path $golden 'agent_end.json') allow
         Invoke-AmpFiveEventProviderContract $golden

--- a/scripts/live-connector-e2e/run-windows.ps1
+++ b/scripts/live-connector-e2e/run-windows.ps1
@@ -591,6 +591,30 @@ function Test-BlockVerdict([string]$Path, [int]$Since) {
     return $false
 }
 
+function Wait-GatewayEvidenceAfter(
+    [string]$Path,
+    [string]$Name,
+    [int]$Since,
+    [bool]$RequireBlock,
+    [int]$TimeoutMilliseconds = 5000
+) {
+    $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMilliseconds)
+    $connectorEvent = $false
+    $blockVerdict = $false
+    do {
+        $connectorEvent = Test-ConnectorEvent $Path $Name $Since
+        $blockVerdict = Test-BlockVerdict $Path $Since
+        if ($connectorEvent -and (-not $RequireBlock -or $blockVerdict)) { break }
+        if ([DateTime]::UtcNow -ge $deadline) { break }
+        Start-Sleep -Milliseconds 100
+    } while ([DateTime]::UtcNow -lt $deadline)
+
+    return [pscustomobject][ordered]@{
+        ConnectorEvent = $connectorEvent
+        BlockVerdict = $blockVerdict
+    }
+}
+
 function Read-SharedText([string]$Path) {
     if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return '' }
     for ($attempt = 1; $attempt -le 20; $attempt++) {
@@ -1191,12 +1215,13 @@ function Invoke-Teardown {
 function Invoke-Hook([string]$EventName, [string]$Payload, [ValidateSet('allow', 'block')][string]$Expected, [bool]$RequireGatewayBlock = $false) {
     $before = @(Get-EventLines $script:GatewayJsonl).Count
     $result = Invoke-Tool (Resolve-ContractHookTool) @('hook', '--connector', $Connector, '--event', $EventName) @(0, 2) -InputPath $Payload
-    Start-Sleep -Milliseconds 800
-    if (-not (Test-ConnectorEvent $script:GatewayJsonl $Connector $before)) { throw "$EventName did not reach the gateway" }
+    $requireBlockEvidence = $Expected -eq 'block' -or $RequireGatewayBlock
+    $evidence = Wait-GatewayEvidenceAfter $script:GatewayJsonl $Connector $before $requireBlockEvidence
+    if (-not $evidence.ConnectorEvent) { throw "$EventName did not reach the gateway" }
     if ($Expected -eq 'allow' -and $result.ExitCode -ne 0) { throw "$EventName should allow but exited $($result.ExitCode)" }
     if ($Expected -eq 'block' -and $result.ExitCode -ne 2 -and $result.StdOut -notmatch '(?i)block|deny') { throw "$EventName did not shape a block decision" }
-    if ($Expected -eq 'block' -and -not (Test-BlockVerdict $script:GatewayJsonl $before)) { throw "$EventName has no gateway block verdict" }
-    if ($RequireGatewayBlock -and -not (Test-BlockVerdict $script:GatewayJsonl $before)) { throw "$EventName has no observe-mode would-block verdict" }
+    if ($Expected -eq 'block' -and -not $evidence.BlockVerdict) { throw "$EventName has no gateway block verdict" }
+    if ($RequireGatewayBlock -and -not $evidence.BlockVerdict) { throw "$EventName has no observe-mode would-block verdict" }
     Write-Result "$EventName`:fires" pass "jsonl line $before"
     Write-Result "$EventName`:verdict" pass "exit=$($result.ExitCode) expected=$Expected"
 }

--- a/scripts/live-connector-e2e/run-windows.ps1
+++ b/scripts/live-connector-e2e/run-windows.ps1
@@ -552,7 +552,24 @@ function Test-CanonicalConnectorRecord([AllowNull()][object]$Record, [string]$Na
         [string]::Equals($connector, $Name, [StringComparison]::OrdinalIgnoreCase)
 }
 
-function Test-ConnectorEvent([string]$Path, [string]$Name, [int]$Since) {
+function Test-ConnectorEvent(
+    [string]$Path,
+    [string]$Name,
+    [int]$Since,
+    [string]$SessionID = '',
+    [string]$HookEvent = '',
+    [string]$RequestID = ''
+) {
+    if (-not [string]::IsNullOrWhiteSpace($SessionID) -or
+        -not [string]::IsNullOrWhiteSpace($HookEvent) -or
+        -not [string]::IsNullOrWhiteSpace($RequestID)) {
+        $decision = Get-LatestHookDecision `
+            -Path $Path -Name $Name -Since $Since `
+            -SessionID $SessionID -HookEvent $HookEvent
+        if ($null -eq $decision) { return $false }
+        return [string]::IsNullOrWhiteSpace($RequestID) -or
+            [string]$decision.request_id -ceq $RequestID
+    }
     $lines = @(Get-EventLines $Path)
     if ($Since -ge $lines.Count) { return $false }
     foreach ($line in $lines[$Since..($lines.Count - 1)]) {
@@ -563,13 +580,28 @@ function Test-ConnectorEvent([string]$Path, [string]$Name, [int]$Since) {
     return $false
 }
 
-function Test-BlockVerdict([string]$Path, [int]$Since) {
+function Test-BlockVerdict(
+    [string]$Path,
+    [int]$Since,
+    [string]$Name = '',
+    [string]$RequestID = ''
+) {
     $lines = @(Get-EventLines $Path)
     if ($Since -ge $lines.Count) { return $false }
     foreach ($line in $lines[$Since..($lines.Count - 1)]) {
         try {
             $eventRecord = $line | ConvertFrom-Json
             if ((Get-JsonPropertyValue $eventRecord 'schema_version') -ne 1) { continue }
+            if (-not [string]::IsNullOrWhiteSpace($Name) -and
+                -not (Test-CanonicalConnectorRecord $eventRecord $Name)) {
+                continue
+            }
+            if (-not [string]::IsNullOrWhiteSpace($RequestID)) {
+                $correlation = Get-JsonPropertyValue $eventRecord 'correlation'
+                if ([string](Get-JsonPropertyValue $correlation 'request_id') -cne $RequestID) {
+                    continue
+                }
+            }
             $eventName = [string](Get-JsonPropertyValue $eventRecord 'event_name')
             $bucket = [string](Get-JsonPropertyValue $eventRecord 'bucket')
             $body = Get-JsonPropertyValue $eventRecord 'body'
@@ -596,14 +628,46 @@ function Wait-GatewayEvidenceAfter(
     [string]$Name,
     [int]$Since,
     [bool]$RequireBlock,
-    [int]$TimeoutMilliseconds = 5000
+    [int]$TimeoutMilliseconds = 5000,
+    [string]$SessionID = '',
+    [string]$HookEvent = ''
 ) {
     $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMilliseconds)
     $connectorEvent = $false
     $blockVerdict = $false
+    $requestID = ''
+    $hasHookIdentity = -not [string]::IsNullOrWhiteSpace($SessionID) -or
+        -not [string]::IsNullOrWhiteSpace($HookEvent)
     do {
-        $connectorEvent = Test-ConnectorEvent $Path $Name $Since
-        $blockVerdict = Test-BlockVerdict $Path $Since
+        $decision = $null
+        if ($hasHookIdentity) {
+            $decision = Get-LatestHookDecision `
+                -Path $Path -Name $Name -Since $Since `
+                -SessionID $SessionID -HookEvent $HookEvent
+            if ($null -ne $decision) {
+                $requestID = [string]$decision.request_id
+                $connectorEvent = Test-ConnectorEvent `
+                    -Path $Path -Name $Name -Since $Since `
+                    -SessionID $SessionID -HookEvent $HookEvent -RequestID $requestID
+            } else {
+                $connectorEvent = $false
+            }
+        } else {
+            $connectorEvent = Test-ConnectorEvent -Path $Path -Name $Name -Since $Since
+        }
+        if ($RequireBlock) {
+            if ($hasHookIdentity) {
+                if ($null -ne $decision -and
+                    [string]$decision.raw_action -cin @('block', 'deny') -and
+                    ([bool]$decision.enforced -or [bool]$decision.would_block) -and
+                    -not [string]::IsNullOrWhiteSpace($requestID)) {
+                    $blockVerdict = Test-BlockVerdict `
+                        -Path $Path -Since $Since -Name $Name -RequestID $requestID
+                }
+            } else {
+                $blockVerdict = Test-BlockVerdict -Path $Path -Since $Since -Name $Name
+            }
+        }
         if ($connectorEvent -and (-not $RequireBlock -or $blockVerdict)) { break }
         if ([DateTime]::UtcNow -ge $deadline) { break }
         Start-Sleep -Milliseconds 100
@@ -612,6 +676,7 @@ function Wait-GatewayEvidenceAfter(
     return [pscustomobject][ordered]@{
         ConnectorEvent = $connectorEvent
         BlockVerdict = $blockVerdict
+        RequestID = $requestID
     }
 }
 
@@ -1214,9 +1279,15 @@ function Invoke-Teardown {
 
 function Invoke-Hook([string]$EventName, [string]$Payload, [ValidateSet('allow', 'block')][string]$Expected, [bool]$RequireGatewayBlock = $false) {
     $before = @(Get-EventLines $script:GatewayJsonl).Count
+    $payloadObject = [IO.File]::ReadAllText($Payload) | ConvertFrom-Json -ErrorAction Stop
+    $sessionID = [string](Get-JsonPropertyValue $payloadObject 'session_id')
+    $hookEvent = [string](Get-JsonPropertyValue $payloadObject 'hook_event_name')
+    if ([string]::IsNullOrWhiteSpace($hookEvent)) { $hookEvent = $EventName }
     $result = Invoke-Tool (Resolve-ContractHookTool) @('hook', '--connector', $Connector, '--event', $EventName) @(0, 2) -InputPath $Payload
     $requireBlockEvidence = $Expected -eq 'block' -or $RequireGatewayBlock
-    $evidence = Wait-GatewayEvidenceAfter $script:GatewayJsonl $Connector $before $requireBlockEvidence
+    $evidence = Wait-GatewayEvidenceAfter `
+        -Path $script:GatewayJsonl -Name $Connector -Since $before `
+        -RequireBlock $requireBlockEvidence -SessionID $sessionID -HookEvent $hookEvent
     if (-not $evidence.ConnectorEvent) { throw "$EventName did not reach the gateway" }
     if ($Expected -eq 'allow' -and $result.ExitCode -ne 0) { throw "$EventName should allow but exited $($result.ExitCode)" }
     if ($Expected -eq 'block' -and $result.ExitCode -ne 2 -and $result.StdOut -notmatch '(?i)block|deny') { throw "$EventName did not shape a block decision" }

--- a/scripts/live-connector-e2e/test-windows.ps1
+++ b/scripts/live-connector-e2e/test-windows.ps1
@@ -820,6 +820,8 @@ private-secret-name = "DefenseClaw must remain redacted"
     $jsonl = Join-Path $temp 'gateway.jsonl'
     $database = Join-Path $temp 'audit.db'
     $requestId = [guid]::NewGuid().ToString()
+    $sessionId = 'windows-contract-session'
+    $hookEvent = 'PreToolUse'
     $observedAt = [DateTime]::UtcNow.ToString('o')
     $provenance = [ordered]@{
         producer = 'defenseclaw'
@@ -832,7 +834,7 @@ private-secret-name = "DefenseClaw must remain redacted"
             schema_version = 1; bucket_catalog_version = 1; timestamp = $observedAt
             record_id = 'windows-contract-verdict'; bucket = 'asset.scan'; signal = 'logs'
             event_name = 'scan.completed'; source = 'scanner'; connector = 'codex'
-            correlation = @{ request_id = $requestId }; provenance = $provenance; field_classes = @{}
+            correlation = @{ request_id = $requestId; session_id = $sessionId }; provenance = $provenance; field_classes = @{}
             mandatory = $false
             body = @{
                 'defenseclaw.scan.verdict' = 'block'
@@ -842,7 +844,7 @@ private-secret-name = "DefenseClaw must remain redacted"
             schema_version = 1; bucket_catalog_version = 1; timestamp = $observedAt
             record_id = 'windows-contract-hook-decision'; bucket = 'guardrail.evaluation'; signal = 'logs'
             event_name = 'hook_decision'; source = 'connector'; connector = 'codex'
-            correlation = @{ request_id = $requestId }; provenance = $provenance; field_classes = @{}
+            correlation = @{ request_id = $requestId; session_id = $sessionId }; provenance = $provenance; field_classes = @{}
             mandatory = $false
             body = @{
                 'defenseclaw.guardrail.effective_action' = 'allow'
@@ -851,13 +853,14 @@ private-secret-name = "DefenseClaw must remain redacted"
                 'defenseclaw.guardrail.would_block' = $true
                 'defenseclaw.guardrail.enforced' = $false
                 'defenseclaw.guardrail.rule_ids' = @('CMD-WIN-REMOVE-ITEM-RF')
+                'defenseclaw.hook.event' = $hookEvent
             }
         },
         [ordered]@{
             schema_version = 1; bucket_catalog_version = 1; timestamp = $observedAt
             record_id = 'windows-contract-tool'; bucket = 'tool.activity'; signal = 'logs'
             event_name = 'tool.invocation.requested'; source = 'connector'; connector = 'codex'
-            correlation = @{ request_id = $requestId }; provenance = $provenance; field_classes = @{}
+            correlation = @{ request_id = $requestId; session_id = $sessionId }; provenance = $provenance; field_classes = @{}
             mandatory = $false; body = @{}
         },
         [ordered]@{
@@ -894,23 +897,61 @@ private-secret-name = "DefenseClaw must remain redacted"
     Assert-True ($LASTEXITCODE -eq 0) 'mock audit correlation'
     Assert-True (Test-ConnectorEvent $jsonl 'codex' 0) 'connector event seam'
     Assert-True (-not (Test-ConnectorEvent $jsonl 'claudecode' 0)) 'connector event seam ignores body-text false positives'
+    Assert-True (Test-ConnectorEvent `
+        -Path $jsonl -Name 'codex' -Since 0 -SessionID $sessionId -HookEvent $hookEvent) `
+        'connector event seam accepts the matching hook identity'
+    Assert-True (-not (Test-ConnectorEvent `
+        -Path $jsonl -Name 'codex' -Since 0 -SessionID 'unrelated-session' -HookEvent $hookEvent)) `
+        'connector event seam rejects an unrelated hook identity'
+    Assert-True (-not (Test-ConnectorEvent `
+        -Path $jsonl -Name 'codex' -Since 0 -SessionID $sessionId -HookEvent $hookEvent `
+        -RequestID 'unrelated-request')) `
+        'connector event seam rejects an unrelated request identity'
     Assert-True (Test-BlockVerdict $jsonl 0) 'block verdict seam'
     Assert-True (-not (Test-BlockVerdict $jsonl 1)) 'block verdict seam rejects hook decisions and non-canonical scan deny values'
+    Assert-True (Test-BlockVerdict `
+        -Path $jsonl -Since 0 -Name 'codex' -RequestID $requestId) `
+        'block verdict seam accepts the matching request identity'
+    Assert-True (-not (Test-BlockVerdict `
+        -Path $jsonl -Since 0 -Name 'codex' -RequestID 'unrelated-request')) `
+        'block verdict seam rejects an unrelated request identity'
     $delayedJsonl = Join-Path $temp 'delayed-gateway-evidence.jsonl'
     [IO.File]::WriteAllText($delayedJsonl, '')
-    $delayedWriter = Start-Job -ArgumentList $delayedJsonl, $fixtureEvents[2], $fixtureEvents[0] -ScriptBlock {
-        param($Path, $ConnectorEvent, $BlockVerdict)
+    $unrelatedDecision = $fixtureEvents[1] | ConvertFrom-Json -ErrorAction Stop
+    $unrelatedDecision.record_id = 'windows-contract-unrelated-hook-decision'
+    $unrelatedDecision.correlation.request_id = 'unrelated-request'
+    $unrelatedDecision.correlation.session_id = 'unrelated-session'
+    $unrelatedVerdict = $fixtureEvents[0] | ConvertFrom-Json -ErrorAction Stop
+    $unrelatedVerdict.record_id = 'windows-contract-unrelated-verdict'
+    $unrelatedVerdict.correlation.request_id = 'unrelated-request'
+    $unrelatedVerdict.correlation.session_id = 'unrelated-session'
+    $delayedWriter = Start-Job -ArgumentList @(
+        $delayedJsonl,
+        ($unrelatedDecision | ConvertTo-Json -Depth 8 -Compress),
+        ($unrelatedVerdict | ConvertTo-Json -Depth 8 -Compress),
+        $fixtureEvents[1],
+        $fixtureEvents[0]
+    ) -ScriptBlock {
+        param($Path, $UnrelatedDecision, $UnrelatedVerdict, $CurrentDecision, $CurrentVerdict)
         Start-Sleep -Milliseconds 100
-        [IO.File]::AppendAllText($Path, $ConnectorEvent + [Environment]::NewLine)
+        [IO.File]::AppendAllText($Path, $UnrelatedDecision + [Environment]::NewLine)
+        [IO.File]::AppendAllText($Path, $UnrelatedVerdict + [Environment]::NewLine)
         Start-Sleep -Milliseconds 1000
-        [IO.File]::AppendAllText($Path, $BlockVerdict + [Environment]::NewLine)
+        [IO.File]::AppendAllText($Path, $CurrentDecision + [Environment]::NewLine)
+        Start-Sleep -Milliseconds 100
+        [IO.File]::AppendAllText($Path, $CurrentVerdict + [Environment]::NewLine)
     }
     try {
-        $delayedEvidence = Wait-GatewayEvidenceAfter $delayedJsonl 'codex' 0 $true 5000
-        Wait-Job $delayedWriter | Out-Null
+        $delayedEvidence = Wait-GatewayEvidenceAfter `
+            -Path $delayedJsonl -Name 'codex' -Since 0 -RequireBlock $true `
+            -TimeoutMilliseconds 5000 -SessionID $sessionId -HookEvent $hookEvent
+        Wait-Job -Job $delayedWriter -Timeout 10 | Out-Null
+        Assert-True ($delayedWriter.State -eq 'Completed') `
+            'delayed gateway evidence writer completed within the bounded wait'
         Receive-Job $delayedWriter -ErrorAction Stop | Out-Null
-        Assert-True ($delayedEvidence.ConnectorEvent -and $delayedEvidence.BlockVerdict) `
-            'gateway evidence polling tolerates a block verdict delayed beyond the former fixed wait'
+        Assert-True ($delayedEvidence.ConnectorEvent -and $delayedEvidence.BlockVerdict -and
+            [string]$delayedEvidence.RequestID -ceq $requestId) `
+            'gateway evidence polling ignores delayed unrelated records and waits for the matching hook request'
     } finally {
         Stop-Job $delayedWriter -ErrorAction SilentlyContinue
         Remove-Job $delayedWriter -Force -ErrorAction SilentlyContinue
@@ -1040,8 +1081,10 @@ private-secret-name = "DefenseClaw must remain redacted"
         '(?s)function Invoke-Hook\b.*?(?=\r?\nfunction )'
     ).Value
     Assert-True ($invokeHookFunction -match 'Wait-GatewayEvidenceAfter' -and
+        $invokeHookFunction -match '-SessionID \$sessionID' -and
+        $invokeHookFunction -match '-HookEvent \$hookEvent' -and
         $invokeHookFunction -notmatch 'Start-Sleep -Milliseconds 800') `
-        'hook evidence uses bounded polling instead of a fixed 800ms delay'
+        'hook evidence uses identity-scoped bounded polling instead of a fixed 800ms delay'
     Assert-True ($nativeWorkflowText -match '(?s)connector-contract:.*?connector: \[codex, claudecode, amp\].*?windows-native-required:') `
         'required Windows contract matrix contains Codex, Claude Code, and Amp'
     Assert-True ($nativeWorkflowText -match '(?m)^\s+name: Windows Native Required\s*$') 'stable aggregate check name exists'

--- a/scripts/live-connector-e2e/test-windows.ps1
+++ b/scripts/live-connector-e2e/test-windows.ps1
@@ -896,6 +896,25 @@ private-secret-name = "DefenseClaw must remain redacted"
     Assert-True (-not (Test-ConnectorEvent $jsonl 'claudecode' 0)) 'connector event seam ignores body-text false positives'
     Assert-True (Test-BlockVerdict $jsonl 0) 'block verdict seam'
     Assert-True (-not (Test-BlockVerdict $jsonl 1)) 'block verdict seam rejects hook decisions and non-canonical scan deny values'
+    $delayedJsonl = Join-Path $temp 'delayed-gateway-evidence.jsonl'
+    [IO.File]::WriteAllText($delayedJsonl, '')
+    $delayedWriter = Start-Job -ArgumentList $delayedJsonl, $fixtureEvents[2], $fixtureEvents[0] -ScriptBlock {
+        param($Path, $ConnectorEvent, $BlockVerdict)
+        Start-Sleep -Milliseconds 100
+        [IO.File]::AppendAllText($Path, $ConnectorEvent + [Environment]::NewLine)
+        Start-Sleep -Milliseconds 1000
+        [IO.File]::AppendAllText($Path, $BlockVerdict + [Environment]::NewLine)
+    }
+    try {
+        $delayedEvidence = Wait-GatewayEvidenceAfter $delayedJsonl 'codex' 0 $true 5000
+        Wait-Job $delayedWriter | Out-Null
+        Receive-Job $delayedWriter -ErrorAction Stop | Out-Null
+        Assert-True ($delayedEvidence.ConnectorEvent -and $delayedEvidence.BlockVerdict) `
+            'gateway evidence polling tolerates a block verdict delayed beyond the former fixed wait'
+    } finally {
+        Stop-Job $delayedWriter -ErrorAction SilentlyContinue
+        Remove-Job $delayedWriter -Force -ErrorAction SilentlyContinue
+    }
     $hookDecision = Get-LatestHookDecision $jsonl 'codex' 0
     Assert-True ($null -ne $hookDecision -and $hookDecision.action -eq 'allow' -and
         $hookDecision.raw_action -eq 'block' -and $hookDecision.mode -eq 'observe' -and
@@ -1016,6 +1035,13 @@ private-secret-name = "DefenseClaw must remain redacted"
         $nativeHarnessText,
         '(?s)function Add-WindowsNativeDiagnosticTail\b.*?(?=\r?\nfunction )'
     ).Value
+    $invokeHookFunction = [regex]::Match(
+        $harnessText,
+        '(?s)function Invoke-Hook\b.*?(?=\r?\nfunction )'
+    ).Value
+    Assert-True ($invokeHookFunction -match 'Wait-GatewayEvidenceAfter' -and
+        $invokeHookFunction -notmatch 'Start-Sleep -Milliseconds 800') `
+        'hook evidence uses bounded polling instead of a fixed 800ms delay'
     Assert-True ($nativeWorkflowText -match '(?s)connector-contract:.*?connector: \[codex, claudecode, amp\].*?windows-native-required:') `
         'required Windows contract matrix contains Codex, Claude Code, and Amp'
     Assert-True ($nativeWorkflowText -match '(?m)^\s+name: Windows Native Required\s*$') 'stable aggregate check name exists'

--- a/scripts/live-connector-e2e/test-windows.ps1
+++ b/scripts/live-connector-e2e/test-windows.ps1
@@ -139,6 +139,33 @@ try {
     . $harness -NoRun
     . $nativeHarness -WorkspaceRoot $root -StateRoot (Join-Path $temp 'synthetic-native') -NoRun
 
+    $ampBlockFixturePath = Join-Path $ampGoldenRoot 'pre_tool_block.json'
+    $ampBlockFixtureText = [IO.File]::ReadAllText($ampBlockFixturePath)
+    $ampBlockFixture = $ampBlockFixtureText | ConvertFrom-Json -ErrorAction Stop
+    $ampActionPayloadPath = New-AmpHookPayloadOccurrence `
+        -Payload $ampBlockFixturePath -IdentitySuffix 'action-block' `
+        -OutputRoot (Join-Path $temp 'amp-hook-occurrences')
+    $ampActionPayload = [IO.File]::ReadAllText($ampActionPayloadPath) |
+        ConvertFrom-Json -ErrorAction Stop
+    Assert-True ([string]$ampActionPayload.source_event_id -ceq
+        "$([string]$ampBlockFixture.source_event_id):action-block" -and
+        [string]$ampActionPayload.tool_call_id -ceq
+        "$([string]$ampBlockFixture.tool_call_id)-action-block" -and
+        [long]$ampActionPayload.source_sequence -eq
+        ([long]$ampBlockFixture.source_sequence + 1000000) -and
+        [string]$ampActionPayload.session_id -ceq [string]$ampBlockFixture.session_id -and
+        [IO.File]::ReadAllText($ampBlockFixturePath) -ceq $ampBlockFixtureText) `
+        'Amp action payload has a unique replay identity without mutating the golden fixture'
+    $invalidAmpIdentityRejected = $false
+    try {
+        New-AmpHookPayloadOccurrence `
+            -Payload $ampBlockFixturePath -IdentitySuffix '..\unsafe' `
+            -OutputRoot (Join-Path $temp 'amp-hook-occurrences') | Out-Null
+    } catch {
+        $invalidAmpIdentityRejected = $_.Exception.Message -match 'invalid Amp hook identity suffix'
+    }
+    Assert-True $invalidAmpIdentityRejected 'Amp occurrence payload rejects unsafe identity suffixes'
+
     $safeRegistrationLocations = @(Get-DefenseClawRegistrationLocations @'
 notify = ["C:\synthetic-private-path\DefenseClaw\bin\launcher.exe", "notify"]
 
@@ -822,6 +849,7 @@ private-secret-name = "DefenseClaw must remain redacted"
     $requestId = [guid]::NewGuid().ToString()
     $sessionId = 'windows-contract-session'
     $hookEvent = 'PreToolUse'
+    $toolInvocationId = 'windows-contract-tool'
     $observedAt = [DateTime]::UtcNow.ToString('o')
     $provenance = [ordered]@{
         producer = 'defenseclaw'
@@ -834,7 +862,10 @@ private-secret-name = "DefenseClaw must remain redacted"
             schema_version = 1; bucket_catalog_version = 1; timestamp = $observedAt
             record_id = 'windows-contract-verdict'; bucket = 'asset.scan'; signal = 'logs'
             event_name = 'scan.completed'; source = 'scanner'; connector = 'codex'
-            correlation = @{ request_id = $requestId; session_id = $sessionId }; provenance = $provenance; field_classes = @{}
+            correlation = @{
+                request_id = $requestId; session_id = $sessionId
+                tool_invocation_id = $toolInvocationId
+            }; provenance = $provenance; field_classes = @{}
             mandatory = $false
             body = @{
                 'defenseclaw.scan.verdict' = 'block'
@@ -844,7 +875,10 @@ private-secret-name = "DefenseClaw must remain redacted"
             schema_version = 1; bucket_catalog_version = 1; timestamp = $observedAt
             record_id = 'windows-contract-hook-decision'; bucket = 'guardrail.evaluation'; signal = 'logs'
             event_name = 'hook_decision'; source = 'connector'; connector = 'codex'
-            correlation = @{ request_id = $requestId; session_id = $sessionId }; provenance = $provenance; field_classes = @{}
+            correlation = @{
+                request_id = $requestId; session_id = $sessionId
+                tool_invocation_id = $toolInvocationId
+            }; provenance = $provenance; field_classes = @{}
             mandatory = $false
             body = @{
                 'defenseclaw.guardrail.effective_action' = 'allow'
@@ -860,7 +894,10 @@ private-secret-name = "DefenseClaw must remain redacted"
             schema_version = 1; bucket_catalog_version = 1; timestamp = $observedAt
             record_id = 'windows-contract-tool'; bucket = 'tool.activity'; signal = 'logs'
             event_name = 'tool.invocation.requested'; source = 'connector'; connector = 'codex'
-            correlation = @{ request_id = $requestId; session_id = $sessionId }; provenance = $provenance; field_classes = @{}
+            correlation = @{
+                request_id = $requestId; session_id = $sessionId
+                tool_invocation_id = $toolInvocationId
+            }; provenance = $provenance; field_classes = @{}
             mandatory = $false; body = @{}
         },
         [ordered]@{
@@ -898,7 +935,8 @@ private-secret-name = "DefenseClaw must remain redacted"
     Assert-True (Test-ConnectorEvent $jsonl 'codex' 0) 'connector event seam'
     Assert-True (-not (Test-ConnectorEvent $jsonl 'claudecode' 0)) 'connector event seam ignores body-text false positives'
     Assert-True (Test-ConnectorEvent `
-        -Path $jsonl -Name 'codex' -Since 0 -SessionID $sessionId -HookEvent $hookEvent) `
+        -Path $jsonl -Name 'codex' -Since 0 -SessionID $sessionId -HookEvent $hookEvent `
+        -ToolInvocationID $toolInvocationId) `
         'connector event seam accepts the matching hook identity'
     Assert-True (-not (Test-ConnectorEvent `
         -Path $jsonl -Name 'codex' -Since 0 -SessionID 'unrelated-session' -HookEvent $hookEvent)) `
@@ -907,24 +945,35 @@ private-secret-name = "DefenseClaw must remain redacted"
         -Path $jsonl -Name 'codex' -Since 0 -SessionID $sessionId -HookEvent $hookEvent `
         -RequestID 'unrelated-request')) `
         'connector event seam rejects an unrelated request identity'
+    Assert-True (-not (Test-ConnectorEvent `
+        -Path $jsonl -Name 'codex' -Since 0 -SessionID $sessionId -HookEvent $hookEvent `
+        -ToolInvocationID 'unrelated-tool')) `
+        'connector event seam rejects an unrelated tool invocation identity'
     Assert-True (Test-BlockVerdict $jsonl 0) 'block verdict seam'
     Assert-True (-not (Test-BlockVerdict $jsonl 1)) 'block verdict seam rejects hook decisions and non-canonical scan deny values'
     Assert-True (Test-BlockVerdict `
-        -Path $jsonl -Since 0 -Name 'codex' -RequestID $requestId) `
+        -Path $jsonl -Since 0 -Name 'codex' -RequestID $requestId `
+        -SessionID $sessionId -ToolInvocationID $toolInvocationId) `
         'block verdict seam accepts the matching request identity'
     Assert-True (-not (Test-BlockVerdict `
         -Path $jsonl -Since 0 -Name 'codex' -RequestID 'unrelated-request')) `
         'block verdict seam rejects an unrelated request identity'
+    Assert-True (-not (Test-BlockVerdict `
+        -Path $jsonl -Since 0 -Name 'codex' -RequestID $requestId `
+        -SessionID $sessionId -ToolInvocationID 'unrelated-tool')) `
+        'block verdict seam rejects an unrelated tool invocation identity'
     $delayedJsonl = Join-Path $temp 'delayed-gateway-evidence.jsonl'
     [IO.File]::WriteAllText($delayedJsonl, '')
     $unrelatedDecision = $fixtureEvents[1] | ConvertFrom-Json -ErrorAction Stop
     $unrelatedDecision.record_id = 'windows-contract-unrelated-hook-decision'
     $unrelatedDecision.correlation.request_id = 'unrelated-request'
-    $unrelatedDecision.correlation.session_id = 'unrelated-session'
+    $unrelatedDecision.correlation.session_id = $sessionId
+    $unrelatedDecision.correlation.tool_invocation_id = 'unrelated-tool'
     $unrelatedVerdict = $fixtureEvents[0] | ConvertFrom-Json -ErrorAction Stop
     $unrelatedVerdict.record_id = 'windows-contract-unrelated-verdict'
     $unrelatedVerdict.correlation.request_id = 'unrelated-request'
-    $unrelatedVerdict.correlation.session_id = 'unrelated-session'
+    $unrelatedVerdict.correlation.session_id = $sessionId
+    $unrelatedVerdict.correlation.tool_invocation_id = 'unrelated-tool'
     $delayedWriter = Start-Job -ArgumentList @(
         $delayedJsonl,
         ($unrelatedDecision | ConvertTo-Json -Depth 8 -Compress),
@@ -944,13 +993,15 @@ private-secret-name = "DefenseClaw must remain redacted"
     try {
         $delayedEvidence = Wait-GatewayEvidenceAfter `
             -Path $delayedJsonl -Name 'codex' -Since 0 -RequireBlock $true `
-            -TimeoutMilliseconds 5000 -SessionID $sessionId -HookEvent $hookEvent
+            -TimeoutMilliseconds 5000 -SessionID $sessionId -HookEvent $hookEvent `
+            -ToolInvocationID $toolInvocationId
         Wait-Job -Job $delayedWriter -Timeout 10 | Out-Null
         Assert-True ($delayedWriter.State -eq 'Completed') `
             'delayed gateway evidence writer completed within the bounded wait'
         Receive-Job $delayedWriter -ErrorAction Stop | Out-Null
         Assert-True ($delayedEvidence.ConnectorEvent -and $delayedEvidence.BlockVerdict -and
-            [string]$delayedEvidence.RequestID -ceq $requestId) `
+            [string]$delayedEvidence.RequestID -ceq $requestId -and
+            [string]$delayedEvidence.ToolInvocationID -ceq $toolInvocationId) `
             'gateway evidence polling ignores delayed unrelated records and waits for the matching hook request'
     } finally {
         Stop-Job $delayedWriter -ErrorAction SilentlyContinue
@@ -1083,8 +1134,11 @@ private-secret-name = "DefenseClaw must remain redacted"
     Assert-True ($invokeHookFunction -match 'Wait-GatewayEvidenceAfter' -and
         $invokeHookFunction -match '-SessionID \$sessionID' -and
         $invokeHookFunction -match '-HookEvent \$hookEvent' -and
+        $invokeHookFunction -match 'Get-JsonPropertyValue \$payloadObject ''tool_call_id''' -and
+        $invokeHookFunction -match '-ToolInvocationID \$toolInvocationID' -and
+        $invokeHookFunction -match 'New-AmpHookPayloadOccurrence' -and
         $invokeHookFunction -notmatch 'Start-Sleep -Milliseconds 800') `
-        'hook evidence uses identity-scoped bounded polling instead of a fixed 800ms delay'
+        'hook evidence uses session, event, and tool-scoped bounded polling instead of a fixed 800ms delay'
     Assert-True ($nativeWorkflowText -match '(?s)connector-contract:.*?connector: \[codex, claudecode, amp\].*?windows-native-required:') `
         'required Windows contract matrix contains Codex, Claude Code, and Amp'
     Assert-True ($nativeWorkflowText -match '(?m)^\s+name: Windows Native Required\s*$') 'stable aggregate check name exists'
@@ -1860,8 +1914,11 @@ private-secret-name = "DefenseClaw must remain redacted"
     ).Value
     Assert-True ($latestHookDecision -match 'Get-JsonPropertyValue \$correlation ''session_id''' -and
         $latestHookDecision -match 'Get-JsonPropertyValue \$body ''defenseclaw\.hook\.event''' -and
+        $latestHookDecision -match 'Get-JsonPropertyValue \$correlation ''tool_invocation_id''' -and
         $hookDecisionWait -match '\$SessionID \$HookEvent') `
         'gateway hook readiness accepts only the current probe session and event decision'
+    Assert-True ($harnessText -match '(?s)\$blockIdentitySuffix = if \(\$Connector -eq ''amp''\).*?Invoke-Hook.*?-IdentitySuffix \$blockIdentitySuffix') `
+        'Amp action block uses a fresh fixture identity so strict hook-decision correlation remains required'
     $isolatedCleanup = [regex]::Match($harnessText, '(?s)function Stop-IsolatedProcessTree\b.*?\n\}').Value
     Assert-True ($isolatedCleanup -match 'HashSet\[int\]' -and
         $isolatedCleanup -match '\$ancestor\[0\]\.ParentProcessId' -and


### PR DESCRIPTION
Base/stack note: Targets `main`, rebased through #683. This PR also carries the minimal CI compatibility and Windows timing repairs required for the current branch rules to evaluate it reliably.

## Problem

`defenseclaw setup redaction remove-all` correctly selects profile `none` for configurable observability log and trace projections, but macOS notifications and agent hook responses use a separate compatibility safety scrub.

For built-in findings, the compatibility scrub treated DefenseClaw's own trusted rule title as if it were scanner-authored content. A reason such as `matched: TRUST-SAFETY-OVERRIDE:Safety override attempt` therefore rendered the title as a `<redacted len=... sha=...>` marker. This made attended alerts unnecessarily opaque and made a successful `remove-all` operation look ineffective.

The PR was also blocked by two CI control-plane problems:

- the repository ruleset still requires `make test (unified)`, but CI stopped emitting that context when the test corpus was sharded;
- the Windows connector contract waited a fixed 800 ms before checking asynchronous gateway evidence, causing valid block verdicts to fail intermittently.

## Current Situation

The v8 destination plan and compatibility display surfaces have distinct redaction boundaries:

- profile `none` already preserves registered fields in configurable observability destinations;
- OS notifications, hook responses, and compatibility inspect responses still apply their own safety scrub;
- the generic reason scrub cannot safely trust every `RULE-ID:title` suffix because external scanners may place matched literals in the title;
- exact ship-authored titles from the compiled-in rule catalog are safe metadata, but were not distinguished from scanner-authored values;
- managed-enterprise per-inspection redaction directives must remain authoritative over every response surface.

The affected preview also reported only effective destination-leg changes, without stating that notifications and hook responses were outside its scope.

CI already runs the complete Go and Python suites through sharded aggregate jobs. Restoring a second literal `make test` execution would duplicate the slow corpus without adding coverage.

## Solution

### Preserve only exact built-in catalog metadata

Add catalog-aware display helpers that recognize a reason only when the complete value is a bounded `matched: ID:title[, ID:title...]` list and every pair exactly matches the compiled-in default catalog.

The trusted carve-out is used by generic agent, Claude Code, and Codex notifications and hook responses, plus compatibility inspect response sanitization.

### Preserve managed policy precedence

Trusted-title passthrough is permitted only under the default compatibility policy. Explicit managed `raw` and `redact` decisions remain authoritative across generic, Claude Code, Codex, notification, and inspect response paths. A managed redact decision also remains authoritative over the inspect reveal header.

```mermaid
flowchart LR
    A["Verdict reason"] --> B{"Effective managed policy"}
    B -- "Force redact" --> R["Compatibility redaction"]
    B -- "Managed raw" --> X["Raw managed response"]
    B -- "Default" --> C{"Exact compiled-in ID:title list?"}
    C -- "Yes" --> T["Show trusted catalog metadata"]
    C -- "No" --> R
```

### Clarify CLI scope

The human-readable redaction preview now states that it governs configurable observability log/trace projections and that OS notifications and agent hook responses retain separate safety redaction. The reference documentation records the same boundary.

### Restore the required check without duplicate work

Add a lightweight `make test (unified)` compatibility job that depends on the existing `Go Test` and `Python Lint & Test` aggregates. It runs no checkout or test corpus and fails unless both upstream aggregates succeed, including when either is failed, cancelled, or skipped.

### Replace the Windows fixed delay with identity-scoped evidence polling

Poll for the matching hook decision for at most five seconds using the connector, payload session, canonical hook event, and tool invocation when present. For blocking checks, use that decision's request ID and require an underlying block record with the same connector, session, tool, and request identity. Normal allow hooks skip the block scan entirely. Preserve the existing distinct failure messages and add a regression that emits an unrelated same-session decision and block first, then delays the current tool request beyond the former 800 ms window.

The static Amp block fixture is used once under observe mode and again under action mode. Stage a disposable action copy with fresh source-event, source-sequence, and tool identities so the second invocation is not classified as a replay. The golden fixture remains byte-for-byte unchanged, and scanner evidence alone still cannot replace the required canonical hook decision.

## What Changed (Where & How)

| Path | Change |
| --- | --- |
| `internal/gateway/reason_display.go` | Adds exact built-in reason validation and policy-aware display helpers for agent, notification, and default compatibility sinks. |
| `internal/gateway/{agent_hook,claude_code_hook,codex_hook}.go` | Routes notification and hook-response reasons through the catalog-aware helpers and propagates the effective managed policy. |
| `internal/gateway/inspect.go` | Preserves exact built-in metadata only under the default policy while retaining evidence redaction and managed policy precedence. |
| `internal/gateway/reason_display_test.go` | Covers trusted and untrusted reasons, response shapers, raw/redact policy precedence, nested response fields, and inspect reveal behavior. |
| `cli/defenseclaw/commands/cmd_setup_redaction.py` | Adds explicit scope lines to mutation previews. |
| `cli/tests/test_cmd_setup_redaction.py` | Pins the new preview guidance. |
| `docs-site/content/docs/reference/redaction.mdx` | Documents the observability-versus-attended-surface boundary. |
| `.github/workflows/ci.yml` | Restores `make test (unified)` as a dependency-only compatibility gate. |
| `cli/tests/test_ci_workflow_efficiency.py` | Safely parses the workflow and verifies the exact required context without any parsed step rerunning `make test`. |
| `scripts/live-connector-e2e/run-windows.ps1` | Replaces the fixed 800 ms check with bounded connector/session/hook/tool/request-scoped polling and gives the repeated Amp action fixture a fresh replay identity. |
| `scripts/live-connector-e2e/test-windows.ps1` | Pins bounded writer cleanup, fixture immutability, safe identity staging, and rejection of unrelated delayed records. |

## Breaking Changes

- No configuration schema, API, or route-policy break.
- User-visible behavior changes: exact ship-authored built-in rule titles are now readable in attended notification/hook surfaces under the default compatibility policy.
- Explicit managed-enterprise redaction directives take precedence over trusted-title passthrough and inspect reveal behavior.
- Text-mode redaction previews contain two additional scope lines. JSON output is unchanged.
- CI now emits the ruleset-required `make test (unified)` context without rerunning the corpus.

## Open Issues / Follow-ups

None.

## Test Plan

- `go test ./internal/gateway -count=1 -run '^(TestTrustedBuiltInMatchReason|TestNotificationDisplayReasonPreservesOnlyTrustedCatalogMetadata|TestAgentAndDefaultSinkDisplayReasonUseTrustedMetadataCarveOut|TestHookResponseDisplayReasonHonorsManagedRedactionPolicy|TestSanitizeForResponseHonorsManagedRedactionDirective|TestAgentReasonCarveOut_HookResponses)$'`
  - Passed: `ok github.com/defenseclaw/defenseclaw/internal/gateway 0.840s`
- `go test ./internal/gateway -count=1`
  - Passed on a clean local rerun with exit status 0.
- `.venv/bin/python -m pytest -q cli/tests/test_cmd_setup_redaction.py cli/tests/test_install_docs_static.py cli/tests/test_ci_workflow_efficiency.py cli/tests/test_telemetry_ci_strategy.py cli/tests/test_release_validation_strategy.py`
  - Local macOS: `97 passed, 1 skipped in 17.47s`
  - Connected macOS arm64: `98 passed in 17.90s`
  - Connected Linux arm64: `97 passed, 1 skipped in 39.21s`
- `actionlint .github/workflows/ci.yml`
  - Passed with no findings.
- `.venv/bin/python -m pytest -q cli/tests/test_ci_workflow_efficiency.py cli/tests/test_telemetry_ci_strategy.py cli/tests/test_release_validation_strategy.py`
  - Passed: `18 passed in 0.57s`.
- `uv run pytest -q cli/tests/test_ci_workflow_efficiency.py`
  - Passed on final head: `5 passed in 0.31s`.
- `git diff --check`
  - Passed with no whitespace errors.
- Connected macOS arm64: `go test ./internal/gateway -count=1`
  - Passed with exit status 0.
- Connected Linux arm64: `umask 022 && TMPDIR=<private-home-temp> go test ./internal/gateway -count=1`
  - Passed with exit status 0. A `/tmp`-rooted attempt correctly failed DefenseClaw's secure-ancestor checks because `/tmp` is world-writable.
- Connected Windows standard-user host: cross-compiled `gateway.test.exe` running the six focused reason-display and managed-policy tests.
  - Passed, including every generic, Codex, and Claude Code subcase.
- Connected Windows standard-user Amp host, Windows PowerShell 5.1: parsed the changed test file and executed the exact strict evidence helpers with scan-only evidence, an unrelated same-session tool decision/block, and the delayed current request; it also verified the replay-safe Amp payload identities.
  - Passed: `pr684-windows-strict-evidence-pass`; the temporary remote fixture directory was removed afterward.
- GitHub CI `make test (unified)`
  - Passed on final head `5ba0b015829e0f3f39b61c22e4d41c30c6eb5fa7` in two seconds without checkout or a duplicate test run; the complete final-head `CI` workflow passed.
- GitHub `Windows Native CI`
  - Passed on final head `5ba0b015829e0f3f39b61c22e4d41c30c6eb5fa7` in `41m55s`, including the `Windows PowerShell harness validation` in `2m37s` and the replay-safe `Windows x64 connector contract / amp` in `3m44s`.
