### PR TITLE
fix: scrub configured gateway token from Splunk children

### DIFF
--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -10318,6 +10318,59 @@ _SPLUNK_LOCAL_HEC_DEFAULTS = {
 
 _SPLUNK_BRIDGE_ENV_REL = os.path.join("splunk-bridge", "env", ".env")
 
+# Every name authored by the current bridge env contract, plus names shipped
+# by earlier supported bundles and the native controller's generated token.
+# The bridge shell and native controller both overlay their private env file
+# after the ambient environment is scrubbed. A configured gateway bearer name
+# must therefore never collide with any of these names or a different managed
+# value would be reintroduced into Docker/Compose descendants.
+_SPLUNK_BRIDGE_MANAGED_ENV_NAMES = frozenset(
+    {
+        "AWS_ACCESS_KEY_ID",
+        "AWS_REGION",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "DEFENSECLAW_HEC_TOKEN",
+        "DEFENSECLAW_HEC_URL",
+        "DEFENSECLAW_INDEX",
+        "DEFENSECLAW_INTEGRATION_ENABLED",
+        "DEFENSECLAW_LOCAL_PASSWORD",
+        "DEFENSECLAW_LOCAL_SPLUNK_HEC_TOKEN",
+        "DEFENSECLAW_LOCAL_USERNAME",
+        "DEFENSECLAW_REF",
+        "DEFENSECLAW_SOURCE",
+        "DEFENSECLAW_SOURCETYPE",
+        "DEPLOYMENT_ENVIRONMENT",
+        "NEMOCLAW_LOCAL_MODEL",
+        "NEMOCLAW_LOCAL_OLLAMA_HOST",
+        "NEMOCLAW_LOCAL_POLICY_MODE",
+        "NEMOCLAW_LOCAL_PROVIDER",
+        "NEMOCLAW_LOCAL_SANDBOX_NAME",
+        "NEMOCLAW_REF",
+        "PHONE_HOME_ENABLED",
+        "PHONE_HOME_HEC_TOKEN",
+        "PHONE_HOME_HEC_URL",
+        "S3_BUCKET",
+        "S3_ENDPOINT_URL",
+        "S3_EXPORT_ENABLED",
+        "S3_EXPORT_INTERVAL_SECONDS",
+        "S3_EXPORT_LOOKBACK_SECONDS",
+        "S3_EXPORT_ONCE",
+        "S3_EXPORT_WINDOW_SECONDS",
+        "S3_PREFIX",
+        "S3_SSE",
+        "SPLUNK_ENV_FILE",
+        "SPLUNK_GENERAL_TERMS",
+        "SPLUNK_HEC_TOKEN",
+        "SPLUNK_IMAGE",
+        "SPLUNK_LICENSE_URI",
+        "SPLUNK_PASSWORD",
+        "SPLUNK_START_ARGS",
+        "TENANT_ID",
+        "WORKSPACE_ID",
+    }
+)
+
 
 def _native_windows_local_splunk() -> bool:
     """Select the argument-vector native controller only on Windows."""
@@ -10546,6 +10599,11 @@ def setup_splunk(
 
     native_combined = _native_windows_local_splunk() and enable_logs and (enable_o11y or enable_enterprise)
     if native_combined:
+        gateway_token_env = _configured_gateway_token_env_name(app.cfg)
+        native_child_env = _splunk_bridge_child_env(
+            gateway_token_env,
+            platform_name="nt",
+        )
         # Resolve every interactive/flag prerequisite and prove the entire
         # native Local Splunk environment before the first remote-pipeline
         # config write. Local Splunk runs last so its gateway reload activates
@@ -10605,6 +10663,7 @@ def setup_splunk(
                 app.cfg.data_dir,
                 license_accepted=True,
                 require_s3=s3_export,
+                environment=native_child_env,
             )
         except LocalStackError as exc:
             raise click.ClickException(f"Local Splunk preflight failed: {exc}") from exc
@@ -10733,6 +10792,13 @@ def _interactive_splunk_setup(
             "  Enable local Splunk (Docker, HEC logs, Free mode)?", default=False
         )
         enable_enterprise = click.confirm("  Enable remote Splunk Enterprise (HEC)?", default=False)
+        if enable_logs:
+            # Reject an invalid configured variable name before any selected
+            # remote integration mutates config in this combined transaction.
+            _validated_splunk_gateway_token_env_name(
+                _configured_gateway_token_env_name(app.cfg),
+                platform_name="nt",
+            )
         combined = enable_logs and (enable_o11y or enable_enterprise)
         config_path = str(config_path_for_data_dir(app.cfg.data_dir))
         dotenv_path = os.path.join(app.cfg.data_dir, ".env")
@@ -11268,7 +11334,16 @@ def _apply_logs_config(
     refresh_bundle: bool = True,
 ) -> None:
     """Configure the local Splunk bridge as a canonical HEC destination."""
-    if bootstrap_bridge and _native_windows_local_splunk():
+    native_windows = bootstrap_bridge and _native_windows_local_splunk()
+    gateway_token_env = (
+        _validated_splunk_gateway_token_env_name(
+            _configured_gateway_token_env_name(app.cfg),
+            platform_name="nt" if native_windows else None,
+        )
+        if bootstrap_bridge
+        else ""
+    )
+    if native_windows:
         _apply_native_windows_logs_config(
             app,
             index=index,
@@ -11279,6 +11354,7 @@ def _apply_logs_config(
             s3_prefix=s3_prefix,
             aws_region=aws_region,
             refresh_bundle=refresh_bundle,
+            gateway_token_env=gateway_token_env,
         )
         return
 
@@ -11286,7 +11362,7 @@ def _apply_logs_config(
     if bootstrap_bridge:
         contract = _bootstrap_bridge(
             app.cfg.data_dir,
-            gateway_token_env=_configured_gateway_token_env_name(app.cfg),
+            gateway_token_env=gateway_token_env,
             s3_export=s3_export,
             s3_bucket=s3_bucket,
             s3_prefix=s3_prefix,
@@ -11338,8 +11414,14 @@ def _apply_native_windows_logs_config(
     s3_prefix: str | None,
     aws_region: str | None,
     refresh_bundle: bool,
+    gateway_token_env: str,
 ) -> None:
     """Commit native Local Splunk, its sink, and gateway as one transaction."""
+
+    native_child_env = _splunk_bridge_child_env(
+        gateway_token_env,
+        platform_name="nt",
+    )
 
     from defenseclaw.observability.local_splunk import (
         LOCAL_TOKEN_ENV,
@@ -11376,7 +11458,7 @@ def _apply_native_windows_logs_config(
             s3_prefix=s3_prefix,
             aws_region=aws_region,
             refresh_bundle=refresh_bundle,
-            environment=_splunk_bridge_child_env(),
+            environment=native_child_env,
         )
         contract = transaction.contract
         click.echo("    Docker Desktop, Compose v2, Linux containers, assets, and ports... ok")
@@ -11551,19 +11633,47 @@ def _resolve_bridge_bin(data_dir: str) -> str | None:
     return splunk_bridge_bin(data_dir)
 
 
-def _configured_gateway_token_env_name(cfg: Any) -> str:
-    """Return the configured gateway token variable name after validation."""
+def _validated_gateway_token_env_name(raw_name: Any) -> str:
+    """Return one exact portable environment name without normalizing it."""
 
-    gateway = getattr(cfg, "gateway", None)
-    raw_name = getattr(gateway, "token_env", "")
     if raw_name is None:
         return ""
     if not isinstance(raw_name, str):
         raise click.ClickException("gateway.token_env must be a portable environment variable name")
-    name = raw_name.strip()
-    if name and not dotenv_key_is_valid(name):
+    if raw_name != raw_name.strip() or (raw_name and not dotenv_key_is_valid(raw_name)):
         raise click.ClickException("gateway.token_env must be a portable environment variable name")
-    return name
+    return raw_name
+
+
+def _configured_gateway_token_env_name(cfg: Any) -> str:
+    """Return the configured gateway token variable name after validation."""
+
+    gateway = getattr(cfg, "gateway", None)
+    return _validated_gateway_token_env_name(getattr(gateway, "token_env", ""))
+
+
+def _validated_splunk_gateway_token_env_name(
+    gateway_token_env: Any,
+    *,
+    platform_name: str | None = None,
+) -> str:
+    """Reject names that a Local Splunk private env overlay can recreate."""
+
+    configured_name = _validated_gateway_token_env_name(gateway_token_env)
+    if not configured_name:
+        return ""
+    case_insensitive = (platform_name or os.name) == "nt"
+    compared_name = configured_name.casefold() if case_insensitive else configured_name
+    managed_names = (
+        {name.casefold() for name in _SPLUNK_BRIDGE_MANAGED_ENV_NAMES}
+        if case_insensitive
+        else _SPLUNK_BRIDGE_MANAGED_ENV_NAMES
+    )
+    if compared_name in managed_names:
+        raise click.ClickException(
+            "gateway.token_env must not collide with a Local Splunk managed environment variable name"
+        )
+    return configured_name
 
 
 def _splunk_bridge_child_env(
@@ -11579,9 +11689,10 @@ def _splunk_bridge_child_env(
     environment. Windows environment names are case-insensitive.
     """
 
-    configured_name = gateway_token_env.strip()
-    if configured_name and not dotenv_key_is_valid(configured_name):
-        raise click.ClickException("gateway.token_env must be a portable environment variable name")
+    configured_name = _validated_splunk_gateway_token_env_name(
+        gateway_token_env,
+        platform_name=platform_name,
+    )
     blocked_names = {
         _GATEWAY_TOKEN_ENV,
         _LEGACY_GATEWAY_TOKEN_ENV,
@@ -11706,8 +11817,8 @@ def _bootstrap_bridge(
     volumes survive ``down``, so user data is preserved) so the new
     bundle is what gets brought back up.
     """
-    env_file = _ensure_private_splunk_bridge_env(data_dir)
     env = _splunk_bridge_child_env(gateway_token_env)
+    env_file = _ensure_private_splunk_bridge_env(data_dir)
     if refresh_bundle:
         _refresh_and_maybe_restart_splunk_bridge(
             data_dir,
@@ -11988,6 +12099,19 @@ def _disable_splunk(
         raise click.ClickException(LOCAL_SHELL_STACKS_UNSUPPORTED_REASON)
     disable_both = not o11y_only and not logs_only and not enterprise_only
     manage_local = local_shell_stacks_supported()
+    native_windows = _native_windows_local_splunk()
+    gateway_token_env = (
+        _validated_splunk_gateway_token_env_name(
+            _configured_gateway_token_env_name(app.cfg),
+            platform_name="nt" if native_windows else None,
+        )
+        if (disable_both or logs_only) and manage_local
+        else ""
+    )
+    native_disable_requested = native_windows and manage_local and (disable_both or logs_only)
+    native_child_env = (
+        _splunk_bridge_child_env(gateway_token_env, platform_name="nt") if native_disable_requested else None
+    )
 
     click.echo()
     click.echo("  Disabling Splunk integration...")
@@ -11996,13 +12120,6 @@ def _disable_splunk(
     native_was_running = False
     native_s3_export = False
     native_s3_overrides: dict[str, str] = {}
-    native_windows = _native_windows_local_splunk()
-    gateway_token_env = (
-        _configured_gateway_token_env_name(app.cfg)
-        if (disable_both or logs_only) and manage_local and not native_windows
-        else ""
-    )
-    native_disable_requested = native_windows and manage_local and (disable_both or logs_only)
     config_snapshot: tuple[bytes | None, int | None] | None = None
     config_path = str(config_path_for_data_dir(app.cfg.data_dir))
 
@@ -12024,7 +12141,10 @@ def _disable_splunk(
         from defenseclaw.observability.local_stack import LocalStackError
 
         try:
-            native_controller, native_was_running = prepare_native_local_splunk_stop(app.cfg.data_dir)
+            native_controller, native_was_running = prepare_native_local_splunk_stop(
+                app.cfg.data_dir,
+                environment=native_child_env,
+            )
             if native_controller is not None and native_was_running:
                 native_s3_export, native_s3_overrides = native_controller.s3_runtime_state()
         except LocalStackError as exc:
@@ -12131,14 +12251,19 @@ def _disable_splunk(
 def _stop_bridge(data_dir: str, *, gateway_token_env: str = "") -> None:
     if not local_shell_stacks_supported():
         return
-    if _native_windows_local_splunk():
+    native_windows = _native_windows_local_splunk()
+    child_env = _splunk_bridge_child_env(
+        gateway_token_env,
+        platform_name="nt" if native_windows else None,
+    )
+    if native_windows:
         from defenseclaw.observability.local_splunk import stop_native_local_splunk
         from defenseclaw.observability.local_stack import LocalStackError
 
         try:
             stopped = stop_native_local_splunk(
                 data_dir,
-                environment=_splunk_bridge_child_env(),
+                environment=child_env,
             )
         except LocalStackError as exc:
             raise click.ClickException(f"could not stop owned Local Splunk stack: {exc}") from exc
@@ -12156,7 +12281,7 @@ def _stop_bridge(data_dir: str, *, gateway_token_env: str = "") -> None:
             capture_output=True,
             text=True,
             timeout=60,
-            env=_splunk_bridge_child_env(gateway_token_env),
+            env=child_env,
         )
         click.echo("    Local Splunk container stopped")
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -33,6 +33,7 @@ import subprocess
 import sys
 import time
 import uuid
+from collections.abc import Mapping
 from contextlib import ExitStack
 from dataclasses import dataclass, replace
 from datetime import datetime
@@ -11285,6 +11286,7 @@ def _apply_logs_config(
     if bootstrap_bridge:
         contract = _bootstrap_bridge(
             app.cfg.data_dir,
+            gateway_token_env=_configured_gateway_token_env_name(app.cfg),
             s3_export=s3_export,
             s3_bucket=s3_bucket,
             s3_prefix=s3_prefix,
@@ -11549,13 +11551,55 @@ def _resolve_bridge_bin(data_dir: str) -> str | None:
     return splunk_bridge_bin(data_dir)
 
 
-def _splunk_bridge_child_env(environment: dict[str, str] | None = None) -> dict[str, str]:
-    """Return the bridge environment without gateway bearer credentials."""
+def _configured_gateway_token_env_name(cfg: Any) -> str:
+    """Return the configured gateway token variable name after validation."""
 
-    env = dict(os.environ if environment is None else environment)
-    env.pop(_GATEWAY_TOKEN_ENV, None)
-    env.pop(_LEGACY_GATEWAY_TOKEN_ENV, None)
-    return env
+    gateway = getattr(cfg, "gateway", None)
+    raw_name = getattr(gateway, "token_env", "")
+    if raw_name is None:
+        return ""
+    if not isinstance(raw_name, str):
+        raise click.ClickException("gateway.token_env must be a portable environment variable name")
+    name = raw_name.strip()
+    if name and not dotenv_key_is_valid(name):
+        raise click.ClickException("gateway.token_env must be a portable environment variable name")
+    return name
+
+
+def _splunk_bridge_child_env(
+    gateway_token_env: str = "",
+    *,
+    environment: Mapping[str, str] | None = None,
+    platform_name: str | None = None,
+) -> dict[str, str]:
+    """Return the bridge environment without any gateway bearer variable.
+
+    Iterate names first and fetch values only for retained entries so the
+    configured gateway token value is never read while constructing the child
+    environment. Windows environment names are case-insensitive.
+    """
+
+    configured_name = gateway_token_env.strip()
+    if configured_name and not dotenv_key_is_valid(configured_name):
+        raise click.ClickException("gateway.token_env must be a portable environment variable name")
+    blocked_names = {
+        _GATEWAY_TOKEN_ENV,
+        _LEGACY_GATEWAY_TOKEN_ENV,
+    }
+    if configured_name:
+        blocked_names.add(configured_name)
+    case_insensitive = (platform_name or os.name) == "nt"
+    if case_insensitive:
+        blocked_names = {name.casefold() for name in blocked_names}
+
+    source = os.environ if environment is None else environment
+    child_env: dict[str, str] = {}
+    for name in source:
+        compared_name = name.casefold() if case_insensitive else name
+        if compared_name in blocked_names:
+            continue
+        child_env[name] = source[name]
+    return child_env
 
 
 def _refresh_and_maybe_restart_splunk_bridge(
@@ -11563,6 +11607,7 @@ def _refresh_and_maybe_restart_splunk_bridge(
     *,
     env_file: str | None = None,
     child_env: dict[str, str] | None = None,
+    gateway_token_env: str = "",
 ) -> RefreshResult:
     """Refresh the seeded Splunk bridge, stopping any running stack first.
 
@@ -11584,7 +11629,10 @@ def _refresh_and_maybe_restart_splunk_bridge(
     happened and never has to wonder why a previously-running stack
     came back up on a different image.
     """
-    effective_child_env = _splunk_bridge_child_env(child_env)
+    effective_child_env = _splunk_bridge_child_env(
+        gateway_token_env,
+        environment=child_env,
+    )
     was_running = is_compose_project_running(
         SPLUNK_COMPOSE_PROJECT,
         environment=effective_child_env,
@@ -11640,6 +11688,7 @@ def _refresh_and_maybe_restart_splunk_bridge(
 def _bootstrap_bridge(
     data_dir: str,
     *,
+    gateway_token_env: str = "",
     s3_export: bool = False,
     s3_bucket: str | None = None,
     s3_prefix: str | None = None,
@@ -11658,12 +11707,13 @@ def _bootstrap_bridge(
     bundle is what gets brought back up.
     """
     env_file = _ensure_private_splunk_bridge_env(data_dir)
-    env = _splunk_bridge_child_env()
+    env = _splunk_bridge_child_env(gateway_token_env)
     if refresh_bundle:
         _refresh_and_maybe_restart_splunk_bridge(
             data_dir,
             env_file=env_file,
             child_env=env,
+            gateway_token_env=gateway_token_env,
         )
 
     bridge = _resolve_bridge_bin(data_dir)
@@ -11947,6 +11997,11 @@ def _disable_splunk(
     native_s3_export = False
     native_s3_overrides: dict[str, str] = {}
     native_windows = _native_windows_local_splunk()
+    gateway_token_env = (
+        _configured_gateway_token_env_name(app.cfg)
+        if (disable_both or logs_only) and manage_local and not native_windows
+        else ""
+    )
     native_disable_requested = native_windows and manage_local and (disable_both or logs_only)
     config_snapshot: tuple[bytes | None, int | None] | None = None
     config_path = str(config_path_for_data_dir(app.cfg.data_dir))
@@ -12025,7 +12080,10 @@ def _disable_splunk(
             if native_controller is not None and native_was_running:
                 native_controller.down()
         elif (disable_both or logs_only) and manage_local and not native_windows:
-            _stop_bridge(app.cfg.data_dir)
+            _stop_bridge(
+                app.cfg.data_dir,
+                gateway_token_env=gateway_token_env,
+            )
     except BaseException as exc:
         rollback_errors: list[str] = []
         if config_snapshot is not None:
@@ -12070,7 +12128,7 @@ def _disable_splunk(
         app.logger.log_action(ACTION_SETUP_SPLUNK, "config", " ".join(parts))
 
 
-def _stop_bridge(data_dir: str) -> None:
+def _stop_bridge(data_dir: str, *, gateway_token_env: str = "") -> None:
     if not local_shell_stacks_supported():
         return
     if _native_windows_local_splunk():
@@ -12098,7 +12156,7 @@ def _stop_bridge(data_dir: str) -> None:
             capture_output=True,
             text=True,
             timeout=60,
-            env=_splunk_bridge_child_env(),
+            env=_splunk_bridge_child_env(gateway_token_env),
         )
         click.echo("    Local Splunk container stopped")
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):

--- a/cli/tests/test_local_splunk_controller.py
+++ b/cli/tests/test_local_splunk_controller.py
@@ -576,6 +576,7 @@ def test_upgrade_rollback_restores_prior_assets_running_stack_and_volumes(
     runner.add_owned(stable, container_id="prior-container")
     runner.add_owned_exporter(stable, container_id="prior-exporter", bucket="restore-me")
     volumes_before = set(runner.volumes)
+    runtime_environment = {"NATIVE_UNRELATED_SETTING": "preserved"}
     monkeypatch.setattr(NativeLocalSplunkController, "_port_in_use", staticmethod(lambda _port: True))
     monkeypatch.setattr(NativeLocalSplunkController, "_web_ready", staticmethod(lambda _timeout: True))
     monkeypatch.setattr(NativeLocalSplunkController, "_hec_ready", lambda self, _timeout: True)
@@ -588,7 +589,7 @@ def test_upgrade_rollback_restores_prior_assets_running_stack_and_volumes(
         docker_path=docker_exe,
         runner=runner,
         os_name="linux",
-        environment={},
+        environment=runtime_environment,
         timeout=2,
     )
     assert b"replacement_index" in (stable / ENV_FILE_REL).read_bytes()
@@ -605,3 +606,6 @@ def test_upgrade_rollback_restores_prior_assets_running_stack_and_volumes(
     assert "--profile" in restored_up[0]
     assert restored_up[2]["S3_BUCKET"] == "restore-me"
     assert restored_up[2]["AWS_REGION"] == "eu-west-1"
+    assert restored_up[2]["NATIVE_UNRELATED_SETTING"] == "preserved"
+    assert "DEFENSECLAW_GATEWAY_TOKEN" not in restored_up[2]
+    assert "OPENCLAW_GATEWAY_TOKEN" not in restored_up[2]

--- a/cli/tests/test_local_splunk_transaction.py
+++ b/cli/tests/test_local_splunk_transaction.py
@@ -82,14 +82,30 @@ def _app(tmp_path: Path) -> AppContext:
     return app
 
 
-def _invoke_native_transaction(app: AppContext, events: list[str], *, restart_ok: bool) -> None:
+def _invoke_native_transaction(
+    app: AppContext,
+    events: list[str],
+    *,
+    restart_ok: bool,
+    gateway_token_env: str = "",
+    forbidden_secret: str = "",
+) -> None:
     transaction = FakeTransaction(events)
 
     def start(*_args, **kwargs):
         environment = kwargs.get("environment")
         assert environment is not None
-        assert "DEFENSECLAW_GATEWAY_TOKEN" not in environment
-        assert "OPENCLAW_GATEWAY_TOKEN" not in environment
+        blocked_names = {
+            "DEFENSECLAW_GATEWAY_TOKEN",
+            "OPENCLAW_GATEWAY_TOKEN",
+            gateway_token_env,
+        }
+        assert not {name.casefold() for name in environment} & {name.casefold() for name in blocked_names if name}
+        if forbidden_secret:
+            assert forbidden_secret not in repr(_args)
+            assert forbidden_secret not in repr(environment)
+        if "NATIVE_UNRELATED_SETTING" in os.environ:
+            assert environment["NATIVE_UNRELATED_SETTING"] == "preserved"
         events.append("runtime-ready")
         return transaction
 
@@ -100,8 +116,7 @@ def _invoke_native_transaction(app: AppContext, events: list[str], *, restart_ok
             b"config_version: 8\nobservability:\n  destinations: []\n",
         )
         atomic_write_private_bytes(
-            Path(app.cfg.data_dir) / ".env",
-            b"KEEP_ME=unchanged\n" + LOCAL_TOKEN_ENV.encode() + b"=new-value\n"
+            Path(app.cfg.data_dir) / ".env", b"KEEP_ME=unchanged\n" + LOCAL_TOKEN_ENV.encode() + b"=new-value\n"
         )
 
     def restart(*_args, **_kwargs):
@@ -128,13 +143,22 @@ def _invoke_native_transaction(app: AppContext, events: list[str], *, restart_ok
             s3_prefix=None,
             aws_region=None,
             refresh_bundle=True,
+            gateway_token_env=gateway_token_env,
         )
 
 
 def test_readiness_precedes_config_gateway_and_commit(tmp_path: Path) -> None:
     app = _app(tmp_path)
     events: list[str] = []
-    _invoke_native_transaction(app, events, restart_ok=True)
+    with patch.dict(
+        os.environ,
+        {
+            "DEFENSECLAW_GATEWAY_TOKEN": "canonical-secret-sentinel",
+            "OPENCLAW_GATEWAY_TOKEN": "legacy-secret-sentinel",
+            "NATIVE_UNRELATED_SETTING": "preserved",
+        },
+    ):
+        _invoke_native_transaction(app, events, restart_ok=True)
     assert events == [
         "runtime-ready",
         "config-write",
@@ -142,6 +166,37 @@ def test_readiness_precedes_config_gateway_and_commit(tmp_path: Path) -> None:
         "telemetry:integration_configured",
         "commit",
     ]
+
+
+def test_native_start_scrubs_mixed_case_custom_gateway_token(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    app = _app(tmp_path)
+    custom_name = "OPERATOR_MANAGED_GATEWAY_TOKEN"
+    secret = "native-start-secret-sentinel"
+    events: list[str] = []
+    with patch.dict(
+        os.environ,
+        {
+            "operator_managed_gateway_token": secret,
+            "DefenseClaw_Gateway_Token": "canonical-secret-sentinel",
+            "openclaw_gateway_token": "legacy-secret-sentinel",
+            "NATIVE_UNRELATED_SETTING": "preserved",
+        },
+    ):
+        _invoke_native_transaction(
+            app,
+            events,
+            restart_ok=True,
+            gateway_token_env=custom_name,
+            forbidden_secret=secret,
+        )
+
+    assert secret not in repr(events)
+    captured = capsys.readouterr()
+    assert secret not in captured.out
+    assert secret not in captured.err
 
 
 def test_gateway_reload_failure_restores_exact_config_and_dotenv(
@@ -186,6 +241,7 @@ def test_startup_failure_never_mutates_configuration(tmp_path: Path) -> None:
             s3_prefix=None,
             aws_region=None,
             refresh_bundle=True,
+            gateway_token_env="",
         )
     assert (cfg_path.read_bytes(), env_path.read_bytes()) == before
 
@@ -215,6 +271,7 @@ def test_keyboard_interrupt_after_runtime_start_rolls_back(tmp_path: Path) -> No
             s3_prefix=None,
             aws_region=None,
             refresh_bundle=True,
+            gateway_token_env="",
         )
     assert ((tmp_path / "config.yaml").read_bytes(), (tmp_path / ".env").read_bytes()) == before
     assert events == ["rollback"]
@@ -222,6 +279,7 @@ def test_keyboard_interrupt_after_runtime_start_rolls_back(tmp_path: Path) -> No
 
 def test_windows_routes_logs_to_native_controller(tmp_path: Path) -> None:
     app = _app(tmp_path)
+    app.cfg.gateway.token_env = "OPERATOR_MANAGED_GATEWAY_TOKEN"
     with (
         patch.object(cmd_setup.platform_support, "host_os", return_value="windows"),
         patch.object(cmd_setup, "_apply_native_windows_logs_config") as native,
@@ -235,12 +293,114 @@ def test_windows_routes_logs_to_native_controller(tmp_path: Path) -> None:
             bootstrap_bridge=True,
         )
     native.assert_called_once()
+    assert native.call_args.kwargs["gateway_token_env"] == "OPERATOR_MANAGED_GATEWAY_TOKEN"
     bridge.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "configured_name",
+    [
+        "INVALID-TOKEN-NAME",
+        " OPERATOR_MANAGED_GATEWAY_TOKEN",
+        "OPERATOR_MANAGED_GATEWAY_TOKEN ",
+        "defenseclaw_local_splunk_hec_token",
+        "defenseclaw_local_password",
+    ],
+)
+def test_invalid_gateway_token_name_fails_before_native_setup_or_config_mutation(
+    tmp_path: Path,
+    configured_name: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    app = _app(tmp_path)
+    app.cfg.gateway.token_env = configured_name
+    secret = "rejected-native-setup-secret-sentinel"
+    before = (
+        (tmp_path / "config.yaml").read_bytes(),
+        (tmp_path / ".env").read_bytes(),
+    )
+    with patch.dict(
+        os.environ,
+        {
+            configured_name: secret,
+            configured_name.strip().swapcase(): secret,
+            "NATIVE_UNRELATED_SETTING": "preserved",
+        },
+    ):
+        with (
+            patch.object(cmd_setup.platform_support, "host_os", return_value="windows"),
+            patch.object(cmd_setup, "_apply_native_windows_logs_config") as native,
+            patch.object(cmd_setup, "_bootstrap_bridge") as bridge,
+            pytest.raises(ClickException, match="gateway.token_env"),
+        ):
+            cmd_setup._apply_logs_config(
+                app,
+                index="defenseclaw_local",
+                source="defenseclaw",
+                sourcetype="defenseclaw:json",
+                bootstrap_bridge=True,
+            )
+
+    native.assert_not_called()
+    bridge.assert_not_called()
+    assert (
+        (tmp_path / "config.yaml").read_bytes(),
+        (tmp_path / ".env").read_bytes(),
+    ) == before
+    captured = capsys.readouterr()
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+@pytest.mark.parametrize(
+    "configured_name",
+    [
+        " OPERATOR_MANAGED_GATEWAY_TOKEN",
+        "defenseclaw_local_splunk_hec_token",
+        "defenseclaw_local_username",
+    ],
+)
+def test_native_apply_rejects_invalid_or_managed_name_before_snapshot_or_start(
+    tmp_path: Path,
+    configured_name: str,
+) -> None:
+    app = _app(tmp_path)
+    before = (
+        (tmp_path / "config.yaml").read_bytes(),
+        (tmp_path / ".env").read_bytes(),
+    )
+    with (
+        patch.object(cmd_setup, "_snapshot_regular_file") as config_snapshot,
+        patch.object(cmd_setup, "_snapshot_dotenv") as dotenv_snapshot,
+        patch("defenseclaw.observability.local_splunk.start_native_local_splunk") as native_start,
+        pytest.raises(ClickException, match="gateway.token_env"),
+    ):
+        cmd_setup._apply_native_windows_logs_config(
+            app,
+            index="defenseclaw_local",
+            source="defenseclaw",
+            sourcetype="defenseclaw:json",
+            s3_export=False,
+            s3_bucket=None,
+            s3_prefix=None,
+            aws_region=None,
+            refresh_bundle=True,
+            gateway_token_env=configured_name,
+        )
+
+    config_snapshot.assert_not_called()
+    dotenv_snapshot.assert_not_called()
+    native_start.assert_not_called()
+    assert (
+        (tmp_path / "config.yaml").read_bytes(),
+        (tmp_path / ".env").read_bytes(),
+    ) == before
 
 
 @pytest.mark.parametrize("os_name", ["darwin", "linux"])
 def test_macos_linux_keep_the_existing_bridge_path(tmp_path: Path, os_name: str) -> None:
     app = _app(tmp_path)
+    app.cfg.gateway.token_env = "OPERATOR_MANAGED_GATEWAY_TOKEN"
     contract = {
         "hec_url": "https://127.0.0.1:8088/services/collector/event",
         "hec_token": "bridge-" + "y" * 32,
@@ -260,6 +420,7 @@ def test_macos_linux_keep_the_existing_bridge_path(tmp_path: Path, os_name: str)
             bootstrap_bridge=True,
         )
     bridge.assert_called_once()
+    assert bridge.call_args.kwargs["gateway_token_env"] == "OPERATOR_MANAGED_GATEWAY_TOKEN"
     writer.assert_called_once()
     native.assert_not_called()
 
@@ -299,10 +460,7 @@ def test_local_and_remote_splunk_tokens_remain_independent(tmp_path: Path) -> No
             secret_value="remote-" + "b" * 32,
         )
     raw = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
-    sinks = {
-        item["name"]: item["token_env"]
-        for item in raw["observability"]["destinations"]
-    }
+    sinks = {item["name"]: item["token_env"] for item in raw["observability"]["destinations"]}
     assert sinks == {
         "local-splunk": LOCAL_TOKEN_ENV,
         "remote-splunk": "DEFENSECLAW_SPLUNK_HEC_TOKEN",
@@ -314,26 +472,49 @@ def test_local_and_remote_splunk_tokens_remain_independent(tmp_path: Path) -> No
 
 def test_native_disable_selects_only_owned_local_sink(tmp_path: Path) -> None:
     app = _app(tmp_path)
+    custom_name = "OPERATOR_MANAGED_GATEWAY_TOKEN"
+    custom_secret = "native-disable-secret-sentinel"
+    app.cfg.gateway.token_env = custom_name
     owned = SimpleNamespace(name="local-splunk", kind="splunk_hec", enabled=True, endpoint="https://127.0.0.1:8088/x")
     foreign = SimpleNamespace(
         name="operator-loopback", kind="splunk_hec", enabled=True, endpoint="https://localhost:8088/x"
     )
     disabled: list[str] = []
-    with (
-        patch.object(cmd_setup.platform_support, "host_os", return_value="windows"),
-        patch(
-            "defenseclaw.commands.cmd_setup_observability._require_v8_operator_status",
-            return_value=SimpleNamespace(destinations=(owned, foreign)),
-        ),
-        patch(
-            "defenseclaw.commands.cmd_setup_observability._set_v8_destination_enabled",
-            side_effect=lambda _data_dir, name, *_: disabled.append(name),
-        ),
-        patch("defenseclaw.observability.local_splunk.prepare_native_local_splunk_stop", return_value=(None, False)),
-        patch.object(cmd_setup, "_reload_cfg_from_data_dir"),
+    with patch.dict(
+        os.environ,
+        {
+            "operator_managed_gateway_token": custom_secret,
+            "DefenseClaw_Gateway_Token": "canonical-secret-sentinel",
+            "openclaw_gateway_token": "legacy-secret-sentinel",
+            "NATIVE_UNRELATED_SETTING": "preserved",
+        },
     ):
-        cmd_setup._disable_splunk(app, False, True, False, True)
+        with (
+            patch.object(cmd_setup.platform_support, "host_os", return_value="windows"),
+            patch(
+                "defenseclaw.commands.cmd_setup_observability._require_v8_operator_status",
+                return_value=SimpleNamespace(destinations=(owned, foreign)),
+            ),
+            patch(
+                "defenseclaw.commands.cmd_setup_observability._set_v8_destination_enabled",
+                side_effect=lambda _data_dir, name, *_: disabled.append(name),
+            ),
+            patch(
+                "defenseclaw.observability.local_splunk.prepare_native_local_splunk_stop",
+                return_value=(None, False),
+            ) as prepare,
+            patch.object(cmd_setup, "_reload_cfg_from_data_dir"),
+        ):
+            cmd_setup._disable_splunk(app, False, True, False, True)
     assert disabled == ["local-splunk"]
+    environment = prepare.call_args.kwargs["environment"]
+    assert not {
+        "operator_managed_gateway_token",
+        "DefenseClaw_Gateway_Token",
+        "openclaw_gateway_token",
+    } & set(environment)
+    assert environment["NATIVE_UNRELATED_SETTING"] == "preserved"
+    assert custom_secret not in repr(prepare.call_args)
 
 
 def test_native_disable_remote_only_skips_local_runtime_preflight(tmp_path: Path) -> None:
@@ -355,9 +536,7 @@ def test_native_disable_remote_only_skips_local_runtime_preflight(tmp_path: Path
             "defenseclaw.commands.cmd_setup_observability._set_v8_destination_enabled",
             side_effect=lambda _data_dir, name, *_: disabled.append(name),
         ),
-        patch(
-            "defenseclaw.observability.local_splunk.prepare_native_local_splunk_stop"
-        ) as native_preflight,
+        patch("defenseclaw.observability.local_splunk.prepare_native_local_splunk_stop") as native_preflight,
         patch.object(cmd_setup, "_stop_bridge") as stop_bridge,
         patch.object(cmd_setup, "_reload_cfg_from_data_dir"),
     ):
@@ -370,19 +549,39 @@ def test_native_disable_remote_only_skips_local_runtime_preflight(tmp_path: Path
 
 def test_native_disable_failure_restores_config_and_running_stack(tmp_path: Path) -> None:
     app = _app(tmp_path)
+    custom_name = "OPERATOR_MANAGED_GATEWAY_TOKEN"
+    app.cfg.gateway.token_env = custom_name
     config_path = tmp_path / "config.yaml"
     before = config_path.read_bytes()
     events: list[str] = []
 
     class Controller:
+        def __init__(self, environment: dict[str, str]) -> None:
+            self.environment = environment
+
+        def assert_sanitized_environment(self) -> None:
+            environment_names = {name.casefold() for name in self.environment}
+            assert not environment_names & {
+                custom_name.casefold(),
+                "defenseclaw_gateway_token",
+                "openclaw_gateway_token",
+            }
+            assert self.environment["NATIVE_UNRELATED_SETTING"] == "preserved"
+            assert "custom-secret-sentinel" not in repr(self.environment)
+            assert "canonical-secret-sentinel" not in repr(self.environment)
+            assert "legacy-secret-sentinel" not in repr(self.environment)
+
         def s3_runtime_state(self):
+            self.assert_sanitized_environment()
             return True, {"S3_EXPORT_ENABLED": "true", "S3_BUCKET": "prior-bucket"}
 
         def down(self):
+            self.assert_sanitized_environment()
             events.append("down")
             raise LocalStackError("compose down failed")
 
         def up(self, **kwargs):
+            self.assert_sanitized_environment()
             events.append(f"up:{kwargs['s3_export']}:{kwargs['overrides']['S3_BUCKET']}")
 
     owned = SimpleNamespace(
@@ -398,30 +597,90 @@ def test_native_disable_failure_restores_config_and_running_stack(tmp_path: Path
             b"config_version: 8\nobservability:\n  destinations: []\n",
         )
 
-    with (
-        patch.object(cmd_setup.platform_support, "host_os", return_value="windows"),
-        patch(
-            "defenseclaw.commands.cmd_setup_observability._require_v8_operator_status",
-            return_value=SimpleNamespace(destinations=(owned,)),
-        ),
-        patch(
-            "defenseclaw.commands.cmd_setup_observability._set_v8_destination_enabled",
-            side_effect=mutate_config,
-        ),
-        patch(
-            "defenseclaw.observability.local_splunk.prepare_native_local_splunk_stop",
-            return_value=(Controller(), True),
-        ),
-        patch.object(cmd_setup, "_reload_cfg_from_data_dir"),
-        pytest.raises(ClickException, match="Splunk disable failed"),
+    def prepare(*_args, **kwargs):
+        return Controller(kwargs["environment"]), True
+
+    with patch.dict(
+        os.environ,
+        {
+            "operator_managed_gateway_token": "custom-secret-sentinel",
+            "DefenseClaw_Gateway_Token": "canonical-secret-sentinel",
+            "openclaw_gateway_token": "legacy-secret-sentinel",
+            "NATIVE_UNRELATED_SETTING": "preserved",
+        },
     ):
-        cmd_setup._disable_splunk(app, False, True, False, True)
+        with (
+            patch.object(cmd_setup.platform_support, "host_os", return_value="windows"),
+            patch(
+                "defenseclaw.commands.cmd_setup_observability._require_v8_operator_status",
+                return_value=SimpleNamespace(destinations=(owned,)),
+            ),
+            patch(
+                "defenseclaw.commands.cmd_setup_observability._set_v8_destination_enabled",
+                side_effect=mutate_config,
+            ),
+            patch(
+                "defenseclaw.observability.local_splunk.prepare_native_local_splunk_stop",
+                side_effect=prepare,
+            ),
+            patch.object(cmd_setup, "_reload_cfg_from_data_dir"),
+            pytest.raises(ClickException, match="Splunk disable failed"),
+        ):
+            cmd_setup._disable_splunk(app, False, True, False, True)
     assert config_path.read_bytes() == before
     assert events == ["down", "up:True:prior-bucket"]
 
 
+@pytest.mark.parametrize(
+    "configured_name",
+    [
+        "INVALID-TOKEN-NAME",
+        " OPERATOR_MANAGED_GATEWAY_TOKEN",
+        "OPERATOR_MANAGED_GATEWAY_TOKEN ",
+        "defenseclaw_local_splunk_hec_token",
+        "defenseclaw_local_password",
+    ],
+)
+def test_invalid_gateway_token_name_fails_before_native_disable_side_effects(
+    tmp_path: Path,
+    configured_name: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    app = _app(tmp_path)
+    app.cfg.gateway.token_env = configured_name
+    secret = "rejected-native-disable-secret-sentinel"
+    before = (tmp_path / "config.yaml").read_bytes()
+    with patch.dict(
+        os.environ,
+        {
+            configured_name: secret,
+            configured_name.strip().swapcase(): secret,
+            "NATIVE_UNRELATED_SETTING": "preserved",
+        },
+    ):
+        with (
+            patch.object(cmd_setup.platform_support, "host_os", return_value="windows"),
+            patch("defenseclaw.commands.cmd_setup_observability._require_v8_operator_status") as status,
+            patch("defenseclaw.commands.cmd_setup_observability._set_v8_destination_enabled") as writer,
+            patch("defenseclaw.observability.local_splunk.prepare_native_local_splunk_stop") as prepare,
+            pytest.raises(ClickException, match="gateway.token_env"),
+        ):
+            cmd_setup._disable_splunk(app, False, True, False, True)
+
+    status.assert_not_called()
+    writer.assert_not_called()
+    prepare.assert_not_called()
+    assert (tmp_path / "config.yaml").read_bytes() == before
+    captured = capsys.readouterr()
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
 def test_combined_native_setup_restores_remote_writes_when_local_fails(tmp_path: Path) -> None:
     app = _app(tmp_path)
+    custom_name = "OPERATOR_MANAGED_GATEWAY_TOKEN"
+    custom_secret = "native-preflight-secret-sentinel"
+    app.cfg.gateway.token_env = custom_name
     config_path = tmp_path / "config.yaml"
     dotenv_path = tmp_path / ".env"
     before = (config_path.read_bytes(), dotenv_path.read_bytes())
@@ -432,11 +691,7 @@ def test_combined_native_setup_restores_remote_writes_when_local_fails(tmp_path:
             events.append(name)
             atomic_write_private_bytes(
                 config_path,
-                (
-                    "config_version: 8\n"
-                    f"environment: {name}\n"
-                    "observability:\n  destinations: []\n"
-                ).encode(),
+                (f"config_version: 8\nenvironment: {name}\nobservability:\n  destinations: []\n").encode(),
             )
             atomic_write_private_bytes(dotenv_path, f"STEP={name}\n".encode())
 
@@ -446,36 +701,119 @@ def test_combined_native_setup_restores_remote_writes_when_local_fails(tmp_path:
         events.append("logs")
         raise LocalStackError("local readiness failed")
 
-    with (
-        patch.object(cmd_setup, "_native_windows_local_splunk", return_value=True),
-        patch.object(cmd_setup, "local_shell_stacks_supported", return_value=True),
-        patch(
-            "defenseclaw.observability.local_splunk.preflight_native_local_splunk_setup",
-        ) as preflight,
-        patch.object(cmd_setup, "_setup_o11y", side_effect=remote_step("o11y")),
-        patch.object(cmd_setup, "_setup_enterprise", side_effect=remote_step("enterprise")),
-        patch.object(cmd_setup, "_setup_logs", side_effect=fail_local),
+    with patch.dict(
+        os.environ,
+        {
+            "operator_managed_gateway_token": custom_secret,
+            "DefenseClaw_Gateway_Token": "canonical-secret-sentinel",
+            "openclaw_gateway_token": "legacy-secret-sentinel",
+            "NATIVE_UNRELATED_SETTING": "preserved",
+        },
     ):
-        result = CliRunner().invoke(
-            cmd_setup.setup,
-            [
-                "splunk",
-                "--o11y",
-                "--access-token",
-                "o11y-token",
-                "--enterprise",
-                "--hec-endpoint",
-                "https://splunk.example.test:8088/services/collector/event",
-                "--hec-token",
-                "remote-token",
-                "--logs",
-                "--accept-splunk-license",
-                "--skip-test",
-                "--non-interactive",
-            ],
-            obj=app,
-        )
+        with (
+            patch.object(cmd_setup, "_native_windows_local_splunk", return_value=True),
+            patch.object(cmd_setup, "local_shell_stacks_supported", return_value=True),
+            patch(
+                "defenseclaw.observability.local_splunk.preflight_native_local_splunk_setup",
+            ) as preflight,
+            patch.object(cmd_setup, "_setup_o11y", side_effect=remote_step("o11y")),
+            patch.object(cmd_setup, "_setup_enterprise", side_effect=remote_step("enterprise")),
+            patch.object(cmd_setup, "_setup_logs", side_effect=fail_local),
+        ):
+            result = CliRunner().invoke(
+                cmd_setup.setup,
+                [
+                    "splunk",
+                    "--o11y",
+                    "--access-token",
+                    "o11y-token",
+                    "--enterprise",
+                    "--hec-endpoint",
+                    "https://splunk.example.test:8088/services/collector/event",
+                    "--hec-token",
+                    "remote-token",
+                    "--logs",
+                    "--accept-splunk-license",
+                    "--skip-test",
+                    "--non-interactive",
+                ],
+                obj=app,
+            )
     assert result.exit_code != 0
     assert events == ["o11y", "enterprise", "logs"]
     assert (config_path.read_bytes(), dotenv_path.read_bytes()) == before
     preflight.assert_called_once()
+    environment = preflight.call_args.kwargs["environment"]
+    assert not {
+        "operator_managed_gateway_token",
+        "DefenseClaw_Gateway_Token",
+        "openclaw_gateway_token",
+    } & set(environment)
+    assert environment["NATIVE_UNRELATED_SETTING"] == "preserved"
+    assert custom_secret not in repr(preflight.call_args)
+
+
+@pytest.mark.parametrize(
+    "configured_name",
+    [
+        "INVALID-TOKEN-NAME",
+        " OPERATOR_MANAGED_GATEWAY_TOKEN",
+        "OPERATOR_MANAGED_GATEWAY_TOKEN ",
+        "defenseclaw_local_splunk_hec_token",
+        "defenseclaw_local_password",
+    ],
+)
+def test_invalid_gateway_token_name_fails_before_combined_native_preflight_or_writes(
+    tmp_path: Path,
+    configured_name: str,
+) -> None:
+    app = _app(tmp_path)
+    app.cfg.gateway.token_env = configured_name
+    secret = "rejected-native-preflight-secret-sentinel"
+    config_path = tmp_path / "config.yaml"
+    dotenv_path = tmp_path / ".env"
+    before = (config_path.read_bytes(), dotenv_path.read_bytes())
+
+    with patch.dict(
+        os.environ,
+        {
+            configured_name: secret,
+            configured_name.strip().swapcase(): secret,
+            "NATIVE_UNRELATED_SETTING": "preserved",
+        },
+    ):
+        with (
+            patch.object(cmd_setup, "_native_windows_local_splunk", return_value=True),
+            patch.object(cmd_setup, "local_shell_stacks_supported", return_value=True),
+            patch(
+                "defenseclaw.observability.local_splunk.preflight_native_local_splunk_setup",
+            ) as preflight,
+            patch.object(cmd_setup, "_setup_o11y") as setup_o11y,
+            patch.object(cmd_setup, "_setup_enterprise") as setup_enterprise,
+            patch.object(cmd_setup, "_setup_logs") as setup_logs,
+        ):
+            result = CliRunner().invoke(
+                cmd_setup.setup,
+                [
+                    "splunk",
+                    "--enterprise",
+                    "--hec-endpoint",
+                    "https://splunk.example.test:8088/services/collector/event",
+                    "--hec-token",
+                    "remote-token",
+                    "--logs",
+                    "--accept-splunk-license",
+                    "--skip-test",
+                    "--non-interactive",
+                ],
+                obj=app,
+            )
+
+    assert result.exit_code != 0
+    assert "gateway.token_env" in result.output
+    preflight.assert_not_called()
+    setup_o11y.assert_not_called()
+    setup_enterprise.assert_not_called()
+    setup_logs.assert_not_called()
+    assert (config_path.read_bytes(), dotenv_path.read_bytes()) == before
+    assert secret not in result.output

--- a/cli/tests/test_setup_refresh_bundle_wiring.py
+++ b/cli/tests/test_setup_refresh_bundle_wiring.py
@@ -158,12 +158,133 @@ class TestSplunkBridgeChildEnvironment(unittest.TestCase):
         self.assertEqual(child_env, {"BRIDGE_UNRELATED_SETTING": "preserved"})
 
     def test_configured_token_name_must_be_a_portable_environment_name(self) -> None:
-        from defenseclaw.commands.cmd_setup import _configured_gateway_token_env_name
+        from defenseclaw.commands.cmd_setup import (
+            _configured_gateway_token_env_name,
+            _splunk_bridge_child_env,
+        )
 
-        cfg = SimpleNamespace(gateway=SimpleNamespace(token_env="INVALID-TOKEN-NAME"))
+        for invalid_name in (
+            "INVALID-TOKEN-NAME",
+            " OPERATOR_MANAGED_GATEWAY_TOKEN",
+            "OPERATOR_MANAGED_GATEWAY_TOKEN ",
+        ):
+            with self.subTest(invalid_name=invalid_name):
+                cfg = SimpleNamespace(gateway=SimpleNamespace(token_env=invalid_name))
+                source = _UnreadableSecretEnvironment(
+                    {
+                        invalid_name: "whitespace-secret-sentinel",
+                        "BRIDGE_UNRELATED_SETTING": "preserved",
+                    },
+                    blocked_names={invalid_name},
+                )
 
-        with self.assertRaisesRegex(ClickException, "gateway.token_env"):
-            _configured_gateway_token_env_name(cfg)
+                with self.assertRaisesRegex(ClickException, "gateway.token_env"):
+                    _configured_gateway_token_env_name(cfg)
+                with self.assertRaisesRegex(ClickException, "gateway.token_env"):
+                    _splunk_bridge_child_env(
+                        invalid_name,
+                        environment=source,
+                        platform_name="nt",
+                    )
+
+    def test_managed_name_contract_covers_current_and_historical_bridge_keys(self) -> None:
+        from defenseclaw.commands.cmd_setup import _SPLUNK_BRIDGE_MANAGED_ENV_NAMES
+        from defenseclaw.paths import bundled_splunk_bridge_dir
+
+        current_names = set(_read_dotenv(str(bundled_splunk_bridge_dir() / "env" / ".env.example")))
+        self.assertLessEqual(current_names, _SPLUNK_BRIDGE_MANAGED_ENV_NAMES)
+        self.assertLessEqual(
+            {
+                "DEFENSECLAW_LOCAL_PASSWORD",
+                "DEFENSECLAW_LOCAL_SPLUNK_HEC_TOKEN",
+                "DEFENSECLAW_LOCAL_USERNAME",
+                "SPLUNK_ENV_FILE",
+            },
+            _SPLUNK_BRIDGE_MANAGED_ENV_NAMES,
+        )
+
+    def test_every_managed_name_collision_is_windows_case_insensitive(self) -> None:
+        from defenseclaw.commands.cmd_setup import (
+            _SPLUNK_BRIDGE_MANAGED_ENV_NAMES,
+            _splunk_bridge_child_env,
+            _validated_splunk_gateway_token_env_name,
+        )
+
+        for managed_name in sorted(_SPLUNK_BRIDGE_MANAGED_ENV_NAMES):
+            mixed_case_name = managed_name.swapcase()
+            source = _UnreadableSecretEnvironment(
+                {
+                    mixed_case_name: "managed-collision-secret-sentinel",
+                    "BRIDGE_UNRELATED_SETTING": "preserved",
+                },
+                blocked_names={mixed_case_name},
+            )
+            with self.subTest(managed_name=managed_name):
+                with self.assertRaisesRegex(ClickException, "Local Splunk managed"):
+                    _validated_splunk_gateway_token_env_name(
+                        mixed_case_name,
+                        platform_name="nt",
+                    )
+                with self.assertRaisesRegex(ClickException, "Local Splunk managed"):
+                    _splunk_bridge_child_env(
+                        mixed_case_name,
+                        environment=source,
+                        platform_name="nt",
+                    )
+
+    def test_managed_name_collision_is_exact_on_posix(self) -> None:
+        from defenseclaw.commands.cmd_setup import (
+            _SPLUNK_BRIDGE_MANAGED_ENV_NAMES,
+            _validated_splunk_gateway_token_env_name,
+        )
+
+        for managed_name in sorted(_SPLUNK_BRIDGE_MANAGED_ENV_NAMES):
+            with self.subTest(managed_name=managed_name):
+                with self.assertRaisesRegex(ClickException, "Local Splunk managed"):
+                    _validated_splunk_gateway_token_env_name(
+                        managed_name,
+                        platform_name="posix",
+                    )
+
+        self.assertEqual(
+            _validated_splunk_gateway_token_env_name(
+                "splunk_image",
+                platform_name="posix",
+            ),
+            "splunk_image",
+        )
+
+    @patch("defenseclaw.commands.cmd_setup._ensure_private_splunk_bridge_env")
+    def test_bootstrap_rejects_invalid_or_managed_name_before_private_env_mutation(
+        self,
+        ensure_private_env: MagicMock,
+    ) -> None:
+        from defenseclaw.commands.cmd_setup import _bootstrap_bridge
+
+        for rejected_name in (
+            " OPERATOR_MANAGED_GATEWAY_TOKEN",
+            "SPLUNK_IMAGE",
+            "DEFENSECLAW_LOCAL_USERNAME",
+        ):
+            secret = "rejected-bootstrap-secret-sentinel"
+            source = _UnreadableSecretEnvironment(
+                {
+                    rejected_name: secret,
+                    "BRIDGE_UNRELATED_SETTING": "preserved",
+                },
+                blocked_names={rejected_name},
+            )
+            with self.subTest(rejected_name=rejected_name):
+                with (
+                    patch("defenseclaw.commands.cmd_setup.os.environ", source),
+                    self.assertRaisesRegex(ClickException, "gateway.token_env"),
+                ):
+                    _bootstrap_bridge(
+                        "/unused",
+                        gateway_token_env=rejected_name,
+                    )
+
+        ensure_private_env.assert_not_called()
 
 
 class TestSetupSplunkRefreshWiring(unittest.TestCase):
@@ -210,16 +331,18 @@ class TestSetupSplunkRefreshWiring(unittest.TestCase):
         )
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout=json.dumps({
-                "splunk_web_url": "http://127.0.0.1:8000",
-                "hec_url": "http://127.0.0.1:8088/services/collector/event",
-                "hec_token": "bootstrap-token",
-                "license_group": "Free",
-                "web_login_required": False,
-                "index": "defenseclaw_local",
-                "source": "defenseclaw",
-                "sourcetype": "defenseclaw:json",
-            }),
+            stdout=json.dumps(
+                {
+                    "splunk_web_url": "http://127.0.0.1:8000",
+                    "hec_url": "http://127.0.0.1:8088/services/collector/event",
+                    "hec_token": "bootstrap-token",
+                    "license_group": "Free",
+                    "web_login_required": False,
+                    "index": "defenseclaw_local",
+                    "source": "defenseclaw",
+                    "sourcetype": "defenseclaw:json",
+                }
+            ),
             stderr="",
         )
 
@@ -306,16 +429,18 @@ class TestSetupSplunkRefreshWiring(unittest.TestCase):
 
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout=json.dumps({
-                "splunk_web_url": "http://127.0.0.1:8000",
-                "hec_url": "http://127.0.0.1:8088/services/collector/event",
-                "hec_token": "bootstrap-token",
-                "license_group": "Free",
-                "web_login_required": False,
-                "index": "defenseclaw_local",
-                "source": "defenseclaw",
-                "sourcetype": "defenseclaw:json",
-            }),
+            stdout=json.dumps(
+                {
+                    "splunk_web_url": "http://127.0.0.1:8000",
+                    "hec_url": "http://127.0.0.1:8088/services/collector/event",
+                    "hec_token": "bootstrap-token",
+                    "license_group": "Free",
+                    "web_login_required": False,
+                    "index": "defenseclaw_local",
+                    "source": "defenseclaw",
+                    "sourcetype": "defenseclaw:json",
+                }
+            ),
             stderr="",
         )
 
@@ -414,14 +539,17 @@ class TestRefreshAndMaybeRestartSplunkBridge(unittest.TestCase):
         self.assertTrue(result.stopped)
         # The down call must precede the refresh call. Pull the
         # subprocess args to confirm we asked the bridge for `down`.
-        self.assertTrue(any(
-            call.args[0] == ["/fake/bin/splunk-claw-bridge", "down", "--env-file", env_file]
-            for call in mock_run.call_args_list
-        ))
+        self.assertTrue(
+            any(
+                call.args[0] == ["/fake/bin/splunk-claw-bridge", "down", "--env-file", env_file]
+                for call in mock_run.call_args_list
+            )
+        )
         down_call = next(
             call
             for call in mock_run.call_args_list
-            if call.args[0] == [
+            if call.args[0]
+            == [
                 "/fake/bin/splunk-claw-bridge",
                 "down",
                 "--env-file",
@@ -495,6 +623,7 @@ class TestStopSplunkBridgeEnvironment(unittest.TestCase):
             {
                 "DEFENSECLAW_GATEWAY_TOKEN": "gateway-sentinel",
                 "OPENCLAW_GATEWAY_TOKEN": "legacy-sentinel",
+                "BRIDGE_UNRELATED_SETTING": "preserved",
             },
         ):
             _stop_bridge("/data")
@@ -503,6 +632,94 @@ class TestStopSplunkBridgeEnvironment(unittest.TestCase):
         environment = native_stop.call_args.kwargs["environment"]
         self.assertNotIn("DEFENSECLAW_GATEWAY_TOKEN", environment)
         self.assertNotIn("OPENCLAW_GATEWAY_TOKEN", environment)
+        self.assertEqual(environment["BRIDGE_UNRELATED_SETTING"], "preserved")
+
+    @patch("defenseclaw.commands.cmd_setup.local_shell_stacks_supported", return_value=True)
+    @patch("defenseclaw.commands.cmd_setup._native_windows_local_splunk", return_value=True)
+    @patch(
+        "defenseclaw.observability.local_splunk.stop_native_local_splunk",
+        return_value=True,
+    )
+    def test_native_disable_scrubs_mixed_case_custom_gateway_token(
+        self,
+        native_stop: MagicMock,
+        _native_windows: MagicMock,
+        _supported: MagicMock,
+    ) -> None:
+        from defenseclaw.commands.cmd_setup import _stop_bridge
+
+        custom_name = "OPERATOR_MANAGED_GATEWAY_TOKEN"
+        custom_secret = "native-stop-secret-sentinel"
+        source = _UnreadableSecretEnvironment(
+            {
+                "operator_managed_gateway_token": custom_secret,
+                "DefenseClaw_Gateway_Token": "canonical-secret-sentinel",
+                "openclaw_gateway_token": "legacy-secret-sentinel",
+                "BRIDGE_UNRELATED_SETTING": "preserved",
+            },
+            blocked_names={
+                custom_name,
+                "DEFENSECLAW_GATEWAY_TOKEN",
+                "OPENCLAW_GATEWAY_TOKEN",
+            },
+        )
+        output = io.StringIO()
+        with (
+            patch("defenseclaw.commands.cmd_setup.os.environ", source),
+            redirect_stdout(output),
+        ):
+            _stop_bridge("/data", gateway_token_env=custom_name)
+
+        environment = native_stop.call_args.kwargs["environment"]
+        self.assertFalse(
+            {
+                "operator_managed_gateway_token",
+                "DefenseClaw_Gateway_Token",
+                "openclaw_gateway_token",
+            }
+            & set(environment)
+        )
+        self.assertEqual(environment["BRIDGE_UNRELATED_SETTING"], "preserved")
+        self.assertNotIn(custom_secret, repr(native_stop.call_args.args))
+        self.assertNotIn(custom_secret, output.getvalue())
+
+    @patch("defenseclaw.commands.cmd_setup.local_shell_stacks_supported", return_value=True)
+    @patch("defenseclaw.commands.cmd_setup._native_windows_local_splunk", return_value=True)
+    @patch("defenseclaw.observability.local_splunk.stop_native_local_splunk")
+    def test_native_disable_rejects_invalid_or_managed_custom_name_before_stop(
+        self,
+        native_stop: MagicMock,
+        _native_windows: MagicMock,
+        _supported: MagicMock,
+    ) -> None:
+        from defenseclaw.commands.cmd_setup import _stop_bridge
+
+        for rejected_name in (
+            "INVALID-TOKEN-NAME",
+            " OPERATOR_MANAGED_GATEWAY_TOKEN",
+            "OPERATOR_MANAGED_GATEWAY_TOKEN ",
+            "defenseclaw_local_splunk_hec_token",
+            "defenseclaw_local_password",
+        ):
+            secret = "rejected-native-stop-secret-sentinel"
+            source = _UnreadableSecretEnvironment(
+                {
+                    rejected_name: secret,
+                    "BRIDGE_UNRELATED_SETTING": "preserved",
+                },
+                blocked_names={rejected_name},
+            )
+            output = io.StringIO()
+            with self.subTest(rejected_name=rejected_name):
+                with (
+                    patch("defenseclaw.commands.cmd_setup.os.environ", source),
+                    redirect_stdout(output),
+                    self.assertRaisesRegex(ClickException, "gateway.token_env"),
+                ):
+                    _stop_bridge("/data", gateway_token_env=rejected_name)
+                self.assertNotIn(secret, output.getvalue())
+
+        native_stop.assert_not_called()
 
     @patch("defenseclaw.commands.cmd_setup.local_shell_stacks_supported", return_value=True)
     @patch("defenseclaw.commands.cmd_setup._native_windows_local_splunk", return_value=False)
@@ -574,8 +791,7 @@ class TestSetupLocalObservabilityRefreshWiring(unittest.TestCase):
                 return_value=controller,
             ),
             patch(
-                "defenseclaw.commands.cmd_setup_local_observability"
-                "._refresh_and_maybe_restart_local_observability",
+                "defenseclaw.commands.cmd_setup_local_observability._refresh_and_maybe_restart_local_observability",
             ) as mock_refresh,
             patch(
                 "defenseclaw.commands.cmd_setup_local_observability._apply_local_otlp_config",
@@ -622,8 +838,7 @@ class TestSetupLocalObservabilityRefreshWiring(unittest.TestCase):
                 return_value=controller,
             ),
             patch(
-                "defenseclaw.commands.cmd_setup_local_observability"
-                "._refresh_and_maybe_restart_local_observability",
+                "defenseclaw.commands.cmd_setup_local_observability._refresh_and_maybe_restart_local_observability",
             ) as mock_refresh,
             patch(
                 "defenseclaw.commands.cmd_setup_local_observability._apply_local_otlp_config",
@@ -657,8 +872,7 @@ class TestSetupLocalObservabilityRefreshWiring(unittest.TestCase):
                 return_value=controller,
             ),
             patch(
-                "defenseclaw.commands.cmd_setup_local_observability"
-                "._refresh_and_maybe_restart_local_observability",
+                "defenseclaw.commands.cmd_setup_local_observability._refresh_and_maybe_restart_local_observability",
             ) as mock_refresh,
             patch(
                 "defenseclaw.commands.cmd_setup_local_observability._apply_local_otlp_config",
@@ -695,8 +909,7 @@ class TestSetupLocalObservabilityRefreshWiring(unittest.TestCase):
                 return_value=controller,
             ),
             patch(
-                "defenseclaw.commands.cmd_setup_local_observability"
-                "._refresh_and_maybe_restart_local_observability",
+                "defenseclaw.commands.cmd_setup_local_observability._refresh_and_maybe_restart_local_observability",
             ) as mock_refresh,
             patch(
                 "defenseclaw.commands.cmd_setup_local_observability._apply_local_otlp_config",
@@ -722,8 +935,7 @@ class TestRefreshAndMaybeRestartLocalObservability(unittest.TestCase):
     """Direct coverage for local-observability refresh messaging."""
 
     @patch(
-        "defenseclaw.commands.cmd_setup_local_observability"
-        ".refresh_local_observability_stack",
+        "defenseclaw.commands.cmd_setup_local_observability.refresh_local_observability_stack",
     )
     def test_preserved_config_hint_is_printed(self, mock_refresh: MagicMock) -> None:
         from defenseclaw.bundle_refresh import RefreshResult

--- a/cli/tests/test_setup_refresh_bundle_wiring.py
+++ b/cli/tests/test_setup_refresh_bundle_wiring.py
@@ -39,6 +39,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import yaml
+from click import ClickException
 from click.testing import CliRunner
 from defenseclaw import config
 from defenseclaw.context import AppContext
@@ -115,6 +116,56 @@ def _bridge_up_args(mock_run: MagicMock) -> list[str]:
     raise AssertionError("Splunk bridge up command was not invoked")
 
 
+class _UnreadableSecretEnvironment(dict[str, str]):
+    """Mapping that fails if a blocked credential value is ever requested."""
+
+    def __init__(self, values: dict[str, str], *, blocked_names: set[str]) -> None:
+        super().__init__(values)
+        self._blocked_names = {name.casefold() for name in blocked_names}
+
+    def __getitem__(self, key: str) -> str:
+        if key.casefold() in self._blocked_names:
+            raise AssertionError(f"secret value for {key!r} was read")
+        return super().__getitem__(key)
+
+
+class TestSplunkBridgeChildEnvironment(unittest.TestCase):
+    def test_windows_scrub_is_case_insensitive_and_never_reads_token_values(self) -> None:
+        from defenseclaw.commands.cmd_setup import _splunk_bridge_child_env
+
+        custom_name = "OPERATOR_MANAGED_GATEWAY_TOKEN"
+        blocked_names = {
+            custom_name,
+            "DEFENSECLAW_GATEWAY_TOKEN",
+            "OPENCLAW_GATEWAY_TOKEN",
+        }
+        source = _UnreadableSecretEnvironment(
+            {
+                "operator_managed_gateway_token": "custom-secret-sentinel",
+                "DefenseClaw_Gateway_Token": "canonical-secret-sentinel",
+                "openclaw_gateway_token": "legacy-secret-sentinel",
+                "BRIDGE_UNRELATED_SETTING": "preserved",
+            },
+            blocked_names=blocked_names,
+        )
+
+        child_env = _splunk_bridge_child_env(
+            custom_name,
+            environment=source,
+            platform_name="nt",
+        )
+
+        self.assertEqual(child_env, {"BRIDGE_UNRELATED_SETTING": "preserved"})
+
+    def test_configured_token_name_must_be_a_portable_environment_name(self) -> None:
+        from defenseclaw.commands.cmd_setup import _configured_gateway_token_env_name
+
+        cfg = SimpleNamespace(gateway=SimpleNamespace(token_env="INVALID-TOKEN-NAME"))
+
+        with self.assertRaisesRegex(ClickException, "gateway.token_env"):
+            _configured_gateway_token_env_name(cfg)
+
+
 class TestSetupSplunkRefreshWiring(unittest.TestCase):
     def setUp(self) -> None:
         self.runner = CliRunner()
@@ -172,7 +223,20 @@ class TestSetupSplunkRefreshWiring(unittest.TestCase):
             stderr="",
         )
 
+        custom_name = "OPERATOR_MANAGED_GATEWAY_TOKEN"
+        custom_secret = "setup-up-secret-sentinel"
+        self.app.cfg.gateway.token_env = custom_name
+
         with (
+            patch.dict(
+                os.environ,
+                {
+                    custom_name: custom_secret,
+                    "DEFENSECLAW_GATEWAY_TOKEN": "canonical-secret-sentinel",
+                    "OPENCLAW_GATEWAY_TOKEN": "legacy-secret-sentinel",
+                    "BRIDGE_UNRELATED_SETTING": "preserved",
+                },
+            ),
             patch(
                 "defenseclaw.commands.cmd_setup_observability._require_v8_operator_status",
                 return_value=SimpleNamespace(destinations=()),
@@ -195,10 +259,17 @@ class TestSetupSplunkRefreshWiring(unittest.TestCase):
         child_env = refresh_call.kwargs["child_env"]
         self.assertNotIn("DEFENSECLAW_GATEWAY_TOKEN", child_env)
         self.assertNotIn("OPENCLAW_GATEWAY_TOKEN", child_env)
+        self.assertNotIn(custom_name, child_env)
+        self.assertEqual(child_env["BRIDGE_UNRELATED_SETTING"], "preserved")
         self.assertEqual(
             _bridge_up_args(mock_run),
             ["/tmp/fake-splunk-claw-bridge", "up", "--env-file", env_file, "--output", "json"],
         )
+        up_call = next(call for call in mock_run.call_args_list if call.args[0][1] == "up")
+        self.assertNotIn(custom_name, up_call.kwargs["env"])
+        self.assertEqual(up_call.kwargs["env"]["BRIDGE_UNRELATED_SETTING"], "preserved")
+        self.assertNotIn(custom_secret, repr(up_call.args[0]))
+        self.assertNotIn(custom_secret, result.output)
 
         assert_owner_only_file(env_file)
         entries = _read_dotenv(env_file)
@@ -317,17 +388,26 @@ class TestRefreshAndMaybeRestartSplunkBridge(unittest.TestCase):
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
         env_file = "/data/splunk-bridge/env/.env"
-        with patch.dict(
-            os.environ,
-            {
-                "DEFENSECLAW_GATEWAY_TOKEN": "gateway-sentinel",
-                "OPENCLAW_GATEWAY_TOKEN": "legacy-sentinel",
-            },
+        custom_name = "OPERATOR_MANAGED_GATEWAY_TOKEN"
+        custom_secret = "refresh-down-secret-sentinel"
+        output = io.StringIO()
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "DEFENSECLAW_GATEWAY_TOKEN": "gateway-sentinel",
+                    "OPENCLAW_GATEWAY_TOKEN": "legacy-sentinel",
+                    custom_name: custom_secret,
+                    "BRIDGE_UNRELATED_SETTING": "preserved",
+                },
+            ),
+            redirect_stdout(output),
         ):
             result = _refresh_and_maybe_restart_splunk_bridge(
                 "/data",
                 env_file=env_file,
                 child_env=os.environ.copy(),
+                gateway_token_env=custom_name,
             )
 
         self.assertTrue(result.was_running)
@@ -353,6 +433,12 @@ class TestRefreshAndMaybeRestartSplunkBridge(unittest.TestCase):
         running_env = _running.call_args.kwargs["environment"]
         self.assertNotIn("DEFENSECLAW_GATEWAY_TOKEN", running_env)
         self.assertNotIn("OPENCLAW_GATEWAY_TOKEN", running_env)
+        self.assertNotIn(custom_name, running_env)
+        self.assertEqual(running_env["BRIDGE_UNRELATED_SETTING"], "preserved")
+        self.assertNotIn(custom_name, down_call.kwargs["env"])
+        self.assertEqual(down_call.kwargs["env"]["BRIDGE_UNRELATED_SETTING"], "preserved")
+        self.assertNotIn(custom_secret, repr(down_call.args[0]))
+        self.assertNotIn(custom_secret, output.getvalue())
         mock_refresh.assert_called_once_with("/data")
 
     @patch(
@@ -434,20 +520,32 @@ class TestStopSplunkBridgeEnvironment(unittest.TestCase):
     ) -> None:
         from defenseclaw.commands.cmd_setup import _stop_bridge
 
-        with patch.dict(
-            os.environ,
-            {
-                "DEFENSECLAW_GATEWAY_TOKEN": "gateway-sentinel",
-                "OPENCLAW_GATEWAY_TOKEN": "legacy-sentinel",
-            },
+        custom_name = "OPERATOR_MANAGED_GATEWAY_TOKEN"
+        custom_secret = "disable-down-secret-sentinel"
+        output = io.StringIO()
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "DEFENSECLAW_GATEWAY_TOKEN": "gateway-sentinel",
+                    "OPENCLAW_GATEWAY_TOKEN": "legacy-sentinel",
+                    custom_name: custom_secret,
+                    "BRIDGE_UNRELATED_SETTING": "preserved",
+                },
+            ),
+            redirect_stdout(output),
         ):
-            _stop_bridge("/data")
+            _stop_bridge("/data", gateway_token_env=custom_name)
 
         mock_run.assert_called_once()
         call = mock_run.call_args
         self.assertEqual(call.args[0], ["/fake/bin/splunk-claw-bridge", "down"])
         self.assertNotIn("DEFENSECLAW_GATEWAY_TOKEN", call.kwargs["env"])
         self.assertNotIn("OPENCLAW_GATEWAY_TOKEN", call.kwargs["env"])
+        self.assertNotIn(custom_name, call.kwargs["env"])
+        self.assertEqual(call.kwargs["env"]["BRIDGE_UNRELATED_SETTING"], "preserved")
+        self.assertNotIn(custom_secret, repr(call.args[0]))
+        self.assertNotIn(custom_secret, output.getvalue())
 
 
 class TestSetupLocalObservabilityRefreshWiring(unittest.TestCase):


### PR DESCRIPTION
**Stack/base:** This PR now targets `main` directly. Its two commits are rebased onto exact main commit `6f03bfc1258e1ae19abfa281f688b55be1ed8057`, which includes the merged Splunk sanitizer/runtime work from #693 and #700 plus the setup lint hotfix from #710. Review heads `5f7953ca1` and `a8af52cc2` together.

## Problem

Local Splunk child processes must never inherit the DefenseClaw gateway bearer. The existing boundary removed the canonical `DEFENSECLAW_GATEWAY_TOKEN` and legacy `OPENCLAW_GATEWAY_TOKEN`, but operators can configure a different variable through `gateway.token_env`. That custom name was not propagated through every native-Windows setup, preflight, stop, disable, and rollback path.

Two validation gaps could also defeat a name-only scrub:

1. Leading or trailing whitespace was stripped before validation, even though configuration token resolution can use the raw name.
2. The native controller and shell bridge overlay a managed private `.env` after ambient filtering. If the configured gateway token name collided with a current or historical managed bridge key, the overlay could recreate that name in Docker/Compose descendants.

Fixes #690.

## Current Situation

Before this change, a valid custom gateway token variable could reach bridge or native Local Splunk children during `up`, refresh-time `down`, native preflight/start, native disable, controller `down`, rollback `up`, or direct native stop. Windows additionally requires case-insensitive name matching.

The vulnerable implementation also normalized whitespace-bearing names and did not reject collisions such as `gateway.token_env=DEFENSECLAW_LOCAL_SPLUNK_HEC_TOKEN`, even though the Local Splunk private environment writes that key after ambient sanitization.

## Solution

### Validate one exact name before effects

The Local Splunk entry points validate the raw configured name without reading its value. Leading/trailing whitespace, non-portable names, and managed-key collisions fail before preflight, lifecycle calls, snapshots, private-env creation, configuration writes, or remote integration writes.

### Reject every managed private-environment collision

The collision contract covers every key in the current bundled bridge `.env.example`, all historical keys previously shipped by that file, the native generated HEC token key, and the runtime `SPLUNK_ENV_FILE` key. Comparisons are case-insensitive on Windows and exact on POSIX; unrelated names remain valid.

### Filter names before fetching values

The child-environment builder iterates keys first and fetches values only for retained keys. Canonical, legacy, and validated custom gateway token values are therefore never read while the sanitized environment is constructed.

### Use the sanitized environment for the complete lifecycle

The same boundary now covers shell bridge startup/refresh/disable and native-Windows combined preflight, setup/start, disable preparation, controller state/down/rollback-up, and direct stop. Unrelated environment variables and existing S3/AWS overrides are preserved.

```mermaid
flowchart LR
    A["Raw cfg.gateway.token_env name"] --> B["Exact portable-name validation"]
    B --> C["Current + historical managed-key collision check"]
    C --> D["Block configured + canonical + legacy names"]
    E["Parent environment keys"] --> F["Platform-aware key-first filter"]
    D --> F
    F -->|"blocked"| G["Skip key; never read value"]
    F -->|"allowed"| H["Copy unrelated value"]
    H --> I["Bridge and native preflight / up / down / rollback / stop"]
```

## What Changed (Where & How)

| Area | Path | Change |
|---|---|---|
| Local Splunk command boundary | `cli/defenseclaw/commands/cmd_setup.py` | Adds exact raw-name and managed-key validation, key-first platform-aware filtering, and sanitized environment propagation across shell and native-Windows lifecycle paths. |
| Bridge/native wiring regressions | `cli/tests/test_setup_refresh_bundle_wiring.py` | Covers no-value-read behavior, the complete current/historical key contract, Windows mixed-case filtering, POSIX exact matching, bootstrap/stop no-side-effects, unrelated sentinels, and no argv/output disclosure. |
| Native transaction regressions | `cli/tests/test_local_splunk_transaction.py` | Covers setup, direct start, combined preflight, disable, controller down/rollback, invalid/whitespace/collision fail-closed behavior, configuration preservation, and remote/POSIX controls. |
| Native controller regression | `cli/tests/test_local_splunk_controller.py` | Proves the sanitized unrelated environment is retained through upgrade rollback without canonical or legacy gateway names. |

## Breaking Changes

Local Splunk setup/disable now rejects whitespace-bearing `gateway.token_env` values and names that collide with current or historical Local Splunk managed private-environment keys. Valid non-colliding custom names and remote-only Splunk workflows are unchanged.

## Open Issues / Follow-ups

None.

## Test Plan

- `make py-lint`
  - Passed: `All checks passed!` on the final post-#710 base.
- `/Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/python -m pytest -q cli/tests/test_cmd_setup_splunk_o11y_dashboards.py cli/tests/test_setup_refresh_bundle_wiring.py cli/tests/test_local_splunk_transaction.py cli/tests/test_local_splunk_controller.py cli/tests/test_local_splunk_packaging.py cli/tests/test_windows_local_observability_gates.py`
  - Passed: `95 passed, 95 subtests passed in 9.73s`.
- `/Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/python -m pytest -q cli/tests/test_cmd_setup_observability.py cli/tests/test_cmd_setup_observability_v8.py cli/tests/test_cmd_setup_local_observability_helpers.py cli/tests/test_local_observability_config_transaction.py cli/tests/test_local_observability_upgrade_wiring.py cli/tests/test_config.py`
  - Passed: `230 passed, 5 subtests passed in 20.21s`.
- `/Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/ruff check cli/tests/test_setup_refresh_bundle_wiring.py cli/tests/test_local_splunk_transaction.py cli/tests/test_local_splunk_controller.py`
  - Passed: `All checks passed!`.
- `/Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/ruff format --check cli/tests/test_setup_refresh_bundle_wiring.py cli/tests/test_local_splunk_transaction.py cli/tests/test_local_splunk_controller.py`
  - Passed: all three files already formatted.
- `/Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/python -m py_compile cli/defenseclaw/commands/cmd_setup.py cli/tests/test_setup_refresh_bundle_wiring.py cli/tests/test_local_splunk_transaction.py cli/tests/test_local_splunk_controller.py`
  - Passed with no output.
- `git diff --check`
  - Passed with no whitespace errors.
- Independent frozen-diff audit
  - Clean on effective diff SHA-256 `29761b5977b1471b8b3d462f10bc99ddaf99d471df4db45820b9b2ad7cb3622b`; no blockers or actionables.
- GitHub Actions / automated review
  - Passed on exact head `a8af52cc2cfbe7253841d32f99a3374e66d33742`: `82 passed`, `8 expected skips`, `0 pending`, `0 failed` across all PR checks.
  - [CI run 31515688256](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/31515688256): final attempt `40 passed`, `4 expected skips`, including green `Go Test (remaining packages)`, `Go Test`, and `make test (unified)`. The first attempt hit the unchanged Galileo shutdown timing test once; its exact race-enabled test passed 20/20 locally and the failed job passed on the same-head rerun.
  - [Windows Native CI run 31515688260](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/31515688260): `13 passed`, `1 expected skip`, including the native Setup install/lifecycle acceptance and complete Python/Go suites.
  - CodeRabbit approved exact head at `2026-08-11T17:08:57Z`; Codex reported no major issues on exact head; `0` unresolved review threads.