### PR TITLE
fix(windows): stabilize committed Setup cleanup

### DIFF
--- a/cmd/defenseclaw-setup/transaction.go
+++ b/cmd/defenseclaw-setup/transaction.go
@@ -1857,23 +1857,23 @@ func finishCommittedSetupTransactionWith(
 	markComplete func(setupTransaction) error,
 ) (bool, error) {
 	if err := converge(transaction); err != nil {
-		return false, err
+		return false, fmt.Errorf("converge committed setup transaction: %w", err)
 	}
 	if err := markConverged(transaction); err != nil {
-		return false, err
+		return false, fmt.Errorf("record converged setup transaction: %w", err)
 	}
 	cleanupErr := cleanup(transaction)
 	restartRequired := errors.Is(cleanupErr, errUninstallCleanupRequiresRestart)
 	if cleanupErr != nil &&
 		!errors.Is(cleanupErr, errTransactionCleanupDeferred) &&
 		!restartRequired {
-		return false, cleanupErr
+		return false, fmt.Errorf("clean converged setup transaction: %w", cleanupErr)
 	}
 	if restartRequired {
 		return true, nil
 	}
 	if err := markComplete(transaction); err != nil {
-		return false, err
+		return false, fmt.Errorf("record completed setup transaction: %w", err)
 	}
 	return false, nil
 }
@@ -2970,6 +2970,29 @@ func loadTransactionInstallState(treeRoot string, transaction setupTransaction) 
 	)
 }
 
+// loadCommittedInstallStateForCleanup authenticates only the immutable state
+// path needed to prove ownership of the live install. Convergence has already
+// started the selected runtime before committed cleanup runs, so recursively
+// walking the entire published payload here races legitimate transient runtime
+// files. Destructive cleanup paths still call removeTransactionTree, which
+// retains the full-tree reparse check immediately before deletion.
+func loadCommittedInstallStateForCleanup(transaction setupTransaction) (*installState, error) {
+	statePath := filepath.Join(transaction.InstallRoot, "installer", "install-state.json")
+	if err := rejectReparseAncestors(statePath); err != nil {
+		return nil, fmt.Errorf("validate committed install state path %s: %w", statePath, err)
+	}
+	state, err := loadInstallStateFromTreeForRoots(
+		transaction.InstallRoot,
+		transaction.InstallRoot,
+		transaction.DataRoot,
+		transaction.MaintenancePath,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("read committed install state %s: %w", statePath, err)
+	}
+	return state, nil
+}
+
 func cleanupStagingTree(transaction setupTransaction) error {
 	if !pathExists(transaction.StagingPath) {
 		return nil
@@ -3183,7 +3206,7 @@ func cleanupCommittedSetupTransactionWithReconciliationReader(
 	readReconciliation func() (*connectorReconciliationState, error),
 ) error {
 	if transaction.Action == "install" {
-		state, err := loadTransactionInstallState(transaction.InstallRoot, transaction)
+		state, err := loadCommittedInstallStateForCleanup(transaction)
 		if err != nil {
 			return err
 		}
@@ -3191,12 +3214,12 @@ func cleanupCommittedSetupTransactionWithReconciliationReader(
 			return errors.New("committed install tree is not owned by the transaction")
 		}
 		if err := cleanupStagingTree(transaction); err != nil {
-			return err
+			return fmt.Errorf("clean committed staging path %s: %w", transaction.StagingPath, err)
 		}
 		if pathExists(transaction.BackupPath) {
 			backupState, err := loadTransactionInstallState(transaction.BackupPath, transaction)
 			if err != nil {
-				return err
+				return fmt.Errorf("validate committed backup path %s: %w", transaction.BackupPath, err)
 			}
 			// Committed cleanup may already have removed install-state.json before
 			// encountering a locked file. The committed marker authorizes finishing
@@ -3205,13 +3228,16 @@ func cleanupCommittedSetupTransactionWithReconciliationReader(
 				return errors.New("committed transaction backup does not match previous state")
 			}
 			if err := removeTransactionTree(transaction.BackupPath, filepath.Dir(transaction.InstallRoot)); err != nil {
-				return err
+				return fmt.Errorf("remove committed backup path %s: %w", transaction.BackupPath, err)
 			}
 		}
 		if err := removeTransactionPath(transaction.MaintenanceNew, filepath.Dir(transaction.MaintenancePath)); err != nil {
-			return err
+			return fmt.Errorf("remove committed maintenance staging path %s: %w", transaction.MaintenanceNew, err)
 		}
-		return removeTransactionPath(transaction.MaintenanceBackup, filepath.Dir(transaction.MaintenancePath))
+		if err := removeTransactionPath(transaction.MaintenanceBackup, filepath.Dir(transaction.MaintenancePath)); err != nil {
+			return fmt.Errorf("remove committed maintenance backup path %s: %w", transaction.MaintenanceBackup, err)
+		}
+		return nil
 	}
 	if pathExists(transaction.InstallRoot) {
 		state, err := loadTransactionInstallState(transaction.InstallRoot, transaction)

--- a/cmd/defenseclaw-setup/transaction_permissions_other_test.go
+++ b/cmd/defenseclaw-setup/transaction_permissions_other_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func denyTestDirectoryListing(t *testing.T, path string) func() {
+func installLivePayloadTraversalTrap(t *testing.T, _ string, path string) func() {
 	t.Helper()
 	if err := os.Chmod(path, 0); err != nil {
 		t.Fatal(err)

--- a/cmd/defenseclaw-setup/transaction_permissions_other_test.go
+++ b/cmd/defenseclaw-setup/transaction_permissions_other_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package main
+
+import (
+	"errors"
+	"os"
+	"sync"
+	"testing"
+)
+
+func denyTestDirectoryListing(t *testing.T, path string) func() {
+	t.Helper()
+	if err := os.Chmod(path, 0); err != nil {
+		t.Fatal(err)
+	}
+	var once sync.Once
+	restore := func() {
+		once.Do(func() {
+			if err := os.Chmod(path, 0o700); err != nil {
+				t.Errorf("restore test directory permissions: %v", err)
+			}
+		})
+	}
+	t.Cleanup(restore)
+	if _, err := os.ReadDir(path); err == nil {
+		restore()
+		t.Skip("test process can bypass directory permissions")
+	} else if !errors.Is(err, os.ErrPermission) {
+		restore()
+		t.Fatalf("inaccessible directory read error = %v, want permission denied", err)
+	}
+	return restore
+}

--- a/cmd/defenseclaw-setup/transaction_permissions_windows_test.go
+++ b/cmd/defenseclaw-setup/transaction_permissions_windows_test.go
@@ -6,92 +6,64 @@
 package main
 
 import (
-	"errors"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
-
-	"github.com/defenseclaw/defenseclaw/internal/winpath"
-	"golang.org/x/sys/windows"
 )
 
-func denyTestDirectoryListing(t *testing.T, path string) func() {
+func installLivePayloadTraversalTrap(t *testing.T, installRoot, path string) func() {
 	t.Helper()
-	extended, err := winpath.Extended(path)
-	if err != nil {
+	target := t.TempDir()
+	sentinelPath := filepath.Join(target, "sentinel")
+	if err := os.WriteFile(sentinelPath, []byte("runtime-target"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	descriptor, err := windows.GetNamedSecurityInfo(
-		extended,
-		windows.SE_FILE_OBJECT,
-		windows.DACL_SECURITY_INFORMATION,
-	)
+	trapPath := filepath.Join(path, "trap")
+	output, err := exec.Command(
+		"cmd.exe", "/D", "/C", "mklink", "/J", trapPath, target,
+	).CombinedOutput()
 	if err != nil {
-		t.Fatalf("capture test directory DACL: %v", err)
-	}
-	originalDACL, _, err := descriptor.DACL()
-	if err != nil || originalDACL == nil {
-		t.Fatalf("capture test directory DACL entries: %v", err)
-	}
-	control, _, err := descriptor.Control()
-	if err != nil {
-		t.Fatalf("capture test directory DACL control: %v", err)
-	}
-	user, err := windows.GetCurrentProcessToken().GetTokenUser()
-	if err != nil || user == nil || user.User.Sid == nil {
-		t.Fatalf("resolve current Windows user: %v", err)
-	}
-	deniedDACL, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
-		AccessPermissions: windows.FILE_LIST_DIRECTORY,
-		AccessMode:        windows.DENY_ACCESS,
-		Inheritance:       windows.NO_INHERITANCE,
-		Trustee: windows.TRUSTEE{
-			TrusteeForm:  windows.TRUSTEE_IS_SID,
-			TrusteeType:  windows.TRUSTEE_IS_USER,
-			TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid),
-		},
-	}}, originalDACL)
-	if err != nil {
-		t.Fatalf("build access-denied test DACL: %v", err)
-	}
-	if err := windows.SetNamedSecurityInfo(
-		extended,
-		windows.SE_FILE_OBJECT,
-		windows.DACL_SECURITY_INFORMATION,
-		nil,
-		nil,
-		deniedDACL,
-		nil,
-	); err != nil {
-		t.Fatalf("apply access-denied test DACL: %v", err)
+		t.Fatalf("create live-runtime reparse trap: %v\n%s", err, output)
 	}
 
 	var once sync.Once
 	restore := func() {
 		once.Do(func() {
-			securityInformation := windows.SECURITY_INFORMATION(windows.DACL_SECURITY_INFORMATION)
-			if control&windows.SE_DACL_PROTECTED != 0 {
-				securityInformation |= windows.PROTECTED_DACL_SECURITY_INFORMATION
-			} else {
-				securityInformation |= windows.UNPROTECTED_DACL_SECURITY_INFORMATION
+			reparse, err := isReparsePoint(trapPath)
+			if err != nil {
+				t.Errorf("inspect preserved live-runtime reparse trap: %v", err)
+			} else if !reparse {
+				t.Errorf("live-runtime reparse trap was removed or replaced")
 			}
-			if err := windows.SetNamedSecurityInfo(
-				extended,
-				windows.SE_FILE_OBJECT,
-				securityInformation,
-				nil,
-				nil,
-				originalDACL,
-				nil,
-			); err != nil {
-				t.Errorf("restore test directory DACL: %v", err)
+			data, err := os.ReadFile(filepath.Join(trapPath, "sentinel"))
+			if err != nil {
+				t.Errorf("read preserved live-runtime reparse target: %v", err)
+			} else if string(data) != "runtime-target" {
+				t.Errorf("live-runtime reparse target = %q, want runtime-target", data)
+			}
+			if err := os.Remove(trapPath); err != nil && !os.IsNotExist(err) {
+				t.Errorf("remove live-runtime reparse trap: %v", err)
 			}
 		})
 	}
 	t.Cleanup(restore)
-	if _, err := os.ReadDir(path); !errors.Is(err, os.ErrPermission) {
+
+	reparse, err := isReparsePoint(trapPath)
+	if err != nil {
 		restore()
-		t.Fatalf("access-denied directory read error = %v, want permission denied", err)
+		t.Fatalf("inspect live-runtime reparse trap: %v", err)
+	}
+	if !reparse {
+		restore()
+		t.Fatal("live-runtime traversal trap is not a reparse point")
+	}
+	if err := rejectReparseTree(installRoot); err == nil ||
+		!strings.Contains(err.Error(), "transaction tree contains a reparse point") {
+		restore()
+		t.Fatalf("legacy full-tree validation error = %v, want reparse rejection", err)
 	}
 	return restore
 }

--- a/cmd/defenseclaw-setup/transaction_permissions_windows_test.go
+++ b/cmd/defenseclaw-setup/transaction_permissions_windows_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/winpath"
+	"golang.org/x/sys/windows"
+)
+
+func denyTestDirectoryListing(t *testing.T, path string) func() {
+	t.Helper()
+	extended, err := winpath.Extended(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor, err := windows.GetNamedSecurityInfo(
+		extended,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		t.Fatalf("capture test directory DACL: %v", err)
+	}
+	originalDACL, _, err := descriptor.DACL()
+	if err != nil || originalDACL == nil {
+		t.Fatalf("capture test directory DACL entries: %v", err)
+	}
+	control, _, err := descriptor.Control()
+	if err != nil {
+		t.Fatalf("capture test directory DACL control: %v", err)
+	}
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil || user == nil || user.User.Sid == nil {
+		t.Fatalf("resolve current Windows user: %v", err)
+	}
+	deniedDACL, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
+		AccessPermissions: windows.FILE_LIST_DIRECTORY,
+		AccessMode:        windows.DENY_ACCESS,
+		Inheritance:       windows.NO_INHERITANCE,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  windows.TRUSTEE_IS_USER,
+			TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid),
+		},
+	}}, originalDACL)
+	if err != nil {
+		t.Fatalf("build access-denied test DACL: %v", err)
+	}
+	if err := windows.SetNamedSecurityInfo(
+		extended,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		deniedDACL,
+		nil,
+	); err != nil {
+		t.Fatalf("apply access-denied test DACL: %v", err)
+	}
+
+	var once sync.Once
+	restore := func() {
+		once.Do(func() {
+			securityInformation := windows.SECURITY_INFORMATION(windows.DACL_SECURITY_INFORMATION)
+			if control&windows.SE_DACL_PROTECTED != 0 {
+				securityInformation |= windows.PROTECTED_DACL_SECURITY_INFORMATION
+			} else {
+				securityInformation |= windows.UNPROTECTED_DACL_SECURITY_INFORMATION
+			}
+			if err := windows.SetNamedSecurityInfo(
+				extended,
+				windows.SE_FILE_OBJECT,
+				securityInformation,
+				nil,
+				nil,
+				originalDACL,
+				nil,
+			); err != nil {
+				t.Errorf("restore test directory DACL: %v", err)
+			}
+		})
+	}
+	t.Cleanup(restore)
+	if _, err := os.ReadDir(path); !errors.Is(err, os.ErrPermission) {
+		restore()
+		t.Fatalf("access-denied directory read error = %v, want permission denied", err)
+	}
+	return restore
+}

--- a/cmd/defenseclaw-setup/transaction_test.go
+++ b/cmd/defenseclaw-setup/transaction_test.go
@@ -324,16 +324,18 @@ func TestCommittedInstallCleanupDoesNotTraverseLivePayload(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(volatileRuntime, "ephemeral"), []byte("runtime-owned"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(volatileRuntime, 0); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(volatileRuntime, 0o700) })
+	restoreRuntimeAccess := denyTestDirectoryListing(t, volatileRuntime)
 
 	if err := cleanupCommittedSetupTransaction(transaction); err != nil {
 		t.Fatalf("cleanup traversed an unrelated live-runtime subtree: %v", err)
 	}
-	if err := os.Chmod(volatileRuntime, 0o700); err != nil {
-		t.Fatal(err)
+	restoreRuntimeAccess()
+	entries, err := os.ReadDir(volatileRuntime)
+	if err != nil {
+		t.Fatalf("read restored live-runtime subtree: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "ephemeral" {
+		t.Fatalf("restored live-runtime subtree entries = %v, want ephemeral", entries)
 	}
 	assertInstallVersion(t, installRoot, transaction, transaction.TargetVersion)
 }

--- a/cmd/defenseclaw-setup/transaction_test.go
+++ b/cmd/defenseclaw-setup/transaction_test.go
@@ -324,7 +324,7 @@ func TestCommittedInstallCleanupDoesNotTraverseLivePayload(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(volatileRuntime, "ephemeral"), []byte("runtime-owned"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	restoreRuntimeAccess := denyTestDirectoryListing(t, volatileRuntime)
+	restoreRuntimeAccess := installLivePayloadTraversalTrap(t, installRoot, volatileRuntime)
 
 	if err := cleanupCommittedSetupTransaction(transaction); err != nil {
 		t.Fatalf("cleanup traversed an unrelated live-runtime subtree: %v", err)

--- a/cmd/defenseclaw-setup/transaction_test.go
+++ b/cmd/defenseclaw-setup/transaction_test.go
@@ -307,6 +307,102 @@ func TestCommittedInstallCleanupPreservesNewTreeAndRemovesArtifacts(t *testing.T
 	}
 }
 
+func TestCommittedInstallCleanupDoesNotTraverseLivePayload(t *testing.T) {
+	installRoot, dataRoot, maintenancePath := testTransactionRoots(t)
+	transaction := testSetupTransactionForRoots("install", installRoot, dataRoot, maintenancePath, nil)
+	writeInstallTree(t, installRoot, testInstallState(
+		installRoot,
+		dataRoot,
+		maintenancePath,
+		transaction.ID,
+		transaction.TargetVersion,
+	))
+	volatileRuntime := filepath.Join(installRoot, "runtime", "volatile")
+	if err := os.MkdirAll(volatileRuntime, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(volatileRuntime, "ephemeral"), []byte("runtime-owned"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(volatileRuntime, 0); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(volatileRuntime, 0o700) })
+
+	if err := cleanupCommittedSetupTransaction(transaction); err != nil {
+		t.Fatalf("cleanup traversed an unrelated live-runtime subtree: %v", err)
+	}
+	if err := os.Chmod(volatileRuntime, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	assertInstallVersion(t, installRoot, transaction, transaction.TargetVersion)
+}
+
+func TestFinishCommittedSetupTransactionLabelsTerminalOperation(t *testing.T) {
+	wantErr := errors.New("file does not exist")
+	tests := []struct {
+		name          string
+		wantOperation string
+		converge      func(setupTransaction) error
+		markConverged func(setupTransaction) error
+		cleanup       func(setupTransaction) error
+		markComplete  func(setupTransaction) error
+	}{
+		{
+			name:          "convergence",
+			wantOperation: "converge committed setup transaction",
+			converge:      func(setupTransaction) error { return wantErr },
+		},
+		{
+			name:          "converged journal",
+			wantOperation: "record converged setup transaction",
+			markConverged: func(setupTransaction) error { return wantErr },
+		},
+		{
+			name:          "cleanup",
+			wantOperation: "clean converged setup transaction",
+			cleanup:       func(setupTransaction) error { return wantErr },
+		},
+		{
+			name:          "terminal journal",
+			wantOperation: "record completed setup transaction",
+			markComplete:  func(setupTransaction) error { return wantErr },
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			noError := func(setupTransaction) error { return nil }
+			converge := test.converge
+			if converge == nil {
+				converge = noError
+			}
+			markConverged := test.markConverged
+			if markConverged == nil {
+				markConverged = noError
+			}
+			cleanup := test.cleanup
+			if cleanup == nil {
+				cleanup = noError
+			}
+			markComplete := test.markComplete
+			if markComplete == nil {
+				markComplete = noError
+			}
+
+			_, err := finishCommittedSetupTransactionWith(
+				setupTransaction{},
+				converge,
+				markConverged,
+				cleanup,
+				markComplete,
+			)
+			if !errors.Is(err, wantErr) || !strings.Contains(err.Error(), test.wantOperation) {
+				t.Fatalf("error = %v, want wrapped %q", err, test.wantOperation)
+			}
+		})
+	}
+}
+
 func TestCommittedUninstallCleanupConvergesAfterRename(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows delayed maintenance-cache cleanup")


### PR DESCRIPTION
Base note: this three-commit fix is based on `main` at `9436470a6abb914c0dfcaec8305ea59a4f968c2f`. The exact reviewed head is `e6b1dac1a12f54041c3d8cd95c950809ec6d3a90` (tree `ef92057cc7858d84894aa209126b2a8a7dda5d4c`). The final commit is test-only and replaces an environment-dependent Windows ACL fixture with a deterministic directory-junction traversal trap.

## Problem

Native Windows Setup could publish and start a valid installation, record the transaction as converged, and then exit `1603` during terminal cleanup with only `file does not exist`. The application, configuration, and running gateway were already present.

Fixes #711.

## Current Situation

Committed install cleanup used the general transaction-tree state loader on the live install root. That loader recursively validates the entire published payload before reading `installer/install-state.json`.

The recursive walk is required immediately before deleting staging or backup trees. It is not appropriate when authenticating a live tree that the newly started runtime may legitimately mutate. A transient runtime entry disappearing during that redundant walk can return `fs.ErrNotExist` after convergence already succeeded.

```mermaid
flowchart LR
    A["Publish install"] --> B["Start runtime"]
    B --> C["Record converged journal"]
    C --> D["Old: recursively walk live payload"]
    D -->|"runtime entry changes"| E["Setup exits 1603"]
    C --> F["New: authenticate fixed install-state path"]
    F --> G["Validate roots and transaction ownership"]
    G --> H["Recursively validate only trees being deleted"]
    H --> I["Record completed journal"]
```

## Solution

### Authenticate the immutable committed-state path

Committed cleanup now validates and reads only `<validated InstallRoot>/installer/install-state.json`. The fixed path still receives reparse-ancestor rejection, strict JSON decoding, native-install schema/root validation, and exact transaction-ID ownership checks.

### Preserve destructive cleanup boundaries

No deletion boundary is weakened. Staging and backup deletion still perform full-tree reparse validation immediately before bounded removal. Maintenance artifacts and uninstall cleanup retain their existing symlink, root, and reparse protections.

### Make terminal failures actionable

Convergence, converged-journal, cleanup, and completed-journal failures now identify the exact operation. Cleanup errors include the concrete staging, backup, or maintenance path while preserving wrapped error identity for `errors.Is`.

### Prove Windows no-traversal behavior deterministically

The Windows regression creates a live-runtime directory junction to a separate sentinel target. It proves the legacy full-tree validator rejects that active reparse point, then proves committed cleanup succeeds without traversing or removing it. The test verifies the junction and sentinel remain, removes only the junction, and verifies the unrelated runtime payload and install state remain. This avoids ACL behavior that can be bypassed by elevated tokens with backup privileges.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `cmd/defenseclaw-setup/transaction.go` | Adds fixed-path committed-state authentication, keeps recursive validation on destructive trees, and adds bounded terminal operation/path context |
| `cmd/defenseclaw-setup/transaction_test.go` | Adds live-runtime no-traversal/preservation and terminal-operation regressions |
| `cmd/defenseclaw-setup/transaction_permissions_windows_test.go` | Uses a deterministic Windows directory-junction traversal trap and guarded junction-only cleanup |
| `cmd/defenseclaw-setup/transaction_permissions_other_test.go` | Preserves the POSIX denied-listing fixture with honest capability-bypass skipping |

## Breaking Changes

None. Setup remains fail-closed when ownership, roots, state, reparse validation, or cleanup actually fail. Only the redundant traversal of an already-published live runtime tree is removed.

## Open Issues / Follow-ups

None.

## Test Plan

### Exact frozen identity

- Head: `e6b1dac1a12f54041c3d8cd95c950809ec6d3a90`
- Parent-to-head test-only delta: 3 files, `+40/-68`
- Parent-to-head plain binary SHA-256: `3b77014344a1b9d4cab45eae4dccc3fdc88921e9bb80a9cbad9a49a796c787f5`
- Parent-to-head full-index SHA-256: `90b9977ee1f8f07d9f9f1f332a50281cd7f8447f6fc0d5450ce8838d2ea1fdd9`
- Full base-to-head full-index SHA-256: `05530ae7cfb14c0baf15ecb9d19ff3d024dda25ecf2e5eaa0eefd4e374435ce5`
- Independent source audit: CLEAN; local CodeRabbit on the exact final delta: 0 findings.

### Native Windows

```bash
go test ./cmd/defenseclaw-setup -run '^TestCommittedInstallCleanupDoesNotTraverseLivePayload$' -count=50
go test ./cmd/defenseclaw-setup -run '<11 cleanup/terminal tests>' -count=20
go test ./cmd/defenseclaw-setup -run '<5 reparse tests>' -count=10
go test ./cmd/defenseclaw-setup -count=1 -timeout=20m
go vet ./cmd/defenseclaw-setup
go build ./cmd/defenseclaw-setup
```

Results on the exact head:

- Junction regression: 50 RUN / 50 PASS / 0 FAIL / 0 SKIP in `2.827s`.
- Cleanup/terminal matrix: 220 RUN / 220 PASS / 0 FAIL / 0 SKIP in `13.578s`.
- Reparse matrix: 50 RUN / 50 PASS / 0 FAIL / 0 SKIP in `3.557s`.
- Full Setup package: PASS in `29.851s`; 336 passed, 1 expected elevated-session skip, 0 failed.
- Vet: PASS in `3.071s`.
- Windows GUI Setup build: PASS in `9.738s`; SHA-256 `4e04625b…da76`.
- Native race was not runnable because the connected host has no C compiler; a compile-only probe failed before tests with `C compiler "gcc" not found`. Local and connected Linux/macOS race gates passed.

Every focused Windows pass creates and identifies the junction, proves the legacy full-tree validator rejects it, proves production cleanup succeeds while it remains active, verifies junction/sentinel preservation, removes only the junction, and verifies the unrelated runtime payload and install state remain.

### Connected Linux and macOS hosts

| Host | Focused ×20 | Full package | Race | Vet | Native build |
|---|---:|---:|---:|---:|---:|
| Ubuntu 24.04.4 ARM64, Go 1.26.4 | PASS, 11s | PASS, 1s | PASS, 18s | PASS, 1s | PASS, 8s |
| macOS 26.3.1 Apple M4 ARM64, Go 1.26.5 | PASS, 4s | PASS, 2s | PASS, 7s | PASS, 1s | PASS, 3s |

Both non-root hosts recorded 20/20 affirmative denied-listing runs with zero skips, reproduced both supplied full-index hashes, stayed source-clean, and removed their disposable roots. Native artifact SHA-256 values were `1747c237…80d` (Linux) and `b4f0764b…6b4` (macOS).

### Local and static gates

```bash
go test ./cmd/defenseclaw-setup -count=50
go test -race ./cmd/defenseclaw-setup -count=20
GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go vet ./cmd/defenseclaw-setup
GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c ./cmd/defenseclaw-setup
gofmt -w cmd/defenseclaw-setup/transaction*.go
git diff --check 9436470a6abb914c0dfcaec8305ea59a4f968c2f..HEAD
```

Results: PASS. Full owning-package normal/race, focused repeated/race, vet, Windows cross-compile, formatting, diff, and immutable identity gates are green.
