### PR TITLE
fix(ci): make telemetry exhaustive gate enforceable

### DIFF
--- a/.github/workflows/telemetry-registry.yml
+++ b/.github/workflows/telemetry-registry.yml
@@ -4,24 +4,10 @@
 name: Telemetry Registry Exhaustive
 
 on:
-  pull_request:
-    paths:
-      - "schemas/telemetry/**"
-      - "scripts/generate_telemetry_registry.py"
-      - "scripts/update_telemetry_registry_upstream.py"
-      - "scripts/render_telemetry_*.py"
-      - "scripts/telemetry_*.py"
-      - "cli/tests/conftest.py"
-      - "cli/tests/test_telemetry_ci_strategy.py"
-      - "cli/tests/test_telemetry_registry_*.py"
-      - "cli/tests/support/telemetry_registry_manifest_driver.py"
-      - "schemas/telemetry/v8/compatibility/v7-compatibility-inputs.yaml"
-      - "internal/observability/zz_generated_telemetry_*.go"
-      - "Makefile"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".github/workflows/ci.yml"
-      - ".github/workflows/telemetry-registry.yml"
+  # Always start on pull requests so the aggregate check below can be made
+  # required without leaving unrelated changes permanently pending. The
+  # changes job keeps the expensive mutation suites selective.
+  pull_request: {}
   schedule:
     - cron: "47 3 * * *"
   workflow_dispatch:
@@ -34,8 +20,70 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  changes:
+    name: Detect telemetry registry changes
+    runs-on: ubuntu-latest
+    outputs:
+      telemetry: ${{ steps.detect.outputs.telemetry }}
+    steps:
+      - if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Select exhaustive suites
+        id: detect
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Nightly and manual runs are exhaustive by definition. Only pull
+          # requests use the internal diff filter.
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "telemetry=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          telemetry_paths=(
+            ':(glob)schemas/telemetry/**'
+            'scripts/generate_telemetry_registry.py'
+            'scripts/update_telemetry_registry_upstream.py'
+            ':(glob)scripts/render_telemetry_*.py'
+            ':(glob)scripts/telemetry_*.py'
+            'cli/tests/conftest.py'
+            'cli/tests/test_telemetry_ci_strategy.py'
+            ':(glob)cli/tests/test_telemetry_registry_*.py'
+            'cli/tests/support/telemetry_registry_manifest_driver.py'
+            'schemas/telemetry/v8/compatibility/v7-compatibility-inputs.yaml'
+            ':(glob)internal/observability/zz_generated_telemetry_*.go'
+            'Makefile'
+            'pyproject.toml'
+            'uv.lock'
+            '.github/workflows/ci.yml'
+            '.github/workflows/telemetry-registry.yml'
+          )
+
+          git cat-file -e "${BASE_SHA}^{commit}"
+          git cat-file -e "${HEAD_SHA}^{commit}"
+          set +e
+          git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- "${telemetry_paths[@]}"
+          diff_status=$?
+          set -e
+
+          case "$diff_status" in
+            0) echo "telemetry=false" >> "$GITHUB_OUTPUT" ;;
+            1) echo "telemetry=true" >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error::telemetry path detection failed (git diff exit $diff_status)"; exit "$diff_status" ;;
+          esac
+
   exhaustive:
     name: ${{ matrix.name }}
+    needs: changes
+    if: ${{ needs.changes.outputs.telemetry == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 50
     strategy:
@@ -66,11 +114,21 @@ jobs:
 
   complete:
     name: Telemetry Registry Exhaustive
-    needs: exhaustive
+    needs: [changes, exhaustive]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require every exhaustive suite
         env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          TELEMETRY_CHANGED: ${{ needs.changes.outputs.telemetry }}
           EXHAUSTIVE_RESULT: ${{ needs.exhaustive.result }}
-        run: test "$EXHAUSTIVE_RESULT" = success
+        run: |
+          set -euo pipefail
+          test "$CHANGES_RESULT" = success
+          if [[ "$TELEMETRY_CHANGED" = "true" ]]; then
+            test "$EXHAUSTIVE_RESULT" = success
+          else
+            test "$TELEMETRY_CHANGED" = "false"
+            test "$EXHAUSTIVE_RESULT" = skipped
+          fi

--- a/cli/tests/test_telemetry_ci_strategy.py
+++ b/cli/tests/test_telemetry_ci_strategy.py
@@ -104,6 +104,9 @@ def test_exhaustive_registry_workflow_always_reports_and_runs_selectively() -> N
     checkout = changes["steps"][0]
     assert checkout["if"] == "${{ github.event_name == 'pull_request' }}"
     assert checkout["with"] == {"fetch-depth": "0", "persist-credentials": "false"}
+    detect = changes["steps"][1]
+    assert detect["env"]["BASE_SHA"] == "${{ github.event.pull_request.base.sha }}"
+    assert detect["env"]["HEAD_SHA"] == "${{ github.event.pull_request.head.sha }}"
     rendered_changes = _render(changes)
     assert 'git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- "${telemetry_paths[@]}"' in rendered_changes
     assert 'echo "telemetry=true" >> "$GITHUB_OUTPUT"' in rendered_changes

--- a/cli/tests/test_telemetry_ci_strategy.py
+++ b/cli/tests/test_telemetry_ci_strategy.py
@@ -42,9 +42,15 @@ def _render(value: object) -> str:
     return str(value)
 
 
-def _pull_request_paths() -> set[str]:
-    pull_request = _workflow(EXHAUSTIVE_PATH)["on"]["pull_request"]
-    return set(pull_request["paths"])
+def _internal_diff_pathspecs() -> set[str]:
+    text = EXHAUSTIVE_PATH.read_text(encoding="utf-8")
+    match = re.search(r"^\s+telemetry_paths=\(\n(?P<body>.*?)^\s+\)$", text, re.MULTILINE | re.DOTALL)
+    assert match is not None
+    return {
+        line.strip().strip("'\"")
+        for line in match.group("body").splitlines()
+        if line.strip()
+    }
 
 
 def _matches_any(path: Path, patterns: set[str]) -> bool:
@@ -78,13 +84,14 @@ def test_ordinary_ci_always_checks_real_registry_without_exhaustive_mutation_sui
     assert "python-coverage-part-telemetry" not in CI_PATH.read_text(encoding="utf-8")
 
 
-def test_exhaustive_registry_workflow_is_path_filtered_nightly_and_manual() -> None:
+def test_exhaustive_registry_workflow_always_reports_and_runs_selectively() -> None:
     workflow = _workflow(EXHAUSTIVE_PATH)
     triggers = workflow["on"]
     jobs = workflow["jobs"]
     text = EXHAUSTIVE_PATH.read_text(encoding="utf-8")
 
     assert set(triggers) == {"pull_request", "schedule", "workflow_dispatch"}
+    assert triggers["pull_request"] == {}
     assert triggers["schedule"] == [{"cron": "47 3 * * *"}]
     assert workflow["permissions"] == {"contents": "read"}
     assert workflow["concurrency"] == {
@@ -92,7 +99,19 @@ def test_exhaustive_registry_workflow_is_path_filtered_nightly_and_manual() -> N
         "cancel-in-progress": "${{ github.event_name == 'pull_request' }}",
     }
 
+    changes = jobs["changes"]
+    assert changes["outputs"] == {"telemetry": "${{ steps.detect.outputs.telemetry }}"}
+    checkout = changes["steps"][0]
+    assert checkout["if"] == "${{ github.event_name == 'pull_request' }}"
+    assert checkout["with"] == {"fetch-depth": "0", "persist-credentials": "false"}
+    rendered_changes = _render(changes)
+    assert 'git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- "${telemetry_paths[@]}"' in rendered_changes
+    assert 'echo "telemetry=true" >> "$GITHUB_OUTPUT"' in rendered_changes
+    assert 'echo "telemetry=false" >> "$GITHUB_OUTPUT"' in rendered_changes
+
     exhaustive = jobs["exhaustive"]
+    assert exhaustive["needs"] == "changes"
+    assert exhaustive["if"] == "${{ needs.changes.outputs.telemetry == 'true' }}"
     cases = exhaustive["strategy"]["matrix"]["include"]
     assert {case["test_file"] for case in cases} == EXHAUSTIVE_TESTS
     assert exhaustive["timeout-minutes"] == "50"
@@ -103,32 +122,37 @@ def test_exhaustive_registry_workflow_is_path_filtered_nightly_and_manual() -> N
     assert "upload-artifact" not in text
 
     complete = jobs["complete"]
-    assert complete["needs"] == "exhaustive"
+    assert complete["needs"] == ["changes", "exhaustive"]
     assert complete["if"] == "${{ always() }}"
-    assert 'test "$EXHAUSTIVE_RESULT" = success' in _render(complete)
+    rendered_complete = _render(complete)
+    assert 'test "$CHANGES_RESULT" = success' in rendered_complete
+    assert 'test "$EXHAUSTIVE_RESULT" = success' in rendered_complete
+    assert 'test "$EXHAUSTIVE_RESULT" = skipped' in rendered_complete
 
 
-def test_exhaustive_path_filter_covers_every_registry_input_and_test_dependency() -> None:
-    patterns = _pull_request_paths()
-    required_patterns = {
-        "schemas/telemetry/**",
+def test_exhaustive_internal_filter_covers_every_registry_input_and_test_dependency() -> None:
+    pathspecs = _internal_diff_pathspecs()
+    required_pathspecs = {
+        ":(glob)schemas/telemetry/**",
         "scripts/generate_telemetry_registry.py",
         "scripts/update_telemetry_registry_upstream.py",
-        "scripts/render_telemetry_*.py",
-        "scripts/telemetry_*.py",
+        ":(glob)scripts/render_telemetry_*.py",
+        ":(glob)scripts/telemetry_*.py",
         "cli/tests/conftest.py",
         "cli/tests/test_telemetry_ci_strategy.py",
-        "cli/tests/test_telemetry_registry_*.py",
+        ":(glob)cli/tests/test_telemetry_registry_*.py",
         "cli/tests/support/telemetry_registry_manifest_driver.py",
         "schemas/telemetry/v8/compatibility/v7-compatibility-inputs.yaml",
-        "internal/observability/zz_generated_telemetry_*.go",
+        ":(glob)internal/observability/zz_generated_telemetry_*.go",
         "Makefile",
         "pyproject.toml",
         "uv.lock",
         ".github/workflows/ci.yml",
         ".github/workflows/telemetry-registry.yml",
     }
-    assert patterns == required_patterns
+    assert pathspecs == required_pathspecs
+
+    patterns = {pathspec.removeprefix(":(glob)") for pathspec in pathspecs}
 
     concrete_inputs = {
         ROOT / "scripts/generate_telemetry_registry.py",


### PR DESCRIPTION
Base note: standalone CI-policy fix based directly on current `main`; no dependent pull requests.

## Problem

Issue #555 identifies an enforcement paradox in the exhaustive telemetry registry workflow. The workflow was filtered at the `pull_request.paths` trigger:

- if its aggregate check is required, unrelated pull requests never start the workflow and can remain pending forever;
- if it is not required, telemetry-sensitive changes can merge without the mutation suites being enforced.

## Current Situation

`.github/workflows/telemetry-registry.yml` currently creates the stable `Telemetry Registry Exhaustive` aggregate only when GitHub's top-level path filter matches. The expensive suites are correctly isolated from ordinary CI, but their aggregate is therefore not safe to add to branch protection.

## Solution

### Always emit the stable aggregate

Start the workflow for every pull request. A small `changes` job determines whether telemetry-owned inputs changed. The final aggregate always runs and fails closed if detection itself fails.

### Keep expensive mutation suites selective

The detector compares the exact pull-request base and head commits with Git pathspecs covering every telemetry registry input and test dependency. The two exhaustive suites run only when that comparison matches. Nightly and manual invocations remain unconditionally exhaustive.

### Preserve fail-closed aggregation

For telemetry-sensitive changes, the aggregate requires the exhaustive matrix to succeed. For unrelated changes, it requires the matrix to have been intentionally skipped. Any detector error or unexpected state fails the aggregate.

```mermaid
flowchart LR
    A["Pull request, schedule, or manual run"] --> B["Detect telemetry-owned changes"]
    B -->|"PR: relevant"| C["Run exhaustive mutation suites"]
    B -->|"PR: unrelated"| D["Skip expensive suites"]
    B -->|"Schedule/manual"| C
    C --> E["Telemetry Registry Exhaustive"]
    D --> E
    B -->|"detector failure"| E
    E -->|"only expected success/skip states"| F["Stable required check"]
```

## What Changed (Where & How)

| Area | Path | Change |
|---|---|---|
| Workflow trigger and selection | `.github/workflows/telemetry-registry.yml` | Removed the top-level path filter, added exact internal diff detection, gated the expensive matrix, and made the aggregate validate both run and intentional-skip states. |
| Contract tests | `cli/tests/test_telemetry_ci_strategy.py` | Asserted always-on triggering, detector wiring, fail-closed aggregation, and complete coverage of telemetry-owned inputs. |

## Breaking Changes

No product, API, or configuration behavior changes. The workflow now starts two short coordination jobs on every pull request so its aggregate can safely become required; the expensive suites remain selective.

## Open Issues / Follow-ups

- #592 — after this PR merges, add `Telemetry Registry Exhaustive` to the protected-main required checks as part of the repository ruleset alignment.

## Test Plan

- `uv run --frozen pytest -q cli/tests/test_telemetry_ci_strategy.py cli/tests/test_ci_workflow_efficiency.py`
  - Observed: 9 passed.
- `uv run --frozen ruff check cli/tests/test_telemetry_ci_strategy.py`
  - Observed: passed.
- `actionlint .github/workflows/telemetry-registry.yml`
  - Observed: passed.
- `git diff --check`
  - Observed: passed.
- Manual detector replay:
  - Non-telemetry change `c162fb69d..c2236353f`: `git diff --quiet` returned 0 (skip).
  - Telemetry workflow change from PR #551: `git diff --quiet` returned 1 (run).

Tracks #555.