### PR TITLE
fix(installer): authenticate sandbox helper before execution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@ scripts/upgrade.sh text eol=lf
 scripts/upgrade.ps1 text eol=lf
 scripts/defenseclaw-rescue.sh text eol=lf
 scripts/defenseclaw-rescue.ps1 text eol=lf
+scripts/install-openshell-sandbox.sh text eol=lf
 scripts/install.sh text eol=lf
 scripts/install.ps1 text eol=lf
 cli/defenseclaw/install_publish.py text eol=lf

--- a/cli/tests/test_install_script_static.py
+++ b/cli/tests/test_install_script_static.py
@@ -133,6 +133,19 @@ def test_sandbox_installer_is_authenticated_before_execution() -> None:
     assert download < authenticate < bind_digest < recheck < execute
 
 
+def test_unsupported_sandbox_release_fails_before_installation_work() -> None:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+
+    release_policy = text.index("load_release_policy\n", text.index("main()"))
+    early_version_gate = text.index(
+        'version_gte "${RELEASE_VERSION}" "${SANDBOX_INSTALLER_ASSET_START_VERSION}"',
+        release_policy,
+    )
+    first_install = text.index("install_gateway\n", release_policy)
+
+    assert release_policy < early_version_gate < first_install
+
+
 def test_sandbox_installer_rejects_tampered_bytes_and_executes_authenticated_bytes(
     tmp_path: Path,
 ) -> None:

--- a/cli/tests/test_install_script_static.py
+++ b/cli/tests/test_install_script_static.py
@@ -13,8 +13,12 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+import shlex
+import shutil
 import subprocess
 from pathlib import Path
+
+import pytest
 
 try:
     import tomllib
@@ -133,6 +137,9 @@ def test_sandbox_installer_rejects_tampered_bytes_and_executes_authenticated_byt
     tmp_path: Path,
 ) -> None:
     text = INSTALL_SH.read_text(encoding="utf-8")
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("Bash is unavailable on this platform")
 
     def shell_function(name: str) -> str:
         match = re.search(rf"(?ms)^{re.escape(name)}\(\) \{{\n.*?^\}}\n", text)
@@ -174,16 +181,16 @@ die() {{ printf '%s\\n' "$*" >&2; exit 71; }}
 MODERN_RELEASE=true
 RELEASE_VERSION=0.8.11
 SANDBOX_INSTALLER_ASSET_START_VERSION=0.8.11
-LOCAL_DIR={release}
-POLICY_DIR={policy}
-CHECKSUMS_FILE={checksums}
+LOCAL_DIR={shlex.quote(release.as_posix())}
+POLICY_DIR={shlex.quote(policy.as_posix())}
+CHECKSUMS_FILE={shlex.quote(checksums.as_posix())}
 VERIFIED_CHECKSUM=''
 install_openshell_sandbox
 """
         environment = os.environ.copy()
-        environment["SANDBOX_EXECUTION_MARKER"] = str(marker)
+        environment["SANDBOX_EXECUTION_MARKER"] = marker.as_posix()
         completed = subprocess.run(
-            ["/bin/bash", "-c", program],
+            [bash, "-c", program],
             env=environment,
             text=True,
             capture_output=True,

--- a/cli/tests/test_install_script_static.py
+++ b/cli/tests/test_install_script_static.py
@@ -10,7 +10,10 @@
 
 from __future__ import annotations
 
+import hashlib
+import os
 import re
+import subprocess
 from pathlib import Path
 
 try:
@@ -113,10 +116,88 @@ def test_windows_native_workflow_builds_exact_setup_before_lifecycle_acceptance(
     assert "-Mode setup-acceptance" in acceptance
 
 
-def test_sandbox_installer_fallback_uses_selected_release() -> None:
+def test_sandbox_installer_is_authenticated_before_execution() -> None:
     text = INSTALL_SH.read_text(encoding="utf-8")
-    assert "raw.githubusercontent.com/${REPO}/main/scripts/install-openshell-sandbox.sh" not in text
-    assert "raw.githubusercontent.com/${REPO}/${RELEASE_VERSION}/scripts/install-openshell-sandbox.sh" in text
+    assert "raw.githubusercontent.com/${REPO}" not in text
+    assert 'local asset_name="install-openshell-sandbox.sh"' in text
+    assert 'version_gte "${RELEASE_VERSION}" "${SANDBOX_INSTALLER_ASSET_START_VERSION}"' in text
+    download = text.index('fetch_artifact "$(artifact_path "${asset_name}")" "${sandbox_installer}"')
+    authenticate = text.index('verify_checksum "${sandbox_installer}" "${asset_name}"', download)
+    bind_digest = text.index('verified_sha256="${VERIFIED_CHECKSUM}"', authenticate)
+    recheck = text.index('"$(sha256_file "${sandbox_installer}")" == "${verified_sha256}"', bind_digest)
+    execute = text.index('bash "${sandbox_installer}"', recheck)
+    assert download < authenticate < bind_digest < recheck < execute
+
+
+def test_sandbox_installer_rejects_tampered_bytes_and_executes_authenticated_bytes(
+    tmp_path: Path,
+) -> None:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+
+    def shell_function(name: str) -> str:
+        match = re.search(rf"(?ms)^{re.escape(name)}\(\) \{{\n.*?^\}}\n", text)
+        assert match is not None, name
+        return match.group(0)
+
+    functions = "\n".join(
+        shell_function(name)
+        for name in (
+            "version_gte",
+            "sha256_file",
+            "artifact_path",
+            "fetch_artifact",
+            "verify_checksum",
+            "install_openshell_sandbox",
+        )
+    )
+    asset_payload = b'#!/usr/bin/env bash\nprintf "executed\\n" > "${SANDBOX_EXECUTION_MARKER}"\n'
+
+    for authenticated in (False, True):
+        case = tmp_path / ("authenticated" if authenticated else "tampered")
+        release = case / "release"
+        policy = case / "policy"
+        release.mkdir(parents=True)
+        policy.mkdir()
+        asset = release / "install-openshell-sandbox.sh"
+        asset.write_bytes(asset_payload)
+        expected = hashlib.sha256(asset_payload).hexdigest() if authenticated else "0" * 64
+        checksums = release / "checksums.txt"
+        checksums.write_text(f"{expected}  {asset.name}\n", encoding="utf-8")
+        marker = case / "executed"
+        program = f"""set -euo pipefail
+has() {{ command -v "$1" >/dev/null 2>&1; }}
+info() {{ :; }}
+warn() {{ :; }}
+step() {{ :; }}
+die() {{ printf '%s\\n' "$*" >&2; exit 71; }}
+{functions}
+MODERN_RELEASE=true
+RELEASE_VERSION=0.8.11
+SANDBOX_INSTALLER_ASSET_START_VERSION=0.8.11
+LOCAL_DIR={release}
+POLICY_DIR={policy}
+CHECKSUMS_FILE={checksums}
+VERIFIED_CHECKSUM=''
+install_openshell_sandbox
+"""
+        environment = os.environ.copy()
+        environment["SANDBOX_EXECUTION_MARKER"] = str(marker)
+        completed = subprocess.run(
+            ["/bin/bash", "-c", program],
+            env=environment,
+            text=True,
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+
+        if authenticated:
+            assert completed.returncode == 0, completed.stdout + completed.stderr
+            assert marker.read_text(encoding="utf-8") == "executed\n"
+        else:
+            assert completed.returncode == 71, completed.stdout + completed.stderr
+            assert "Checksum mismatch" in completed.stderr
+            assert not marker.exists()
 
 
 def test_release_installers_track_known_connector_choices() -> None:

--- a/cli/tests/test_release_candidate.py
+++ b/cli/tests/test_release_candidate.py
@@ -1405,15 +1405,24 @@ def test_public_installers_are_immutable_checksummed_assets_from_088_forward(
         "install.ps1",
         "install.sh",
     )
-    payload = set(release_candidate.payload_asset_names("0.8.8", "unverified"))
-    published = set(release_candidate.published_asset_names("0.8.8", "unverified"))
-    assert {"install.sh", "install.ps1"} <= payload <= published
+    assert release_candidate.installer_asset_names("0.8.10") == (
+        "install.ps1",
+        "install.sh",
+    )
+    assert release_candidate.installer_asset_names("0.8.11") == (
+        "install-openshell-sandbox.sh",
+        "install.ps1",
+        "install.sh",
+    )
+    payload = set(release_candidate.payload_asset_names("0.8.11", "unverified"))
+    published = set(release_candidate.published_asset_names("0.8.11", "unverified"))
+    assert {"install.sh", "install.ps1", "install-openshell-sandbox.sh"} <= payload <= published
 
     staged = tmp_path / "installers"
     staged.mkdir()
-    release_candidate._copy_installer_assets(staged, "0.8.8")
-    release_candidate._validate_installer_assets(staged, "0.8.8")
-    for name in release_candidate.installer_asset_names("0.8.8"):
+    release_candidate._copy_installer_assets(staged, "0.8.11")
+    release_candidate._validate_installer_assets(staged, "0.8.11")
+    for name in release_candidate.installer_asset_names("0.8.11"):
         assert (staged / name).read_bytes() == release_candidate.INSTALLER_ASSETS[name].source.read_bytes()
 
     if os.name == "posix":
@@ -1422,14 +1431,14 @@ def test_public_installers_are_immutable_checksummed_assets_from_088_forward(
             release_candidate.CandidateError,
             match="installer mode differs from reviewed source",
         ):
-            release_candidate._validate_installer_assets(staged, "0.8.8")
+            release_candidate._validate_installer_assets(staged, "0.8.11")
         (staged / "install.sh").chmod(
             stat.S_IMODE(release_candidate.INSTALLER_ASSETS["install.sh"].source.stat().st_mode)
         )
 
     (staged / "install.sh").write_bytes(b"#!/bin/sh\nexit 0\n")
     with pytest.raises(release_candidate.CandidateError, match="differs from reviewed source"):
-        release_candidate._validate_installer_assets(staged, "0.8.8")
+        release_candidate._validate_installer_assets(staged, "0.8.11")
 
 
 def test_windows_setup_custody_starts_at_086_and_survives_legacy_omission() -> None:
@@ -2459,6 +2468,7 @@ def test_exact_reviewed_release_sources_have_cross_platform_lf_attributes() -> N
     reviewed = (
         "scripts/defenseclaw-rescue.sh",
         "scripts/defenseclaw-rescue.ps1",
+        "scripts/install-openshell-sandbox.sh",
         "scripts/install.sh",
         "scripts/install.ps1",
         "scripts/upgrade.sh",

--- a/scripts/install-openshell-sandbox.sh
+++ b/scripts/install-openshell-sandbox.sh
@@ -318,3 +318,4 @@ echo ""
 }
 
 main "$@"
+# DefenseClaw OpenShell sandbox installer complete v1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -71,6 +71,7 @@ readonly MIN_PYTHON_VERSION="3.10"
 readonly MAX_PYTHON_VERSION_EXCLUSIVE="3.14"
 readonly COSIGN_BOOTSTRAP_VERSION="2.6.3"
 readonly COSIGN_BOOTSTRAP_MAX_BYTES="209715200"
+readonly SANDBOX_INSTALLER_ASSET_START_VERSION="0.8.11"
 VERIFIED_CHECKSUM=""
 COSIGN_BIN=""
 
@@ -1339,6 +1340,30 @@ verify_checksum() {
     VERIFIED_CHECKSUM="${actual}"
 }
 
+install_openshell_sandbox() {
+    step "Installing openshell-sandbox"
+    [[ "${MODERN_RELEASE:-false}" == true ]] \
+        || die "Sandbox installation requires a signed DefenseClaw release bundle; no sandbox installer was executed"
+    version_gte "${RELEASE_VERSION}" "${SANDBOX_INSTALLER_ASSET_START_VERSION}" \
+        || die "DefenseClaw ${RELEASE_VERSION} does not publish an authenticated sandbox installer; use ${SANDBOX_INSTALLER_ASSET_START_VERSION} or newer"
+
+    local asset_name="install-openshell-sandbox.sh"
+    local sandbox_installer="${POLICY_DIR}/${asset_name}"
+    local verified_sha256=""
+    info "Downloading the signed release sandbox installer..."
+    fetch_artifact "$(artifact_path "${asset_name}")" "${sandbox_installer}"
+    verify_checksum "${sandbox_installer}" "${asset_name}"
+    verified_sha256="${VERIFIED_CHECKSUM}"
+    [[ "${verified_sha256}" =~ ^[0-9A-Fa-f]{64}$ ]] \
+        || die "Signed checksums do not authenticate the sandbox installer; no sandbox installer was executed"
+    chmod 500 "${sandbox_installer}" \
+        || die "Could not protect the authenticated sandbox installer; no sandbox installer was executed"
+    [[ "$(sha256_file "${sandbox_installer}")" == "${verified_sha256}" ]] \
+        || die "Authenticated sandbox installer changed before execution; no sandbox installer was executed"
+    bash "${sandbox_installer}" \
+        || die "OpenShell sandbox installation failed"
+}
+
 # ── Install: Gateway binary ──────────────────────────────────────────────────
 
 install_gateway() {
@@ -1970,18 +1995,7 @@ if [[ "${INSTALL_SANDBOX}" == true ]]; then
     elif [[ "${OS}" != "linux" ]]; then
         warn "Sandbox mode requires Linux — skipping openshell-sandbox"
     else
-        local script_dir
-        script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-        local sandbox_installer="${script_dir}/install-openshell-sandbox.sh"
-        if [[ -f "${sandbox_installer}" ]]; then
-            bash "${sandbox_installer}"
-        else
-            step "Installing openshell-sandbox"
-            info "Downloading installer..."
-            curl -fsSL \
-                "https://raw.githubusercontent.com/${REPO}/${RELEASE_VERSION}/scripts/install-openshell-sandbox.sh" \
-                | bash
-        fi
+        install_openshell_sandbox
     fi
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1922,6 +1922,12 @@ resolve_version
 ensure_uv
 ensure_python
 load_release_policy
+if [[ "${INSTALL_SANDBOX}" == true ]]; then
+    [[ "${MODERN_RELEASE}" == true ]] \
+        || die "Sandbox installation requires a signed DefenseClaw release bundle; no sandbox installer was executed"
+    version_gte "${RELEASE_VERSION}" "${SANDBOX_INSTALLER_ASSET_START_VERSION}" \
+        || die "DefenseClaw ${RELEASE_VERSION} does not publish an authenticated sandbox installer; use ${SANDBOX_INSTALLER_ASSET_START_VERSION} or newer"
+fi
 if [[ "${MODERN_RELEASE}" == true ]]; then
     # Bind both roots before publishing payloads or rollback-token hardlinks.
     # A custom state home may be on another filesystem; its sibling custody is

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -170,9 +170,14 @@ RESOLVER_ASSETS = {
     ),
 }
 RELEASE_CHANNEL_BOOTSTRAP_START_VERSION = (0, 8, 8)
+SANDBOX_INSTALLER_ASSET_START_VERSION = (0, 8, 11)
 MAX_RESOLVER_BYTES = 4 * 1024 * 1024
 MAX_INSTALLER_BYTES = 4 * 1024 * 1024
 INSTALLER_ASSETS = {
+    "install-openshell-sandbox.sh": ReviewedScriptAsset(
+        ROOT / "scripts" / "install-openshell-sandbox.sh",
+        b"# DefenseClaw OpenShell sandbox installer complete v1",
+    ),
     "install.sh": ReviewedScriptAsset(
         ROOT / "scripts" / "install.sh",
         b"# DefenseClaw POSIX installer complete v1",
@@ -1013,12 +1018,16 @@ def resolver_asset_names(version: str) -> tuple[str, ...]:
 
 
 def installer_asset_names(version: str) -> tuple[str, ...]:
-    """Return reviewed public installers shipped as immutable 0.8.8+ assets."""
+    """Return reviewed public installers shipped for one immutable release."""
 
     _validate_version(version)
-    if tuple(map(int, version.split("."))) < RELEASE_CHANNEL_BOOTSTRAP_START_VERSION:
+    version_key = tuple(map(int, version.split(".")))
+    if version_key < RELEASE_CHANNEL_BOOTSTRAP_START_VERSION:
         return ()
-    return tuple(sorted(INSTALLER_ASSETS))
+    names = set(INSTALLER_ASSETS)
+    if version_key < SANDBOX_INSTALLER_ASSET_START_VERSION:
+        names.remove("install-openshell-sandbox.sh")
+    return tuple(sorted(names))
 
 
 def release_identity_asset_names(version: str) -> tuple[str, ...]:


### PR DESCRIPTION
## Problem

When `install.sh --sandbox` could not find an adjacent `install-openshell-sandbox.sh`, it streamed a pinned Git tag from `raw.githubusercontent.com` directly into Bash. A tag pin provides version selection, but it does not authenticate the bytes before execution. A network, release-account, or mutable-reference compromise could therefore cross the installer trust boundary.

Fixes #408.

## Current Situation

The primary installer already authenticates modern release policy through the Sigstore-signed `checksums.txt` bundle, but the sandbox helper bypassed that boundary:

```mermaid
flowchart LR
    A["Pinned raw GitHub URL"] --> B["curl response"]
    B --> C["bash (executed before authentication)"]
```

The helper also was not part of the release candidate's reviewed immutable installer set, so it had no signed release-asset digest to verify.

## Solution

### Publish the helper as a reviewed release asset

Starting with release 0.8.11, the release candidate includes `install-openshell-sandbox.sh` in the immutable payload set. Candidate assembly validates its bounded regular-file snapshot, executable mode, completeness marker, exact bytes, and LF representation. The existing release pipeline then includes its SHA-256 digest in the Sigstore-signed checksum bundle.

Historical releases remain historically exact: 0.8.8–0.8.10 still require only the installer assets they actually published.

### Authenticate before execution

The primary installer now downloads/copies the helper into its private release-policy staging directory, verifies it against the already authenticated checksum bundle, protects its mode, re-hashes the bytes immediately before execution, and only then invokes Bash.

```mermaid
flowchart LR
    A["Release workflow OIDC identity"] --> B["Sigstore-signed checksums.txt"]
    B --> C["install-openshell-sandbox.sh SHA-256"]
    D["Immutable release asset"] --> E["Private policy staging"]
    C --> F["Checksum verification"]
    E --> F
    F --> G["Immediate pre-exec re-hash"]
    G --> H["bash authenticated local file"]
```

Missing, tampered, historically unavailable, or pre-execution-mutated helpers fail closed without executing sandbox-installer bytes. Unsupported sandbox releases are rejected immediately after authenticated policy loading, before gateway, CLI, plugin, OpenClaw, or connector installation can mutate the host.

### Prove both security and compatibility

A shell-level regression harness exercises the real download/copy, checksum, digest-binding, and execution functions. It proves a mismatched artifact never executes and a matching artifact still does.

## What Changed (Where & How)

| Path | Change |
| --- | --- |
| `scripts/install.sh` | Replaced raw `curl | bash` and unverified adjacent execution with signed-release download, checksum verification, private staging, and pre-exec digest binding. |
| `scripts/install-openshell-sandbox.sh` | Added the reviewed completeness marker used by candidate validation. |
| `scripts/release_candidate.py` | Added the helper to the immutable installer asset set from 0.8.11 onward without rewriting historical asset contracts. |
| `.gitattributes` | Made helper bytes stable across release runners with LF checkout. |
| `cli/tests/test_install_script_static.py` | Added ordering assertions plus tampered/authenticated execution controls through the real shell functions. |
| `cli/tests/test_release_candidate.py` | Added version-gated asset, staging, checksum-set, and cross-platform byte-contract coverage. |

## Breaking Changes

A newer `install.sh` invoked with `--sandbox` while explicitly selecting DefenseClaw 0.8.10 or older now fails closed because those immutable releases did not publish an authenticated sandbox-helper asset. Normal installation without `--sandbox` is unchanged. Release 0.8.11 and newer publish the authenticated helper.

## Open Issues / Follow-ups

None.

## Test Plan

- `PYTHONPATH=. uv run --frozen pytest -q cli/tests/test_install_script_static.py cli/tests/test_release_candidate.py cli/tests/test_release_workflow_staged.py`
  - **265 passed**
- `PYTHONPATH=. uv run --frozen pytest -q cli/tests/test_install_docs_static.py cli/tests/test_release_channel.py`
  - **160 passed**
- `uv run --frozen ruff check scripts/release_candidate.py cli/tests/test_install_script_static.py cli/tests/test_release_candidate.py`
  - **Passed**
- `bash -n scripts/install.sh && bash -n scripts/install-openshell-sandbox.sh`
  - **Passed**
- `shellcheck -e SC2012,SC2034,SC2059,SC2086,SC2155 scripts/install.sh scripts/install-openshell-sandbox.sh`
  - **Passed** (the exclusions are the repository's existing diagnostics outside this change)
- `git diff --check`
  - **Passed**