### PR TITLE
fix(ci): make macOS aggregate always report

### DIFF
--- a/.github/workflows/macos-app.yml
+++ b/.github/workflows/macos-app.yml
@@ -36,6 +36,33 @@ jobs:
   changes:
     name: Detect macOS app changes
     runs-on: ubuntu-latest
+    env:
+      MACOS_PATHS: >-
+        :(glob)macos/**
+        scripts/build-macos-app-release.sh
+        scripts/check-macos-upstream.py
+        scripts/export-uv-overrides.py
+        scripts/generate-upgrade-manifest.py
+        scripts/macos_license_headers.py
+        scripts/release_candidate.py
+        scripts/source_release_identity.py
+        scripts/stamp-version.sh
+        scripts/test-upgrade-protocol-release.sh
+        scripts/test-upgrade-release.sh
+        scripts/update-macos-app.sh
+        scripts/verify-macos-app-release.sh
+        release/source-install-identity.json
+        release/upgrade-baselines.json
+        Makefile
+        pyproject.toml
+        :(glob)cli/**
+        go.mod
+        go.sum
+        :(glob)cmd/**
+        :(glob)internal/**
+        :(glob)extensions/defenseclaw/**
+        .github/workflows/macos-app.yml
+        .github/workflows/release-candidate-smoke.yml
     outputs:
       macos: ${{ steps.detect.outputs.macos }}
     steps:
@@ -80,38 +107,16 @@ jobs:
             exit 1
           fi
 
-          macos_paths=(
-            ':(glob)macos/**'
-            'scripts/build-macos-app-release.sh'
-            'scripts/check-macos-upstream.py'
-            'scripts/export-uv-overrides.py'
-            'scripts/generate-upgrade-manifest.py'
-            'scripts/macos_license_headers.py'
-            'scripts/release_candidate.py'
-            'scripts/source_release_identity.py'
-            'scripts/stamp-version.sh'
-            'scripts/test-upgrade-protocol-release.sh'
-            'scripts/test-upgrade-release.sh'
-            'scripts/update-macos-app.sh'
-            'scripts/verify-macos-app-release.sh'
-            'release/source-install-identity.json'
-            'release/upgrade-baselines.json'
-            'Makefile'
-            'pyproject.toml'
-            ':(glob)cli/**'
-            'go.mod'
-            'go.sum'
-            ':(glob)cmd/**'
-            ':(glob)internal/**'
-            ':(glob)extensions/defenseclaw/**'
-            '.github/workflows/macos-app.yml'
-            '.github/workflows/release-candidate-smoke.yml'
-          )
+          read -r -a macos_paths <<< "$MACOS_PATHS"
+          if ((${#macos_paths[@]} == 0)); then
+            echo "::error::macOS app path contract is empty"
+            exit 1
+          fi
 
           git cat-file -e "${BASE_SHA}^{commit}"
           git cat-file -e "${HEAD_SHA}^{commit}"
           set +e
-          git diff --quiet --no-renames "$BASE_SHA" "$HEAD_SHA" -- "${macos_paths[@]}"
+          git diff --quiet --no-renames "$BASE_SHA...$HEAD_SHA" -- "${macos_paths[@]}"
           diff_status=$?
           set -e
 

--- a/.github/workflows/macos-app.yml
+++ b/.github/workflows/macos-app.yml
@@ -19,33 +19,10 @@ name: macOS App
 on:
   push:
     branches: [main]
-  pull_request:
-    paths:
-      - "macos/**"
-      - "scripts/build-macos-app-release.sh"
-      - "scripts/check-macos-upstream.py"
-      - "scripts/export-uv-overrides.py"
-      - "scripts/generate-upgrade-manifest.py"
-      - "scripts/macos_license_headers.py"
-      - "scripts/release_candidate.py"
-      - "scripts/source_release_identity.py"
-      - "scripts/stamp-version.sh"
-      - "scripts/test-upgrade-protocol-release.sh"
-      - "scripts/test-upgrade-release.sh"
-      - "scripts/update-macos-app.sh"
-      - "scripts/verify-macos-app-release.sh"
-      - "release/source-install-identity.json"
-      - "release/upgrade-baselines.json"
-      - "Makefile"
-      - "pyproject.toml"
-      - "cli/**"
-      - "go.mod"
-      - "go.sum"
-      - "cmd/**"
-      - "internal/**"
-      - "extensions/defenseclaw/**"
-      - ".github/workflows/macos-app.yml"
-      - ".github/workflows/release-candidate-smoke.yml"
+  # Always start on pull requests so the stable aggregate below can be made
+  # required without leaving unrelated changes permanently pending. The
+  # changes job keeps the expensive macOS work selective.
+  pull_request: {}
   workflow_dispatch:
 
 permissions:
@@ -56,8 +33,101 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect macOS app changes
+    runs-on: ubuntu-latest
+    outputs:
+      macos: ${{ steps.detect.outputs.macos }}
+    steps:
+      - if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Select macOS app validation
+        id: detect
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          case "$EVENT_NAME" in
+            push|workflow_dispatch)
+              echo "macos=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+            pull_request)
+              ;;
+            *)
+              echo "::error::unexpected macOS app workflow event: $EVENT_NAME"
+              exit 1
+              ;;
+          esac
+
+          if [[ ! "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::pull request base SHA is not an exact commit ID"
+            exit 1
+          fi
+          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::pull request head SHA is not an exact commit ID"
+            exit 1
+          fi
+          if [[ "$BASE_SHA" == "$HEAD_SHA" ]]; then
+            echo "::error::pull request base and head SHAs must differ"
+            exit 1
+          fi
+
+          macos_paths=(
+            ':(glob)macos/**'
+            'scripts/build-macos-app-release.sh'
+            'scripts/check-macos-upstream.py'
+            'scripts/export-uv-overrides.py'
+            'scripts/generate-upgrade-manifest.py'
+            'scripts/macos_license_headers.py'
+            'scripts/release_candidate.py'
+            'scripts/source_release_identity.py'
+            'scripts/stamp-version.sh'
+            'scripts/test-upgrade-protocol-release.sh'
+            'scripts/test-upgrade-release.sh'
+            'scripts/update-macos-app.sh'
+            'scripts/verify-macos-app-release.sh'
+            'release/source-install-identity.json'
+            'release/upgrade-baselines.json'
+            'Makefile'
+            'pyproject.toml'
+            ':(glob)cli/**'
+            'go.mod'
+            'go.sum'
+            ':(glob)cmd/**'
+            ':(glob)internal/**'
+            ':(glob)extensions/defenseclaw/**'
+            '.github/workflows/macos-app.yml'
+            '.github/workflows/release-candidate-smoke.yml'
+          )
+
+          git cat-file -e "${BASE_SHA}^{commit}"
+          git cat-file -e "${HEAD_SHA}^{commit}"
+          set +e
+          git diff --quiet --no-renames "$BASE_SHA" "$HEAD_SHA" -- "${macos_paths[@]}"
+          diff_status=$?
+          set -e
+
+          case "$diff_status" in
+            0) echo "macos=false" >> "$GITHUB_OUTPUT" ;;
+            1) echo "macos=true" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "::error::macOS app path detection failed (git diff exit $diff_status)"
+              exit "$diff_status"
+              ;;
+          esac
+
   license-headers:
     name: Cisco License Headers
+    needs: changes
+    if: ${{ needs.changes.outputs.macos == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -67,6 +137,8 @@ jobs:
 
   build-and-test:
     name: Build and Test (arm64)
+    needs: changes
+    if: ${{ needs.changes.outputs.macos == 'true' }}
     runs-on: macos-15
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -194,14 +266,31 @@ jobs:
 
   macos-app-required:
     name: macOS App Required
-    needs: [license-headers, build-and-test]
+    needs: [changes, license-headers, build-and-test]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require every macOS app check
         env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          MACOS_CHANGED: ${{ needs.changes.outputs.macos }}
           LICENSE_HEADERS_RESULT: ${{ needs.license-headers.result }}
           BUILD_AND_TEST_RESULT: ${{ needs.build-and-test.result }}
         run: |
-          test "$LICENSE_HEADERS_RESULT" = success
-          test "$BUILD_AND_TEST_RESULT" = success
+          set -euo pipefail
+          test "$CHANGES_RESULT" = success
+          case "$MACOS_CHANGED" in
+            true)
+              test "$LICENSE_HEADERS_RESULT" = success
+              test "$BUILD_AND_TEST_RESULT" = success
+              ;;
+            false)
+              test "$LICENSE_HEADERS_RESULT" = skipped
+              test "$BUILD_AND_TEST_RESULT" = skipped
+              echo "No macOS app paths changed; expensive validation was intentionally skipped."
+              ;;
+            *)
+              echo "::error::unexpected macOS app path decision: $MACOS_CHANGED"
+              exit 1
+              ;;
+          esac

--- a/cli/tests/test_macos_runtime_installer_upgrade_guard.py
+++ b/cli/tests/test_macos_runtime_installer_upgrade_guard.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import hashlib
 import os
-import re
 import subprocess
 import textwrap
 from pathlib import Path
@@ -32,18 +31,11 @@ def _source() -> str:
 
 
 def _internal_macos_pathspecs() -> set[str]:
-    text = MACOS_CI_WORKFLOW.read_text(encoding="utf-8")
-    match = re.search(
-        r"^\s+macos_paths=\(\n(?P<body>.*?)^\s+\)$",
-        text,
-        re.MULTILINE | re.DOTALL,
+    workflow = yaml.load(
+        MACOS_CI_WORKFLOW.read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
     )
-    assert match is not None
-    return {
-        line.strip().strip("'\"")
-        for line in match.group("body").splitlines()
-        if line.strip()
-    }
+    return set(workflow["jobs"]["changes"]["env"]["MACOS_PATHS"].split())
 
 
 def test_bundled_runtime_installer_is_fresh_install_only_before_mutation() -> None:
@@ -311,7 +303,7 @@ def test_macos_package_ci_always_reports_and_runs_expensive_work_selectively() -
     assert detection.count("=~ ^[0-9a-f]{40}$") == 2
     assert '[[ "$BASE_SHA" == "$HEAD_SHA" ]]' in detection
     assert (
-        'git diff --quiet --no-renames "$BASE_SHA" "$HEAD_SHA" -- "${macos_paths[@]}"'
+        'git diff --quiet --no-renames "$BASE_SHA...$HEAD_SHA" -- "${macos_paths[@]}"'
         in detection
     )
     assert 'echo "macos=false" >> "$GITHUB_OUTPUT"' in detection

--- a/cli/tests/test_macos_runtime_installer_upgrade_guard.py
+++ b/cli/tests/test_macos_runtime_installer_upgrade_guard.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 import subprocess
 import textwrap
 from pathlib import Path
@@ -28,6 +29,21 @@ UPGRADE_RELEASE_SMOKE = ROOT / "scripts" / "test-upgrade-release.sh"
 
 def _source() -> str:
     return INSTALLER.read_text(encoding="utf-8")
+
+
+def _internal_macos_pathspecs() -> set[str]:
+    text = MACOS_CI_WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(
+        r"^\s+macos_paths=\(\n(?P<body>.*?)^\s+\)$",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None
+    return {
+        line.strip().strip("'\"")
+        for line in match.group("body").splitlines()
+        if line.strip()
+    }
 
 
 def test_bundled_runtime_installer_is_fresh_install_only_before_mutation() -> None:
@@ -260,7 +276,7 @@ def test_macos_release_signing_credentials_have_exact_optional_tristate() -> Non
     assert "DefenseClawMac-${VERSION}-macos-arm64-unverified.zip" in build
 
 
-def test_macos_package_ci_runs_for_every_exact_main_sha_with_stable_aggregate() -> None:
+def test_macos_package_ci_always_reports_and_runs_expensive_work_selectively() -> None:
     workflow = yaml.load(
         MACOS_CI_WORKFLOW.read_text(encoding="utf-8"),
         Loader=yaml.BaseLoader,
@@ -269,21 +285,63 @@ def test_macos_package_ci_runs_for_every_exact_main_sha_with_stable_aggregate() 
 
     assert set(triggers) == {"push", "pull_request", "workflow_dispatch"}
     assert triggers["push"] == {"branches": ["main"]}
+    assert triggers["pull_request"] == {}
     assert workflow["concurrency"] == {
         "group": ("macos-app-${{ github.event_name }}-${{ github.event.pull_request.number || github.sha }}"),
         "cancel-in-progress": "true",
     }
+
+    changes = workflow["jobs"]["changes"]
+    assert changes["outputs"] == {"macos": "${{ steps.detect.outputs.macos }}"}
+    checkout = changes["steps"][0]
+    assert checkout["if"] == "${{ github.event_name == 'pull_request' }}"
+    assert checkout["with"] == {
+        "fetch-depth": "0",
+        "persist-credentials": "false",
+    }
+    detector = changes["steps"][1]
+    assert detector["env"] == {
+        "EVENT_NAME": "${{ github.event_name }}",
+        "BASE_SHA": "${{ github.event.pull_request.base.sha }}",
+        "HEAD_SHA": "${{ github.event.pull_request.head.sha }}",
+    }
+    detection = detector["run"]
+    assert 'git cat-file -e "${BASE_SHA}^{commit}"' in detection
+    assert 'git cat-file -e "${HEAD_SHA}^{commit}"' in detection
+    assert detection.count("=~ ^[0-9a-f]{40}$") == 2
+    assert '[[ "$BASE_SHA" == "$HEAD_SHA" ]]' in detection
+    assert (
+        'git diff --quiet --no-renames "$BASE_SHA" "$HEAD_SHA" -- "${macos_paths[@]}"'
+        in detection
+    )
+    assert 'echo "macos=false" >> "$GITHUB_OUTPUT"' in detection
+    assert 'echo "macos=true" >> "$GITHUB_OUTPUT"' in detection
+    assert "unexpected macOS app workflow event" in detection
+    assert "macOS app path detection failed" in detection
+
+    for job_name in ("license-headers", "build-and-test"):
+        job = workflow["jobs"][job_name]
+        assert job["needs"] == "changes"
+        assert job["if"] == "${{ needs.changes.outputs.macos == 'true' }}"
+
     aggregate = workflow["jobs"]["macos-app-required"]
     assert aggregate["name"] == "macOS App Required"
-    assert aggregate["needs"] == ["license-headers", "build-and-test"]
+    assert aggregate["needs"] == ["changes", "license-headers", "build-and-test"]
     assert aggregate["if"] == "${{ always() }}"
     assert aggregate["steps"][0]["env"] == {
+        "CHANGES_RESULT": "${{ needs.changes.result }}",
+        "MACOS_CHANGED": "${{ needs.changes.outputs.macos }}",
         "LICENSE_HEADERS_RESULT": "${{ needs.license-headers.result }}",
         "BUILD_AND_TEST_RESULT": "${{ needs.build-and-test.result }}",
     }
     command = aggregate["steps"][0]["run"]
+    assert 'test "$CHANGES_RESULT" = success' in command
     assert 'test "$LICENSE_HEADERS_RESULT" = success' in command
     assert 'test "$BUILD_AND_TEST_RESULT" = success' in command
+    assert 'test "$LICENSE_HEADERS_RESULT" = skipped' in command
+    assert 'test "$BUILD_AND_TEST_RESULT" = skipped' in command
+    assert "expensive validation was intentionally skipped" in command
+    assert "unexpected macOS app path decision" in command
 
 
 def test_macos_ci_gates_release_wrappers_with_system_bash() -> None:
@@ -291,10 +349,34 @@ def test_macos_ci_gates_release_wrappers_with_system_bash() -> None:
         MACOS_CI_WORKFLOW.read_text(encoding="utf-8"),
         Loader=yaml.BaseLoader,
     )
-    triggers = workflow["on"]
-    watched_paths = triggers["pull_request"]["paths"]
-    assert "scripts/test-upgrade-protocol-release.sh" in watched_paths
-    assert ".github/workflows/release-candidate-smoke.yml" in watched_paths
+    pathspecs = _internal_macos_pathspecs()
+    assert pathspecs == {
+        ":(glob)macos/**",
+        "scripts/build-macos-app-release.sh",
+        "scripts/check-macos-upstream.py",
+        "scripts/export-uv-overrides.py",
+        "scripts/generate-upgrade-manifest.py",
+        "scripts/macos_license_headers.py",
+        "scripts/release_candidate.py",
+        "scripts/source_release_identity.py",
+        "scripts/stamp-version.sh",
+        "scripts/test-upgrade-protocol-release.sh",
+        "scripts/test-upgrade-release.sh",
+        "scripts/update-macos-app.sh",
+        "scripts/verify-macos-app-release.sh",
+        "release/source-install-identity.json",
+        "release/upgrade-baselines.json",
+        "Makefile",
+        "pyproject.toml",
+        ":(glob)cli/**",
+        "go.mod",
+        "go.sum",
+        ":(glob)cmd/**",
+        ":(glob)internal/**",
+        ":(glob)extensions/defenseclaw/**",
+        ".github/workflows/macos-app.yml",
+        ".github/workflows/release-candidate-smoke.yml",
+    }
 
     steps = workflow["jobs"]["build-and-test"]["steps"]
     gate = next(step for step in steps if step.get("name") == "Exercise release wrappers with system Bash")
@@ -359,18 +441,17 @@ def test_macos_ci_builds_and_verifies_reviewed_runtime_fixture_first() -> None:
     package_step = workflow[package : workflow.index("- uses:", package)]
     assert 'scripts/build-macos-app-release.sh "$MACOS_CI_RELEASE_VERSION" dist' in package_step
     assert "make macos-app-release" not in package_step
-    for watched in (
-        '"cli/**"',
-        '"release/source-install-identity.json"',
-        '"release/upgrade-baselines.json"',
-        '"scripts/generate-upgrade-manifest.py"',
-        '"scripts/release_candidate.py"',
-        '"scripts/source_release_identity.py"',
-        '"scripts/test-upgrade-protocol-release.sh"',
-        '"scripts/test-upgrade-release.sh"',
-        '".github/workflows/release-candidate-smoke.yml"',
-    ):
-        assert workflow.count(watched) == 1
+    assert {
+        ":(glob)cli/**",
+        "release/source-install-identity.json",
+        "release/upgrade-baselines.json",
+        "scripts/generate-upgrade-manifest.py",
+        "scripts/release_candidate.py",
+        "scripts/source_release_identity.py",
+        "scripts/test-upgrade-protocol-release.sh",
+        "scripts/test-upgrade-release.sh",
+        ".github/workflows/release-candidate-smoke.yml",
+    }.issubset(_internal_macos_pathspecs())
     assert 'make -C "${build_root}" dist-cli DIST_DIR="${out}"' in smoke
     assert 'make -C "${build_root}" dist-plugin DIST_DIR="${out}"' in smoke
     assert '"${build_root}/scripts/generate-upgrade-manifest.py"' in smoke

--- a/cli/tests/test_release_validation_strategy.py
+++ b/cli/tests/test_release_validation_strategy.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -239,6 +240,10 @@ def test_no_pull_request_workflow_can_run_full_or_signed_certification() -> None
         "cosign sign-blob",
         "historical-dependency-canary:",
     )
+    protocol_invocation = re.compile(
+        r"^\s*(?:bash\s+)?scripts/test-upgrade-protocol-release\.sh(?:\s|\\|$)",
+        re.MULTILINE,
+    )
     for path in pull_request_workflows:
         text = path.read_text(encoding="utf-8")
         for contract in forbidden:
@@ -246,9 +251,9 @@ def test_no_pull_request_workflow_can_run_full_or_signed_certification() -> None
 
         for job in (_workflow(path).get("jobs") or {}).values():
             for step in job.get("steps", []):
-                rendered = _render(step)
-                if "scripts/test-upgrade-protocol-release.sh" in rendered:
-                    assert "--refusal-contract-only" in rendered, path
+                command = _render(step.get("run", ""))
+                if protocol_invocation.search(command):
+                    assert "--refusal-contract-only" in command, path
 
 
 def test_main_smoke_is_bound_to_exact_sha_and_runs_representative_canary() -> None:

--- a/cli/tests/test_release_validation_strategy.py
+++ b/cli/tests/test_release_validation_strategy.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
 from typing import Any
 
@@ -240,10 +239,6 @@ def test_no_pull_request_workflow_can_run_full_or_signed_certification() -> None
         "cosign sign-blob",
         "historical-dependency-canary:",
     )
-    protocol_invocation = re.compile(
-        r"^\s*(?:bash\s+)?scripts/test-upgrade-protocol-release\.sh(?:\s|\\|$)",
-        re.MULTILINE,
-    )
     for path in pull_request_workflows:
         text = path.read_text(encoding="utf-8")
         for contract in forbidden:
@@ -251,9 +246,9 @@ def test_no_pull_request_workflow_can_run_full_or_signed_certification() -> None
 
         for job in (_workflow(path).get("jobs") or {}).values():
             for step in job.get("steps", []):
-                command = _render(step.get("run", ""))
-                if protocol_invocation.search(command):
-                    assert "--refusal-contract-only" in command, path
+                rendered = _render(step)
+                if "scripts/test-upgrade-protocol-release.sh" in rendered:
+                    assert "--refusal-contract-only" in rendered, path
 
 
 def test_main_smoke_is_bound_to_exact_sha_and_runs_representative_canary() -> None:


### PR DESCRIPTION
Base: `main`. This is the source-controlled prerequisite for #592; it deliberately does **not** modify the live repository ruleset. PR #695 is telemetry-specific and does not overlap this change.

## Problem

The `macOS App` workflow currently uses a top-level pull-request path filter. On an unrelated pull request the workflow never starts, so its stable `macOS App Required` aggregate never reports. Adding that context to branch protection in this state would leave unrelated pull requests permanently pending.

## Current Situation

- `macOS App Required` already aggregates the license-header and arm64 build/test jobs when the workflow runs.
- The workflow starts only for pull requests matching its macOS/release/runtime path list.
- Running the arm64 build on every pull request would make the context enforceable, but would spend a macOS runner on changes that cannot affect the app.
- The active GitHub ruleset is out of scope for this PR and remains tracked in #592.

## Solution

### Always-reporting workflow entry

Start `macOS App` on every pull request so GitHub always receives the stable aggregate context. Preserve the existing behavior for `main` pushes and manual dispatches.

### Exact internal path decision

Move the existing watched-path contract into a lightweight Ubuntu planning job. For pull requests it:

1. checks out full history without persisting credentials;
2. consumes the event's exact `base.sha` and `head.sha`, rather than the synthetic merge SHA;
3. validates both IDs, verifies that both objects are commits, and rejects an identical base/head state;
4. runs a local, rename-disabled three-dot Git diff from the pull-request merge base to the exact head against the migrated macOS pathspecs; and
5. treats every detector error or unknown event as a hard failure.

Pushes to `main` and manual dispatches intentionally select full macOS validation.

### Explicit aggregate states

The expensive license and arm64 build/test jobs run only when the planning output is `true`. `macOS App Required` succeeds in exactly two states:

- relevant change: both expensive jobs succeeded;
- irrelevant change: both expensive jobs were intentionally skipped.

A failed detector, missing/unknown output, or inconsistent downstream result fails the aggregate closed.

```mermaid
flowchart TD
    PR["Any pull request"] --> D["Exact base/head path detector"]
    D -->|"Relevant path"] L["License headers"]
    D -->|"Relevant path"] B["macOS arm64 build and test"]
    D -->|"No relevant path"] S["Intentional expensive-job skips"]
    D -->|"Error or unknown state"] F["Fail closed"]
    L --> A["macOS App Required"]
    B --> A
    S --> A
    F --> A
```

## What Changed (Where & How)

| Path | Change |
|---|---|
| `.github/workflows/macos-app.yml` | Always triggers for PRs, detects relevant paths from exact event SHAs, gates expensive jobs, and validates both success and intentional-skip aggregate states. |
| `cli/tests/test_macos_runtime_installer_upgrade_guard.py` | Locks the trigger, detector inputs, complete migrated path contract, selective jobs, stable aggregate, and fail-closed behavior. |

## Breaking Changes

No product, API, configuration, or runtime behavior changes.

CI behavior changes intentionally: every pull request now receives `macOS App Required`. Irrelevant changes run only the lightweight detector and aggregate jobs; relevant changes retain the existing license and macOS arm64 work.

## Open Issues / Follow-ups

- #592 — after this workflow is merged and observed on both relevant and irrelevant test pull requests, update the live `main protection` ruleset to require `macOS App Required`, reconcile the remaining required contexts, and complete the audited bypass-policy work.

## Test Plan

- `PYTHONPATH=. uv run --frozen pytest -q cli/tests/test_macos_runtime_installer_upgrade_guard.py cli/tests/test_release_validation_strategy.py`
  - Observed: `25 passed in 1.24s`.
- `uv run --frozen ruff check cli/tests/test_macos_runtime_installer_upgrade_guard.py cli/tests/test_release_validation_strategy.py`
  - Observed: `All checks passed!`.
- `actionlint .github/workflows/macos-app.yml`
  - Observed: exit 0 with no findings.
- `uv run --frozen python -c 'from pathlib import Path; import yaml; data=yaml.load(Path(".github/workflows/macos-app.yml").read_text(encoding="utf-8"), Loader=yaml.BaseLoader); assert data["on"]["pull_request"] == {}; assert data["jobs"]["macos-app-required"]["name"] == "macOS App Required"; print("YAML parse: OK")'`
  - Observed: `YAML parse: OK`.
- `git diff --check` and `git diff origin/main...HEAD --check`
  - Observed: both exited 0 with no findings.
