### PR TITLE
fix(release): bind baseline validation to captured bytes

### DIFF
--- a/cli/tests/test_release_candidate.py
+++ b/cli/tests/test_release_candidate.py
@@ -2011,6 +2011,120 @@ def test_candidate_verification_rejects_effective_baseline_snapshot_mutation(
         release_candidate.verify(root, VERSION, COMMIT)
 
 
+def test_effective_baseline_validation_aba_parses_and_hashes_captured_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "candidate"
+    root.mkdir()
+    policy = root / release_candidate.EFFECTIVE_UPGRADE_BASELINES_FILENAME
+    captured = (ROOT / "release/upgrade-baselines.json").read_bytes()
+    replacement = b"{}"
+    policy.write_bytes(captured)
+    read_bounded = release_candidate._read_bounded_regular_file
+    read_count = 0
+
+    def aba_read(path: Path, *, label: str, max_bytes: int) -> bytes:
+        nonlocal read_count
+        read_count += 1
+        if read_count == 2:
+            assert policy.read_bytes() == replacement
+            policy.write_bytes(captured)
+        payload = read_bounded(path, label=label, max_bytes=max_bytes)
+        if read_count == 1:
+            assert payload == captured
+            policy.write_bytes(replacement)
+        return payload
+
+    monkeypatch.setattr(release_candidate, "_read_bounded_regular_file", aba_read)
+
+    digest = release_candidate._validated_effective_upgrade_baselines(root, VERSION)
+
+    assert read_count == 2
+    assert digest == hashlib.sha256(captured).hexdigest()
+    assert policy.read_bytes() == captured
+
+
+def test_effective_baseline_validation_rejects_invalid_captured_payload_during_aba(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "candidate"
+    root.mkdir()
+    policy = root / release_candidate.EFFECTIVE_UPGRADE_BASELINES_FILENAME
+    captured = b"{}"
+    replacement = (ROOT / "release/upgrade-baselines.json").read_bytes()
+    policy.write_bytes(captured)
+    read_bounded = release_candidate._read_bounded_regular_file
+    parse_payload = release_candidate._parse_upgrade_baseline_policy_payload
+    read_count = 0
+
+    def aba_read(path: Path, *, label: str, max_bytes: int) -> bytes:
+        nonlocal read_count
+        read_count += 1
+        if read_count == 2:
+            assert policy.read_bytes() == replacement
+            policy.write_bytes(captured)
+        payload = read_bounded(path, label=label, max_bytes=max_bytes)
+        if read_count == 1:
+            assert payload == captured
+            policy.write_bytes(replacement)
+        return payload
+
+    def parse_and_restore(candidate_version: str, payload: bytes) -> tuple[list[str], dict[str, list[str]]]:
+        assert payload == captured
+        try:
+            return parse_payload(candidate_version, payload)
+        finally:
+            assert policy.read_bytes() == replacement
+            policy.write_bytes(captured)
+
+    monkeypatch.setattr(release_candidate, "_read_bounded_regular_file", aba_read)
+    monkeypatch.setattr(release_candidate, "_parse_upgrade_baseline_policy_payload", parse_and_restore)
+
+    with pytest.raises(
+        release_candidate.CandidateError,
+        match="tested upgrade baseline policy is invalid",
+    ):
+        release_candidate._validated_effective_upgrade_baselines(root, VERSION)
+
+    assert read_count == 1
+    assert policy.read_bytes() == captured
+
+
+def test_effective_baseline_validation_rejects_mutation_after_captured_read(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "candidate"
+    root.mkdir()
+    policy = root / release_candidate.EFFECTIVE_UPGRADE_BASELINES_FILENAME
+    captured = (ROOT / "release/upgrade-baselines.json").read_bytes()
+    mutated = captured + b"\n"
+    policy.write_bytes(captured)
+    read_bounded = release_candidate._read_bounded_regular_file
+    read_count = 0
+
+    def mutating_read(path: Path, *, label: str, max_bytes: int) -> bytes:
+        nonlocal read_count
+        read_count += 1
+        payload = read_bounded(path, label=label, max_bytes=max_bytes)
+        if read_count == 1:
+            policy.write_bytes(mutated)
+        return payload
+
+    monkeypatch.setattr(release_candidate, "_read_bounded_regular_file", mutating_read)
+
+    with pytest.raises(
+        release_candidate.CandidateError,
+        match="policy changed during validation",
+    ):
+        release_candidate._validated_effective_upgrade_baselines(root, VERSION)
+
+    assert read_count == 2
+    assert policy.read_bytes() == mutated
+
+
 def test_publication_can_omit_every_windows_specific_asset(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -1296,30 +1296,13 @@ def stage_installers(directory: Path, version: str) -> None:
     _validate_installer_assets(directory, version, snapshots=snapshots)
 
 
-def _load_upgrade_baseline_policy(
-    candidate_version: str | None = None,
-    policy_path: Path | None = None,
+def _parse_upgrade_baseline_policy_payload(
+    candidate_version: str,
+    payload: bytes,
 ) -> tuple[list[str], dict[str, list[str]]]:
-    if candidate_version is None:
-        try:
-            source_identity = json.loads(
-                (ROOT / "release" / "source-install-identity.json").read_text(encoding="utf-8")
-            )
-            candidate_version = source_identity["source_release"]
-        except (
-            OSError,
-            UnicodeError,
-            json.JSONDecodeError,
-            KeyError,
-            TypeError,
-        ) as exc:
-            raise CandidateError("could not resolve source release for baseline validation") from exc
-        if not isinstance(candidate_version, str) or not VERSION_RE.fullmatch(candidate_version):
-            raise CandidateError("source release for baseline validation is invalid")
-    policy_path = policy_path or UPGRADE_BASELINES_PATH
     try:
-        document = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        document = json.loads(payload.decode("utf-8", errors="strict"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise CandidateError(f"could not load tested upgrade baselines: {exc}") from exc
     configured = document.get("published_baselines")
     config_versions = document.get("published_baseline_config_versions")
@@ -1364,6 +1347,34 @@ def _load_upgrade_baseline_policy(
         raise CandidateError("tested Windows upgrade baseline policy is invalid")
     _validate_historical_artifact_digest_policy(configured)
     return configured, {"windows": windows}
+
+
+def _load_upgrade_baseline_policy(
+    candidate_version: str | None = None,
+    policy_path: Path | None = None,
+) -> tuple[list[str], dict[str, list[str]]]:
+    if candidate_version is None:
+        try:
+            source_identity = json.loads(
+                (ROOT / "release" / "source-install-identity.json").read_text(encoding="utf-8")
+            )
+            candidate_version = source_identity["source_release"]
+        except (
+            OSError,
+            UnicodeError,
+            json.JSONDecodeError,
+            KeyError,
+            TypeError,
+        ) as exc:
+            raise CandidateError("could not resolve source release for baseline validation") from exc
+        if not isinstance(candidate_version, str) or not VERSION_RE.fullmatch(candidate_version):
+            raise CandidateError("source release for baseline validation is invalid")
+    policy_path = policy_path or UPGRADE_BASELINES_PATH
+    try:
+        payload = policy_path.read_bytes()
+    except OSError as exc:
+        raise CandidateError(f"could not load tested upgrade baselines: {exc}") from exc
+    return _parse_upgrade_baseline_policy_payload(candidate_version, payload)
 
 
 def _validate_historical_artifact_digest_policy(configured: list[str]) -> None:
@@ -5013,20 +5024,20 @@ def record_windows_unverified(
 
 def _validated_effective_upgrade_baselines(root: Path, version: str) -> str:
     path = root / EFFECTIVE_UPGRADE_BASELINES_FILENAME
-    before = _read_bounded_regular_file(
+    captured = _read_bounded_regular_file(
         path,
         label="effective upgrade-baseline policy",
         max_bytes=MAX_EFFECTIVE_UPGRADE_BASELINES_BYTES,
     )
-    _load_upgrade_baseline_policy(version, path)
-    after = _read_bounded_regular_file(
+    _parse_upgrade_baseline_policy_payload(version, captured)
+    current = _read_bounded_regular_file(
         path,
         label="effective upgrade-baseline policy",
         max_bytes=MAX_EFFECTIVE_UPGRADE_BASELINES_BYTES,
     )
-    if before != after:
+    if captured != current:
         raise CandidateError("effective upgrade-baseline policy changed during validation")
-    return hashlib.sha256(after).hexdigest()
+    return hashlib.sha256(captured).hexdigest()
 
 
 def assemble(


### PR DESCRIPTION
Base: `main`. This is a standalone fix for #553 with no stack dependencies.

Fixes #553.

## Problem

`_validated_effective_upgrade_baselines()` performed three pathname-based operations over the candidate policy: a bounded byte read, validation through `_load_upgrade_baseline_policy()` reopening the path, and a later bounded read whose bytes were hashed. An A→B→A pathname swap could therefore make validation observe B while the sealed digest described A.

The release candidate must bind policy validation and the recorded SHA-256 digest to one captured byte payload.

## Current Situation

The affected helper is used by candidate assembly, sealing, and verification. The bounded reader protects each individual read from leaf symlinks and in-read mutation, but the old validation call reopened the pathname between those reads.

A deterministic regression applied to the untouched base commit failed at `_load_upgrade_baseline_policy()` because the intermediate B payload was parsed instead of the captured A payload. This confirms the vulnerable control path rather than only testing the refactored helper.

## Solution

### Captured-payload validation

A new `_parse_upgrade_baseline_policy_payload()` helper owns UTF-8 decoding, JSON parsing, schema validation, version validation, platform validation, and historical digest-policy validation for caller-supplied bytes.

`_validated_effective_upgrade_baselines()` now:

1. captures A once through the existing bounded regular-file reader;
2. parses and validates exactly A;
3. performs one later bounded read solely to detect mutation;
4. rejects when the later bytes differ; and
5. records `SHA-256(A)`.

Normal path-based callers keep `_load_upgrade_baseline_policy()`, which reads the requested path once and passes those bytes to the same parser.

### Custody flow

```mermaid
flowchart LR
    A["Bounded read: capture A"] --> B["Parse and validate A"]
    B --> C["Bounded reread: mutation detection only"]
    C --> D{"Current bytes equal A?"}
    D -- No --> E["Reject candidate"]
    D -- Yes --> F["Record SHA-256 of A"]
```

### Regression coverage

The tests cover both sides of the boundary:

- legitimate A remains accepted and hashed during an A→invalid-B→A swap;
- invalid captured A is rejected even when the pathname temporarily exposes valid B before returning to A;
- a one-way mutation after capture is still detected and rejected; and
- the existing post-seal policy-digest mutation contract remains intact.

## What Changed (Where & How)

| Path | Change |
| --- | --- |
| `scripts/release_candidate.py` | Extracted byte-payload parsing/validation and bound effective-policy validation plus hashing to the first bounded payload. |
| `cli/tests/test_release_candidate.py` | Added deterministic positive, adversarial, and mutation-detection coverage for the policy custody boundary. |

## Breaking Changes

None. Path-based policy callers retain the same interface and `CandidateError` behavior. Candidate assembly, sealing, and verification continue to reject observable mutation.

## Open Issues / Follow-ups

None.

## Test Plan

- Pre-fix control on detached `c2236353f32e50f5c3c770f2fca16fca8c1cfca2`:
  - `python -m pytest -q cli/tests/test_release_candidate.py -k 'effective_baseline_validation_aba_parses_and_hashes_captured_bytes'`
  - Observed: expected failure in the old `_load_upgrade_baseline_policy()` pathname reopen while B was present.
- `uv run --frozen python -m pytest -q cli/tests/test_release_candidate.py -k 'effective_baseline_validation or candidate_verification_rejects_effective_baseline_snapshot_mutation or candidate_seals_and_verifies_exact_publish_set'`
  - Observed: `5 passed, 206 deselected`.
- `uv run --frozen python -m pytest -q cli/tests/test_release_candidate.py`
  - Observed: `211 passed`.
- `uv run --frozen python -m pytest -q cli/tests/test_install_ps1.py cli/tests/test_macos_runtime_installer_upgrade_guard.py cli/tests/test_release_channel.py cli/tests/test_release_channel_repair.py cli/tests/test_release_validation_strategy.py`
  - Observed: `157 passed, 17 skipped`.
- `uv run --frozen python -m pytest -q cli/tests/test_release_workflow_staged.py cli/tests/test_resolve_upgrade_baselines.py cli/tests/test_source_release_identity.py cli/tests/test_upgrade_release_smoke_contract.py cli/tests/test_upgrade_smoke_static.py cli/tests/test_windows_release_certification.py`
  - Observed: `283 passed, 19 skipped`.
- `uv run --frozen ruff check scripts/release_candidate.py cli/tests/test_release_candidate.py`
  - Observed: all checks passed.
- `uv run --frozen ruff check cli/defenseclaw/`
  - Observed: all checks passed.
- `uv run --frozen ruff format --check scripts/release_candidate.py cli/tests/test_release_candidate.py`
  - Observed: two files already formatted.
- `uv run --frozen python -m py_compile scripts/release_candidate.py cli/tests/test_release_candidate.py`
  - Observed: passed.
- `git diff --check`
  - Observed: passed.