### PR TITLE
fix(setup): import secure PID-generation reader

### DIFF
--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -93,6 +93,7 @@ from defenseclaw.file_permissions import (
     darwin_acl_write_error,
     delete_file_durable,
     dotenv_key_is_valid,
+    read_regular_file_no_follow,
     reject_reparse_path,
     windows_acl_custody_confidentiality_error,
     windows_acl_custody_write_error,

--- a/cli/tests/test_guardrail.py
+++ b/cli/tests/test_guardrail.py
@@ -1860,6 +1860,17 @@ class TestIsPidAlive(unittest.TestCase):
         self.assertFalse(_gateway_pid_file_identifies_gateway(pid_file))
 
 
+class TestGatewayPidGenerationMarker(unittest.TestCase):
+    def test_reads_current_pid_record(self):
+        from defenseclaw.commands.cmd_setup import _gateway_pid_generation_marker
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pid_record = b'{"pid":4242,"start_time":12345}\n'
+            Path(tmpdir, "gateway.pid").write_bytes(pid_record)
+
+            self.assertEqual(_gateway_pid_generation_marker(tmpdir), pid_record)
+
+
 class TestRestartDefenseGateway(unittest.TestCase):
     @unittest.skipUnless(os.name == "nt", "native Windows package contract")
     @patch(


### PR DESCRIPTION
Targets current `main` at `e9b987c3be937f9ee34cd4d9411a875b831b04f2`. This is an independent hotfix with no stack dependency.

## Problem

`defenseclaw.commands.cmd_setup._gateway_pid_generation_marker` calls `read_regular_file_no_follow`, but `cmd_setup.py` does not import that symbol from `defenseclaw.file_permissions`.

The undefined name breaks setup restart paths when they capture the current gateway generation, and it causes the repository Python lint gate to fail with `F821`.

## Current Situation

The helper's restart-readiness callers and existing mocked tests are present on `main`, but the concrete PID-record read is not exercised by the owning test module. Tests that patch `_gateway_pid_generation_marker` therefore cannot detect the missing dependency.

## Solution

Import the existing bounded, no-follow file reader into `cmd_setup.py` and add a direct owning regression that writes a real `gateway.pid` record and verifies the helper returns its exact bytes.

This keeps the existing secure-read implementation, size bound, and `OSError` handling unchanged.

## What Changed (Where & How)

| Path | Change |
| --- | --- |
| `cli/defenseclaw/commands/cmd_setup.py` | Import `read_regular_file_no_follow` from the existing file-permissions module. |
| `cli/tests/test_guardrail.py` | Exercise `_gateway_pid_generation_marker` against a real PID record so an undefined reader fails directly. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

- `PYTHONPATH="$PWD/cli" /Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/python -m pytest -q cli/tests/test_guardrail.py::TestGatewayPidGenerationMarker cli/tests/test_guardrail.py::TestRestartDefenseGateway` — **6 passed, 1 expected Windows-only skip**.
- `PYTHONPATH="$PWD/cli" /Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/python -m pytest -q cli/tests/test_guardrail.py` — **158 passed, 1 expected Windows-only skip**.
- `/Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/ruff check cli/defenseclaw/` — **passed**.
- `/Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/ruff check cli/tests/test_guardrail.py` — **passed**.
- `git diff --check` — **passed**.

Fixes #709
