### PR TITLE
fix: accept OTLP batches and complete unrouted traces

### DIFF
--- a/docs-site/content/docs/reference/gateway-api.mdx
+++ b/docs-site/content/docs/reference/gateway-api.mdx
@@ -105,7 +105,10 @@ non-local browser origin.
 
 All ordinary mutations also reject a non-local `Origin`; cross-site requests
 are rejected when `Sec-Fetch-Site` identifies them. A shared middleware caps
-POST, PUT, and PATCH bodies at 1 MiB.
+ordinary POST, PUT, and PATCH bodies at 1 MiB. Exact authenticated OTLP-HTTP
+ingest routes use a separate 64 MiB receiver limit so exporter batches can
+follow the protocol's recommended bound without increasing the limit for the
+rest of the API.
 
 ```
 X-DefenseClaw-Client: cli
@@ -408,7 +411,9 @@ supports bounded cursor pagination.
 
 The gateway accepts OTLP-HTTP from configured connectors. Both OTLP JSON and
 protobuf content types are accepted; decoding is implemented in
-`internal/gateway/otel_ingest.go`.
+`internal/gateway/otel_ingest.go`. Request bodies are bounded at 64 MiB; larger
+batches receive HTTP 413 and are recorded as content-free `body_too_large`
+rejections.
 
 | Method | Path | Purpose |
 | --- | --- | --- |

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -908,7 +908,7 @@ func (a *APIServer) Run(ctx context.Context) error {
 	mux.HandleFunc("/api/v1/codex/notify", a.handleCodexNotify)
 	mux.HandleFunc("/v1/connectors", a.handleConnectors)
 
-	handler := maxBodyMiddleware(mux, 1<<20)
+	handler := apiBodyLimitMiddleware(mux, apiRequestBodyMaxBytes, otlpRequestBodyMaxBytes)
 	handler = a.apiCSRFProtect(handler)
 	handler = a.tokenAuth(handler)
 	handler = a.metricsMiddleware(handler)
@@ -3376,23 +3376,44 @@ func (a *APIServer) apiCSRFProtect(next http.Handler) http.Handler {
 	})
 }
 
+const (
+	apiRequestBodyMaxBytes  int64 = 1 << 20
+	otlpRequestBodyMaxBytes int64 = 64 << 20
+)
+
+// apiBodyLimitMiddleware preserves the ordinary API mutation ceiling while
+// allowing exact OTLP-HTTP ingest routes to receive exporter batches. The
+// 64 MiB OTLP limit follows the protocol's recommended receiver default and
+// matches the observability pipeline's supported maximum export batch size.
+func apiBodyLimitMiddleware(next http.Handler, maxBytes, otlpMaxBytes int64) http.Handler {
+	return bodyLimitMiddleware(next, func(r *http.Request) int64 {
+		if isOTLPEndpointPath(r.URL.Path) {
+			return otlpMaxBytes
+		}
+		return maxBytes
+	})
+}
+
+// maxBodyMiddleware applies one uniform cap to all state-changing methods.
+func maxBodyMiddleware(next http.Handler, maxBytes int64) http.Handler {
+	return bodyLimitMiddleware(next, func(*http.Request) int64 { return maxBytes })
+}
+
+func bodyLimitMiddleware(next http.Handler, maxBytes func(*http.Request) int64) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodPatch {
+			r.Body = http.MaxBytesReader(w, r.Body, maxBytes(r))
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // csrfProtect wraps a handler with localhost CSRF defenses. Mutating methods
 // (POST, PUT, PATCH, DELETE) require:
 //  1. X-DefenseClaw-Client header (blocks simple/no-cors browser requests)
 //  2. Content-Type containing "application/json"
 //  3. Origin, if present, must be a localhost address
 //
-// maxBodyMiddleware caps the request body size for state-changing methods
-// to prevent memory exhaustion from oversized payloads.
-func maxBodyMiddleware(next http.Handler, maxBytes int64) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodPatch {
-			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
 // Read-only requests (GET, HEAD, OPTIONS) are exempt.
 func csrfProtect(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/gateway/api_body_limit_test.go
+++ b/internal/gateway/api_body_limit_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAPIBodyLimitMiddlewareUsesLargerBoundOnlyForExactOTLPRoutes(t *testing.T) {
+	inner := bodyLimitTestHandler()
+	handler := apiBodyLimitMiddleware(inner, apiRequestBodyMaxBytes, otlpRequestBodyMaxBytes)
+
+	for _, path := range []string{
+		"/v1/logs",
+		"/v1/metrics",
+		"/v1/traces",
+		"/otlp/codex/path-token/v1/traces",
+	} {
+		t.Run("accepts above API limit "+path, func(t *testing.T) {
+			response := serveBodyLimitRequest(
+				handler,
+				path,
+				apiRequestBodyMaxBytes+1,
+			)
+			if response.Code != http.StatusNoContent {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusNoContent)
+			}
+		})
+	}
+
+	for _, path := range []string{
+		"/api/v1/config",
+		"/api/x/v1/traces",
+		"/v1/traces/not-an-ingest-route",
+		"/otlp/codex/path-token/v1/traces/not-an-ingest-route",
+	} {
+		t.Run("retains API limit "+path, func(t *testing.T) {
+			response := serveBodyLimitRequest(
+				handler,
+				path,
+				apiRequestBodyMaxBytes+1,
+			)
+			if response.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusRequestEntityTooLarge)
+			}
+		})
+	}
+
+	t.Run("rejects OTLP above configured bounded limit", func(t *testing.T) {
+		const (
+			testAPIMaxBytes  = 8
+			testOTLPMaxBytes = 16
+		)
+		boundedHandler := apiBodyLimitMiddleware(inner, testAPIMaxBytes, testOTLPMaxBytes)
+		response := serveBodyLimitRequest(
+			boundedHandler,
+			"/v1/traces",
+			testOTLPMaxBytes+1,
+		)
+		if response.Code != http.StatusRequestEntityTooLarge {
+			t.Fatalf("status = %d, want %d", response.Code, http.StatusRequestEntityTooLarge)
+		}
+	})
+}
+
+func TestMaxBodyMiddlewareRemainsUniformForOTLPPaths(t *testing.T) {
+	const maxBytes = 8
+	handler := maxBodyMiddleware(bodyLimitTestHandler(), maxBytes)
+	response := serveBodyLimitRequest(handler, "/v1/traces", maxBytes+1)
+	if response.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestOTLPIngestAcceptsValidBatchesAboveOrdinaryAPILimit(t *testing.T) {
+	fixture := newSidecarRuntimeFixture(t, true)
+	api := &APIServer{}
+	api.bindOTLPObservabilityRuntime(fixture.runtime)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/logs", api.handleOTLPLogs)
+	mux.HandleFunc("/v1/metrics", api.handleOTLPMetrics)
+	mux.HandleFunc("/v1/traces", api.handleOTLPTraces)
+	handler := apiBodyLimitMiddleware(mux, apiRequestBodyMaxBytes, otlpRequestBodyMaxBytes)
+
+	for _, test := range []struct {
+		path     string
+		envelope string
+	}{
+		{path: "/v1/logs", envelope: `{"resourceLogs":[]}`},
+		{path: "/v1/metrics", envelope: `{"resourceMetrics":[]}`},
+		{path: "/v1/traces", envelope: `{"resourceSpans":[]}`},
+	} {
+		t.Run(test.path, func(t *testing.T) {
+			body := strings.Repeat(" ", int(apiRequestBodyMaxBytes+1)) + test.envelope
+			request := httptest.NewRequest(http.MethodPost, test.path, strings.NewReader(body))
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set(otelSourceHeader, "codex")
+			response := httptest.NewRecorder()
+
+			handler.ServeHTTP(response, request)
+
+			if response.Code != http.StatusOK || response.Body.String() != "{}" {
+				t.Fatalf("response = %d %q, want 200 %q", response.Code, response.Body.String(), "{}")
+			}
+		})
+	}
+}
+
+func bodyLimitTestHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.Copy(io.Discard, r.Body); err != nil {
+			var maxBytesError *http.MaxBytesError
+			if errors.As(err, &maxBytesError) {
+				http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+			http.Error(w, "read request body", http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func serveBodyLimitRequest(handler http.Handler, path string, bodyBytes int64) *httptest.ResponseRecorder {
+	body := strings.NewReader(strings.Repeat("x", int(bodyBytes)))
+	request := httptest.NewRequest(http.MethodPost, path, body)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	return response
+}

--- a/internal/gateway/otel_ingest.go
+++ b/internal/gateway/otel_ingest.go
@@ -24,9 +24,10 @@
 //   - All three endpoints are gated by tokenAuth + apiCSRFProtect
 //     (the same chain as /api/v1/codex/hook). Unauthenticated POSTs
 //     are rejected upstream of this handler.
-//   - Body size is capped by maxBodyMiddleware (1 MiB). The OTLP
-//     spec recommends batching; one MiB covers roughly 50-100 log
-//     records or 500-1000 metric data points per batch.
+//   - Body size is capped by apiBodyLimitMiddleware (64 MiB), following the
+//     OTLP-HTTP receiver recommendation and matching the observability
+//     pipeline's supported maximum export batch size. The rest of the
+//     state-changing API retains its 1 MiB request limit.
 //   - Payload parsing failures emit content-free mandatory v8 health evidence
 //     and still return OTLP success; retrying the same bad batch would only
 //     create gateway load and noisier telemetry.

--- a/internal/observability/runtime/generated_telemetry_trace_test.go
+++ b/internal/observability/runtime/generated_telemetry_trace_test.go
@@ -149,6 +149,41 @@ func TestGeneratedTelemetryTracePreservesHierarchyNamesAndFacts(t *testing.T) {
 	}
 }
 
+func TestGeneratedTelemetryTraceCompletesWithoutSpanDestinations(t *testing.T) {
+	dependencies := newRuntimeTestDependencies(t)
+	pipelines := &generatedTracePipelines{
+		consumers: make(map[uint64]*generatedTraceConsumer), withoutSpanDestinations: true,
+	}
+	plan := runtimeTestPlan(t, dependencies.storePath, dependencies.judgePath, 90,
+		func(source *config.ObservabilityV8Source) {
+			source.TracePolicy.Sampler = "always_on"
+		},
+	)
+	runtime := newGeneratedTraceRuntime(t, dependencies, pipelines, plan)
+	base := time.Now().UTC().Add(-time.Second)
+	receiveInput := generatedTelemetryReceiveInput(base, base.Add(500*time.Millisecond))
+	_, receive, err := runtime.StartTelemetryReceiveTrace(t.Context(), receiveInput)
+	if err != nil || receive == nil {
+		t.Fatalf("start receive=%v err=%v", receive, err)
+	}
+	normalizeInput := generatedTelemetryNormalizeInput(
+		base.Add(time.Millisecond), base.Add(400*time.Millisecond),
+	)
+	normalize, err := receive.StartNormalize(normalizeInput)
+	if err != nil || normalize == nil {
+		t.Fatalf("start normalize=%v err=%v", normalize, err)
+	}
+	if err := normalize.End(normalizeInput); err != nil {
+		t.Fatalf("end normalize without destination: %v", err)
+	}
+	if err := receive.End(receiveInput); err != nil {
+		t.Fatalf("end receive without destination: %v", err)
+	}
+	if len(pipelines.consumers) != 0 {
+		t.Fatalf("zero-destination generation unexpectedly created consumers: %d", len(pipelines.consumers))
+	}
+}
+
 func TestGeneratedTelemetryTraceSamplingCollectionAndReload(t *testing.T) {
 	for _, test := range []struct {
 		name               string

--- a/internal/observability/runtime/generated_trace_test.go
+++ b/internal/observability/runtime/generated_trace_test.go
@@ -86,8 +86,9 @@ func (consumer *generatedTraceConsumer) snapshot() []telemetry.V8CanonicalEndedS
 }
 
 type generatedTracePipelines struct {
-	mu        sync.Mutex
-	consumers map[uint64]*generatedTraceConsumer
+	mu                      sync.Mutex
+	consumers               map[uint64]*generatedTraceConsumer
+	withoutSpanDestinations bool
 }
 
 func (pipelines *generatedTracePipelines) build(
@@ -96,6 +97,9 @@ func (pipelines *generatedTracePipelines) build(
 	generation uint64,
 	_ telemetry.V8MetricReaderSpec,
 ) (telemetry.V8GenerationPipelines, error) {
+	if pipelines.withoutSpanDestinations {
+		return telemetry.V8GenerationPipelines{}, nil
+	}
 	consumer := &generatedTraceConsumer{}
 	pipelines.mu.Lock()
 	pipelines.consumers[generation] = consumer

--- a/internal/telemetry/provider_v8.go
+++ b/internal/telemetry/provider_v8.go
@@ -630,7 +630,7 @@ func newProviderV8Inactive(
 		}
 	}
 	var composite *v8CompositeSpanProcessor
-	if len(pipelines.SpanPipelines) > 0 {
+	if len(traceCollect) > 0 {
 		var compositeErr error
 		composite, compositeErr = newV8CompositeSpanProcessor(
 			generation, v8DefaultCanonicalSpanHandoffCapacity, pipelines.SpanPipelines,

--- a/internal/telemetry/provider_v8_span_handoff.go
+++ b/internal/telemetry/provider_v8_span_handoff.go
@@ -470,13 +470,14 @@ func newV8CompositeSpanProcessor(
 	capacity int,
 	pipelines []V8GenerationSpanPipeline,
 ) (*v8CompositeSpanProcessor, error) {
-	if len(pipelines) == 0 {
-		return nil, errors.New("telemetry: empty v8 span pipelines")
-	}
 	cloned := append([]V8GenerationSpanPipeline(nil), pipelines...)
 	if !validV8SpanPipelines(cloned) {
 		return nil, errors.New("telemetry: invalid v8 span pipelines")
 	}
+	// Collection and destination selection are independent. Keep the canonical
+	// handoff processor even when no trace destination is selected so a sampled,
+	// locally collected span can finish without pretending that the provider is
+	// unavailable. OnEnd consumes the handoff and the empty fan-out is a no-op.
 	return &v8CompositeSpanProcessor{
 		pipelines: cloned,
 		handoff:   newV8SpanHandoff(generation, capacity, v8DefaultCanonicalSpanHandoffBytes),

--- a/internal/telemetry/provider_v8_span_handoff_test.go
+++ b/internal/telemetry/provider_v8_span_handoff_test.go
@@ -528,6 +528,53 @@ func TestV8CompositeCanonicalFanoutExactlyOnceAndCopyIsolation(t *testing.T) {
 	}
 }
 
+func TestV8CanonicalHandoffCompletesWithoutDestinations(t *testing.T) {
+	rig := newV8HandoffRig(t)
+	if rig.composite == nil || len(rig.composite.pipelines) != 0 {
+		t.Fatalf("zero-destination composite = %v", rig.composite)
+	}
+	start := time.Unix(1_783_080_025, 0).UTC()
+	span, record := v8StartHandoffSpan(t, rig, start, start.Add(time.Millisecond), nil)
+	if got := rig.provider.EndV8CanonicalSpan(span, record); got != V8CanonicalSpanRegistered {
+		t.Fatalf("zero-destination handoff = %s, want %s", got, V8CanonicalSpanRegistered)
+	}
+	if len(rig.composite.handoff.pending) != 0 || rig.composite.handoff.pendingBytes != 0 {
+		t.Fatal("zero-destination End retained a pending canonical record")
+	}
+}
+
+func TestV8CanonicalImportCompletesWithoutDestinationsAndStillValidates(t *testing.T) {
+	rig := newV8HandoffRig(t)
+	start := time.Unix(1_783_080_026, 0).UTC()
+	traceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	spanID := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
+	record := v8HandoffRecord(
+		t, traceID, spanID, start, start.Add(time.Millisecond), rig.provider.v8.planDigest,
+		"", observability.Absent[string](), 0x101, rig.provider,
+	)
+	result, err := rig.provider.ImportV8CanonicalSpanWithPolicy(record, V8ImportedExportPolicy{})
+	if err != nil || result != (V8ImportedSpanResult{}) {
+		t.Fatalf("zero-destination import = %+v/%v, want empty result/nil", result, err)
+	}
+
+	if result, err = rig.provider.ImportV8CanonicalSpanWithPolicy(
+		observability.Record{}, V8ImportedExportPolicy{},
+	); err == nil || result != (V8ImportedSpanResult{}) {
+		t.Fatalf("invalid zero-destination import = %+v/%v, want empty result/error", result, err)
+	}
+	mismatched := v8HandoffRecord(
+		t, traceID, trace.SpanID{8, 7, 6, 5, 4, 3, 2, 1}, start,
+		start.Add(time.Millisecond), strings.Repeat("a", 64), "",
+		observability.Absent[string](), 0x101, rig.provider,
+	)
+	if result, err = rig.provider.ImportV8CanonicalSpanWithPolicy(
+		mismatched, V8ImportedExportPolicy{},
+	); err == nil || err.Error() != "telemetry: imported canonical span generation mismatch" ||
+		result != (V8ImportedSpanResult{}) {
+		t.Fatalf("mismatched zero-destination import = %+v/%v, want generation error", result, err)
+	}
+}
+
 func TestV8CanonicalHandoffCopiesTraceStateFlagsScopeAndResource(t *testing.T) {
 	consumer := &v8HandoffConsumer{}
 	rig := newV8HandoffRig(t, V8GenerationSpanPipeline{Destination: "canonical", Canonical: consumer})


### PR DESCRIPTION
> Base: `main`. This PR is intentionally scoped to OTLP ingress sizing and zero-destination trace finalization.

## Problem

DefenseClaw could emit a continuous stream of `canonical receive trace completion failed` and `canonical normalize trace completion failed` messages under the default observability setup. Separately, realistic Codex OTLP trace batches larger than 1 MiB were rejected with HTTP 413 and dropped.

## Current Situation

- Every POST, PUT, and PATCH request shared a 1 MiB body limit, including authenticated OTLP-HTTP ingestion.
- The v8 observability compiler collects traces by default, while the implicit `local-sqlite` destination selects logs only.
- The telemetry provider created the canonical span handoff only when a trace destination existed.
- With collection enabled and no trace destination, sampled receive/normalize spans started successfully but ended against a missing handoff, producing the repeated completion failures.
- Oversized trace batches followed a different failure path: the gateway rejected them as `body_too_large` before OTLP decoding.

## Solution

### Bound OTLP requests separately

Exact authenticated OTLP ingest routes now accept bodies up to 64 MiB, matching the OTLP receiver recommendation and DefenseClaw's supported maximum outbound batch size. Ordinary state-changing API routes remain capped at 1 MiB. Strict route classification prevents suffix-shaped lookalikes from receiving the larger allowance.

### Complete collected traces without a destination

The provider now installs the canonical trace handoff whenever trace collection is enabled. When no trace destination is selected, finalization consumes the handoff through an empty no-op fan-out. This preserves the distinction between collection and delivery: the span completes locally without claiming it was exported.

### Add end-to-end regressions

Tests cover shared and scoped OTLP routes, all three signal handlers with valid payloads above 1 MiB, upper-bound rejection, ordinary/lookalike routes, generated receive/normalize traces without destinations, direct canonical handoff, imported traces, and retained validation errors.

## Architecture Diagram

```mermaid
flowchart LR
  E["OTLP exporter"] --> A["Token auth + CSRF"]
  A --> P{"Exact OTLP ingest path?"}
  P -->|"Yes"| O["64 MiB bounded body"]
  P -->|"No"| R["1 MiB API body"]
  O --> I["Decode + canonical import"]
  I --> T{"Trace destination selected?"}
  T -->|"Yes"| F["Canonical destination fan-out"]
  T -->|"No"| N["Consume handoff with empty no-op fan-out"]
```

## What Changed (Where & How)

| Path | Change |
| --- | --- |
| `internal/gateway/api.go` | Added strict route-aware body limits: 64 MiB for exact OTLP ingestion and 1 MiB elsewhere. |
| `internal/gateway/api_body_limit_test.go` | Added middleware and real-handler regressions for accepted and rejected request sizes. |
| `internal/gateway/otel_ingest.go` | Updated the ingress threat-model comment for the bounded OTLP limit. |
| `internal/telemetry/provider_v8.go` | Creates the canonical trace processor whenever traces are collected. |
| `internal/telemetry/provider_v8_span_handoff.go` | Permits an empty destination fan-out while retaining canonical handoff consumption. |
| `internal/telemetry/provider_v8_span_handoff_test.go` | Covers zero-destination completion, import behavior, and validation failures. |
| `internal/observability/runtime/generated_trace_test.go` | Adds a zero-span-destination runtime test fixture mode. |
| `internal/observability/runtime/generated_telemetry_trace_test.go` | Verifies receive and normalize traces complete with no trace destination. |
| `docs-site/content/docs/reference/gateway-api.mdx` | Documents the split 1 MiB/64 MiB request limits and 413 behavior. |

## Breaking Changes

None. Exact authenticated OTLP ingestion gains a larger bounded request allowance; ordinary API limits, configuration schemas, and public response contracts are unchanged.

## Open Issues / Follow-ups

None.

## Test Plan

Passed locally:

- `go test -race -count=1 -timeout 45m ./internal/gateway ./internal/telemetry ./internal/observability/runtime`
  - gateway: pass (1322.127s)
  - telemetry: pass (4.034s)
  - observability runtime: pass (150.622s)
- `go vet ./internal/gateway ./internal/telemetry ./internal/observability/runtime`
- `make go-lint` (repository fallback `go vet ./...` used because `golangci-lint` is not installed locally)
- `make telemetry-check`
- `make check VERIFY_OBSERVABILITY_BASELINE_ANCESTRY=1`
- `CI_REQUIRE_OPA=1 npm ci --no-audit --no-fund` from `docs-site`
- `npm run test:policy-creator` (58/58)
- `npm run test:feature-demos` (11/11)
- `npm run validate-snippets` (315 documentation fences)
- `npm run validate-links` (0 errors)
- `BASE_PATH=/defenseclaw SITE_URL=https://cisco-ai-defense.github.io/defenseclaw NEXT_TELEMETRY_DISABLED=1 npm run build` (171 static pages)

A local `go test -count=1 -timeout 45m ./...` also passed all changed packages. Four unrelated tests fail on macOS because `/var` is a symlink to `/private/var`; each failure was reproduced unchanged against `origin/main` at `308917b149e0a43349057adb181eac1a048c749a`. The OpenClaw connector tests pass after the repository's required extension build/sync step.
