### PR TITLE
fix(managed): inspect provider-native top-level prompts

### DIFF
--- a/internal/gateway/guardrail.go
+++ b/internal/gateway/guardrail.go
@@ -591,7 +591,11 @@ func (g *GuardrailInspector) Inspect(ctx context.Context, direction, content str
 		// the sole decision-maker. Local regex, judge, and OPA are all
 		// skipped; a request AID cannot decide fails open. See
 		// inspectManagedAIDOnly.
-		verdict = g.inspectManagedAIDOnly(ctx, direction, messages)
+		verdict = g.inspectManagedAIDOnly(
+			ctx,
+			direction,
+			managedAIDMessagesForInspection(direction, content, messages),
+		)
 	case strategy == "regex_judge":
 		verdict = g.inspectRegexJudge(ctx, direction, content, messages, model, mode)
 	case strategy == "judge_first":
@@ -709,6 +713,27 @@ func managedAIDMessagesHaveInspectableContent(messages []ChatMessage) bool {
 		}
 	}
 	return false
+}
+
+// managedAIDMessagesForInspection closes the gap between provider-native
+// prompt formats and the canonical message payload sent to Cisco AI Defense.
+// Passthrough routes expose top-level prompt text through content, while both
+// Cisco clients serialize only ChatMessage.Content. When no existing message
+// has serializable text, preserve the original history and append one user
+// turn carrying that prompt. Existing chat history is already authoritative
+// and must not receive a duplicate; blank prompts keep the benign no_content
+// path. Completion/response payloads are normalized to one assistant message
+// before this helper runs and are intentionally left alone.
+func managedAIDMessagesForInspection(direction, content string, messages []ChatMessage) []ChatMessage {
+	if direction != "prompt" ||
+		!managedAIDContentIsInspectable(content) ||
+		managedAIDMessagesHaveInspectableContent(messages) {
+		return messages
+	}
+
+	normalized := make([]ChatMessage, len(messages), len(messages)+1)
+	copy(normalized, messages)
+	return append(normalized, ChatMessage{Role: "user", Content: content})
 }
 
 // managedAIDFailOpenComponent is the stable diagnostic component / message

--- a/internal/gateway/managed_aid_only_test.go
+++ b/internal/gateway/managed_aid_only_test.go
@@ -18,8 +18,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -158,6 +160,207 @@ func TestProxyManagedAIDOnly_ReturnsAIDVerdict(t *testing.T) {
 	}
 	if stub.calls != 1 {
 		t.Fatalf("expected AID consulted once, got %d calls", stub.calls)
+	}
+}
+
+func TestHandlePassthrough_ManagedAIDInspectsProviderNativeTopLevelPrompts(t *testing.T) {
+	var forwarded atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		forwarded.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"unexpected-forward","object":"response","status":"completed"}`))
+	}))
+	defer upstream.Close()
+
+	target, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+	registerProviderDomainForTest(t, target.Hostname(), "openai")
+
+	tests := []struct {
+		name string
+		path string
+		body string
+		want string
+	}{
+		{
+			name: "OpenAI Responses string input",
+			path: "/v1/responses",
+			body: `{"model":"gpt-4.1","input":"responses native prompt"}`,
+			want: "responses native prompt",
+		},
+		{
+			name: "Ollama top-level prompt",
+			path: "/api/generate",
+			body: `{"model":"llama3.2","prompt":"ollama native prompt"}`,
+			want: "ollama native prompt",
+		},
+		{
+			name: "system-only provider request",
+			path: "/v1/messages",
+			body: `{"model":"claude-sonnet-4","system":"system-only native prompt"}`,
+			want: "system-only native prompt",
+		},
+		{
+			name: "OpenAI Responses instructions-only request",
+			path: "/v1/responses",
+			body: `{"model":"gpt-4.1","instructions":"responses instructions prompt"}`,
+			want: "responses instructions prompt",
+		},
+		{
+			name: "Gemini systemInstruction-only request",
+			path: "/v1beta/models/gemini-2.5-pro:generateContent",
+			body: `{"model":"gemini-2.5-pro","systemInstruction":{"parts":[{"text":"gemini system prompt"}]}}`,
+			want: "gemini system prompt",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &stubAIDInspector{verdict: blockVerdict()}
+			guardrail := NewGuardrailInspector("both", nil, nil, "")
+			guardrail.SetManagedMode(true)
+			guardrail.SetCiscoInspector(stub)
+			proxy := newTestProxy(t, &mockProvider{}, guardrail, "action")
+
+			before := forwarded.Load()
+			req := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-DC-Target-URL", upstream.URL)
+			req.Header.Set("X-AI-Auth", "Bearer inert-upstream-token")
+			req.RemoteAddr = "127.0.0.1:12345"
+			rec := httptest.NewRecorder()
+
+			proxy.handlePassthrough(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want managed block response 200; body=%s", rec.Code, rec.Body.String())
+			}
+			if stub.calls != 1 {
+				t.Fatalf("AID calls = %d, want exactly 1", stub.calls)
+			}
+			wantMessages := []ChatMessage{{Role: "user", Content: tc.want}}
+			if !reflect.DeepEqual(stub.messages, wantMessages) {
+				t.Fatalf("AID messages = %#v, want %#v", stub.messages, wantMessages)
+			}
+			if got := forwarded.Load(); got != before {
+				t.Fatalf("upstream calls advanced from %d to %d despite managed block", before, got)
+			}
+		})
+	}
+}
+
+func TestProxyManagedAIDOnly_NormalizesTopLevelPromptContent(t *testing.T) {
+	tests := []struct {
+		name       string
+		aidVerdict *ScanVerdict
+		wantAction string
+	}{
+		{name: "allow remains allow", aidVerdict: allowVerdict("ai-defense"), wantAction: "allow"},
+		{name: "block remains block", aidVerdict: blockVerdict(), wantAction: "block"},
+		{name: "unavailable remains fail open", wantAction: "allow"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &stubAIDInspector{verdict: tc.aidVerdict}
+			guardrail := NewGuardrailInspector("both", nil, nil, "")
+			guardrail.SetManagedMode(true)
+			guardrail.SetCiscoInspector(stub)
+
+			verdict := guardrail.Inspect(
+				t.Context(), "prompt", "provider-native prompt", nil, "provider/model", "action",
+			)
+			if verdict == nil || verdict.Action != tc.wantAction {
+				t.Fatalf("verdict = %+v, want action %q", verdict, tc.wantAction)
+			}
+			if stub.calls != 1 {
+				t.Fatalf("AID calls = %d, want 1", stub.calls)
+			}
+			wantMessages := []ChatMessage{{Role: "user", Content: "provider-native prompt"}}
+			if !reflect.DeepEqual(stub.messages, wantMessages) {
+				t.Fatalf("AID messages = %#v, want %#v", stub.messages, wantMessages)
+			}
+		})
+	}
+}
+
+func TestProxyManagedAIDOnly_PreservesHistoryWithoutDuplication(t *testing.T) {
+	t.Run("serializable history is authoritative", func(t *testing.T) {
+		original := []ChatMessage{
+			{Role: "system", Content: "system context"},
+			{Role: "assistant", Content: "prior answer"},
+			{Role: "user", Content: "current prompt"},
+		}
+		stub := &stubAIDInspector{verdict: blockVerdict()}
+		guardrail := NewGuardrailInspector("both", nil, nil, "")
+		guardrail.SetManagedMode(true)
+		guardrail.SetCiscoInspector(stub)
+
+		verdict := guardrail.Inspect(
+			t.Context(), "prompt", "current prompt", original, "provider/model", "action",
+		)
+		if verdict == nil || verdict.Action != "block" {
+			t.Fatalf("verdict = %+v, want block", verdict)
+		}
+		if stub.calls != 1 {
+			t.Fatalf("AID calls = %d, want 1", stub.calls)
+		}
+		if !reflect.DeepEqual(stub.messages, original) {
+			t.Fatalf("AID messages = %#v, want original history %#v", stub.messages, original)
+		}
+	})
+
+	t.Run("unserializable history is retained before synthetic turn", func(t *testing.T) {
+		original := []ChatMessage{{
+			Role:       "assistant",
+			Content:    " \t",
+			RawContent: json.RawMessage(`[{"type":"image_url"}]`),
+			ToolCalls:  json.RawMessage(`[{"id":"call-1"}]`),
+		}}
+		before := append([]ChatMessage(nil), original...)
+		stub := &stubAIDInspector{verdict: blockVerdict()}
+		guardrail := NewGuardrailInspector("both", nil, nil, "")
+		guardrail.SetManagedMode(true)
+		guardrail.SetCiscoInspector(stub)
+
+		verdict := guardrail.Inspect(
+			t.Context(), "prompt", "provider-native prompt", original, "provider/model", "action",
+		)
+		if verdict == nil || verdict.Action != "block" {
+			t.Fatalf("verdict = %+v, want block", verdict)
+		}
+		wantMessages := append(before, ChatMessage{Role: "user", Content: "provider-native prompt"})
+		if !reflect.DeepEqual(stub.messages, wantMessages) {
+			t.Fatalf("AID messages = %#v, want preserved history plus synthetic turn %#v", stub.messages, wantMessages)
+		}
+		if !reflect.DeepEqual(original, before) {
+			t.Fatalf("caller messages mutated: got %#v, want %#v", original, before)
+		}
+	})
+}
+
+func TestProxyManagedAIDOnly_CompletionRemainsAssistantOnly(t *testing.T) {
+	stub := &stubAIDInspector{verdict: blockVerdict()}
+	guardrail := NewGuardrailInspector("both", nil, nil, "")
+	guardrail.SetManagedMode(true)
+	guardrail.SetCiscoInspector(stub)
+
+	verdict := guardrail.Inspect(
+		t.Context(),
+		"completion",
+		"provider response",
+		[]ChatMessage{{Role: "user", Content: "prior prompt"}},
+		"provider/model",
+		"action",
+	)
+	if verdict == nil || verdict.Action != "block" {
+		t.Fatalf("verdict = %+v, want block", verdict)
+	}
+	wantMessages := []ChatMessage{{Role: "assistant", Content: "provider response"}}
+	if !reflect.DeepEqual(stub.messages, wantMessages) {
+		t.Fatalf("AID messages = %#v, want assistant-only payload %#v", stub.messages, wantMessages)
 	}
 }
 
@@ -1566,6 +1769,12 @@ func TestProxyManagedAIDOnly_BlankMessagePayloadsRecordNoContent(t *testing.T) {
 				{Role: "user", Content: "\r\n"},
 			},
 			wired: true,
+		},
+		{
+			name:      "unicode-whitespace-only top-level prompt",
+			direction: "prompt",
+			content:   "\u00a0\u2003",
+			wired:     true,
 		},
 		{
 			name:      "whitespace-only completion rewritten to assistant message",


### PR DESCRIPTION
Base note: this is a single-commit change based on `main` at `9436470a6abb914c0dfcaec8305ea59a4f968c2f`. The reviewed head is `e8aec08e7864ffe7d9d0152c576f5944d92c0266` (tree `b604ad49ce5185086f3d2e859e3e41560467b720`).

Fixes #712.

## Problem

Several provider-native request formats carry their effective prompt in a top-level field while leaving the canonical chat-message slice empty. In managed mode, the gateway previously sent only that empty slice to Cisco AI Defense. The managed inspector therefore returned the benign `no_content` outcome without making an AID request, and the gateway forwarded a prompt that had never been inspected.

The bypass was reproducible through real passthrough routes for:

- OpenAI Responses string `input`;
- Ollama top-level `prompt`;
- string-valued provider `system` content;
- OpenAI Responses `instructions` without an input message; and
- Gemini `systemInstruction` without a content message.

## Current Situation

The route extractor already makes these provider-native prompt values available as the `content` argument passed to `GuardrailInspector.Inspect`. Both managed Cisco inspection clients, however, serialize only `ChatMessage.Content`. Before this change, managed mode discarded the extracted top-level prompt at that boundary whenever `messages` contained no serializable text.

```mermaid
flowchart LR
    A[Provider-native request] --> B[Route extracts top-level prompt]
    B --> C[GuardrailInspector content]
    A --> D[Empty or metadata-only messages]
    D --> E[Managed AID client]
    E --> F[no_content; no AID call]
    F --> G[Request forwarded uninspected]
```

## Solution

### Normalize at the managed inspection boundary

When the direction is `prompt`, the extracted top-level content is non-blank, and no existing message has serializable content, the guardrail now copies the caller-owned history and appends one synthetic user message containing the extracted prompt. The normalized message list is then passed to the existing managed AID-only inspector.

```mermaid
flowchart LR
    A[Provider-native request] --> B[Existing route extraction]
    B --> C{Managed prompt has inspectable message content?}
    C -->|Yes| D[Use existing history unchanged]
    C -->|No, top-level prompt is non-blank| E[Copy history and append one user message]
    D --> F[Cisco AI Defense inspection]
    E --> F
    F -->|Block| G[Stop before upstream]
    F -->|Allow or documented fail-open| H[Continue existing flow]
```

### Preserve existing managed and unmanaged semantics

- Existing inspectable chat history remains authoritative and is never duplicated.
- Metadata-only history is retained before the synthetic user turn.
- Empty and Unicode-whitespace-only prompts retain the benign `no_content` behavior and make no AID call.
- Completion/response inspection remains a single assistant message.
- Managed `inspector_unwired` and `aid_unavailable` fail-open behavior is unchanged.
- Unmanaged regex, judge, OPA, and passthrough behavior is untouched.
- The caller's message slice is never mutated.

## What Changed (Where & How)

| Path | Change |
| --- | --- |
| `internal/gateway/guardrail.go` | Normalizes provider-native top-level prompt text into a copied managed-inspection message list only when no existing message has inspectable content. |
| `internal/gateway/managed_aid_only_test.go` | Adds real-route enforcement regressions for five provider-native shapes plus direct boundary coverage for allow/block, fail-open, whitespace, history preservation, caller ownership, and completion semantics. |

## Breaking Changes

Managed provider-native prompts that previously bypassed AID with `no_content` can now be blocked by Cisco AI Defense. This is the intended security enforcement change.

There are no configuration, API, schema, storage, or operator-workflow changes. Unmanaged behavior is unchanged.

## Open Issues / Follow-ups

- #717 — [Inspect structured system-only chat prompts](https://github.com/cisco-ai-defense/defenseclaw/issues/717).
- #718 — [Inspect Ollama prompt when system and prompt coexist](https://github.com/cisco-ai-defense/defenseclaw/issues/718).

## Test Plan

Regression-first proof:

- Before the production change, the new real-route test reproduced the bypass: each affected request produced `no_content`, made zero AID calls, and reached the upstream handler.
- After the production change, all five routes send exactly one inspectable user message to AID; the blocking fixture prevents every upstream call.

Validation on the exact reviewed tree:

- `go test ./internal/gateway -run 'TestHandlePassthrough_ManagedAIDInspectsProviderNativeTopLevelPrompts|TestProxyManagedAIDOnly_(NormalizesTopLevelPromptContent|PreservesHistoryWithoutDuplication|CompletionRemainsAssistantOnly)' -count=20` — PASS (`ok`, 6.072s).
- Managed/passthrough owning regression selection — PASS (`ok`, 9.053s).
- `go test -race ./internal/gateway -count=1` — PASS (`ok`, 1468.514s).
- `go test ./... -count=1` — PASS (all packages; representative timings: `internal/gateway` 411.247s, `internal/gateway/connector` 210.412s, `internal/audit` 214.576s, `test/e2e` 36.693s).
- `go vet ./...` — PASS.
- Linux/amd64 gateway test-binary compile — PASS.
- Windows/amd64 gateway test-binary compile — PASS.
- `gofmt` and `git diff --check` — PASS.
- Independent exact-diff security review — CLEAN, no actionable finding.

Immutable review ledger:

- Base: `9436470a6abb914c0dfcaec8305ea59a4f968c2f`
- Head: `e8aec08e7864ffe7d9d0152c576f5944d92c0266`
- Tree: `b604ad49ce5185086f3d2e859e3e41560467b720`
- `git diff HEAD^ HEAD --binary --no-ext-diff` SHA-256: `3957be6156bf969e10bd266f20d5f12c73451b808655efa5bbc7814976a8b4c4`
- `git diff HEAD^ HEAD --binary --full-index --no-ext-diff` SHA-256: `3799e152a8208d4f41956e5d1d06f6ba9bf296f67c55fbbd8d5d83f23926b487`
- Diff stat: 2 files changed, 235 insertions, 1 deletion.
