### PR TITLE
fix(ci): contain untrusted connector radar execution

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+self-hosted-runner:
+  labels:
+    - connector-lab
+    - connector-lab-ephemeral
+    - defenseclaw-macos
+    - e2e
+
+config-variables: null

--- a/.github/workflows/connector-version-radar.yml
+++ b/.github/workflows/connector-version-radar.yml
@@ -231,6 +231,46 @@ jobs:
           echo "baseline=${baseline}" >> "${GITHUB_OUTPUT}"
           echo "candidate=${candidate}" >> "${GITHUB_OUTPUT}"
 
+      - name: Create immutable attempt receipt
+        shell: bash
+        env:
+          CONNECTOR: ${{ matrix.connector }}
+          BASELINE_VERSION: ${{ steps.versions.outputs.baseline }}
+          CANDIDATE_VERSION: ${{ steps.versions.outputs.candidate }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["RUNNER_TEMP"]) / "connector-version-radar-attempt"
+          root.mkdir(mode=0o700, parents=True, exist_ok=True)
+          output = root / "attempt.json"
+          temporary = root / "attempt.json.tmp"
+          payload = {
+              "schema_version": 1,
+              "intent": "attempt",
+              "connector": os.environ["CONNECTOR"],
+              "baseline_version": os.environ["BASELINE_VERSION"],
+              "candidate_version": os.environ["CANDIDATE_VERSION"],
+          }
+          temporary.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+          os.chmod(temporary, 0o600)
+          os.replace(temporary, output)
+          PY
+
+      # Upload before invoking candidate code. Artifacts are immutable, so a
+      # candidate running as the ephemeral account cannot rewrite this receipt.
+      - name: Upload immutable attempt receipt
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: connector-version-radar-attempt-${{ matrix.connector }}-${{ steps.versions.outputs.candidate }}
+          path: ${{ runner.temp }}/connector-version-radar-attempt/attempt.json
+          if-no-files-found: error
+          retention-days: 30
+          include-hidden-files: false
+
       - name: Run isolated upgrade regression harness
         id: harness
         shell: bash
@@ -258,56 +298,6 @@ jobs:
           # Defer failure until state and artifacts have been handled.
           exit 0
 
-      - name: Record meaningful radar outcome
-        if: ${{ always() }}
-        shell: bash
-        env:
-          CONNECTOR: ${{ matrix.connector }}
-          FALLBACK_CANDIDATE: ${{ steps.versions.outputs.candidate }}
-          RESOLVED_CANDIDATE: ${{ steps.harness.outputs.candidate_version }}
-          CLASSIFICATION: ${{ steps.harness.outputs.classification }}
-          RESULT_ROOT: ${{ steps.harness.outputs.result_root }}
-          BASELINE_VERSION: ${{ steps.versions.outputs.baseline }}
-          BASELINE_OVERRIDE: ${{ inputs.baseline_version || '' }}
-          CANDIDATE_OVERRIDE: ${{ inputs.candidate_version || '' }}
-        run: |
-          set -euo pipefail
-          state="${HOME}/Library/Application Support/DefenseClawConnectorLab/version-radar-state.json"
-          version="${RESOLVED_CANDIDATE:-${FALLBACK_CANDIDATE}}"
-          if [ -n "${BASELINE_OVERRIDE}" ] || [ -n "${CANDIDATE_OVERRIDE}" ]; then
-            echo "Not advancing daily radar state for an explicit historical/manual comparison."
-            if [ -n "${RESULT_ROOT}" ] && [ -f "${state}" ]; then
-              /bin/cp -p "${state}" "${RESULT_ROOT}/radar-state-after.json"
-            fi
-            exit 0
-          fi
-          case "${CLASSIFICATION}" in
-            pass)
-              python3 scripts/connector-version-radar.py mark \
-                --state "${state}" --connector "${CONNECTOR}" \
-                --version "${version}" --result passed
-              ;;
-            candidate_regression)
-              if [ "${BASELINE_VERSION}" != "${version}" ]; then
-                # The harness proved this exact baseline before the candidate
-                # failed. Preserve it as the next comparison's known-good
-                # release even if the globally installed CLI auto-updates.
-                python3 scripts/connector-version-radar.py mark \
-                  --state "${state}" --connector "${CONNECTOR}" \
-                  --version "${BASELINE_VERSION}" --result passed
-              fi
-              python3 scripts/connector-version-radar.py mark \
-                --state "${state}" --connector "${CONNECTOR}" \
-                --version "${version}" --result attempted
-              ;;
-            *)
-              echo "Not advancing radar state for classification=${CLASSIFICATION:-missing}; a later run will retry."
-              ;;
-          esac
-          if [ -n "${RESULT_ROOT}" ] && [ -f "${state}" ]; then
-            /bin/cp -p "${state}" "${RESULT_ROOT}/radar-state-after.json"
-          fi
-
       - name: Upload live evidence
         if: ${{ always() }}
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -319,7 +309,6 @@ jobs:
           path: |
             ${{ steps.harness.outputs.result_root }}/classification.json
             ${{ steps.harness.outputs.result_root }}/results.jsonl
-            ${{ steps.harness.outputs.result_root }}/radar-state-after.json
           if-no-files-found: error
           retention-days: 30
           include-hidden-files: false
@@ -336,6 +325,56 @@ jobs:
             2|3|4|5) exit "${HARNESS_EXIT_CODE}" ;;
             *) echo "::error::Unexpected harness exit code: ${HARNESS_EXIT_CODE:-missing}"; exit 4 ;;
           esac
+
+  persist:
+    name: Persist validated radar outcomes
+    needs: [detect, live]
+    # Run for both successful candidates and classified regressions. Historical
+    # overrides are audited but deliberately do not advance daily state.
+    if: ${{ always() && needs.detect.result == 'success' && needs.live.result != 'skipped' && github.ref == 'refs/heads/main' }}
+    runs-on: [self-hosted, macOS, ARM64, connector-lab, defenseclaw-macos]
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Download trusted detector evidence
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: connector-version-radar-detection
+          path: ${{ runner.temp }}/connector-version-radar-transfer/detection
+
+      - name: Download immutable attempt receipts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: connector-version-radar-attempt-*
+          path: ${{ runner.temp }}/connector-version-radar-transfer/receipts
+          merge-multiple: false
+
+      - name: Reconcile isolated outcomes into detector state
+        shell: bash
+        env:
+          BASELINE_OVERRIDE: ${{ inputs.baseline_version || '' }}
+          CANDIDATE_OVERRIDE: ${{ inputs.candidate_version || '' }}
+        run: |
+          set -euo pipefail
+          if [ -n "${BASELINE_OVERRIDE}" ] || [ -n "${CANDIDATE_OVERRIDE}" ]; then
+            echo "Not advancing daily radar state for an explicit historical/manual comparison."
+            exit 0
+          fi
+          state_dir="${HOME}/Library/Application Support/DefenseClawConnectorLab"
+          transfer="${RUNNER_TEMP}/connector-version-radar-transfer"
+          mkdir -p "${state_dir}"
+          chmod 700 "${state_dir}"
+          python3 scripts/connector-version-radar.py reconcile \
+            --state "${state_dir}/version-radar-state.json" \
+            --expected-radar "${transfer}/detection/radar.json" \
+            --receipts-root "${transfer}/receipts"
 
   report:
     name: Report connector regressions

--- a/.github/workflows/connector-version-radar.yml
+++ b/.github/workflows/connector-version-radar.yml
@@ -384,7 +384,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      issues: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -401,30 +400,14 @@ jobs:
           # JSONL files, and flattening can overwrite identical result names.
           merge-multiple: false
 
-      - name: Ensure regression label exists
+      # Candidate-writable JSON is review-only evidence. It may make this job
+      # red and render a summary, but it never reaches a repository write token.
+      - name: Render review-only regression summary
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh label create connector-regression \
-            --description "Upstream connector version compatibility regression" \
-            --color d73a4a \
-            --force
-
-      - name: Render summary and open or update the regression issue
-        env:
-          GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           mkdir -p radar-results
-          open_flag=()
-          while IFS= read -r -d '' classification; do
-            if jq -e '.classification == "candidate_regression"' "${classification}" >/dev/null; then
-              open_flag+=(--open-issue)
-              break
-            fi
-          done < <(find radar-results -name classification.json -type f -print0)
           python3 scripts/live-connector-e2e/report.py \
             --results-dir radar-results \
-            "${open_flag[@]}" \
             --run-url "${RUN_URL}"

--- a/.github/workflows/connector-version-radar.yml
+++ b/.github/workflows/connector-version-radar.yml
@@ -1,7 +1,9 @@
 # Daily upstream connector version radar and isolated macOS upgrade regression
-# harness. This workflow is intentionally separate from connector-live-e2e.yml:
-# the existing hosted Layer A contract matrix remains unchanged, while only
-# trusted default-branch code can reach the persistent connector-lab runner.
+# harness. Detection may use the persistent connector lab, but untrusted
+# candidate binaries are disabled by default and may run only after repository
+# admins provision a dedicated ephemeral runner label plus the explicit opt-in
+# variable below. This workflow remains separate from connector-live-e2e.yml so
+# the hosted Layer A contract matrix is unchanged.
 
 name: Connector Version Radar
 
@@ -33,8 +35,8 @@ on:
         type: string
         default: ""
 
-# The lab is persistent. Prevent overlap and never cancel a harness midway
-# through connector config restoration. GitHub retains at most one pending run.
+# Prevent overlap and never cancel detection or a harness midway through state
+# handling. GitHub retains at most one pending run.
 concurrency:
   group: connector-version-radar-main
   cancel-in-progress: false
@@ -154,8 +156,13 @@ jobs:
   live:
     name: Upgrade ${{ matrix.connector }} ${{ inputs.baseline_version || matrix.baseline_version }} to ${{ inputs.candidate_version || matrix.candidate_version }}
     needs: detect
-    if: ${{ needs.detect.outputs.any_new == 'true' && github.ref == 'refs/heads/main' }}
-    runs-on: [self-hosted, macOS, ARM64, connector-lab, defenseclaw-macos]
+    # Candidate releases are untrusted code. CONNECTOR_RADAR_LIVE_ENABLED must
+    # remain unset/false until admins provision the dedicated ephemeral label
+    # with an isolated OS account, HOME/Keychain, scoped credentials, and
+    # teardown-after-one-job semantics. The persistent detector runner is not
+    # an acceptable fallback for this job.
+    if: ${{ needs.detect.outputs.any_new == 'true' && github.ref == 'refs/heads/main' && vars.CONNECTOR_RADAR_LIVE_ENABLED == 'true' }}
+    runs-on: [self-hosted, macOS, ARM64, connector-lab-ephemeral, defenseclaw-macos]
     timeout-minutes: 45
     permissions:
       contents: read
@@ -306,10 +313,16 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: connector-version-radar-${{ matrix.connector }}-${{ steps.versions.outputs.candidate }}
-          path: ${{ steps.harness.outputs.result_root }}
+          # Upload only bounded, structured classifications. Candidate
+          # stdout/stderr, gateway logs, SQLite databases, connector config,
+          # and hidden files can contain credentials and remain excluded.
+          path: |
+            ${{ steps.harness.outputs.result_root }}/classification.json
+            ${{ steps.harness.outputs.result_root }}/results.jsonl
+            ${{ steps.harness.outputs.result_root }}/radar-state-after.json
           if-no-files-found: error
           retention-days: 30
-          include-hidden-files: true
+          include-hidden-files: false
 
       - name: Propagate harness classification
         if: ${{ always() }}

--- a/cli/tests/test_connector_version_radar.py
+++ b/cli/tests/test_connector_version_radar.py
@@ -338,6 +338,13 @@ class ConnectorVersionRadarTests(unittest.TestCase):
         self.assertEqual(result["updates"], [])
         self.assertEqual(self.state.read_bytes(), original)
 
+    def test_bounded_json_loader_rejects_non_utf8_json_encodings(self):
+        encoded = self.root / "utf16.json"
+        encoded.write_bytes('{"intent":"attempt"}'.encode("utf-16"))
+
+        with self.assertRaisesRegex(radar.RadarError, "not valid UTF-8 JSON"):
+            radar._load_bounded_json(encoded, label="attempt receipt")
+
     def test_mark_rejects_unsupported_result_before_state_mutation(self):
         original = b'{"schema_version":1,"connectors":{}}\n'
         self.state.write_bytes(original)

--- a/cli/tests/test_connector_version_radar.py
+++ b/cli/tests/test_connector_version_radar.py
@@ -192,6 +192,166 @@ class ConnectorVersionRadarTests(unittest.TestCase):
             ],
         )
 
+    def test_reconcile_attempt_receipts_records_scheduled_candidates_atomically(self):
+        self.state.write_text(
+            json.dumps({"schema_version": 1, "connectors": {}}) + "\n",
+            encoding="utf-8",
+        )
+        expected = self.root / "radar.json"
+        expected.write_text(
+            json.dumps(
+                {
+                    "candidates": [
+                        {
+                            "connector": "codex",
+                            "baseline_version": "0.142.5",
+                            "candidate_version": "0.144.1",
+                        },
+                        {
+                            "connector": "claudecode",
+                            "baseline_version": "2.1.207",
+                            "candidate_version": "2.1.208",
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        receipts = self.root / "receipts"
+        codex = receipts / "connector-version-radar-attempt-codex-0.144.1"
+        claude = receipts / "connector-version-radar-attempt-claudecode-2.1.208"
+        codex.mkdir(parents=True)
+        claude.mkdir(parents=True)
+        (codex / "attempt.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "intent": "attempt",
+                    "connector": "codex",
+                    "baseline_version": "0.142.5",
+                    "candidate_version": "0.144.1",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (claude / "attempt.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "intent": "attempt",
+                    "connector": "claudecode",
+                    "baseline_version": "2.1.207",
+                    "candidate_version": "2.1.208",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = radar.reconcile_attempt_receipts(
+            state_path=self.state,
+            expected_radar_path=expected,
+            receipts_root=receipts,
+            now="2026-08-11T12:00:00Z",
+        )
+
+        self.assertEqual(
+            result["updates"],
+            [
+                {"connector": "codex", "version": "0.144.1", "result": "attempted"},
+                {"connector": "claudecode", "version": "2.1.208", "result": "attempted"},
+            ],
+        )
+        persisted = json.loads(self.state.read_text(encoding="utf-8"))
+        self.assertEqual(persisted["connectors"]["codex"]["last_attempted_version"], "0.144.1")
+        self.assertEqual(persisted["connectors"]["claudecode"]["last_attempted_version"], "2.1.208")
+        self.assertNotIn("last_passed_version", persisted["connectors"]["codex"])
+        self.assertNotIn("last_passed_version", persisted["connectors"]["claudecode"])
+
+    def test_reconcile_rejects_mismatched_candidate_without_partial_state_write(self):
+        original = b'{"schema_version":1,"connectors":{}}\n'
+        self.state.write_bytes(original)
+        expected = self.root / "radar.json"
+        expected.write_text(
+            json.dumps(
+                {
+                    "candidates": [
+                        {
+                            "connector": "codex",
+                            "baseline_version": "0.142.5",
+                            "candidate_version": "0.144.1",
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        receipts = self.root / "receipts"
+        receipts.mkdir()
+        (receipts / "attempt.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "intent": "attempt",
+                    "connector": "codex",
+                    "baseline_version": "0.142.5",
+                    "candidate_version": "9.9.9",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(radar.RadarError, "do not match detection"):
+            radar.reconcile_attempt_receipts(
+                state_path=self.state,
+                expected_radar_path=expected,
+                receipts_root=receipts,
+            )
+        self.assertEqual(self.state.read_bytes(), original)
+
+    def test_reconcile_with_no_attempt_receipts_does_not_write_state(self):
+        original = b'{"schema_version":1,"connectors":{}}\n'
+        self.state.write_bytes(original)
+        expected = self.root / "radar.json"
+        expected.write_text(
+            json.dumps(
+                {
+                    "candidates": [
+                        {
+                            "connector": "codex",
+                            "baseline_version": "0.142.5",
+                            "candidate_version": "0.144.1",
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        receipts = self.root / "receipts"
+        receipts.mkdir()
+
+        result = radar.reconcile_attempt_receipts(
+            state_path=self.state,
+            expected_radar_path=expected,
+            receipts_root=receipts,
+        )
+
+        self.assertEqual(result["updates"], [])
+        self.assertEqual(self.state.read_bytes(), original)
+
+    def test_mark_rejects_unsupported_result_before_state_mutation(self):
+        original = b'{"schema_version":1,"connectors":{}}\n'
+        self.state.write_bytes(original)
+
+        with self.assertRaisesRegex(ValueError, "unsupported state result"):
+            radar.mark_state(
+                state_path=self.state,
+                connector="codex",
+                version="0.144.1",
+                result="ignored",
+            )
+
+        self.assertEqual(self.state.read_bytes(), original)
+
     def test_last_passed_release_remains_baseline_after_global_cli_updates(self):
         initial_runner = self._runner()
         radar.check_radar(

--- a/cli/tests/test_live_connector_upgrade_harness.py
+++ b/cli/tests/test_live_connector_upgrade_harness.py
@@ -153,6 +153,17 @@ def test_radar_upload_excludes_raw_candidate_and_gateway_evidence() -> None:
     }
 
 
+def test_candidate_writable_radar_evidence_has_no_repository_write_token() -> None:
+    workflow = RADAR_WORKFLOW.read_text(encoding="utf-8")
+    report_start = workflow.index("  report:\n")
+    report = workflow[report_start:]
+
+    assert "issues: write" not in report
+    assert "GH_TOKEN:" not in report
+    assert "--open-issue" not in report
+    assert "Render review-only regression summary" in report
+
+
 def test_harness_never_globally_installs_or_removes_auth_homes() -> None:
     text = HARNESS.read_text(encoding="utf-8")
     persist_text = PERSIST.read_text(encoding="utf-8")

--- a/cli/tests/test_live_connector_upgrade_harness.py
+++ b/cli/tests/test_live_connector_upgrade_harness.py
@@ -15,6 +15,7 @@ import pytest
 REPO = Path(__file__).resolve().parents[2]
 HARNESS = REPO / "scripts" / "live-connector-e2e" / "upgrade-regression.sh"
 RADAR_WORKFLOW = REPO / ".github" / "workflows" / "connector-version-radar.yml"
+ACTIONLINT_CONFIG = REPO / ".github" / "actionlint.yaml"
 PERSIST = REPO / "scripts" / "live-connector-e2e" / "lib" / "persistent-macos.sh"
 REPORT = REPO / "scripts" / "live-connector-e2e" / "report.py"
 ANTIGRAVITY_DRIVER = REPO / "scripts" / "live-connector-e2e" / "drivers" / "antigravity.sh"
@@ -79,12 +80,54 @@ def test_harness_cli_exposes_workflow_contract() -> None:
 def test_radar_candidate_execution_requires_isolated_runner_opt_in() -> None:
     workflow = RADAR_WORKFLOW.read_text(encoding="utf-8")
     live_start = workflow.index("  live:\n")
-    live_end = workflow.index("  report:\n", live_start)
+    live_end = workflow.index("  persist:\n", live_start)
     live = workflow[live_start:live_end]
 
     assert "vars.CONNECTOR_RADAR_LIVE_ENABLED == 'true'" in live
     assert "runs-on: [self-hosted, macOS, ARM64, connector-lab-ephemeral, defenseclaw-macos]" in live
     assert "runs-on: [self-hosted, macOS, ARM64, connector-lab, defenseclaw-macos]" not in live
+
+
+def test_radar_attempt_receipts_are_immutable_before_candidate_execution() -> None:
+    workflow = RADAR_WORKFLOW.read_text(encoding="utf-8")
+    live_start = workflow.index("  live:\n")
+    persist_start = workflow.index("  persist:\n", live_start)
+    report_start = workflow.index("  report:\n", persist_start)
+    live = workflow[live_start:persist_start]
+    persist = workflow[persist_start:report_start]
+
+    create_receipt = live.index("      - name: Create immutable attempt receipt\n")
+    upload_receipt = live.index("      - name: Upload immutable attempt receipt\n")
+    run_candidate = live.index("      - name: Run isolated upgrade regression harness\n")
+    assert create_receipt < upload_receipt < run_candidate
+    assert "name: connector-version-radar-attempt-${{ matrix.connector }}-" in live
+    assert "runs-on: [self-hosted, macOS, ARM64, connector-lab, defenseclaw-macos]" in persist
+    assert "name: connector-version-radar-detection" in persist
+    assert "pattern: connector-version-radar-attempt-*" in persist
+    assert "scripts/connector-version-radar.py reconcile" in persist
+    assert 'expected-radar "${transfer}/detection/radar.json"' in persist
+    assert 'receipts-root "${transfer}/receipts"' in persist
+    assert "classification.json" not in persist
+    assert "connector-lab-ephemeral" not in persist
+
+
+def test_radar_persistent_state_transactions_are_workflow_serialized() -> None:
+    workflow = RADAR_WORKFLOW.read_text(encoding="utf-8")
+    jobs_start = workflow.index("jobs:\n")
+    global_config = workflow[:jobs_start]
+    persist_start = workflow.index("  persist:\n", jobs_start)
+    report_start = workflow.index("  report:\n", persist_start)
+    persist = workflow[persist_start:report_start]
+
+    assert "group: connector-version-radar-main" in global_config
+    assert "cancel-in-progress: false" in global_config
+    assert "needs: [detect, live]" in persist
+
+
+def test_actionlint_knows_all_repository_self_hosted_labels() -> None:
+    config = ACTIONLINT_CONFIG.read_text(encoding="utf-8")
+    for label in ("connector-lab", "connector-lab-ephemeral", "defenseclaw-macos", "e2e"):
+        assert f"    - {label}\n" in config
 
 
 def test_radar_upload_excludes_raw_candidate_and_gateway_evidence() -> None:
@@ -97,7 +140,7 @@ def test_radar_upload_excludes_raw_candidate_and_gateway_evidence() -> None:
     assert f"path: {result_root}\n" not in upload
     assert f"{result_root}/classification.json" in upload
     assert f"{result_root}/results.jsonl" in upload
-    assert f"{result_root}/radar-state-after.json" in upload
+    assert f"{result_root}/radar-state-after.json" not in upload
     assert "include-hidden-files: true" not in upload
     uploaded_paths = {
         line.strip()
@@ -107,7 +150,6 @@ def test_radar_upload_excludes_raw_candidate_and_gateway_evidence() -> None:
     assert uploaded_paths == {
         f"{result_root}/classification.json",
         f"{result_root}/results.jsonl",
-        f"{result_root}/radar-state-after.json",
     }
 
 

--- a/cli/tests/test_live_connector_upgrade_harness.py
+++ b/cli/tests/test_live_connector_upgrade_harness.py
@@ -14,6 +14,7 @@ import pytest
 
 REPO = Path(__file__).resolve().parents[2]
 HARNESS = REPO / "scripts" / "live-connector-e2e" / "upgrade-regression.sh"
+RADAR_WORKFLOW = REPO / ".github" / "workflows" / "connector-version-radar.yml"
 PERSIST = REPO / "scripts" / "live-connector-e2e" / "lib" / "persistent-macos.sh"
 REPORT = REPO / "scripts" / "live-connector-e2e" / "report.py"
 ANTIGRAVITY_DRIVER = REPO / "scripts" / "live-connector-e2e" / "drivers" / "antigravity.sh"
@@ -73,6 +74,41 @@ def test_harness_cli_exposes_workflow_contract() -> None:
         "--classification-output",
     ):
         assert flag in proc.stdout
+
+
+def test_radar_candidate_execution_requires_isolated_runner_opt_in() -> None:
+    workflow = RADAR_WORKFLOW.read_text(encoding="utf-8")
+    live_start = workflow.index("  live:\n")
+    live_end = workflow.index("  report:\n", live_start)
+    live = workflow[live_start:live_end]
+
+    assert "vars.CONNECTOR_RADAR_LIVE_ENABLED == 'true'" in live
+    assert "runs-on: [self-hosted, macOS, ARM64, connector-lab-ephemeral, defenseclaw-macos]" in live
+    assert "runs-on: [self-hosted, macOS, ARM64, connector-lab, defenseclaw-macos]" not in live
+
+
+def test_radar_upload_excludes_raw_candidate_and_gateway_evidence() -> None:
+    workflow = RADAR_WORKFLOW.read_text(encoding="utf-8")
+    upload_start = workflow.index("      - name: Upload live evidence\n")
+    upload_end = workflow.index("      - name: Propagate harness classification\n", upload_start)
+    upload = workflow[upload_start:upload_end]
+
+    result_root = "${{ steps.harness.outputs.result_root }}"
+    assert f"path: {result_root}\n" not in upload
+    assert f"{result_root}/classification.json" in upload
+    assert f"{result_root}/results.jsonl" in upload
+    assert f"{result_root}/radar-state-after.json" in upload
+    assert "include-hidden-files: true" not in upload
+    uploaded_paths = {
+        line.strip()
+        for line in upload.splitlines()
+        if line.strip().startswith(result_root)
+    }
+    assert uploaded_paths == {
+        f"{result_root}/classification.json",
+        f"{result_root}/results.jsonl",
+        f"{result_root}/radar-state-after.json",
+    }
 
 
 def test_harness_never_globally_installs_or_removes_auth_homes() -> None:

--- a/scripts/connector-version-radar.py
+++ b/scripts/connector-version-radar.py
@@ -48,6 +48,7 @@ import json
 import os
 import platform
 import re
+import stat
 import subprocess
 import sys
 import tempfile
@@ -61,6 +62,7 @@ SCHEMA_VERSION = 1
 EXIT_OK = 0
 EXIT_INFRASTRUCTURE_ERROR = 2
 DEFAULT_TIMEOUT_SECONDS = 20.0
+MAX_LIVE_EVIDENCE_BYTES = 64 * 1024
 ANTIGRAVITY_MANIFEST_BASE = (
     "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests"
 )
@@ -610,18 +612,19 @@ def mark_state(
     """Persist a candidate attempt or a successful live certification run."""
 
     normalized = parse_version(version).normalized
+    if not isinstance(connector, str) or connector not in SPECS:
+        raise ValueError(f"unsupported connector: {connector!r}")
+    if result not in {"attempted", "passed"}:
+        raise ValueError(f"unsupported state result: {result!r}")
     timestamp = now or utc_now()
     state = load_state(state_path)
-    entry = state["connectors"].setdefault(connector, {})
-    if not isinstance(entry, dict):
-        entry = {}
-        state["connectors"][connector] = entry
-    entry["last_attempted_version"] = normalized
-    entry["last_attempted_at"] = timestamp
-    if result == "passed":
-        entry["last_passed_version"] = normalized
-        entry["last_passed_at"] = timestamp
-    state["updated_at"] = timestamp
+    _mark_state_payload(
+        state,
+        connector=connector,
+        version=normalized,
+        result=result,
+        timestamp=timestamp,
+    )
     try:
         atomic_write_json(state_path, state)
     except OSError as exc:
@@ -632,6 +635,136 @@ def mark_state(
         "connector": connector,
         "version": normalized,
         "result": result,
+        "recorded_at": timestamp,
+    }
+
+
+def _mark_state_payload(
+    state: dict[str, Any],
+    *,
+    connector: str,
+    version: str,
+    result: str,
+    timestamp: str,
+) -> None:
+    """Apply one already-validated mark to an in-memory state document."""
+
+    entry = state["connectors"].setdefault(connector, {})
+    if not isinstance(entry, dict):
+        entry = {}
+        state["connectors"][connector] = entry
+    entry["last_attempted_version"] = version
+    entry["last_attempted_at"] = timestamp
+    if result == "passed":
+        entry["last_passed_version"] = version
+        entry["last_passed_at"] = timestamp
+    state["updated_at"] = timestamp
+
+
+def _load_bounded_json(path: Path, *, label: str) -> Any:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise RadarError(f"could not inspect {label} {path}: {exc}") from exc
+    if not stat.S_ISREG(metadata.st_mode):
+        raise RadarError(f"{label} must be a regular file: {path}")
+    if metadata.st_size > MAX_LIVE_EVIDENCE_BYTES:
+        raise RadarError(f"{label} exceeds {MAX_LIVE_EVIDENCE_BYTES} bytes: {path}")
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise RadarError(f"could not read {label} {path}: {exc}") from exc
+    if len(raw) > MAX_LIVE_EVIDENCE_BYTES:
+        raise RadarError(f"{label} exceeds {MAX_LIVE_EVIDENCE_BYTES} bytes: {path}")
+    try:
+        return json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RadarError(f"{label} is not valid UTF-8 JSON: {path}: {exc}") from exc
+
+
+def reconcile_attempt_receipts(
+    *,
+    state_path: Path,
+    expected_radar_path: Path,
+    receipts_root: Path,
+    now: str | None = None,
+) -> dict[str, Any]:
+    """Validate pre-execution receipts and atomically record scheduled attempts."""
+
+    expected_radar = _load_bounded_json(expected_radar_path, label="expected radar document")
+    if not isinstance(expected_radar, dict) or not isinstance(expected_radar.get("candidates"), list):
+        raise RadarError("expected radar document must contain a candidates array")
+
+    expected: dict[str, tuple[str, str]] = {}
+    for candidate in expected_radar["candidates"]:
+        if not isinstance(candidate, dict):
+            raise RadarError("each expected radar candidate must be a JSON object")
+        connector = candidate.get("connector")
+        baseline = candidate.get("baseline_version")
+        version = candidate.get("candidate_version")
+        if (
+            not isinstance(connector, str)
+            or connector not in SPECS
+            or not isinstance(baseline, str)
+            or not isinstance(version, str)
+        ):
+            raise RadarError("expected radar candidates require a known connector and exact versions")
+        try:
+            normalized_baseline = parse_version(baseline).normalized
+            normalized_version = parse_version(version).normalized
+        except ValueError as exc:
+            raise RadarError(f"expected radar candidate {connector} has an invalid version: {exc}") from exc
+        if normalized_baseline != baseline or normalized_version != version:
+            raise RadarError(f"expected radar candidate {connector} versions must be normalized")
+        if connector in expected:
+            raise RadarError(f"expected radar document repeats connector {connector}")
+        expected[connector] = (baseline, version)
+
+    receipt_paths = sorted(receipts_root.rglob("attempt.json"))
+    attempted: dict[str, tuple[str, str]] = {}
+    for path in receipt_paths:
+        payload = _load_bounded_json(path, label="attempt receipt")
+        if not isinstance(payload, dict):
+            raise RadarError(f"attempt receipt must be a JSON object: {path}")
+        connector = payload.get("connector")
+        if not isinstance(connector, str) or connector not in expected:
+            raise RadarError(f"attempt receipt names an unexpected connector: {connector!r}")
+        if payload.get("schema_version") != SCHEMA_VERSION or payload.get("intent") != "attempt":
+            raise RadarError(f"attempt receipt has an unsupported schema or intent: {path}")
+        baseline = payload.get("baseline_version")
+        version = payload.get("candidate_version")
+        if (baseline, version) != expected[connector]:
+            raise RadarError(f"attempt receipt versions do not match detection for {connector}")
+        if connector in attempted:
+            raise RadarError(f"multiple attempt receipts found for {connector}")
+        attempted[connector] = (baseline, version)
+
+    timestamp = now or utc_now()
+    state = load_state(state_path)
+    updates: list[dict[str, str]] = []
+    for connector in CONNECTOR_ORDER:
+        if connector not in attempted:
+            continue
+        _baseline, version = attempted[connector]
+        _mark_state_payload(
+            state,
+            connector=connector,
+            version=version,
+            result="attempted",
+            timestamp=timestamp,
+        )
+        updates.append({"connector": connector, "version": version, "result": "attempted"})
+
+    if updates:
+        try:
+            atomic_write_json(state_path, state)
+        except OSError as exc:
+            raise RadarError(f"could not persist state {state_path}: {exc}") from exc
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "ok",
+        "receipt_count": len(receipt_paths),
+        "updates": updates,
         "recorded_at": timestamp,
     }
 
@@ -712,6 +845,14 @@ def _build_parser() -> argparse.ArgumentParser:
     mark.add_argument("--connector", required=True, choices=CONNECTOR_ORDER)
     mark.add_argument("--version", required=True)
     mark.add_argument("--result", required=True, choices=("attempted", "passed"))
+
+    reconcile = subparsers.add_parser(
+        "reconcile",
+        help="Validate immutable pre-execution receipts and persist attempts.",
+    )
+    reconcile.add_argument("--state", required=True, type=Path)
+    reconcile.add_argument("--expected-radar", required=True, type=Path)
+    reconcile.add_argument("--receipts-root", required=True, type=Path)
     return parser
 
 
@@ -726,6 +867,20 @@ def main(argv: Sequence[str] | None = None) -> int:
                 result=args.result,
             )
         except (RadarError, ValueError) as exc:
+            payload = infrastructure_payload(str(exc))
+            print(json.dumps(payload, sort_keys=True))
+            return EXIT_INFRASTRUCTURE_ERROR
+        print(json.dumps(payload, sort_keys=True))
+        return EXIT_OK
+
+    if args.command == "reconcile":
+        try:
+            payload = reconcile_attempt_receipts(
+                state_path=args.state,
+                expected_radar_path=args.expected_radar,
+                receipts_root=args.receipts_root,
+            )
+        except RadarError as exc:
             payload = infrastructure_payload(str(exc))
             print(json.dumps(payload, sort_keys=True))
             return EXIT_INFRASTRUCTURE_ERROR

--- a/scripts/connector-version-radar.py
+++ b/scripts/connector-version-radar.py
@@ -677,7 +677,7 @@ def _load_bounded_json(path: Path, *, label: str) -> Any:
     if len(raw) > MAX_LIVE_EVIDENCE_BYTES:
         raise RadarError(f"{label} exceeds {MAX_LIVE_EVIDENCE_BYTES} bytes: {path}")
     try:
-        return json.loads(raw)
+        return json.loads(raw.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise RadarError(f"{label} is not valid UTF-8 JSON: {path}: {exc}") from exc
 


### PR DESCRIPTION
## Problem

The scheduled connector radar installs newly released upstream agent binaries and runs them with auto-approved shell-tool modes. The `live` job previously targeted the persistent `defenseclaw-macos` runner under its real user `HOME` and Keychain, then uploaded the complete result tree, including raw agent output and gateway databases.

A compromised candidate could therefore read durable connector/provider credentials, exfiltrate them directly, or copy them into uploaded artifacts before compatibility assertions finished.

This PR is immediate containment for #503. The issue remains open for the dedicated ephemeral runner, scoped credential infrastructure, and a separately trusted pass-attestation mechanism.

## Current Situation

- `CONNECTOR_RADAR_LIVE_ENABLED` is currently unset.
- The only matching macOS runner is the persistent `defenseclaw-macos` / `connector-lab` runner.
- No runner currently has the new `connector-lab-ephemeral` trust label.
- Candidate-written classification files cannot safely be treated as trusted pass attestations, even on an ephemeral runner, because candidate code and the harness currently share an OS principal.
- The prior live artifact upload selected the complete `result_root`, including probe stdout/stderr, gateway logs, `audit.db`, `judge_bodies.db`, connector configuration, and hidden files.

```mermaid
flowchart LR
    A["Untrusted upstream candidate"] --> B["Persistent connector-lab user"]
    B --> C["Real HOME and Keychain"]
    B --> D["Auto-approved shell tools"]
    C --> E["Raw logs and SQLite artifact upload"]
    D --> E
```

## Solution

### Disable candidate execution by default

The live job now requires both:

1. repository variable `CONNECTOR_RADAR_LIVE_ENABLED == true`; and
2. a self-hosted runner carrying the dedicated `connector-lab-ephemeral` label.

The variable remains unset, and the persistent runner does not match the new label. Version detection remains active and never installs a candidate.

### Preserve retry state without trusting candidate-writable evidence

Immediately before candidate execution, trusted workflow steps create and upload a small immutable attempt receipt containing only the connector and exact detected baseline/candidate versions. After the live matrix finishes, a trusted job on the persistent detector runner:

1. downloads the detector's own radar document and only the pre-execution attempt receipts;
2. validates each receipt's schema, connector, normalized versions, size, and exact match to detection;
3. rejects duplicates or foreign/mismatched data before any write; and
4. atomically records only `attempted` state.

Candidate-written `classification.json` and `results.jsonl` are never inputs to persistent state. A pass is deliberately not promoted automatically until #503 provides a distinct trusted collector/principal.

```mermaid
flowchart LR
    A["Trusted main: detect versions"] --> B["Trusted radar document"]
    B --> C{"Opt-in + ephemeral runner?"}
    C -->|No| D["Live job skipped"]
    C -->|Yes| E["Upload immutable attempt receipt"]
    E --> F["Run untrusted candidate"]
    E --> G["Trusted detector validates exact receipt"]
    G --> H["Atomically mark attempted"]
    F --> I["Bounded classification for hosted reporting only"]
```

Global workflow concurrency already serializes detection and persistence across runs, and `persist` depends on the complete live matrix. This prevents overlapping radar runs from racing state updates.

### Stop exporting raw credential-bearing evidence

The live upload is now an exact allowlist of:

- `classification.json`
- `results.jsonl`

Raw candidate stdout/stderr, gateway logs, SQLite databases, connector configuration, hidden files, and candidate-writable state snapshots are excluded. The hosted report job has no `issues: write` permission and never passes `--open-issue`; candidate evidence may render a job summary or fail the job, but it cannot create or modify repository issues.

### Register custom runner labels with Actionlint

The repository Actionlint configuration now declares all existing custom self-hosted labels, including the new ephemeral label, so runner-label validation remains enabled without blanket ignores.

## What Changed (Where & How)

| Path | Change |
| --- | --- |
| `.github/workflows/connector-version-radar.yml` | Added default-off gating, required the ephemeral runner label, uploaded immutable pre-candidate attempt receipts, reconciled those receipts on the trusted detector, and reduced live artifacts to an exact structured allowlist. |
| `.github/actionlint.yaml` | Registered the repository's four custom self-hosted runner labels. |
| `scripts/connector-version-radar.py` | Added bounded receipt validation, exact detection matching, duplicate rejection, and one atomic state update; also rejects invalid direct `mark` inputs. |
| `cli/tests/test_connector_version_radar.py` | Added pass/fail tests for receipt reconciliation, transactionality, mismatches, empty receipt sets, and invalid mark results. |
| `cli/tests/test_live_connector_upgrade_harness.py` | Added workflow security contracts for default-off isolation, pre-candidate immutable receipts, trusted persistence, serialization, Actionlint labels, and bounded uploads. |

## Breaking Changes

Scheduled and manual live candidate comparisons are intentionally disabled until repository admins provision the isolated runner described in #503 and explicitly set `CONNECTOR_RADAR_LIVE_ENABLED=true`. Version detection remains available.

When live execution is later enabled, scheduled candidates are conservatively recorded as attempted from a pre-execution receipt. Candidate-written evidence cannot promote a version to `last_passed_version`; that requires the trusted attestation follow-up in #503. Operators can still deliberately rerun a version with the existing manual `force` input. Automatic regression issue creation is also disabled until #503 provides a trusted classification boundary; red job status and review-only summaries remain.

## Open Issues / Follow-ups

- #503 — provision the dedicated ephemeral macOS runner/OS account, scoped revocable connector credentials, egress restrictions, destruction-after-job semantics, and a trusted pass-attestation collector before enabling the repository variable.

## Test Plan

- `uv run pytest -q cli/tests/test_connector_version_radar.py cli/tests/test_live_connector_upgrade_harness.py`
  - **33 passed**
- `uv run ruff check scripts/connector-version-radar.py cli/tests/test_connector_version_radar.py cli/tests/test_live_connector_upgrade_harness.py`
  - **Passed**
- `uv run python -m py_compile scripts/connector-version-radar.py`
  - **Passed**
- `actionlint .github/workflows/connector-version-radar.yml`
  - **Passed** with the checked-in custom runner-label catalog
- YAML parse of `.github/actionlint.yaml` and `.github/workflows/connector-version-radar.yml`
  - **Passed**
- `git diff --check`
  - **Passed**
- `coderabbit review --uncommitted --include-untracked --agent --light`
  - **0 findings** across all five changed files after the final design revision
- GitHub Actions
  - **Running** for commit `598a46561`