### PR TITLE
fix(ci): isolate persistent E2E source installs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,7 +73,10 @@ jobs:
     steps:
       - name: Select isolated DefenseClaw home
         run: |
-          E2E_INSTALL_HOME="${RUNNER_TEMP}/${E2E_INSTALL_NAME}"
+          # RUNNER_TEMP is emptied by the Actions runner before each job. Keep
+          # marker-authenticated crash recovery beside the checkout instead so
+          # our own helper controls repair and retirement on the next schedule.
+          E2E_INSTALL_HOME="${RUNNER_WORKSPACE}/${E2E_INSTALL_NAME}"
           {
             echo "E2E_INSTALL_HOME=${E2E_INSTALL_HOME}"
             echo "DEFENSECLAW_HOME=${E2E_INSTALL_HOME}/.defenseclaw"
@@ -729,7 +732,10 @@ jobs:
     steps:
       - name: Select isolated DefenseClaw home
         run: |
-          E2E_INSTALL_HOME="${RUNNER_TEMP}/${E2E_INSTALL_NAME}"
+          # RUNNER_TEMP is emptied by the Actions runner before each job. Keep
+          # marker-authenticated crash recovery beside the checkout instead so
+          # our own helper controls repair and retirement on the next schedule.
+          E2E_INSTALL_HOME="${RUNNER_WORKSPACE}/${E2E_INSTALL_NAME}"
           {
             echo "E2E_INSTALL_HOME=${E2E_INSTALL_HOME}"
             echo "DEFENSECLAW_HOME=${E2E_INSTALL_HOME}/.defenseclaw"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,11 +5,11 @@ on:
     - cron: "0 7 * * *"
 
 concurrency:
-  # Pull-request E2E runs share a scarce self-hosted runner. Keep them queued
-  # rather than canceling an in-flight PR job when another stacked PR updates or
-  # is rerun; branch/manual/scheduled runs still collapse to the newest ref.
+  # The schedule uses two stable, marker-owned slots on a persistent runner.
+  # Preserve the active execution when schedules overlap. GitHub retains the
+  # newest pending run, whose fail-closed recovery reuses these stable slots.
   group: e2e-${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
   core:
@@ -45,6 +45,9 @@ jobs:
       SPLUNK_ENV_FILE: ../env/.env.example
       SPLUNK_PASSWORD: DefenseClawLocalMode1!
       E2E_PROFILE: core
+      # Stable per-job slots let a later serialized schedule authenticate,
+      # repair, and replace state left by a hard-aborted prior run.
+      E2E_INSTALL_NAME: defenseclaw-e2e-slot-core
       DEFENSECLAW_RUN_ID: gh-${{ github.run_id }}-${{ github.run_attempt }}-core
       E2E_TEST_PREFIX: e2e-gh-${{ github.run_id }}-${{ github.run_attempt }}-core
       E2E_REQUIRE_AGENT_INSTALL: "false"
@@ -68,10 +71,27 @@ jobs:
       run:
         shell: bash
     steps:
+      - name: Select isolated DefenseClaw home
+        run: |
+          E2E_INSTALL_HOME="${RUNNER_TEMP}/${E2E_INSTALL_NAME}"
+          {
+            echo "E2E_INSTALL_HOME=${E2E_INSTALL_HOME}"
+            echo "DEFENSECLAW_HOME=${E2E_INSTALL_HOME}/.defenseclaw"
+            echo "DEFENSECLAW_CUSTOM_PROVIDERS_PATH=${E2E_INSTALL_HOME}/.defenseclaw/custom-providers.json"
+          } >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
+        with:
+          # This job runs on a persistent host and never pushes. Do not leave
+          # the short-lived Actions credential behind in its Git config.
+          persist-credentials: false
 
       - name: Clean DefenseClaw
         run: |
+          # Refuse an unowned path before cleanup follows it. An owned retry
+          # may contain root-owned test output, so repair it before replacement.
+          python3 scripts/e2e-source-install.py authorize-cleanup "${E2E_INSTALL_HOME}"
+
           if [ -f "${SPLUNK_MOCK_PID_FILE}" ]; then
             kill -TERM "$(cat "${SPLUNK_MOCK_PID_FILE}")" 2>/dev/null || true
             rm -f "${SPLUNK_MOCK_PID_FILE}"
@@ -90,8 +110,7 @@ jobs:
           # /tmp/go-build* etc.) — see scripts/runner-cleanup.sh.
           bash scripts/runner-cleanup.sh
 
-          rm -rf ~/.defenseclaw
-          rm -f ~/.local/bin/defenseclaw-gateway
+          python3 scripts/e2e-source-install.py prepare "${E2E_INSTALL_HOME}"
           rm -rf ~/.openclaw/extensions/defenseclaw*
           rm -rf ~/.openclaw/workspace/skills/"${E2E_TEST_PREFIX}"* 2>/dev/null || true
           rm -rf ~/.openclaw/skills/"${E2E_TEST_PREFIX}"* 2>/dev/null || true
@@ -105,7 +124,7 @@ jobs:
 
           prefix = os.environ["E2E_TEST_PREFIX"]
           cfg_path = Path(os.path.expanduser("~/.openclaw/openclaw.json"))
-          quarantine_root = Path(os.path.expanduser("~/.defenseclaw/quarantine"))
+          quarantine_root = Path(os.environ["DEFENSECLAW_HOME"]) / "quarantine"
           for sub in ("skills", "plugins"):
               root = quarantine_root / sub
               if root.is_dir():
@@ -332,12 +351,17 @@ jobs:
         # `gateway-install` -> `sync-openclaw-extension` picks up the
         # real tree. `make plugin install` gives us that sequence in
         # one line.
-        run: make plugin install
+        run: |
+          E2E_PATH="$(python3 scripts/e2e-source-install.py path "${E2E_INSTALL_HOME}")"
+          PATH="${E2E_PATH}" make \
+            USER_HOME="${E2E_INSTALL_HOME}" \
+            OC_EXT_DIR="$HOME/.openclaw/extensions/defenseclaw" \
+            plugin install
 
       - name: Activate venv
         run: |
           echo "${{ github.workspace }}/.venv/bin" >> "$GITHUB_PATH"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "${E2E_INSTALL_HOME}/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install OPA
         run: |
@@ -358,25 +382,26 @@ jobs:
           curl -fsSL \
             -o /tmp/opa \
             "https://openpolicyagent.org/downloads/v1.14.1/opa_linux_${OPA_ARCH}_static"
-          install -m 0755 /tmp/opa "$HOME/.local/bin/opa"
+          install -d -m 0755 "${E2E_INSTALL_HOME}/.local/bin"
+          install -m 0755 /tmp/opa "${E2E_INSTALL_HOME}/.local/bin/opa"
           opa version
 
       - name: Init DefenseClaw
         run: |
           defenseclaw init
 
-          echo "DEFENSECLAW_GATEWAY_TOKEN=${DEFENSECLAW_GATEWAY_TOKEN}" >> ~/.defenseclaw/.env
-          echo "OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}" >> ~/.defenseclaw/.env
-          echo "DEFENSECLAW_RUN_ID=${DEFENSECLAW_RUN_ID}" >> ~/.defenseclaw/.env
+          echo "DEFENSECLAW_GATEWAY_TOKEN=${DEFENSECLAW_GATEWAY_TOKEN}" >> "${DEFENSECLAW_HOME}/.env"
+          echo "OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}" >> "${DEFENSECLAW_HOME}/.env"
+          echo "DEFENSECLAW_RUN_ID=${DEFENSECLAW_RUN_ID}" >> "${DEFENSECLAW_HOME}/.env"
           if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
-            echo "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" >> ~/.defenseclaw/.env
+            echo "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" >> "${DEFENSECLAW_HOME}/.env"
           fi
           if [ -n "${OPENAI_API_KEY:-}" ]; then
-            echo "OPENAI_API_KEY=${OPENAI_API_KEY}" >> ~/.defenseclaw/.env
+            echo "OPENAI_API_KEY=${OPENAI_API_KEY}" >> "${DEFENSECLAW_HOME}/.env"
           fi
           if [ -n "${SPLUNK_ACCESS_TOKEN:-}" ]; then
-            echo "SPLUNK_ACCESS_TOKEN=${SPLUNK_ACCESS_TOKEN}" >> ~/.defenseclaw/.env
-            echo "SPLUNK_REALM=${SPLUNK_REALM}" >> ~/.defenseclaw/.env
+            echo "SPLUNK_ACCESS_TOKEN=${SPLUNK_ACCESS_TOKEN}" >> "${DEFENSECLAW_HOME}/.env"
+            echo "SPLUNK_REALM=${SPLUNK_REALM}" >> "${DEFENSECLAW_HOME}/.env"
           fi
 
           defenseclaw setup skill-scanner \
@@ -405,13 +430,13 @@ jobs:
           GUARDRAIL_ENABLED=false
           GUARDRAIL_REASON="core profile does not require live guardrail"
 
-          echo "DEFENSECLAW_SPLUNK_HEC_TOKEN=00000000-0000-0000-0000-000000000001" >> ~/.defenseclaw/.env
+          echo "DEFENSECLAW_SPLUNK_HEC_TOKEN=00000000-0000-0000-0000-000000000001" >> "${DEFENSECLAW_HOME}/.env"
           export OC_MODEL MODEL_NAME API_KEY_ENV GUARDRAIL_ENABLED GUARDRAIL_REASON
           python3 - <<'PY'
           import os
           import yaml
 
-          cfg_path = os.path.expanduser('~/.defenseclaw/config.yaml')
+          cfg_path = os.path.join(os.environ['DEFENSECLAW_HOME'], 'config.yaml')
           with open(cfg_path) as f:
               cfg = yaml.safe_load(f) or {}
 
@@ -431,7 +456,7 @@ jobs:
                   'name':    'e2e-gateway-jsonl',
                   'kind':    'jsonl',
                   'enabled': True,
-                  'path':    os.path.expanduser('~/.defenseclaw/gateway.jsonl'),
+                  'path':    os.path.join(os.environ['DEFENSECLAW_HOME'], 'gateway.jsonl'),
                   'send': {
                       'signals': ['logs'],
                       'buckets': ['*'],
@@ -507,18 +532,18 @@ jobs:
           done
           defenseclaw-gateway status || {
             echo "--- gateway.log (tail) ---"
-            tail -n 200 ~/.defenseclaw/gateway.log 2>/dev/null || true
+            tail -n 200 "${DEFENSECLAW_HOME}/gateway.log" 2>/dev/null || true
             echo "--- gateway.jsonl (tail) ---"
-            tail -n 200 ~/.defenseclaw/gateway.jsonl 2>/dev/null || true
+            tail -n 200 "${DEFENSECLAW_HOME}/gateway.jsonl" 2>/dev/null || true
             echo "--- watchdog.log (tail) ---"
-            tail -n 200 ~/.defenseclaw/watchdog.log 2>/dev/null || true
+            tail -n 200 "${DEFENSECLAW_HOME}/watchdog.log" 2>/dev/null || true
             exit 1
           }
 
       - name: Validate canonical v8 JSONL destination
         run: |
-          if [ -s ~/.defenseclaw/gateway.jsonl ]; then
-            python3 scripts/assert-observability-v8-jsonl.py ~/.defenseclaw/gateway.jsonl --min-records 1
+          if [ -s "${DEFENSECLAW_HOME}/gateway.jsonl" ]; then
+            python3 scripts/assert-observability-v8-jsonl.py "${DEFENSECLAW_HOME}/gateway.jsonl" --min-records 1
           else
             echo "optional v8 JSONL test destination not yet populated — deferred until post-traffic assertions"
           fi
@@ -536,16 +561,18 @@ jobs:
         run: uv pip install --group dev --python "${{ github.workspace }}/.venv/bin/python"
 
       - name: Unit tests
-        run: make test
+        run: make USER_HOME="${E2E_INSTALL_HOME}" test
 
       - name: TypeScript plugin tests
-        run: make ts-test
+        run: make USER_HOME="${E2E_INSTALL_HOME}" ts-test
 
       - name: Rego policy tests
-        run: make rego-test
+        run: make USER_HOME="${E2E_INSTALL_HOME}" rego-test
 
       - name: Repair persistent state and config before E2E tests
-        run: RUNNER_CLEANUP_STATE_ONLY=1 bash scripts/runner-cleanup.sh
+        run: |
+          python3 scripts/e2e-source-install.py verify "${E2E_INSTALL_HOME}"
+          RUNNER_CLEANUP_STATE_ONLY=1 bash scripts/runner-cleanup.sh
 
       - name: E2E tests
         run: bash scripts/test-e2e-full-stack.sh
@@ -567,8 +594,8 @@ jobs:
             echo "[assertions] splunk-mock log captured $(wc -l <"${SPLUNK_MOCK_LOG}" | tr -d ' ') envelope(s)"
           fi
           bash test/e2e/observability_assertions.sh \
-              --jsonl ~/.defenseclaw/gateway.jsonl \
-              --db ~/.defenseclaw/audit.db \
+              --jsonl "${DEFENSECLAW_HOME}/gateway.jsonl" \
+              --db "${DEFENSECLAW_HOME}/audit.db" \
               --ts-window-seconds 3600 \
               --no-require-verdict \
               "${MOCK_ARGS[@]}"
@@ -580,9 +607,9 @@ jobs:
           STAGE=/tmp/defenseclaw-logs-core
           rm -rf "$STAGE"
           mkdir -p "$STAGE"
-          if [ -d "$HOME/.defenseclaw" ]; then
+          if [ -d "${DEFENSECLAW_HOME}" ]; then
             for pat in '*.log' '*.jsonl' 'config.yaml' 'doctor_cache.json'; do
-              find "$HOME/.defenseclaw" -maxdepth 2 -type f -name "$pat" -exec cp --parents {} "$STAGE/" \; 2>/dev/null || true
+              find "${DEFENSECLAW_HOME}" -maxdepth 2 -type f -name "$pat" -exec cp --parents {} "$STAGE/" \; 2>/dev/null || true
             done
           fi
           cp -v /tmp/splunk-mock-core.log "$STAGE/" 2>/dev/null || true
@@ -614,18 +641,19 @@ jobs:
             cd -
           } || true
 
-          rm -rf ~/.defenseclaw
-          rm -f ~/.local/bin/defenseclaw-gateway
           rm -rf ~/.openclaw/extensions/defenseclaw*
 
-          # Generic host-wide cleanup — see scripts/runner-cleanup.sh.
+          # Stop services and repair root-owned state before removing the
+          # exact marker-authenticated run root.
+          python3 scripts/e2e-source-install.py authorize-cleanup "${E2E_INSTALL_HOME}"
           bash scripts/runner-cleanup.sh
+          python3 scripts/e2e-source-install.py cleanup "${E2E_INSTALL_HOME}"
 
   full-live:
     name: Full Live E2E
     # Core and full-live both mutate persistent self-hosted runner state
-    # (~/.defenseclaw, ~/.openclaw, docker/systemd user services, and shared
-    # cleanup scripts). Run full-live only after core so their setup/cleanup
+    # (run-owned DefenseClaw state, ~/.openclaw, docker/systemd user services,
+    # and shared cleanup scripts). Run full-live only after core so their setup/cleanup
     # phases cannot cancel or corrupt each other on the same runner.
     needs: core
     if: ${{ always() && (github.event_name == 'schedule' || (needs.core.result == 'success' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)))) }}
@@ -669,6 +697,9 @@ jobs:
       SPLUNK_ENV_FILE: ../env/.env.example
       SPLUNK_PASSWORD: DefenseClawLocalMode1!
       E2E_PROFILE: full-live
+      # Stable per-job slots let a later serialized schedule authenticate,
+      # repair, and replace state left by a hard-aborted prior run.
+      E2E_INSTALL_NAME: defenseclaw-e2e-slot-full-live
       DEFENSECLAW_RUN_ID: gh-${{ github.run_id }}-${{ github.run_attempt }}-full-live
       E2E_TEST_PREFIX: e2e-gh-${{ github.run_id }}-${{ github.run_attempt }}-full-live
       E2E_REQUIRE_AGENT_INSTALL: "true"
@@ -696,10 +727,27 @@ jobs:
       run:
         shell: bash
     steps:
+      - name: Select isolated DefenseClaw home
+        run: |
+          E2E_INSTALL_HOME="${RUNNER_TEMP}/${E2E_INSTALL_NAME}"
+          {
+            echo "E2E_INSTALL_HOME=${E2E_INSTALL_HOME}"
+            echo "DEFENSECLAW_HOME=${E2E_INSTALL_HOME}/.defenseclaw"
+            echo "DEFENSECLAW_CUSTOM_PROVIDERS_PATH=${E2E_INSTALL_HOME}/.defenseclaw/custom-providers.json"
+          } >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
+        with:
+          # This job runs on a persistent host and never pushes. Do not leave
+          # the short-lived Actions credential behind in its Git config.
+          persist-credentials: false
 
       - name: Clean DefenseClaw
         run: |
+          # Refuse an unowned path before cleanup follows it. An owned retry
+          # may contain root-owned test output, so repair it before replacement.
+          python3 scripts/e2e-source-install.py authorize-cleanup "${E2E_INSTALL_HOME}"
+
           if [ -f "${SPLUNK_MOCK_PID_FILE}" ]; then
             kill -TERM "$(cat "${SPLUNK_MOCK_PID_FILE}")" 2>/dev/null || true
             rm -f "${SPLUNK_MOCK_PID_FILE}"
@@ -738,8 +786,7 @@ jobs:
           # Generic host-wide cleanup — see scripts/runner-cleanup.sh.
           bash scripts/runner-cleanup.sh
 
-          rm -rf ~/.defenseclaw
-          rm -f ~/.local/bin/defenseclaw-gateway
+          python3 scripts/e2e-source-install.py prepare "${E2E_INSTALL_HOME}"
           rm -rf ~/.openclaw/extensions/defenseclaw*
           rm -rf ~/.openclaw/workspace/skills/"${E2E_TEST_PREFIX}"* 2>/dev/null || true
           rm -rf ~/.openclaw/skills/"${E2E_TEST_PREFIX}"* 2>/dev/null || true
@@ -753,7 +800,7 @@ jobs:
 
           prefix = os.environ["E2E_TEST_PREFIX"]
           cfg_path = Path(os.path.expanduser("~/.openclaw/openclaw.json"))
-          quarantine_root = Path(os.path.expanduser("~/.defenseclaw/quarantine"))
+          quarantine_root = Path(os.environ["DEFENSECLAW_HOME"]) / "quarantine"
           for sub in ("skills", "plugins"):
               root = quarantine_root / sub
               if root.is_dir():
@@ -974,12 +1021,17 @@ jobs:
         # `gateway-install` -> `sync-openclaw-extension` picks up the
         # real tree. `make plugin install` gives us that sequence in
         # one line.
-        run: make plugin install
+        run: |
+          E2E_PATH="$(python3 scripts/e2e-source-install.py path "${E2E_INSTALL_HOME}")"
+          PATH="${E2E_PATH}" make \
+            USER_HOME="${E2E_INSTALL_HOME}" \
+            OC_EXT_DIR="$HOME/.openclaw/extensions/defenseclaw" \
+            plugin install
 
       - name: Activate venv
         run: |
           echo "${{ github.workspace }}/.venv/bin" >> "$GITHUB_PATH"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "${E2E_INSTALL_HOME}/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install OPA
         run: |
@@ -1000,7 +1052,8 @@ jobs:
           curl -fsSL \
             -o /tmp/opa \
             "https://openpolicyagent.org/downloads/v1.14.1/opa_linux_${OPA_ARCH}_static"
-          install -m 0755 /tmp/opa "$HOME/.local/bin/opa"
+          install -d -m 0755 "${E2E_INSTALL_HOME}/.local/bin"
+          install -m 0755 /tmp/opa "${E2E_INSTALL_HOME}/.local/bin/opa"
           opa version
 
       - name: Prepare OpenClaw Anthropic model + auth
@@ -1180,6 +1233,8 @@ jobs:
           # kept for our in-process Bifrost callers. Both point at the same
           # ABSK… token held in the BIFROST_API_KEY secret.
           for key in (
+              "DEFENSECLAW_HOME",
+              "DEFENSECLAW_CUSTOM_PROVIDERS_PATH",
               "ANTHROPIC_API_KEY",
               "OPENAI_API_KEY",
               "OPENCLAW_GATEWAY_TOKEN",
@@ -1207,20 +1262,20 @@ jobs:
         run: |
           defenseclaw init
 
-          echo "DEFENSECLAW_GATEWAY_TOKEN=${DEFENSECLAW_GATEWAY_TOKEN}" >> ~/.defenseclaw/.env
-          echo "OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}" >> ~/.defenseclaw/.env
-          echo "DEFENSECLAW_RUN_ID=${DEFENSECLAW_RUN_ID}" >> ~/.defenseclaw/.env
+          echo "DEFENSECLAW_GATEWAY_TOKEN=${DEFENSECLAW_GATEWAY_TOKEN}" >> "${DEFENSECLAW_HOME}/.env"
+          echo "OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}" >> "${DEFENSECLAW_HOME}/.env"
+          echo "DEFENSECLAW_RUN_ID=${DEFENSECLAW_RUN_ID}" >> "${DEFENSECLAW_HOME}/.env"
           if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
-            echo "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" >> ~/.defenseclaw/.env
+            echo "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" >> "${DEFENSECLAW_HOME}/.env"
           fi
           if [ -n "${OPENAI_API_KEY:-}" ]; then
-            echo "OPENAI_API_KEY=${OPENAI_API_KEY}" >> ~/.defenseclaw/.env
+            echo "OPENAI_API_KEY=${OPENAI_API_KEY}" >> "${DEFENSECLAW_HOME}/.env"
           fi
           if [ -n "${GOOGLE_API_KEY:-}" ]; then
-            echo "GOOGLE_API_KEY=${GOOGLE_API_KEY}" >> ~/.defenseclaw/.env
+            echo "GOOGLE_API_KEY=${GOOGLE_API_KEY}" >> "${DEFENSECLAW_HOME}/.env"
           fi
           if [ -n "${AZURE_OPENAI_API_KEY:-}" ]; then
-            echo "AZURE_OPENAI_API_KEY=${AZURE_OPENAI_API_KEY}" >> ~/.defenseclaw/.env
+            echo "AZURE_OPENAI_API_KEY=${AZURE_OPENAI_API_KEY}" >> "${DEFENSECLAW_HOME}/.env"
           fi
           # BIFROST_API_KEY = AWS Bedrock bearer token (ABSK…). Consumed by the
           # guardrail sidecar via api_key_env=BIFROST_API_KEY (set in the
@@ -1228,17 +1283,17 @@ jobs:
           # AWS_BEARER_TOKEN_BEDROCK + AWS_REGION feed OpenClaw's stock
           # amazon-bedrock provider (AWS SDK default chain).
           if [ -n "${BIFROST_API_KEY:-}" ]; then
-            echo "BIFROST_API_KEY=${BIFROST_API_KEY}" >> ~/.defenseclaw/.env
+            echo "BIFROST_API_KEY=${BIFROST_API_KEY}" >> "${DEFENSECLAW_HOME}/.env"
           fi
           if [ -n "${AWS_BEARER_TOKEN_BEDROCK:-}" ]; then
-            echo "AWS_BEARER_TOKEN_BEDROCK=${AWS_BEARER_TOKEN_BEDROCK}" >> ~/.defenseclaw/.env
+            echo "AWS_BEARER_TOKEN_BEDROCK=${AWS_BEARER_TOKEN_BEDROCK}" >> "${DEFENSECLAW_HOME}/.env"
           fi
           if [ -n "${AWS_REGION:-}" ]; then
-            echo "AWS_REGION=${AWS_REGION}" >> ~/.defenseclaw/.env
+            echo "AWS_REGION=${AWS_REGION}" >> "${DEFENSECLAW_HOME}/.env"
           fi
           if [ -n "${SPLUNK_ACCESS_TOKEN:-}" ]; then
-            echo "SPLUNK_ACCESS_TOKEN=${SPLUNK_ACCESS_TOKEN}" >> ~/.defenseclaw/.env
-            echo "SPLUNK_REALM=${SPLUNK_REALM}" >> ~/.defenseclaw/.env
+            echo "SPLUNK_ACCESS_TOKEN=${SPLUNK_ACCESS_TOKEN}" >> "${DEFENSECLAW_HOME}/.env"
+            echo "SPLUNK_REALM=${SPLUNK_REALM}" >> "${DEFENSECLAW_HOME}/.env"
           fi
 
           defenseclaw setup skill-scanner \
@@ -1305,13 +1360,13 @@ jobs:
             echo "Guardrail live check status: ${GUARDRAIL_REASON}"
           fi
 
-          echo "DEFENSECLAW_SPLUNK_HEC_TOKEN=00000000-0000-0000-0000-000000000001" >> ~/.defenseclaw/.env
+          echo "DEFENSECLAW_SPLUNK_HEC_TOKEN=00000000-0000-0000-0000-000000000001" >> "${DEFENSECLAW_HOME}/.env"
           export OC_MODEL GUARDRAIL_MODEL MODEL_NAME API_KEY_ENV GUARDRAIL_ENABLED GUARDRAIL_REASON
           python3 - <<'PY'
           import os
           import yaml
 
-          cfg_path = os.path.expanduser('~/.defenseclaw/config.yaml')
+          cfg_path = os.path.join(os.environ['DEFENSECLAW_HOME'], 'config.yaml')
           with open(cfg_path) as f:
               cfg = yaml.safe_load(f) or {}
 
@@ -1331,7 +1386,7 @@ jobs:
                   'name':    'e2e-gateway-jsonl',
                   'kind':    'jsonl',
                   'enabled': True,
-                  'path':    os.path.expanduser('~/.defenseclaw/gateway.jsonl'),
+                  'path':    os.path.join(os.environ['DEFENSECLAW_HOME'], 'gateway.jsonl'),
                   'send': {
                       'signals': ['logs'],
                       'buckets': ['*'],
@@ -1434,19 +1489,19 @@ jobs:
           done
           defenseclaw-gateway status || {
             echo "--- gateway.log (tail) ---"
-            tail -n 200 ~/.defenseclaw/gateway.log 2>/dev/null || true
+            tail -n 200 "${DEFENSECLAW_HOME}/gateway.log" 2>/dev/null || true
             echo "--- gateway.jsonl (tail) ---"
-            tail -n 200 ~/.defenseclaw/gateway.jsonl 2>/dev/null || true
+            tail -n 200 "${DEFENSECLAW_HOME}/gateway.jsonl" 2>/dev/null || true
             echo "--- watchdog.log (tail) ---"
-            tail -n 200 ~/.defenseclaw/watchdog.log 2>/dev/null || true
+            tail -n 200 "${DEFENSECLAW_HOME}/watchdog.log" 2>/dev/null || true
             exit 1
           }
 
       - name: Validate canonical v8 JSONL destination
         if: ${{ env.FULL_LIVE_SKIP != '1' }}
         run: |
-          if [ -s ~/.defenseclaw/gateway.jsonl ]; then
-            python3 scripts/assert-observability-v8-jsonl.py ~/.defenseclaw/gateway.jsonl --min-records 1
+          if [ -s "${DEFENSECLAW_HOME}/gateway.jsonl" ]; then
+            python3 scripts/assert-observability-v8-jsonl.py "${DEFENSECLAW_HOME}/gateway.jsonl" --min-records 1
           else
             echo "optional v8 JSONL test destination not yet populated — deferred until post-traffic assertions"
           fi
@@ -1466,15 +1521,15 @@ jobs:
 
       - name: Unit tests
         if: ${{ env.FULL_LIVE_SKIP != '1' }}
-        run: make test
+        run: make USER_HOME="${E2E_INSTALL_HOME}" test
 
       - name: TypeScript plugin tests
         if: ${{ env.FULL_LIVE_SKIP != '1' }}
-        run: make ts-test
+        run: make USER_HOME="${E2E_INSTALL_HOME}" ts-test
 
       - name: Rego policy tests
         if: ${{ env.FULL_LIVE_SKIP != '1' }}
-        run: make rego-test
+        run: make USER_HOME="${E2E_INSTALL_HOME}" rego-test
 
       - name: E2E tests
         if: ${{ env.FULL_LIVE_SKIP != '1' }}
@@ -1497,7 +1552,7 @@ jobs:
           GUARDRAIL_ENABLED=$(python3 -c '
           import yaml, os
           try:
-              with open(os.path.expanduser("~/.defenseclaw/config.yaml")) as f:
+              with open(os.path.join(os.environ["DEFENSECLAW_HOME"], "config.yaml")) as f:
                   cfg = yaml.safe_load(f) or {}
               print(str(cfg.get("guardrail", {}).get("enabled", False)).lower())
           except Exception:
@@ -1516,8 +1571,8 @@ jobs:
               echo "[assertions] guardrail_enabled=${GUARDRAIL_ENABLED}; full-live-success-marker=${marker_present} - skipping splunk-mock sourcetype assertion"
           fi
           bash test/e2e/observability_assertions.sh \
-              --jsonl ~/.defenseclaw/gateway.jsonl \
-              --db ~/.defenseclaw/audit.db \
+              --jsonl "${DEFENSECLAW_HOME}/gateway.jsonl" \
+              --db "${DEFENSECLAW_HOME}/audit.db" \
               --ts-window-seconds 3600 \
               --no-require-verdict \
               "${MOCK_ARGS[@]}"
@@ -1529,9 +1584,9 @@ jobs:
           STAGE=/tmp/defenseclaw-logs-full-live
           rm -rf "$STAGE"
           mkdir -p "$STAGE"
-          if [ -d "$HOME/.defenseclaw" ]; then
+          if [ -d "${DEFENSECLAW_HOME}" ]; then
             for pat in '*.log' '*.jsonl' 'config.yaml' 'doctor_cache.json'; do
-              find "$HOME/.defenseclaw" -maxdepth 2 -type f -name "$pat" -exec cp --parents {} "$STAGE/" \; 2>/dev/null || true
+              find "${DEFENSECLAW_HOME}" -maxdepth 2 -type f -name "$pat" -exec cp --parents {} "$STAGE/" \; 2>/dev/null || true
             done
           fi
           cp -v /tmp/splunk-mock-full-live.log "$STAGE/" 2>/dev/null || true
@@ -1583,12 +1638,13 @@ jobs:
             cd -
           } || true
 
-          rm -rf ~/.defenseclaw
-          rm -f ~/.local/bin/defenseclaw-gateway
           rm -rf ~/.openclaw/extensions/defenseclaw*
 
-          # Generic host-wide cleanup — see scripts/runner-cleanup.sh.
+          # Stop services and repair root-owned state before removing the
+          # exact marker-authenticated run root.
+          python3 scripts/e2e-source-install.py authorize-cleanup "${E2E_INSTALL_HOME}"
           bash scripts/runner-cleanup.sh
+          python3 scripts/e2e-source-install.py cleanup "${E2E_INSTALL_HOME}"
 
   # Plan E4 / item 2: connector matrix axis. Runs the four connector
   # artifact + lifecycle test packages in parallel on the public

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -363,16 +363,11 @@ jobs:
 
       - name: Activate venv
         run: |
-          echo "${{ github.workspace }}/.venv/bin" >> "$GITHUB_PATH"
-          echo "${E2E_INSTALL_HOME}/.local/bin" >> "$GITHUB_PATH"
+          E2E_PATH="$(python3 scripts/e2e-source-install.py path "${E2E_INSTALL_HOME}")"
+          echo "PATH=${{ github.workspace }}/.venv/bin:${E2E_PATH}" >> "$GITHUB_ENV"
 
       - name: Install OPA
         run: |
-          if command -v opa >/dev/null 2>&1; then
-            opa version
-            exit 0
-          fi
-
           case "$(uname -m)" in
             aarch64|arm64) OPA_ARCH="arm64" ;;
             x86_64|amd64) OPA_ARCH="amd64" ;;
@@ -387,7 +382,7 @@ jobs:
             "https://openpolicyagent.org/downloads/v1.14.1/opa_linux_${OPA_ARCH}_static"
           install -d -m 0755 "${E2E_INSTALL_HOME}/.local/bin"
           install -m 0755 /tmp/opa "${E2E_INSTALL_HOME}/.local/bin/opa"
-          opa version
+          "${E2E_INSTALL_HOME}/.local/bin/opa" version
 
       - name: Init DefenseClaw
         run: |
@@ -1036,16 +1031,11 @@ jobs:
 
       - name: Activate venv
         run: |
-          echo "${{ github.workspace }}/.venv/bin" >> "$GITHUB_PATH"
-          echo "${E2E_INSTALL_HOME}/.local/bin" >> "$GITHUB_PATH"
+          E2E_PATH="$(python3 scripts/e2e-source-install.py path "${E2E_INSTALL_HOME}")"
+          echo "PATH=${{ github.workspace }}/.venv/bin:${E2E_PATH}" >> "$GITHUB_ENV"
 
       - name: Install OPA
         run: |
-          if command -v opa >/dev/null 2>&1; then
-            opa version
-            exit 0
-          fi
-
           case "$(uname -m)" in
             aarch64|arm64) OPA_ARCH="arm64" ;;
             x86_64|amd64) OPA_ARCH="amd64" ;;
@@ -1060,7 +1050,7 @@ jobs:
             "https://openpolicyagent.org/downloads/v1.14.1/opa_linux_${OPA_ARCH}_static"
           install -d -m 0755 "${E2E_INSTALL_HOME}/.local/bin"
           install -m 0755 /tmp/opa "${E2E_INSTALL_HOME}/.local/bin/opa"
-          opa version
+          "${E2E_INSTALL_HOME}/.local/bin/opa" version
 
       - name: Prepare OpenClaw Anthropic model + auth
         run: |

--- a/cli/tests/test_e2e_workflow_cleanup.py
+++ b/cli/tests/test_e2e_workflow_cleanup.py
@@ -159,7 +159,10 @@ def test_persistent_e2e_jobs_use_the_source_install_helper_once() -> None:
         assert install.count(path) == 1
         assert 'USER_HOME="${E2E_INSTALL_HOME}"' in install
         assert 'OC_EXT_DIR="$HOME/.openclaw/extensions/defenseclaw"' in install
-        assert 'echo "${E2E_INSTALL_HOME}/.local/bin" >> "$GITHUB_PATH"' in _step_script(job, "Activate venv")
+        activate = _step_script(job, "Activate venv")
+        assert activate.count(path) == 1
+        assert 'echo "PATH=${{ github.workspace }}/.venv/bin:${E2E_PATH}" >> "$GITHUB_ENV"' in activate
+        assert "$GITHUB_PATH" not in activate
         for test_step in ("Unit tests", "TypeScript plugin tests", "Rego policy tests"):
             assert 'USER_HOME="${E2E_INSTALL_HOME}"' in _step_script(job, test_step)
 
@@ -169,6 +172,8 @@ def test_opa_is_installed_into_the_isolated_job_bin() -> None:
         install_opa = _step_script(job, "Install OPA")
         assert 'install -d -m 0755 "${E2E_INSTALL_HOME}/.local/bin"' in install_opa
         assert 'install -m 0755 /tmp/opa "${E2E_INSTALL_HOME}/.local/bin/opa"' in install_opa
+        assert '"${E2E_INSTALL_HOME}/.local/bin/opa" version' in install_opa
+        assert "command -v opa" not in install_opa
         assert "$HOME/.local/bin/opa" not in install_opa
 
 

--- a/cli/tests/test_e2e_workflow_cleanup.py
+++ b/cli/tests/test_e2e_workflow_cleanup.py
@@ -56,13 +56,13 @@ def _substring_offsets(text: str, needle: str) -> list[int]:
     return offsets
 
 
-def _helper_env(runner_temp: Path, persistent_home: Path, *, path: str | None = None) -> dict[str, str]:
+def _helper_env(runner_workspace: Path, persistent_home: Path, *, path: str | None = None) -> dict[str, str]:
     environment = os.environ.copy()
     environment.update(
         {
             "HOME": os.fspath(persistent_home),
             "USERPROFILE": os.fspath(persistent_home),
-            "RUNNER_TEMP": os.fspath(runner_temp),
+            "RUNNER_WORKSPACE": os.fspath(runner_workspace),
         }
     )
     if path is not None:
@@ -74,7 +74,7 @@ def _run_helper(
     command: str,
     root: Path,
     *,
-    runner_temp: Path,
+    runner_workspace: Path,
     persistent_home: Path,
     path: str | None = None,
     check: bool = True,
@@ -84,7 +84,7 @@ def _run_helper(
         check=check,
         capture_output=True,
         text=True,
-        env=_helper_env(runner_temp, persistent_home, path=path),
+        env=_helper_env(runner_workspace, persistent_home, path=path),
     )
 
 
@@ -104,7 +104,7 @@ def test_persistent_e2e_jobs_are_serialized_through_cleanup() -> None:
         assert _step(job, "Post-run cleanup")["if"] == "always()"
 
 
-def test_persistent_e2e_jobs_use_distinct_run_owned_install_homes() -> None:
+def test_persistent_e2e_jobs_use_distinct_persistent_install_homes() -> None:
     install_names: dict[str, str] = {}
     for job in ("core", "full-live"):
         environment = WORKFLOW["jobs"][job]["env"]
@@ -113,7 +113,9 @@ def test_persistent_e2e_jobs_use_distinct_run_owned_install_homes() -> None:
         select_home = _step_script(job, "Select isolated DefenseClaw home")
         assert install_name == expected
         assert "/" not in install_name
-        assert 'E2E_INSTALL_HOME="${RUNNER_TEMP}/${E2E_INSTALL_NAME}"' in select_home
+        assert 'E2E_INSTALL_HOME="${RUNNER_WORKSPACE}/${E2E_INSTALL_NAME}"' in select_home
+        assert 'E2E_INSTALL_HOME="${RUNNER_TEMP}/${E2E_INSTALL_NAME}"' not in select_home
+        assert "RUNNER_TEMP is emptied by the Actions runner before each job" in select_home
         assert 'echo "DEFENSECLAW_HOME=${E2E_INSTALL_HOME}/.defenseclaw"' in select_home
         assert (
             'echo "DEFENSECLAW_CUSTOM_PROVIDERS_PATH=${E2E_INSTALL_HOME}/.defenseclaw/'
@@ -434,13 +436,33 @@ def test_runner_cleanup_accepts_a_safe_isolated_state_root(tmp_path: Path) -> No
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_runner_cleanup_pins_the_state_tree_during_privileged_repair() -> None:
+    cleanup = RUNNER_CLEANUP.read_text(encoding="utf-8")
+
+    assert "sudo -n chown -R" not in cleanup
+    assert "sudo -n chmod -R" not in cleanup
+    assert "sudo -n setfacl -R" not in cleanup
+    assert "descriptor = os.open(os.path.sep, directory_flags)" in cleanup
+    assert "child = os.open(component, directory_flags, dir_fd=descriptor)" in cleanup
+    assert "| os.O_NOFOLLOW" in cleanup
+    assert "os.listdir(descriptor)" in cleanup
+    assert "os.stat(name, dir_fd=descriptor, follow_symlinks=False)" in cleanup
+    assert "os.fchown(descriptor, uid, gid)" in cleanup
+    assert "os.fchmod(descriptor" in cleanup
+    assert "state directory changed during repair" in cleanup
+    assert "Avoid every pathname-based privileged mutation" in cleanup
+    assert "state repair refuses multiply-linked files" in cleanup
+    assert "directory_mode &= ~(stat.S_ISUID | stat.S_ISGID | stat.S_ISVTX)" in cleanup
+    assert "mode &= ~(stat.S_ISUID | stat.S_ISGID | stat.S_ISVTX)" in cleanup
+
+
 def test_source_install_helper_lifecycle_preserves_persistent_home(tmp_path: Path) -> None:
-    runner_temp = tmp_path / "runner-temp"
+    runner_workspace = tmp_path / "runner-workspace"
     persistent_home = tmp_path / "persistent-home"
     persistent_bin = persistent_home / ".local" / "bin"
     persistent_state = persistent_home / ".defenseclaw" / "config.yaml"
     unrelated_bin = tmp_path / "unrelated-bin"
-    runner_temp.mkdir()
+    runner_workspace.mkdir()
     persistent_bin.mkdir(parents=True)
     persistent_state.parent.mkdir()
     unrelated_bin.mkdir()
@@ -448,9 +470,9 @@ def test_source_install_helper_lifecycle_preserves_persistent_home(tmp_path: Pat
     for name in ("defenseclaw", "defenseclaw-gateway", ".defenseclaw-source-root"):
         (persistent_bin / name).write_text("persistent\n", encoding="utf-8")
 
-    root = runner_temp / "defenseclaw-e2e-slot-core"
-    _run_helper("prepare", root, runner_temp=runner_temp, persistent_home=persistent_home)
-    _run_helper("verify", root, runner_temp=runner_temp, persistent_home=persistent_home)
+    root = runner_workspace / "defenseclaw-e2e-slot-core"
+    _run_helper("prepare", root, runner_workspace=runner_workspace, persistent_home=persistent_home)
+    _run_helper("verify", root, runner_workspace=runner_workspace, persistent_home=persistent_home)
     assert (root / OWNER_MARKER).read_text(encoding="utf-8") == f"{root.name}\n"
 
     isolated_bin = root / ".local" / "bin"
@@ -459,7 +481,7 @@ def test_source_install_helper_lifecycle_preserves_persistent_home(tmp_path: Pat
         _run_helper(
             "path",
             root,
-            runner_temp=runner_temp,
+            runner_workspace=runner_workspace,
             persistent_home=persistent_home,
             path=os.pathsep.join((os.fspath(persistent_bin), os.fspath(unrelated_bin), os.fspath(isolated_bin))),
         )
@@ -472,11 +494,11 @@ def test_source_install_helper_lifecycle_preserves_persistent_home(tmp_path: Pat
         workflow_path = _run_helper(
             "path",
             root,
-            runner_temp=runner_temp,
+            runner_workspace=runner_workspace,
             persistent_home=persistent_home,
             path=os.pathsep.join((os.fspath(persistent_bin), os.defpath)),
         ).stdout.strip()
-        preflight_env = _helper_env(runner_temp, persistent_home, path=workflow_path)
+        preflight_env = _helper_env(runner_workspace, persistent_home, path=workflow_path)
         preflight_env["DEFENSECLAW_HOME"] = os.fspath(root / ".defenseclaw")
         preflight = subprocess.run(
             [
@@ -497,27 +519,141 @@ def test_source_install_helper_lifecycle_preserves_persistent_home(tmp_path: Pat
         assert preflight.returncode == 0, preflight.stdout + preflight.stderr
 
     (root / ".defenseclaw").mkdir()
-    _run_helper("cleanup", root, runner_temp=runner_temp, persistent_home=persistent_home)
+    _run_helper("cleanup", root, runner_workspace=runner_workspace, persistent_home=persistent_home)
     assert not root.exists()
     assert persistent_state.read_text(encoding="utf-8") == "persistent: true\n"
     for name in ("defenseclaw", "defenseclaw-gateway", ".defenseclaw-source-root"):
         assert (persistent_bin / name).read_text(encoding="utf-8") == "persistent\n"
 
 
-def test_stable_slot_retry_replaces_only_owned_crash_state(tmp_path: Path) -> None:
+def test_source_install_helper_rejects_the_ephemeral_runner_temp(tmp_path: Path) -> None:
+    runner_workspace = tmp_path / "runner-workspace"
     runner_temp = tmp_path / "runner-temp"
     persistent_home = tmp_path / "persistent-home"
-    root = runner_temp / "defenseclaw-e2e-slot-core"
+    runner_workspace.mkdir()
     runner_temp.mkdir()
     persistent_home.mkdir()
+    environment = _helper_env(runner_workspace, persistent_home)
+    environment["RUNNER_TEMP"] = os.fspath(runner_temp)
+    result = subprocess.run(
+        [
+            sys.executable,
+            os.fspath(SOURCE_INSTALL_HELPER),
+            "prepare",
+            os.fspath(runner_temp / "defenseclaw-e2e-slot-core"),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
 
-    _run_helper("prepare", root, runner_temp=runner_temp, persistent_home=persistent_home)
+    assert result.returncode != 0
+    assert "install home must be a direct child of RUNNER_WORKSPACE" in result.stderr
+    assert not (runner_temp / "defenseclaw-e2e-slot-core").exists()
+
+
+@POSIX_SHELL_ONLY
+def test_isolated_path_preserves_only_required_account_build_tools(tmp_path: Path) -> None:
+    runner_workspace = tmp_path / "runner-workspace"
+    persistent_home = tmp_path / "persistent-home"
+    persistent_bin = persistent_home / ".local" / "bin"
+    unrelated_bin = tmp_path / "unrelated-bin"
+    runner_workspace.mkdir()
+    persistent_bin.mkdir(parents=True)
+    unrelated_bin.mkdir()
+
+    for name in ("uv", "npm", "go", "node", "opa", "defenseclaw"):
+        executable = persistent_bin / name
+        executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        executable.chmod(0o700)
+
+    root = runner_workspace / "defenseclaw-e2e-slot-core"
+    _run_helper("prepare", root, runner_workspace=runner_workspace, persistent_home=persistent_home)
+    selected = Path(
+        _run_helper(
+            "path",
+            root,
+            runner_workspace=runner_workspace,
+            persistent_home=persistent_home,
+            path=os.pathsep.join((os.fspath(persistent_bin), os.fspath(unrelated_bin))),
+        )
+        .stdout.strip()
+        .split(os.pathsep)[1]
+    )
+
+    assert selected.name == ".e2e-build-tools"
+    assert not selected.is_symlink()
+    assert {entry.name for entry in selected.iterdir()} == {"go", "node", "npm", "uv"}
+    for name in ("go", "node", "npm", "uv"):
+        assert (selected / name).is_symlink()
+        assert (selected / name).resolve(strict=True) == (persistent_bin / name).resolve(strict=True)
+    assert not (selected / "opa").exists()
+    assert not (selected / "defenseclaw").exists()
+
+
+@POSIX_SHELL_ONLY
+def test_isolated_path_refreshes_the_bounded_build_tool_shims(tmp_path: Path) -> None:
+    runner_workspace = tmp_path / "runner-workspace"
+    persistent_home = tmp_path / "persistent-home"
+    persistent_bin = persistent_home / ".local" / "bin"
+    unrelated_bin = tmp_path / "unrelated-bin"
+    runner_workspace.mkdir()
+    persistent_bin.mkdir(parents=True)
+    unrelated_bin.mkdir()
+
+    uv = persistent_bin / "uv"
+    uv.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    uv.chmod(0o700)
+    root = runner_workspace / "defenseclaw-e2e-slot-core"
+    _run_helper("prepare", root, runner_workspace=runner_workspace, persistent_home=persistent_home)
+    selected = (
+        _run_helper(
+            "path",
+            root,
+            runner_workspace=runner_workspace,
+            persistent_home=persistent_home,
+            path=os.pathsep.join((os.fspath(persistent_bin), os.fspath(unrelated_bin))),
+        )
+        .stdout.strip()
+        .split(os.pathsep)
+    )
+    shim_dir = Path(selected[1])
+    assert {entry.name for entry in shim_dir.iterdir()} == {"uv"}
+
+    uv.unlink()
+    npm = persistent_bin / "npm"
+    npm.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    npm.chmod(0o700)
+    refreshed = (
+        _run_helper(
+            "path",
+            root,
+            runner_workspace=runner_workspace,
+            persistent_home=persistent_home,
+            path=os.pathsep.join((os.fspath(persistent_bin), os.fspath(unrelated_bin))),
+        )
+        .stdout.strip()
+        .split(os.pathsep)
+    )
+    assert refreshed[1] == os.fspath(shim_dir)
+    assert {entry.name for entry in shim_dir.iterdir()} == {"npm"}
+
+
+def test_stable_slot_retry_replaces_only_owned_crash_state(tmp_path: Path) -> None:
+    runner_workspace = tmp_path / "runner-workspace"
+    persistent_home = tmp_path / "persistent-home"
+    root = runner_workspace / "defenseclaw-e2e-slot-core"
+    runner_workspace.mkdir()
+    persistent_home.mkdir()
+
+    _run_helper("prepare", root, runner_workspace=runner_workspace, persistent_home=persistent_home)
     stale = root / ".defenseclaw" / "root-owned-from-crash"
     stale.parent.mkdir()
     stale.write_text("stale\n", encoding="utf-8")
 
-    _run_helper("authorize-cleanup", root, runner_temp=runner_temp, persistent_home=persistent_home)
-    _run_helper("prepare", root, runner_temp=runner_temp, persistent_home=persistent_home)
+    _run_helper("authorize-cleanup", root, runner_workspace=runner_workspace, persistent_home=persistent_home)
+    _run_helper("prepare", root, runner_workspace=runner_workspace, persistent_home=persistent_home)
     assert not stale.exists()
     assert (root / OWNER_MARKER).read_text(encoding="utf-8") == f"{root.name}\n"
 
@@ -553,16 +689,16 @@ def test_owned_tree_removal_reports_an_e2e_refusal(tmp_path: Path, monkeypatch: 
 
 
 def test_prepare_resumes_a_marked_prepublication_stage(tmp_path: Path) -> None:
-    runner_temp = tmp_path / "runner-temp"
+    runner_workspace = tmp_path / "runner-workspace"
     persistent_home = tmp_path / "persistent-home"
-    root = runner_temp / "defenseclaw-e2e-slot-core"
+    root = runner_workspace / "defenseclaw-e2e-slot-core"
     staging, _ = _transaction_paths(root)
-    runner_temp.mkdir()
+    runner_workspace.mkdir()
     persistent_home.mkdir()
     staging.mkdir(mode=0o700)
     (staging / OWNER_MARKER).write_text(f"{root.name}\n", encoding="utf-8")
 
-    _run_helper("prepare", root, runner_temp=runner_temp, persistent_home=persistent_home)
+    _run_helper("prepare", root, runner_workspace=runner_workspace, persistent_home=persistent_home)
 
     assert root.is_dir()
     assert not staging.exists()
@@ -570,13 +706,13 @@ def test_prepare_resumes_a_marked_prepublication_stage(tmp_path: Path) -> None:
 
 
 def test_prepare_recovers_a_marked_midretirement_tombstone(tmp_path: Path) -> None:
-    runner_temp = tmp_path / "runner-temp"
+    runner_workspace = tmp_path / "runner-workspace"
     persistent_home = tmp_path / "persistent-home"
-    root = runner_temp / "defenseclaw-e2e-slot-full-live"
+    root = runner_workspace / "defenseclaw-e2e-slot-full-live"
     _, tombstone = _transaction_paths(root)
-    runner_temp.mkdir()
+    runner_workspace.mkdir()
     persistent_home.mkdir()
-    _run_helper("prepare", root, runner_temp=runner_temp, persistent_home=persistent_home)
+    _run_helper("prepare", root, runner_workspace=runner_workspace, persistent_home=persistent_home)
     stale = root / ".defenseclaw" / "partial-retirement"
     stale.parent.mkdir()
     stale.write_text("stale\n", encoding="utf-8")
@@ -585,12 +721,12 @@ def test_prepare_recovers_a_marked_midretirement_tombstone(tmp_path: Path) -> No
     _run_helper(
         "authorize-cleanup",
         root,
-        runner_temp=runner_temp,
+        runner_workspace=runner_workspace,
         persistent_home=persistent_home,
     )
     assert root.is_dir()
     assert not tombstone.exists()
-    _run_helper("prepare", root, runner_temp=runner_temp, persistent_home=persistent_home)
+    _run_helper("prepare", root, runner_workspace=runner_workspace, persistent_home=persistent_home)
 
     assert root.is_dir()
     assert not tombstone.exists()
@@ -598,14 +734,18 @@ def test_prepare_recovers_a_marked_midretirement_tombstone(tmp_path: Path) -> No
     assert {entry.name for entry in root.iterdir()} == {OWNER_MARKER}
 
 
-@pytest.mark.parametrize("suffix", [STAGING_SUFFIX, TOMBSTONE_SUFFIX])
+@pytest.mark.parametrize("transaction_index", [0, 1])
 @pytest.mark.parametrize("command", ["prepare", "authorize-cleanup", "cleanup"])
-def test_helper_preserves_an_unmarked_transaction_path(tmp_path: Path, suffix: str, command: str) -> None:
-    runner_temp = tmp_path / "runner-temp"
+def test_helper_preserves_an_unmarked_transaction_path(
+    tmp_path: Path,
+    transaction_index: int,
+    command: str,
+) -> None:
+    runner_workspace = tmp_path / "runner-workspace"
     persistent_home = tmp_path / "persistent-home"
-    root = runner_temp / "defenseclaw-e2e-slot-core"
-    transaction = runner_temp / f".{root.name}{suffix}"
-    runner_temp.mkdir()
+    root = runner_workspace / "defenseclaw-e2e-slot-core"
+    transaction = _transaction_paths(root)[transaction_index]
+    runner_workspace.mkdir()
     persistent_home.mkdir()
     transaction.mkdir()
     sentinel = transaction / "keep.txt"
@@ -614,7 +754,7 @@ def test_helper_preserves_an_unmarked_transaction_path(tmp_path: Path, suffix: s
     result = _run_helper(
         command,
         root,
-        runner_temp=runner_temp,
+        runner_workspace=runner_workspace,
         persistent_home=persistent_home,
         check=False,
     )
@@ -625,11 +765,11 @@ def test_helper_preserves_an_unmarked_transaction_path(tmp_path: Path, suffix: s
 
 
 def test_cleanup_resumes_marked_staging_and_tombstone_state(tmp_path: Path) -> None:
-    runner_temp = tmp_path / "runner-temp"
+    runner_workspace = tmp_path / "runner-workspace"
     persistent_home = tmp_path / "persistent-home"
-    root = runner_temp / "defenseclaw-e2e-slot-core"
+    root = runner_workspace / "defenseclaw-e2e-slot-core"
     staging, tombstone = _transaction_paths(root)
-    runner_temp.mkdir()
+    runner_workspace.mkdir()
     persistent_home.mkdir()
 
     for transaction in (staging, tombstone):
@@ -640,10 +780,10 @@ def test_cleanup_resumes_marked_staging_and_tombstone_state(tmp_path: Path) -> N
     _run_helper(
         "authorize-cleanup",
         root,
-        runner_temp=runner_temp,
+        runner_workspace=runner_workspace,
         persistent_home=persistent_home,
     )
-    _run_helper("cleanup", root, runner_temp=runner_temp, persistent_home=persistent_home)
+    _run_helper("cleanup", root, runner_workspace=runner_workspace, persistent_home=persistent_home)
 
     assert not root.exists()
     assert not staging.exists()
@@ -652,11 +792,11 @@ def test_cleanup_resumes_marked_staging_and_tombstone_state(tmp_path: Path) -> N
 
 @pytest.mark.parametrize("command", ["prepare", "authorize-cleanup", "cleanup"])
 def test_helper_rejects_ambiguous_canonical_and_tombstone_state(tmp_path: Path, command: str) -> None:
-    runner_temp = tmp_path / "runner-temp"
+    runner_workspace = tmp_path / "runner-workspace"
     persistent_home = tmp_path / "persistent-home"
-    root = runner_temp / "defenseclaw-e2e-slot-core"
+    root = runner_workspace / "defenseclaw-e2e-slot-core"
     _, tombstone = _transaction_paths(root)
-    runner_temp.mkdir()
+    runner_workspace.mkdir()
     persistent_home.mkdir()
 
     for transaction in (root, tombstone):
@@ -670,7 +810,7 @@ def test_helper_rejects_ambiguous_canonical_and_tombstone_state(tmp_path: Path, 
     result = _run_helper(
         command,
         root,
-        runner_temp=runner_temp,
+        runner_workspace=runner_workspace,
         persistent_home=persistent_home,
         check=False,
     )
@@ -683,9 +823,9 @@ def test_helper_rejects_ambiguous_canonical_and_tombstone_state(tmp_path: Path, 
 
 @pytest.mark.parametrize("command", ["prepare", "verify", "authorize-cleanup", "cleanup"])
 def test_helper_rejects_an_unmarked_existing_root(tmp_path: Path, command: str) -> None:
-    runner_temp = tmp_path / "runner-temp"
+    runner_workspace = tmp_path / "runner-workspace"
     persistent_home = tmp_path / "persistent-home"
-    root = runner_temp / "defenseclaw-e2e-slot-full-live"
+    root = runner_workspace / "defenseclaw-e2e-slot-full-live"
     root.mkdir(parents=True)
     persistent_home.mkdir()
     sentinel = root / "keep.txt"
@@ -693,7 +833,7 @@ def test_helper_rejects_an_unmarked_existing_root(tmp_path: Path, command: str) 
     result = _run_helper(
         command,
         root,
-        runner_temp=runner_temp,
+        runner_workspace=runner_workspace,
         persistent_home=persistent_home,
         check=False,
     )
@@ -703,16 +843,16 @@ def test_helper_rejects_an_unmarked_existing_root(tmp_path: Path, command: str) 
 
 
 def test_cleanup_authorization_accepts_absence_but_rejects_unowned_state(tmp_path: Path) -> None:
-    runner_temp = tmp_path / "runner-temp"
+    runner_workspace = tmp_path / "runner-workspace"
     persistent_home = tmp_path / "persistent-home"
-    root = runner_temp / "defenseclaw-e2e-slot-core"
-    runner_temp.mkdir()
+    root = runner_workspace / "defenseclaw-e2e-slot-core"
+    runner_workspace.mkdir()
     persistent_home.mkdir()
 
     absent = _run_helper(
         "authorize-cleanup",
         root,
-        runner_temp=runner_temp,
+        runner_workspace=runner_workspace,
         persistent_home=persistent_home,
         check=False,
     )
@@ -724,7 +864,7 @@ def test_cleanup_authorization_accepts_absence_but_rejects_unowned_state(tmp_pat
     unowned = _run_helper(
         "authorize-cleanup",
         root,
-        runner_temp=runner_temp,
+        runner_workspace=runner_workspace,
         persistent_home=persistent_home,
         check=False,
     )
@@ -735,11 +875,11 @@ def test_cleanup_authorization_accepts_absence_but_rejects_unowned_state(tmp_pat
 
 @pytest.mark.parametrize("command", ["prepare", "verify", "authorize-cleanup", "cleanup"])
 def test_helper_rejects_a_symlink_root(tmp_path: Path, command: str) -> None:
-    runner_temp = tmp_path / "runner-temp"
+    runner_workspace = tmp_path / "runner-workspace"
     persistent_home = tmp_path / "persistent-home"
     target = tmp_path / "target"
-    root = runner_temp / "defenseclaw-e2e-slot-core"
-    runner_temp.mkdir()
+    root = runner_workspace / "defenseclaw-e2e-slot-core"
+    runner_workspace.mkdir()
     persistent_home.mkdir()
     target.mkdir()
     sentinel = target / "keep.txt"
@@ -752,7 +892,7 @@ def test_helper_rejects_a_symlink_root(tmp_path: Path, command: str) -> None:
     result = _run_helper(
         command,
         root,
-        runner_temp=runner_temp,
+        runner_workspace=runner_workspace,
         persistent_home=persistent_home,
         check=False,
     )

--- a/cli/tests/test_e2e_workflow_cleanup.py
+++ b/cli/tests/test_e2e_workflow_cleanup.py
@@ -1,0 +1,762 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts for isolated source installs in persistent-runner E2E jobs."""
+
+from __future__ import annotations
+
+import os
+import runpy
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "e2e.yml"
+SOURCE_INSTALL_HELPER = ROOT / "scripts" / "e2e-source-install.py"
+SOURCE_INSTALL_PREFLIGHT = ROOT / "scripts" / "source-install-preflight.sh"
+RUNNER_CLEANUP = ROOT / "scripts" / "runner-cleanup.sh"
+WORKFLOW = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+SOURCE_INSTALL_API = runpy.run_path(os.fspath(SOURCE_INSTALL_HELPER))
+OWNER_MARKER = SOURCE_INSTALL_API["_OWNER_MARKER"]
+STAGING_SUFFIX = SOURCE_INSTALL_API["_STAGING_SUFFIX"]
+TOMBSTONE_SUFFIX = SOURCE_INSTALL_API["_TOMBSTONE_SUFFIX"]
+POSIX_SHELL_ONLY = pytest.mark.skipif(
+    os.name == "nt",
+    reason="runner-cleanup.sh requires a native POSIX shell",
+)
+
+
+def _transaction_paths(root: Path) -> tuple[Path, Path]:
+    return SOURCE_INSTALL_API["_transaction_paths"](root)
+
+
+def _step(job: str, name: str) -> dict[str, object]:
+    steps = WORKFLOW["jobs"][job]["steps"]
+    matches = [step for step in steps if step.get("name") == name]
+    assert len(matches) == 1, f"expected one {name!r} step in {job!r}"
+    return matches[0]
+
+
+def _step_script(job: str, name: str) -> str:
+    script = _step(job, name).get("run")
+    assert isinstance(script, str), f"expected {job}/{name} to be a run step"
+    return script
+
+
+def _substring_offsets(text: str, needle: str) -> list[int]:
+    offsets: list[int] = []
+    cursor = 0
+    while (offset := text.find(needle, cursor)) >= 0:
+        offsets.append(offset)
+        cursor = offset + len(needle)
+    return offsets
+
+
+def _helper_env(runner_temp: Path, persistent_home: Path, *, path: str | None = None) -> dict[str, str]:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "HOME": os.fspath(persistent_home),
+            "USERPROFILE": os.fspath(persistent_home),
+            "RUNNER_TEMP": os.fspath(runner_temp),
+        }
+    )
+    if path is not None:
+        environment["PATH"] = path
+    return environment
+
+
+def _run_helper(
+    command: str,
+    root: Path,
+    *,
+    runner_temp: Path,
+    persistent_home: Path,
+    path: str | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, os.fspath(SOURCE_INSTALL_HELPER), command, os.fspath(root)],
+        check=check,
+        capture_output=True,
+        text=True,
+        env=_helper_env(runner_temp, persistent_home, path=path),
+    )
+
+
+def test_persistent_e2e_jobs_are_serialized_through_cleanup() -> None:
+    """Full-live must wait for core's always-run post-cleanup step."""
+
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    trigger_block = workflow_text.split("concurrency:", 1)[0]
+    assert "schedule:" in trigger_block
+    assert "workflow_dispatch:" not in trigger_block
+    assert "pull_request:" not in trigger_block
+    assert WORKFLOW["concurrency"]["cancel-in-progress"] is False
+    full_live = WORKFLOW["jobs"]["full-live"]
+    assert full_live["needs"] == "core"
+    assert "always()" in full_live["if"]
+    for job in ("core", "full-live"):
+        assert _step(job, "Post-run cleanup")["if"] == "always()"
+
+
+def test_persistent_e2e_jobs_use_distinct_run_owned_install_homes() -> None:
+    install_names: dict[str, str] = {}
+    for job in ("core", "full-live"):
+        environment = WORKFLOW["jobs"][job]["env"]
+        install_name = environment["E2E_INSTALL_NAME"]
+        expected = f"defenseclaw-e2e-slot-{job}"
+        select_home = _step_script(job, "Select isolated DefenseClaw home")
+        assert install_name == expected
+        assert "/" not in install_name
+        assert 'E2E_INSTALL_HOME="${RUNNER_TEMP}/${E2E_INSTALL_NAME}"' in select_home
+        assert 'echo "DEFENSECLAW_HOME=${E2E_INSTALL_HOME}/.defenseclaw"' in select_home
+        assert (
+            'echo "DEFENSECLAW_CUSTOM_PROVIDERS_PATH=${E2E_INSTALL_HOME}/.defenseclaw/'
+            'custom-providers.json"' in select_home
+        )
+        assert "OPENCLAW_HOME" not in select_home
+        install_names[job] = install_name
+    assert install_names["core"] != install_names["full-live"]
+
+
+def test_persistent_e2e_checkouts_do_not_persist_job_credentials() -> None:
+    for job in ("core", "full-live"):
+        checkouts = [
+            step
+            for step in WORKFLOW["jobs"][job]["steps"]
+            if isinstance(step.get("uses"), str) and step["uses"].startswith("actions/checkout@")
+        ]
+        assert len(checkouts) == 1
+        options = checkouts[0].get("with")
+        assert isinstance(options, dict)
+        assert options.get("persist-credentials") is False
+
+
+def test_persistent_e2e_jobs_use_the_source_install_helper_once() -> None:
+    prepare = 'python3 scripts/e2e-source-install.py prepare "${E2E_INSTALL_HOME}"'
+    cleanup = 'python3 scripts/e2e-source-install.py cleanup "${E2E_INSTALL_HOME}"'
+    path = 'python3 scripts/e2e-source-install.py path "${E2E_INSTALL_HOME}"'
+    authorization = 'python3 scripts/e2e-source-install.py authorize-cleanup "${E2E_INSTALL_HOME}"'
+    for job in ("core", "full-live"):
+        clean = _step_script(job, "Clean DefenseClaw")
+        assert clean.count(prepare) == 1
+        assert clean.count(authorization) == 1
+        first_cleanup = clean.index("bash scripts/runner-cleanup.sh")
+        assert clean.index(authorization) < first_cleanup < clean.index(prepare)
+        assert all(
+            clean.index(authorization) < offset
+            for offset in _substring_offsets(clean, "bash scripts/runner-cleanup.sh")
+        )
+        assert _step_script(job, "Post-run cleanup").count(cleanup) == 1
+        install = _step_script(job, "Install DefenseClaw")
+        assert install.count(path) == 1
+        assert 'USER_HOME="${E2E_INSTALL_HOME}"' in install
+        assert 'OC_EXT_DIR="$HOME/.openclaw/extensions/defenseclaw"' in install
+        assert 'echo "${E2E_INSTALL_HOME}/.local/bin" >> "$GITHUB_PATH"' in _step_script(job, "Activate venv")
+        for test_step in ("Unit tests", "TypeScript plugin tests", "Rego policy tests"):
+            assert 'USER_HOME="${E2E_INSTALL_HOME}"' in _step_script(job, test_step)
+
+
+def test_opa_is_installed_into_the_isolated_job_bin() -> None:
+    for job in ("core", "full-live"):
+        install_opa = _step_script(job, "Install OPA")
+        assert 'install -d -m 0755 "${E2E_INSTALL_HOME}/.local/bin"' in install_opa
+        assert 'install -m 0755 /tmp/opa "${E2E_INSTALL_HOME}/.local/bin/opa"' in install_opa
+        assert "$HOME/.local/bin/opa" not in install_opa
+
+
+def test_workflow_preserves_the_account_level_source_install() -> None:
+    forbidden = (
+        "~/.defenseclaw",
+        "$HOME/.defenseclaw",
+        "${HOME}/.defenseclaw",
+        "~/.local/bin/defenseclaw",
+        "$HOME/.local/bin/defenseclaw",
+        "${HOME}/.local/bin/defenseclaw",
+        "~/.local/bin/defenseclaw-gateway",
+        "$HOME/.local/bin/defenseclaw-gateway",
+        "${HOME}/.local/bin/defenseclaw-gateway",
+        "~/.local/bin/.defenseclaw-source-root",
+        "$HOME/.local/bin/.defenseclaw-source-root",
+        "${HOME}/.local/bin/.defenseclaw-source-root",
+    )
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    for target in forbidden:
+        assert target not in workflow_text
+
+
+def test_selected_state_reaches_runtime_and_failure_cleanup() -> None:
+    full_stack = (ROOT / "scripts" / "test-e2e-full-stack.sh").read_text(encoding="utf-8")
+    refs = [line for line in full_stack.splitlines() if "$HOME/.defenseclaw" in line or "~/.defenseclaw" in line]
+    assert refs == ['DC_HOME="${DEFENSECLAW_HOME:-$HOME/.defenseclaw}"']
+    cleanup_script = (ROOT / "scripts" / "runner-cleanup.sh").read_text(encoding="utf-8")
+    assert 'DC_STATE_HOME="${DEFENSECLAW_HOME:-$HOME/.defenseclaw}"' in cleanup_script
+    assert 'OC_STATE_HOME="$HOME/.openclaw"' in cleanup_script
+    service = _step_script("full-live", "Prepare OpenClaw Anthropic model + auth")
+    assert '  "DEFENSECLAW_HOME",' in service
+    assert '  "DEFENSECLAW_CUSTOM_PROVIDERS_PATH",' in service
+    assert '  "HOME",' not in service
+    assert '  "OPENCLAW_HOME",' not in service
+
+    for job in ("core", "full-live"):
+        post = _step_script(job, "Post-run cleanup")
+        authorization = 'python3 scripts/e2e-source-install.py authorize-cleanup "${E2E_INSTALL_HOME}"'
+        assert post.index(authorization) < post.index("bash scripts/runner-cleanup.sh")
+        assert post.index("bash scripts/runner-cleanup.sh") < post.index(
+            'python3 scripts/e2e-source-install.py cleanup "${E2E_INSTALL_HOME}"'
+        )
+
+
+@POSIX_SHELL_ONLY
+@pytest.mark.parametrize("unsafe_kind", ["relative", "root", "broad", "symlink-root"])
+def test_runner_cleanup_rejects_unsafe_defenseclaw_home(tmp_path: Path, unsafe_kind: str) -> None:
+    persistent_home = tmp_path / "persistent-home"
+    persistent_home.mkdir()
+    if unsafe_kind == "relative":
+        unsafe_home = "relative/state"
+        expected = "DEFENSECLAW_HOME must be absolute"
+    elif unsafe_kind == "root":
+        unsafe_home = "/"
+        expected = "DEFENSECLAW_HOME must not resolve to /"
+    elif unsafe_kind == "broad":
+        unsafe_home = os.fspath(tmp_path / "broad-home")
+        expected = "explicit DEFENSECLAW_HOME must name a .defenseclaw state directory"
+    else:
+        link = tmp_path / "root-link"
+        try:
+            link.symlink_to("/", target_is_directory=True)
+        except (NotImplementedError, OSError) as exc:
+            pytest.skip(f"directory symlinks are unavailable: {exc}")
+        unsafe_home = os.fspath(link)
+        expected = "DEFENSECLAW_HOME must not be a symlink"
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "HOME": os.fspath(persistent_home),
+            "DEFENSECLAW_HOME": unsafe_home,
+            "RUNNER_CLEANUP_STATE_ONLY": "1",
+        }
+    )
+    result = subprocess.run(
+        ["bash", os.fspath(RUNNER_CLEANUP)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    assert result.returncode == 2
+    assert expected in result.stderr
+
+
+@POSIX_SHELL_ONLY
+def test_runner_cleanup_preserves_the_legacy_default_state_path(tmp_path: Path) -> None:
+    persistent_home = tmp_path / "persistent-home"
+    default_state = persistent_home / ".defenseclaw"
+    default_state.mkdir(parents=True)
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "HOME": os.fspath(persistent_home),
+            "RUNNER_CLEANUP_REPAIR_PERMISSIONS_ONLY": "1",
+        }
+    )
+    environment.pop("DEFENSECLAW_HOME", None)
+
+    result = subprocess.run(
+        ["bash", os.fspath(RUNNER_CLEANUP)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@POSIX_SHELL_ONLY
+def test_runner_cleanup_does_not_follow_a_state_symlink(tmp_path: Path) -> None:
+    persistent_home = tmp_path / "persistent-home"
+    isolated_home = tmp_path / "isolated-home"
+    victim = tmp_path / "victim"
+    sentinel = victim / "quarantine" / "skills" / "e2e-must-survive"
+    persistent_home.mkdir()
+    sentinel.mkdir(parents=True)
+    try:
+        isolated_home.symlink_to(victim, target_is_directory=True)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"directory symlinks are unavailable: {exc}")
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "HOME": os.fspath(persistent_home),
+            "DEFENSECLAW_HOME": os.fspath(isolated_home),
+            "RUNNER_CLEANUP_STATE_ONLY": "1",
+        }
+    )
+    result = subprocess.run(
+        ["bash", os.fspath(RUNNER_CLEANUP)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    assert result.returncode == 2
+    assert "DEFENSECLAW_HOME must not be a symlink" in result.stderr
+    assert sentinel.is_dir()
+
+
+@POSIX_SHELL_ONLY
+@pytest.mark.parametrize(
+    "cleanup_flag",
+    ["RUNNER_CLEANUP_STATE_ONLY", "RUNNER_CLEANUP_PERMISSIONS_ONLY"],
+)
+def test_runner_cleanup_does_not_follow_a_state_symlink_ancestor(tmp_path: Path, cleanup_flag: str) -> None:
+    persistent_home = tmp_path / "persistent-home"
+    linked_parent = tmp_path / "linked-parent"
+    victim_parent = tmp_path / "victim-parent"
+    victim_state = victim_parent / ".defenseclaw"
+    sentinel = victim_state / "quarantine" / "skills" / "e2e-must-survive"
+    persistent_home.mkdir()
+    sentinel.mkdir(parents=True)
+    try:
+        linked_parent.symlink_to(victim_parent, target_is_directory=True)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"directory symlinks are unavailable: {exc}")
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "HOME": os.fspath(persistent_home),
+            "DEFENSECLAW_HOME": os.fspath(linked_parent / ".defenseclaw"),
+            cleanup_flag: "1",
+        }
+    )
+    result = subprocess.run(
+        ["bash", os.fspath(RUNNER_CLEANUP)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert result.returncode == 2
+    assert "DEFENSECLAW_HOME must not contain a symlink" in result.stderr
+    assert sentinel.is_dir()
+
+
+@POSIX_SHELL_ONLY
+@pytest.mark.parametrize(
+    ("cleanup_flag", "cleanup_value"),
+    [
+        ("RUNNER_CLEANUP_STATE_ONLY", "1"),
+        ("RUNNER_CLEANUP_PERMISSIONS_ONLY", "1"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("link_parts", "sentinel_parts"),
+    [
+        (("quarantine",), ("skills", "e2e-must-survive")),
+        (("quarantine", "skills"), ("e2e-must-survive",)),
+        (("quarantine", "plugins"), ("e2e-must-survive",)),
+    ],
+)
+def test_runner_cleanup_does_not_follow_a_quarantine_symlink(
+    tmp_path: Path,
+    cleanup_flag: str,
+    cleanup_value: str,
+    link_parts: tuple[str, ...],
+    sentinel_parts: tuple[str, ...],
+) -> None:
+    persistent_home = tmp_path / "persistent-home"
+    isolated_state = tmp_path / "isolated" / ".defenseclaw"
+    victim = tmp_path / "victim"
+    link = isolated_state.joinpath(*link_parts)
+    sentinel = victim.joinpath(*sentinel_parts)
+    persistent_home.mkdir()
+    isolated_state.mkdir(parents=True)
+    link.parent.mkdir(parents=True, exist_ok=True)
+    sentinel.mkdir(parents=True)
+    try:
+        link.symlink_to(victim, target_is_directory=True)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"directory symlinks are unavailable: {exc}")
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "HOME": os.fspath(persistent_home),
+            "DEFENSECLAW_HOME": os.fspath(isolated_state),
+            cleanup_flag: cleanup_value,
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", os.fspath(RUNNER_CLEANUP)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert result.returncode == 2
+    assert "DefenseClaw cleanup path must not be a symlink" in result.stderr
+    assert sentinel.is_dir()
+
+
+@POSIX_SHELL_ONLY
+def test_runner_cleanup_accepts_a_safe_isolated_state_root(tmp_path: Path) -> None:
+    persistent_home = tmp_path / "persistent-home"
+    isolated_state = tmp_path / "isolated" / ".defenseclaw"
+    persistent_home.mkdir()
+    isolated_state.mkdir(parents=True)
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "HOME": os.fspath(persistent_home),
+            "DEFENSECLAW_HOME": os.fspath(isolated_state),
+            "RUNNER_CLEANUP_REPAIR_PERMISSIONS_ONLY": "1",
+        }
+    )
+    result = subprocess.run(
+        ["bash", os.fspath(RUNNER_CLEANUP)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_source_install_helper_lifecycle_preserves_persistent_home(tmp_path: Path) -> None:
+    runner_temp = tmp_path / "runner-temp"
+    persistent_home = tmp_path / "persistent-home"
+    persistent_bin = persistent_home / ".local" / "bin"
+    persistent_state = persistent_home / ".defenseclaw" / "config.yaml"
+    unrelated_bin = tmp_path / "unrelated-bin"
+    runner_temp.mkdir()
+    persistent_bin.mkdir(parents=True)
+    persistent_state.parent.mkdir()
+    unrelated_bin.mkdir()
+    persistent_state.write_text("persistent: true\n", encoding="utf-8")
+    for name in ("defenseclaw", "defenseclaw-gateway", ".defenseclaw-source-root"):
+        (persistent_bin / name).write_text("persistent\n", encoding="utf-8")
+
+    root = runner_temp / "defenseclaw-e2e-slot-core"
+    _run_helper("prepare", root, runner_temp=runner_temp, persistent_home=persistent_home)
+    _run_helper("verify", root, runner_temp=runner_temp, persistent_home=persistent_home)
+    assert (root / OWNER_MARKER).read_text(encoding="utf-8") == f"{root.name}\n"
+
+    isolated_bin = root / ".local" / "bin"
+    isolated_bin.mkdir(parents=True)
+    selected = (
+        _run_helper(
+            "path",
+            root,
+            runner_temp=runner_temp,
+            persistent_home=persistent_home,
+            path=os.pathsep.join((os.fspath(persistent_bin), os.fspath(unrelated_bin), os.fspath(isolated_bin))),
+        )
+        .stdout.strip()
+        .split(os.pathsep)
+    )
+    assert selected == [os.fspath(isolated_bin), os.fspath(unrelated_bin)]
+
+    if os.name != "nt":
+        workflow_path = _run_helper(
+            "path",
+            root,
+            runner_temp=runner_temp,
+            persistent_home=persistent_home,
+            path=os.pathsep.join((os.fspath(persistent_bin), os.defpath)),
+        ).stdout.strip()
+        preflight_env = _helper_env(runner_temp, persistent_home, path=workflow_path)
+        preflight_env["DEFENSECLAW_HOME"] = os.fspath(root / ".defenseclaw")
+        preflight = subprocess.run(
+            [
+                "bash",
+                os.fspath(SOURCE_INSTALL_PREFLIGHT),
+                "check",
+                os.fspath(ROOT),
+                os.fspath(isolated_bin),
+                ".venv/bin",
+                "defenseclaw",
+                "defenseclaw-gateway",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=preflight_env,
+        )
+        assert preflight.returncode == 0, preflight.stdout + preflight.stderr
+
+    (root / ".defenseclaw").mkdir()
+    _run_helper("cleanup", root, runner_temp=runner_temp, persistent_home=persistent_home)
+    assert not root.exists()
+    assert persistent_state.read_text(encoding="utf-8") == "persistent: true\n"
+    for name in ("defenseclaw", "defenseclaw-gateway", ".defenseclaw-source-root"):
+        assert (persistent_bin / name).read_text(encoding="utf-8") == "persistent\n"
+
+
+def test_stable_slot_retry_replaces_only_owned_crash_state(tmp_path: Path) -> None:
+    runner_temp = tmp_path / "runner-temp"
+    persistent_home = tmp_path / "persistent-home"
+    root = runner_temp / "defenseclaw-e2e-slot-core"
+    runner_temp.mkdir()
+    persistent_home.mkdir()
+
+    _run_helper("prepare", root, runner_temp=runner_temp, persistent_home=persistent_home)
+    stale = root / ".defenseclaw" / "root-owned-from-crash"
+    stale.parent.mkdir()
+    stale.write_text("stale\n", encoding="utf-8")
+
+    _run_helper("authorize-cleanup", root, runner_temp=runner_temp, persistent_home=persistent_home)
+    _run_helper("prepare", root, runner_temp=runner_temp, persistent_home=persistent_home)
+    assert not stale.exists()
+    assert (root / OWNER_MARKER).read_text(encoding="utf-8") == f"{root.name}\n"
+
+
+def test_transaction_fixture_names_match_helper_constants() -> None:
+    # These names are a persisted crash-recovery contract across workflow runs.
+    assert OWNER_MARKER == ".defenseclaw-e2e-owner"
+    assert STAGING_SUFFIX == ".staging"
+    assert TOMBSTONE_SUFFIX == ".tombstone"
+
+
+def test_owned_tree_removal_reports_an_e2e_refusal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    helper = SOURCE_INSTALL_API
+    root = tmp_path / "defenseclaw-e2e-slot-core"
+    _, tombstone = _transaction_paths(root)
+    child = tombstone / "unremovable"
+    tombstone.mkdir()
+    child.mkdir()
+    (tombstone / OWNER_MARKER).write_text(f"{root.name}\n", encoding="utf-8")
+
+    def refuse_removal(_path: Path) -> None:
+        raise PermissionError("injected removal failure")
+
+    monkeypatch.setattr(helper["shutil"], "rmtree", refuse_removal)
+    with pytest.raises(
+        SystemExit,
+        match="e2e source install refused: could not remove owned E2E transaction contents",
+    ):
+        helper["_remove_owned_tree"](tombstone, root)
+
+    assert child.is_dir()
+    assert (tombstone / OWNER_MARKER).is_file()
+
+
+def test_prepare_resumes_a_marked_prepublication_stage(tmp_path: Path) -> None:
+    runner_temp = tmp_path / "runner-temp"
+    persistent_home = tmp_path / "persistent-home"
+    root = runner_temp / "defenseclaw-e2e-slot-core"
+    staging, _ = _transaction_paths(root)
+    runner_temp.mkdir()
+    persistent_home.mkdir()
+    staging.mkdir(mode=0o700)
+    (staging / OWNER_MARKER).write_text(f"{root.name}\n", encoding="utf-8")
+
+    _run_helper("prepare", root, runner_temp=runner_temp, persistent_home=persistent_home)
+
+    assert root.is_dir()
+    assert not staging.exists()
+    assert {entry.name for entry in root.iterdir()} == {OWNER_MARKER}
+
+
+def test_prepare_recovers_a_marked_midretirement_tombstone(tmp_path: Path) -> None:
+    runner_temp = tmp_path / "runner-temp"
+    persistent_home = tmp_path / "persistent-home"
+    root = runner_temp / "defenseclaw-e2e-slot-full-live"
+    _, tombstone = _transaction_paths(root)
+    runner_temp.mkdir()
+    persistent_home.mkdir()
+    _run_helper("prepare", root, runner_temp=runner_temp, persistent_home=persistent_home)
+    stale = root / ".defenseclaw" / "partial-retirement"
+    stale.parent.mkdir()
+    stale.write_text("stale\n", encoding="utf-8")
+    root.rename(tombstone)
+
+    _run_helper(
+        "authorize-cleanup",
+        root,
+        runner_temp=runner_temp,
+        persistent_home=persistent_home,
+    )
+    assert root.is_dir()
+    assert not tombstone.exists()
+    _run_helper("prepare", root, runner_temp=runner_temp, persistent_home=persistent_home)
+
+    assert root.is_dir()
+    assert not tombstone.exists()
+    assert not stale.exists()
+    assert {entry.name for entry in root.iterdir()} == {OWNER_MARKER}
+
+
+@pytest.mark.parametrize("suffix", [STAGING_SUFFIX, TOMBSTONE_SUFFIX])
+@pytest.mark.parametrize("command", ["prepare", "authorize-cleanup", "cleanup"])
+def test_helper_preserves_an_unmarked_transaction_path(tmp_path: Path, suffix: str, command: str) -> None:
+    runner_temp = tmp_path / "runner-temp"
+    persistent_home = tmp_path / "persistent-home"
+    root = runner_temp / "defenseclaw-e2e-slot-core"
+    transaction = runner_temp / f".{root.name}{suffix}"
+    runner_temp.mkdir()
+    persistent_home.mkdir()
+    transaction.mkdir()
+    sentinel = transaction / "keep.txt"
+    sentinel.write_text("keep\n", encoding="utf-8")
+
+    result = _run_helper(
+        command,
+        root,
+        runner_temp=runner_temp,
+        persistent_home=persistent_home,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "has no E2E ownership marker" in result.stderr
+    assert sentinel.read_text(encoding="utf-8") == "keep\n"
+
+
+def test_cleanup_resumes_marked_staging_and_tombstone_state(tmp_path: Path) -> None:
+    runner_temp = tmp_path / "runner-temp"
+    persistent_home = tmp_path / "persistent-home"
+    root = runner_temp / "defenseclaw-e2e-slot-core"
+    staging, tombstone = _transaction_paths(root)
+    runner_temp.mkdir()
+    persistent_home.mkdir()
+
+    for transaction in (staging, tombstone):
+        transaction.mkdir(mode=0o700)
+        (transaction / OWNER_MARKER).write_text(f"{root.name}\n", encoding="utf-8")
+    (tombstone / "partial-state").write_text("stale\n", encoding="utf-8")
+
+    _run_helper(
+        "authorize-cleanup",
+        root,
+        runner_temp=runner_temp,
+        persistent_home=persistent_home,
+    )
+    _run_helper("cleanup", root, runner_temp=runner_temp, persistent_home=persistent_home)
+
+    assert not root.exists()
+    assert not staging.exists()
+    assert not tombstone.exists()
+
+
+@pytest.mark.parametrize("command", ["prepare", "authorize-cleanup", "cleanup"])
+def test_helper_rejects_ambiguous_canonical_and_tombstone_state(tmp_path: Path, command: str) -> None:
+    runner_temp = tmp_path / "runner-temp"
+    persistent_home = tmp_path / "persistent-home"
+    root = runner_temp / "defenseclaw-e2e-slot-core"
+    _, tombstone = _transaction_paths(root)
+    runner_temp.mkdir()
+    persistent_home.mkdir()
+
+    for transaction in (root, tombstone):
+        transaction.mkdir(mode=0o700)
+        (transaction / OWNER_MARKER).write_text(f"{root.name}\n", encoding="utf-8")
+    root_sentinel = root / "keep-root.txt"
+    retired_sentinel = tombstone / "keep-retired.txt"
+    root_sentinel.write_text("root\n", encoding="utf-8")
+    retired_sentinel.write_text("retired\n", encoding="utf-8")
+
+    result = _run_helper(
+        command,
+        root,
+        runner_temp=runner_temp,
+        persistent_home=persistent_home,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "canonical and retired install homes both exist" in result.stderr
+    assert root_sentinel.read_text(encoding="utf-8") == "root\n"
+    assert retired_sentinel.read_text(encoding="utf-8") == "retired\n"
+
+
+@pytest.mark.parametrize("command", ["prepare", "verify", "authorize-cleanup", "cleanup"])
+def test_helper_rejects_an_unmarked_existing_root(tmp_path: Path, command: str) -> None:
+    runner_temp = tmp_path / "runner-temp"
+    persistent_home = tmp_path / "persistent-home"
+    root = runner_temp / "defenseclaw-e2e-slot-full-live"
+    root.mkdir(parents=True)
+    persistent_home.mkdir()
+    sentinel = root / "keep.txt"
+    sentinel.write_text("keep\n", encoding="utf-8")
+    result = _run_helper(
+        command,
+        root,
+        runner_temp=runner_temp,
+        persistent_home=persistent_home,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "has no E2E ownership marker" in result.stderr
+    assert sentinel.read_text(encoding="utf-8") == "keep\n"
+
+
+def test_cleanup_authorization_accepts_absence_but_rejects_unowned_state(tmp_path: Path) -> None:
+    runner_temp = tmp_path / "runner-temp"
+    persistent_home = tmp_path / "persistent-home"
+    root = runner_temp / "defenseclaw-e2e-slot-core"
+    runner_temp.mkdir()
+    persistent_home.mkdir()
+
+    absent = _run_helper(
+        "authorize-cleanup",
+        root,
+        runner_temp=runner_temp,
+        persistent_home=persistent_home,
+        check=False,
+    )
+    assert absent.returncode == 0
+
+    root.mkdir()
+    sentinel = root / "keep.txt"
+    sentinel.write_text("keep\n", encoding="utf-8")
+    unowned = _run_helper(
+        "authorize-cleanup",
+        root,
+        runner_temp=runner_temp,
+        persistent_home=persistent_home,
+        check=False,
+    )
+    assert unowned.returncode != 0
+    assert "has no E2E ownership marker" in unowned.stderr
+    assert sentinel.read_text(encoding="utf-8") == "keep\n"
+
+
+@pytest.mark.parametrize("command", ["prepare", "verify", "authorize-cleanup", "cleanup"])
+def test_helper_rejects_a_symlink_root(tmp_path: Path, command: str) -> None:
+    runner_temp = tmp_path / "runner-temp"
+    persistent_home = tmp_path / "persistent-home"
+    target = tmp_path / "target"
+    root = runner_temp / "defenseclaw-e2e-slot-core"
+    runner_temp.mkdir()
+    persistent_home.mkdir()
+    target.mkdir()
+    sentinel = target / "keep.txt"
+    sentinel.write_text("keep\n", encoding="utf-8")
+    (target / OWNER_MARKER).write_text(f"{root.name}\n", encoding="utf-8")
+    try:
+        root.symlink_to(target, target_is_directory=True)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"directory symlinks are unavailable: {exc}")
+    result = _run_helper(
+        command,
+        root,
+        runner_temp=runner_temp,
+        persistent_home=persistent_home,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "install home is not a real directory" in result.stderr
+    assert root.is_symlink()
+    assert sentinel.read_text(encoding="utf-8") == "keep\n"

--- a/extensions/defenseclaw/src/__tests__/sidecar-config.test.ts
+++ b/extensions/defenseclaw/src/__tests__/sidecar-config.test.ts
@@ -33,13 +33,28 @@ import { loadSidecarConfig, _resetSidecarConfigCache } from "../sidecar-config.j
 const mockReadFileSync = vi.mocked(readFileSync);
 
 describe("loadSidecarConfig", () => {
+  const savedDefenseClawHome = process.env.DEFENSECLAW_HOME;
+  const savedE2EGatewayToken = process.env.E2E_GATEWAY_TOKEN;
+
   beforeEach(() => {
     _resetSidecarConfigCache();
     mockReadFileSync.mockReset();
+    delete process.env.DEFENSECLAW_HOME;
+    delete process.env.E2E_GATEWAY_TOKEN;
   });
 
   afterEach(() => {
     _resetSidecarConfigCache();
+    if (savedDefenseClawHome === undefined) {
+      delete process.env.DEFENSECLAW_HOME;
+    } else {
+      process.env.DEFENSECLAW_HOME = savedDefenseClawHome;
+    }
+    if (savedE2EGatewayToken === undefined) {
+      delete process.env.E2E_GATEWAY_TOKEN;
+    } else {
+      process.env.E2E_GATEWAY_TOKEN = savedE2EGatewayToken;
+    }
   });
 
   it("returns defaults when config file is missing", () => {
@@ -66,6 +81,67 @@ describe("loadSidecarConfig", () => {
       join("/mock-home", ".defenseclaw", "config.yaml"),
       "utf8"
     );
+  });
+
+  it("reads config and dotenv from an absolute DEFENSECLAW_HOME", () => {
+    process.env.DEFENSECLAW_HOME = "/isolated-defenseclaw";
+    mockReadFileSync.mockImplementation((path) => {
+      const selectedPath = String(path);
+      if (selectedPath === join("/isolated-defenseclaw", "config.yaml")) {
+        return "gateway:\n  host: 10.0.0.8\n  token_env: E2E_GATEWAY_TOKEN\n";
+      }
+      if (selectedPath === join("/isolated-defenseclaw", ".env")) {
+        return "E2E_GATEWAY_TOKEN=isolated-token\n";
+      }
+      throw new Error(`unexpected path: ${selectedPath}`);
+    });
+
+    const cfg = loadSidecarConfig();
+    expect(cfg.host).toBe("10.0.0.8");
+    expect(cfg.token).toBe("isolated-token");
+    expect(mockReadFileSync).not.toHaveBeenCalledWith(
+      join("/mock-home", ".defenseclaw", "config.yaml"),
+      "utf8"
+    );
+    expect(mockReadFileSync).not.toHaveBeenCalledWith(
+      join("/mock-home", ".defenseclaw", ".env"),
+      "utf8"
+    );
+  });
+
+  it("uses the default home when DEFENSECLAW_HOME is empty", () => {
+    process.env.DEFENSECLAW_HOME = "";
+    mockReadFileSync.mockImplementation((path) => {
+      const selectedPath = String(path);
+      if (selectedPath === join("/mock-home", ".defenseclaw", "config.yaml")) {
+        return "gateway:\n  host: 127.0.0.2\n";
+      }
+      throw new Error(`unexpected path: ${selectedPath}`);
+    });
+
+    expect(loadSidecarConfig().host).toBe("127.0.0.2");
+    expect(mockReadFileSync).toHaveBeenCalledWith(
+      join("/mock-home", ".defenseclaw", "config.yaml"),
+      "utf8"
+    );
+  });
+
+  it("rejects a relative DEFENSECLAW_HOME without reading persistent state", () => {
+    process.env.DEFENSECLAW_HOME = "relative/state";
+
+    expect(() => loadSidecarConfig()).toThrow(
+      "DEFENSECLAW_HOME must be an absolute path"
+    );
+    expect(mockReadFileSync).not.toHaveBeenCalled();
+  });
+
+  it("rejects a whitespace DEFENSECLAW_HOME without reading persistent state", () => {
+    process.env.DEFENSECLAW_HOME = "   ";
+
+    expect(() => loadSidecarConfig()).toThrow(
+      "DEFENSECLAW_HOME must be an absolute path"
+    );
+    expect(mockReadFileSync).not.toHaveBeenCalled();
   });
 
   it("reads approval timeout and hilt flag from config.yaml", () => {

--- a/extensions/defenseclaw/src/sidecar-config.ts
+++ b/extensions/defenseclaw/src/sidecar-config.ts
@@ -17,7 +17,7 @@
  */
 
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join, normalize } from "node:path";
 import { homedir } from "node:os";
 import yaml from "js-yaml";
 
@@ -56,6 +56,18 @@ interface SidecarConfig {
 
 let cached: SidecarConfig | undefined;
 
+/** Resolve the exact DefenseClaw data root selected by the host process. */
+function resolveDefenseClawHome(): string {
+  const override = process.env.DEFENSECLAW_HOME;
+  if (override === undefined || override === "") {
+    return join(homedir(), ".defenseclaw");
+  }
+  if (!isAbsolute(override)) {
+    throw new Error("DEFENSECLAW_HOME must be an absolute path");
+  }
+  return normalize(override);
+}
+
 /**
  * Read gateway.host, gateway.api_port, and gateway token from
  * ~/.defenseclaw/config.yaml. Token resolution mirrors the Go sidecar:
@@ -65,6 +77,11 @@ let cached: SidecarConfig | undefined;
  */
 export function loadSidecarConfig(): SidecarConfig {
   if (cached) return cached;
+
+  // Resolve outside the permissive config-file fallback below. An invalid
+  // explicit data-root override must fail closed instead of silently reading
+  // an unrelated account-level installation.
+  const defenseClawHome = resolveDefenseClawHome();
 
   let host = DEFAULT_HOST;
   let apiPort = DEFAULT_API_PORT;
@@ -77,7 +94,7 @@ export function loadSidecarConfig(): SidecarConfig {
   let enforcementMode: "observe" | "action" = "observe";
 
   try {
-    const cfgPath = join(homedir(), ".defenseclaw", "config.yaml");
+    const cfgPath = join(defenseClawHome, "config.yaml");
     const raw = yaml.load(readFileSync(cfgPath, "utf8")) as Record<string, unknown> | null;
     if (raw && typeof raw === "object") {
       const gw = raw["gateway"] as Record<string, unknown> | undefined;
@@ -97,7 +114,7 @@ export function loadSidecarConfig(): SidecarConfig {
         // common case in production because the Go bootstrap writes
         // DEFENSECLAW_GATEWAY_TOKEN there but does not export it
         // into the Node process that loads this extension.
-        const envVal = process.env[tokenEnv] || readDotEnvToken(tokenEnv);
+        const envVal = process.env[tokenEnv] || readDotEnvToken(defenseClawHome, tokenEnv);
         if (envVal) token = envVal;
       }
       const gr = raw["guardrail"] as Record<string, unknown> | undefined;
@@ -134,7 +151,7 @@ export function loadSidecarConfig(): SidecarConfig {
       token = envVal;
       break;
     }
-    const dotenvVal = readDotEnvToken(name);
+    const dotenvVal = readDotEnvToken(defenseClawHome, name);
     if (dotenvVal) {
       token = dotenvVal;
       break;
@@ -159,9 +176,9 @@ export function loadSidecarConfig(): SidecarConfig {
  * The Go sidecar loads this file into its own process env, but the
  * OpenClaw Node.js process is separate and won't have it.
  */
-function readDotEnvToken(key: string): string {
+function readDotEnvToken(defenseClawHome: string, key: string): string {
   try {
-    const envPath = join(homedir(), ".defenseclaw", ".env");
+    const envPath = join(defenseClawHome, ".env");
     const content = readFileSync(envPath, "utf8");
     for (const line of content.split("\n")) {
       const trimmed = line.trim();

--- a/scripts/e2e-source-install.py
+++ b/scripts/e2e-source-install.py
@@ -21,6 +21,8 @@ _ROOT_RE = re.compile(r"defenseclaw-e2e-slot-(?:core|full-live)")
 _OWNER_MARKER = ".defenseclaw-e2e-owner"
 _STAGING_SUFFIX = ".staging"
 _TOMBSTONE_SUFFIX = ".tombstone"
+_BUILD_TOOL_NAMES = ("go", "node", "npm", "uv")
+_BUILD_TOOL_SHIM_DIR = ".e2e-build-tools"
 
 
 def _fail(message: str) -> NoReturn:
@@ -29,33 +31,33 @@ def _fail(message: str) -> NoReturn:
     raise SystemExit(f"e2e source install refused: {message}")
 
 
-def _runner_temp() -> Path:
-    """Return the real, trusted GitHub runner temp directory."""
+def _runner_workspace() -> Path:
+    """Return the real, persistent GitHub runner workspace directory."""
 
-    value = os.environ.get("RUNNER_TEMP", "")
+    value = os.environ.get("RUNNER_WORKSPACE", "")
     if not value:
-        _fail("RUNNER_TEMP is required")
+        _fail("RUNNER_WORKSPACE is required")
     candidate = Path(value)
     if not candidate.is_absolute():
-        _fail("RUNNER_TEMP must be absolute")
+        _fail("RUNNER_WORKSPACE must be absolute")
     try:
         info = candidate.lstat()
     except FileNotFoundError:
-        _fail("RUNNER_TEMP does not exist")
+        _fail("RUNNER_WORKSPACE does not exist")
     if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
-        _fail("RUNNER_TEMP must be a real directory")
+        _fail("RUNNER_WORKSPACE must be a real directory")
     return candidate.resolve(strict=True)
 
 
 def _root(value: str) -> Path:
-    """Validate one canonical stable-slot child of the runner temp directory."""
+    """Validate one canonical stable-slot child of the persistent workspace."""
 
     candidate = Path(value)
     if not candidate.is_absolute() or not _ROOT_RE.fullmatch(candidate.name):
-        _fail("install home must be an absolute, run-named E2E path")
-    base = _runner_temp()
+        _fail("install home must be an absolute, slot-named E2E path")
+    base = _runner_workspace()
     if candidate.parent.resolve(strict=True) != base:
-        _fail("install home must be a direct child of RUNNER_TEMP")
+        _fail("install home must be a direct child of RUNNER_WORKSPACE")
     return base / candidate.name
 
 
@@ -256,8 +258,56 @@ def authorize_cleanup(root_value: str) -> None:
         _validate_owned(root)
 
 
+def _preserve_persistent_build_tools(root: Path, persistent_bin: Path) -> Path | None:
+    """Expose only required build tools that resolve from the filtered account bin."""
+
+    preserved: dict[str, Path] = {}
+    for name in _BUILD_TOOL_NAMES:
+        resolved = shutil.which(name)
+        if not resolved:
+            continue
+        candidate = Path(resolved)
+        if candidate.parent.resolve(strict=False) != persistent_bin:
+            continue
+        try:
+            target = candidate.resolve(strict=True)
+            info = target.stat()
+        except OSError:
+            _fail(f"persistent build tool {name} is not a stable executable")
+        if not stat.S_ISREG(info.st_mode) or not os.access(target, os.X_OK):
+            _fail(f"persistent build tool {name} is not a stable executable")
+        preserved[name] = target
+
+    if not preserved:
+        return None
+
+    shim_dir = root / _BUILD_TOOL_SHIM_DIR
+    if _entry_exists(shim_dir):
+        info = shim_dir.lstat()
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+            _fail("isolated build-tool directory is not a real directory")
+        if hasattr(os, "getuid") and info.st_uid != os.getuid():
+            _fail("isolated build-tool directory is not owned by the current user")
+        unexpected = {entry.name for entry in shim_dir.iterdir()} - set(_BUILD_TOOL_NAMES)
+        if unexpected:
+            _fail("isolated build-tool directory contains unexpected entries")
+        for entry in shim_dir.iterdir():
+            if not stat.S_ISLNK(entry.lstat().st_mode):
+                _fail(f"isolated build-tool shim {entry.name} is not a symbolic link")
+            entry.unlink()
+    else:
+        shim_dir.mkdir(mode=0o700)
+
+    for name, target in preserved.items():
+        shim = shim_dir / name
+        shim.symlink_to(target)
+        if shim.resolve(strict=True) != target:
+            _fail(f"isolated build-tool shim {name} does not match its executable")
+    return shim_dir
+
+
 def isolated_path(root_value: str) -> str:
-    """Prepend the isolated bin and remove the persistent account's bin."""
+    """Prepend isolated bins without exposing unrelated account executables."""
 
     root = _root(root_value)
     _validate_owned(root)
@@ -270,7 +320,11 @@ def isolated_path(root_value: str) -> str:
         if Path(component).resolve(strict=False) in (persistent_bin, isolated_bin):
             continue
         components.append(component)
-    return os.pathsep.join((os.fspath(isolated_bin), *components))
+    build_tools = _preserve_persistent_build_tools(root, persistent_bin)
+    prefix = [os.fspath(isolated_bin)]
+    if build_tools is not None:
+        prefix.append(os.fspath(build_tools))
+    return os.pathsep.join((*prefix, *components))
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:

--- a/scripts/e2e-source-install.py
+++ b/scripts/e2e-source-install.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Own one isolated DefenseClaw source-install home for persistent E2E."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import secrets
+import shutil
+import stat
+import sys
+import tempfile
+from pathlib import Path
+from typing import NoReturn
+
+_ROOT_RE = re.compile(r"defenseclaw-e2e-slot-(?:core|full-live)")
+_OWNER_MARKER = ".defenseclaw-e2e-owner"
+_STAGING_SUFFIX = ".staging"
+_TOMBSTONE_SUFFIX = ".tombstone"
+
+
+def _fail(message: str) -> NoReturn:
+    """Exit without changing an untrusted install root."""
+
+    raise SystemExit(f"e2e source install refused: {message}")
+
+
+def _runner_temp() -> Path:
+    """Return the real, trusted GitHub runner temp directory."""
+
+    value = os.environ.get("RUNNER_TEMP", "")
+    if not value:
+        _fail("RUNNER_TEMP is required")
+    candidate = Path(value)
+    if not candidate.is_absolute():
+        _fail("RUNNER_TEMP must be absolute")
+    try:
+        info = candidate.lstat()
+    except FileNotFoundError:
+        _fail("RUNNER_TEMP does not exist")
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        _fail("RUNNER_TEMP must be a real directory")
+    return candidate.resolve(strict=True)
+
+
+def _root(value: str) -> Path:
+    """Validate one canonical stable-slot child of the runner temp directory."""
+
+    candidate = Path(value)
+    if not candidate.is_absolute() or not _ROOT_RE.fullmatch(candidate.name):
+        _fail("install home must be an absolute, run-named E2E path")
+    base = _runner_temp()
+    if candidate.parent.resolve(strict=True) != base:
+        _fail("install home must be a direct child of RUNNER_TEMP")
+    return base / candidate.name
+
+
+def _entry_exists(path: Path) -> bool:
+    """Return whether a path entry exists without following a dangling link."""
+
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def _validate_owned(root: Path, *, slot_name: str | None = None) -> None:
+    """Prove that an existing root was created for this exact E2E job."""
+
+    try:
+        info = root.lstat()
+    except FileNotFoundError:
+        _fail("install home disappeared during validation")
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        _fail("install home is not a real directory")
+    if hasattr(os, "getuid") and info.st_uid != os.getuid():
+        _fail("install home is not owned by the current user")
+
+    marker = root / _OWNER_MARKER
+    try:
+        marker_info = marker.lstat()
+    except FileNotFoundError:
+        _fail("install home has no E2E ownership marker")
+    if not stat.S_ISREG(marker_info.st_mode) or stat.S_ISLNK(marker_info.st_mode):
+        _fail("E2E ownership marker is not a regular file")
+    if hasattr(os, "getuid") and marker_info.st_uid != os.getuid():
+        _fail("E2E ownership marker is not owned by the current user")
+    expected_name = root.name if slot_name is None else slot_name
+    if marker.read_text(encoding="utf-8") != f"{expected_name}\n":
+        _fail("E2E ownership marker does not match this job")
+
+
+def _transaction_paths(root: Path) -> tuple[Path, Path]:
+    """Return the exact crash-recovery siblings for one stable slot."""
+
+    return (
+        root.parent / f".{root.name}{_STAGING_SUFFIX}",
+        root.parent / f".{root.name}{_TOMBSTONE_SUFFIX}",
+    )
+
+
+def _write_owner_marker(directory: Path, slot_name: str) -> None:
+    """Durably mark a newly created private directory before publication."""
+
+    marker = directory / _OWNER_MARKER
+    descriptor = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        handle.write(f"{slot_name}\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _validate_staging(staging: Path, root: Path) -> None:
+    """Accept only the marker-only tree produced before slot publication."""
+
+    _validate_owned(staging, slot_name=root.name)
+    if {entry.name for entry in staging.iterdir()} != {_OWNER_MARKER}:
+        _fail("E2E staging home contains unexpected state")
+
+
+def _remove_owned_tree(path: Path, root: Path) -> None:
+    """Drain a transaction tree without ever unmarking its exact path."""
+
+    _validate_owned(path, slot_name=root.name)
+    try:
+        for child in path.iterdir():
+            if child.name == _OWNER_MARKER:
+                continue
+            info = child.lstat()
+            if stat.S_ISDIR(info.st_mode) and not stat.S_ISLNK(info.st_mode):
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+    except OSError:
+        _fail("could not remove owned E2E transaction contents")
+
+    _validate_owned(path, slot_name=root.name)
+    if {entry.name for entry in path.iterdir()} != {_OWNER_MARKER}:
+        _fail("E2E transaction home changed during cleanup")
+
+    # Move the empty, still-marked tree away from the exact recovery name
+    # before the final marker unlink/rmdir pair. A hard abort can therefore
+    # leave only a random inert entry, never an unmarked canonical blocker.
+    garbage = path.parent / f".{root.name}.gc-{secrets.token_hex(12)}"
+    os.rename(path, garbage)
+    (garbage / _OWNER_MARKER).unlink()
+    garbage.rmdir()
+
+
+def _build_staging(root: Path, staging: Path) -> None:
+    """Build a marked tree privately, then publish the exact staging path."""
+
+    temporary = Path(tempfile.mkdtemp(prefix=f".{root.name}.build-", dir=root.parent))
+    try:
+        temporary.chmod(0o700)
+        _write_owner_marker(temporary, root.name)
+        _validate_staging(temporary, root)
+        if _entry_exists(staging):
+            _fail("E2E staging home appeared during preparation")
+        os.rename(temporary, staging)
+    finally:
+        if _entry_exists(temporary):
+            shutil.rmtree(temporary)
+
+
+def _retire(root: Path, tombstone: Path) -> None:
+    """Atomically retire an owned canonical slot before recursive removal."""
+
+    _validate_owned(root)
+    if _entry_exists(tombstone):
+        _fail("canonical and retired install homes both exist")
+    os.rename(root, tombstone)
+    _remove_owned_tree(tombstone, root)
+
+
+def prepare(root_value: str) -> None:
+    """Transactionally publish a fresh home, replacing only an owned retry."""
+
+    root = _root(root_value)
+    staging, tombstone = _transaction_paths(root)
+
+    if _entry_exists(root):
+        _validate_owned(root)
+    if _entry_exists(staging):
+        _validate_staging(staging, root)
+    if _entry_exists(tombstone):
+        _validate_owned(tombstone, slot_name=root.name)
+    if _entry_exists(root) and _entry_exists(tombstone):
+        _fail("canonical and retired install homes both exist")
+    if _entry_exists(tombstone):
+        _fail("retired install home must be authorized and repaired before preparation")
+
+    if not _entry_exists(staging):
+        _build_staging(root, staging)
+    if _entry_exists(root):
+        _retire(root, tombstone)
+
+    if _entry_exists(root):
+        _fail("install home appeared during publication")
+    os.rename(staging, root)
+    _validate_owned(root)
+
+
+def cleanup(root_value: str) -> None:
+    """Transactionally retire marked E2E state; preserve every unknown path."""
+
+    root = _root(root_value)
+    staging, tombstone = _transaction_paths(root)
+
+    if _entry_exists(staging):
+        _validate_staging(staging, root)
+    if _entry_exists(tombstone):
+        _validate_owned(tombstone, slot_name=root.name)
+    if _entry_exists(root):
+        _validate_owned(root)
+    if _entry_exists(root) and _entry_exists(tombstone):
+        _fail("canonical and retired install homes both exist")
+    if _entry_exists(tombstone):
+        _fail("retired install home must be authorized and repaired before cleanup")
+
+    if _entry_exists(staging):
+        _remove_owned_tree(staging, root)
+    if _entry_exists(root):
+        _retire(root, tombstone)
+
+
+def verify(root_value: str) -> None:
+    """Validate ownership without changing the selected install home."""
+
+    _validate_owned(_root(root_value))
+
+
+def authorize_cleanup(root_value: str) -> None:
+    """Allow cleanup only when the selected root is absent or already owned."""
+
+    root = _root(root_value)
+    staging, tombstone = _transaction_paths(root)
+    if _entry_exists(root):
+        _validate_owned(root)
+    if _entry_exists(staging):
+        _validate_staging(staging, root)
+    if _entry_exists(tombstone):
+        _validate_owned(tombstone, slot_name=root.name)
+    if _entry_exists(root) and _entry_exists(tombstone):
+        _fail("canonical and retired install homes both exist")
+    if _entry_exists(tombstone):
+        # A killed recursive retirement can leave root-owned descendants.
+        # Restore the still-marked tree to the canonical slot so the workflow's
+        # next runner-cleanup invocation repairs it before prepare/cleanup.
+        os.rename(tombstone, root)
+        _validate_owned(root)
+
+
+def isolated_path(root_value: str) -> str:
+    """Prepend the isolated bin and remove the persistent account's bin."""
+
+    root = _root(root_value)
+    _validate_owned(root)
+    persistent_bin = (Path.home() / ".local" / "bin").resolve(strict=False)
+    isolated_bin = root / ".local" / "bin"
+    components: list[str] = []
+    for component in os.environ.get("PATH", "").split(os.pathsep):
+        if not component:
+            continue
+        if Path(component).resolve(strict=False) in (persistent_bin, isolated_bin):
+            continue
+        components.append(component)
+    return os.pathsep.join((os.fspath(isolated_bin), *components))
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse the small workflow-only command surface."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "command",
+        choices=("prepare", "verify", "authorize-cleanup", "cleanup", "path"),
+    )
+    parser.add_argument("root")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run one isolated-home operation."""
+
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    if args.command == "prepare":
+        prepare(args.root)
+    elif args.command == "verify":
+        verify(args.root)
+    elif args.command == "authorize-cleanup":
+        authorize_cleanup(args.root)
+    elif args.command == "cleanup":
+        cleanup(args.root)
+    else:
+        print(isolated_path(args.root))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/runner-cleanup.sh
+++ b/scripts/runner-cleanup.sh
@@ -81,17 +81,87 @@ PY
 validate_defenseclaw_state_home || exit $?
 
 repair_state_path() {
-  local state_path="$1"
+  local state_path="$1" runner_uid runner_gid
   [ -e "$state_path" ] || return 0
-  if sudo -n chown -R -- "$runner_uid:$runner_gid" "$state_path" 2>/dev/null; then
-    chmod -R u+rwX -- "$state_path" 2>/dev/null || true
-    return 0
-  fi
-  if sudo -n setfacl -R -m "u:${runner_uid}:rwX" -- "$state_path" 2>/dev/null; then
-    return 0
-  fi
-  if sudo -n chmod -R a+rwX -- "$state_path" 2>/dev/null; then
-    log "Relaxed permissions on $state_path after ownership repair failed"
+  runner_uid="$(id -u)"
+  runner_gid="$(id -g)"
+  if sudo -n python3 - "$state_path" "$runner_uid" "$runner_gid" <<'PY'
+import os
+import stat
+import sys
+
+root, uid_text, gid_text = sys.argv[1:]
+uid = int(uid_text)
+gid = int(gid_text)
+directory_flags = (
+    os.O_RDONLY
+    | os.O_DIRECTORY
+    | os.O_NOFOLLOW
+    | os.O_CLOEXEC
+)
+
+
+def repair_directory(descriptor):
+    os.fchown(descriptor, uid, gid)
+    directory_mode = stat.S_IMODE(os.fstat(descriptor).st_mode)
+    directory_mode &= ~(stat.S_ISUID | stat.S_ISGID | stat.S_ISVTX)
+    os.fchmod(descriptor, directory_mode | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+    for name in os.listdir(descriptor):
+        metadata = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+        if stat.S_ISLNK(metadata.st_mode):
+            # Ownership of a link is irrelevant to unlinking it; leave it
+            # untouched and never cross it into an external target.
+            continue
+        if stat.S_ISDIR(metadata.st_mode):
+            child = os.open(name, directory_flags, dir_fd=descriptor)
+            try:
+                opened = os.fstat(child)
+                if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
+                    raise OSError("state directory changed during repair")
+                repair_directory(child)
+            finally:
+                os.close(child)
+            continue
+        if not stat.S_ISREG(metadata.st_mode):
+            # Sockets, devices, and FIFOs do not need recursive permission
+            # repair. Avoid every pathname-based privileged mutation.
+            continue
+        if metadata.st_nlink != 1:
+            raise OSError("state repair refuses multiply-linked files")
+        flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC
+        child = os.open(name, flags, dir_fd=descriptor)
+        try:
+            opened = os.fstat(child)
+            if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
+                raise OSError("state entry changed during repair")
+            if opened.st_nlink != 1:
+                raise OSError("state repair refuses multiply-linked files")
+            os.fchown(child, uid, gid)
+            repaired = os.fstat(child)
+            mode = stat.S_IMODE(repaired.st_mode)
+            mode &= ~(stat.S_ISUID | stat.S_ISGID | stat.S_ISVTX)
+            mode |= stat.S_IRUSR | stat.S_IWUSR
+            if repaired.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
+                mode |= stat.S_IXUSR
+            os.fchmod(child, mode)
+        finally:
+            os.close(child)
+
+
+absolute = os.path.abspath(root)
+descriptor = os.open(os.path.sep, directory_flags)
+try:
+    for component in absolute.split(os.path.sep)[1:]:
+        if not component:
+            continue
+        child = os.open(component, directory_flags, dir_fd=descriptor)
+        os.close(descriptor)
+        descriptor = child
+    repair_directory(descriptor)
+finally:
+    os.close(descriptor)
+PY
+  then
     return 0
   fi
   return 1

--- a/scripts/runner-cleanup.sh
+++ b/scripts/runner-cleanup.sh
@@ -16,8 +16,69 @@
 # section headers and leave individual rm/prune output on stdout.
 set -u
 [ "${RUNNER_CLEANUP_VERBOSE:-0}" = "1" ] && set -x
+DC_STATE_HOME="${DEFENSECLAW_HOME:-$HOME/.defenseclaw}"
+DC_STATE_HOME_IS_OVERRIDE=0
+[ -n "${DEFENSECLAW_HOME+x}" ] && DC_STATE_HOME_IS_OVERRIDE=1
+OC_STATE_HOME="$HOME/.openclaw"
 
 log() { printf '[runner-cleanup] %s\n' "$*"; }
+
+validate_defenseclaw_state_home() {
+  local canonical cleanup_path resolved
+  case "$DC_STATE_HOME" in
+    /*) ;;
+    *)
+      printf '[runner-cleanup] ERROR: DEFENSECLAW_HOME must be absolute: %s\n' "$DC_STATE_HOME" >&2
+      return 2
+      ;;
+  esac
+  if [ -L "$DC_STATE_HOME" ]; then
+    printf '[runner-cleanup] ERROR: DEFENSECLAW_HOME must not be a symlink: %s\n' "$DC_STATE_HOME" >&2
+    return 2
+  fi
+  canonical="$(python3 - "$DC_STATE_HOME" <<'PY'
+import os
+import sys
+
+print(os.path.abspath(sys.argv[1]))
+PY
+)" || return 2
+  resolved="$(python3 - "$DC_STATE_HOME" <<'PY'
+import os
+import sys
+
+print(os.path.realpath(sys.argv[1]))
+PY
+)" || return 2
+  if [ "$resolved" != "$canonical" ]; then
+    printf '[runner-cleanup] ERROR: DEFENSECLAW_HOME must not contain a symlink: %s\n' "$DC_STATE_HOME" >&2
+    return 2
+  fi
+  if [ "$resolved" = "/" ]; then
+    printf '[runner-cleanup] ERROR: DEFENSECLAW_HOME must not resolve to /\n' >&2
+    return 2
+  fi
+  if [ "$DC_STATE_HOME_IS_OVERRIDE" -eq 1 ] && [ "$(basename "$DC_STATE_HOME")" != ".defenseclaw" ]; then
+    printf '[runner-cleanup] ERROR: explicit DEFENSECLAW_HOME must name a .defenseclaw state directory: %s\n' "$DC_STATE_HOME" >&2
+    return 2
+  fi
+
+  # This script recursively repairs the selected DefenseClaw state and prunes
+  # only its quarantine subtree. Refuse a link at every directory boundary the
+  # prune can traverse so a crash artifact cannot redirect cleanup outside the
+  # marker-authenticated E2E slot.
+  for cleanup_path in \
+    "$DC_STATE_HOME/quarantine" \
+    "$DC_STATE_HOME/quarantine/skills" \
+    "$DC_STATE_HOME/quarantine/plugins"; do
+    if [ -L "$cleanup_path" ]; then
+      printf '[runner-cleanup] ERROR: DefenseClaw cleanup path must not be a symlink: %s\n' "$cleanup_path" >&2
+      return 2
+    fi
+  done
+}
+
+validate_defenseclaw_state_home || exit $?
 
 repair_state_path() {
   local state_path="$1"
@@ -40,11 +101,13 @@ repair_persistent_state_permissions() {
   local runner_uid runner_gid state_dir repaired resolved_state_dir
   runner_uid="$(id -u)"
   runner_gid="$(id -g)"
-  for state_dir in "$HOME/.defenseclaw" "$HOME/.openclaw"; do
+  for state_dir in "$DC_STATE_HOME" "$OC_STATE_HOME"; do
     [ -e "$state_dir" ] || continue
     repaired=0
 
     # Sandbox setup can leave ~/.openclaw as a symlink to a root-owned target.
+    # DEFENSECLAW_HOME has already been rejected when it is a symlink; only
+    # the persistent OpenClaw state is intentionally followed here.
     # Repair the resolved target first; chown -R on the symlink path itself may
     # only affect the link and leave openclaw.json unreadable.
     if [ -L "$state_dir" ]; then
@@ -70,15 +133,15 @@ repair_persistent_state_permissions() {
 prune_stale_openclaw_e2e_artifacts() {
   local dir
   for dir in \
-    "$HOME/.openclaw/workspace/skills" \
-    "$HOME/.openclaw/skills" \
-    "$HOME/.openclaw/extensions"; do
+    "$OC_STATE_HOME/workspace/skills" \
+    "$OC_STATE_HOME/skills" \
+    "$OC_STATE_HOME/extensions"; do
     [ -d "$dir" ] || continue
     find "$dir" -mindepth 1 -maxdepth 1 -name 'e2e-*' -exec rm -rf {} + 2>/dev/null || true
   done
   for dir in \
-    "$HOME/.defenseclaw/quarantine/skills" \
-    "$HOME/.defenseclaw/quarantine/plugins"; do
+    "$DC_STATE_HOME/quarantine/skills" \
+    "$DC_STATE_HOME/quarantine/plugins"; do
     [ -d "$dir" ] || continue
     find "$dir" -mindepth 1 -maxdepth 2 -name 'e2e-*' -exec rm -rf {} + 2>/dev/null || true
   done
@@ -87,7 +150,7 @@ prune_stale_openclaw_e2e_artifacts() {
 prune_stale_openclaw_channel_plugin_projects() {
   local project_root project removed
   removed=0
-  for project_root in /data/openclaw/npm/projects "$HOME/.openclaw/npm/projects"; do
+  for project_root in /data/openclaw/npm/projects "$OC_STATE_HOME/npm/projects"; do
     [ -d "$project_root" ] || continue
     while IFS= read -r -d '' project; do
       if rm -rf -- "$project" 2>/dev/null; then
@@ -109,7 +172,7 @@ prune_stale_openclaw_channel_plugin_projects() {
 }
 
 normalize_openclaw_ci_config() {
-  local oc_home="$HOME/.openclaw"
+  local oc_home="$OC_STATE_HOME"
   [ -d "$oc_home" ] || return 0
   python3 - "$oc_home" <<'PY'
 import json

--- a/scripts/test-e2e-full-stack.sh
+++ b/scripts/test-e2e-full-stack.sh
@@ -42,6 +42,12 @@ OPENCLAW_MODEL_PATCHED="${OPENCLAW_MODEL_PATCHED:-false}"
 OPENCLAW_MODEL_BACKUP_PATH="${OPENCLAW_MODEL_BACKUP_PATH:-/tmp/defenseclaw-openclaw.full-live.backup.json}"
 ANTHROPIC_PASSTHROUGH_RAN="${ANTHROPIC_PASSTHROUGH_RAN:-false}"
 RUNTIME_TOOL_INSPECTION_EXERCISED=false
+DC_HOME="${DEFENSECLAW_HOME:-$HOME/.defenseclaw}"
+case "$DC_HOME" in
+    /*) ;;
+    *) echo "error: DEFENSECLAW_HOME must be absolute (got '$DC_HOME')" >&2; exit 2 ;;
+esac
+export DEFENSECLAW_HOME="$DC_HOME"
 
 sanitize_name() {
     printf '%s' "$1" | tr -cs '[:alnum:]._-' '-'
@@ -142,7 +148,7 @@ derive_proxy_master_key() {
 import hashlib
 import os
 
-key_file = os.path.expanduser("~/.defenseclaw/device.key")
+key_file = os.path.join(os.environ["DEFENSECLAW_HOME"], "device.key")
 try:
     with open(key_file, "rb") as f:
         data = f.read()
@@ -275,7 +281,7 @@ count_nonempty_lines() {
 
 read_dotenv_value() {
     local key="$1"
-    local env_path="$HOME/.defenseclaw/.env"
+    local env_path="$DC_HOME/.env"
     local line
     [ -f "$env_path" ] || return 0
     line=$(grep -E "^${key}=" "$env_path" 2>/dev/null | tail -n 1 || true)
@@ -372,7 +378,7 @@ get_gateway_token() {
 
     # Strategy 1: token persisted by the sidecar/OpenClaw auth repair path.
     # The CI shell can retain stale exported tokens while the daemon has
-    # already refreshed ~/.defenseclaw/.env after an OpenClaw token mismatch.
+    # already refreshed $DEFENSECLAW_HOME/.env after an OpenClaw token mismatch.
     sync_gateway_token_env_from_dotenv
     if [ "$GATEWAY_TOKEN_CACHE" != "__unset__" ]; then
         printf '%s\n' "$GATEWAY_TOKEN_CACHE"
@@ -403,9 +409,9 @@ PY
     fi
 
     # Strategy 5: read token_env name from config, then check that env var.
-    if [ -z "$GATEWAY_TOKEN_CACHE" ] && [ -f "$HOME/.defenseclaw/config.yaml" ]; then
+    if [ -z "$GATEWAY_TOKEN_CACHE" ] && [ -f "$DC_HOME/config.yaml" ]; then
         local token_env_name
-        token_env_name=$(grep 'token_env:' "$HOME/.defenseclaw/config.yaml" 2>/dev/null | head -1 | awk '{print $2}' | tr -d "'\"" || true)
+        token_env_name=$(grep 'token_env:' "$DC_HOME/config.yaml" 2>/dev/null | head -1 | awk '{print $2}' | tr -d "'\"" || true)
         if [ -n "$token_env_name" ]; then
             GATEWAY_TOKEN_CACHE="${!token_env_name:-}"
         fi
@@ -487,7 +493,7 @@ sidecar_api_authenticated() {
 }
 
 restart_sidecar_after_openclaw_token_repair() {
-    local log_file="$HOME/.defenseclaw/gateway.log"
+    local log_file="$DC_HOME/gateway.log"
     [ -f "$log_file" ] || return 0
     if ! tail -n 120 "$log_file" 2>/dev/null | grep -q "gateway token refreshed from openclaw.json"; then
         return 0
@@ -516,7 +522,7 @@ alerts_for_run() {
     if [ "${matched_count}" != "?" ] && [ "${matched_count}" -gt 0 ] 2>/dev/null; then
         printf '%s\n' "$raw" | jq --arg id "$DEFENSECLAW_RUN_ID" '[.[] | select(.run_id == $id)]' 2>/dev/null || echo '[]'
     else
-        # The DB is fresh each CI run (rm -rf ~/.defenseclaw in Clean step),
+        # The DB is fresh each CI run (a new isolated home is prepared),
         # so all events belong to the current run. The Go API's pure-Go SQLite
         # may not surface run_id written by the Python CLI (WAL cross-process
         # visibility between modernc.org/sqlite and C sqlite3). Return all
@@ -609,7 +615,7 @@ PY
         return
     fi
 
-    printf '%s\n%s\n' "$HOME/.defenseclaw/plugins" "$HOME/.openclaw/extensions" | awk 'NF && !seen[$0]++'
+    printf '%s\n%s\n' "$DC_HOME/plugins" "$HOME/.openclaw/extensions" | awk 'NF && !seen[$0]++'
 }
 
 get_governance_plugin_dirs() {
@@ -630,7 +636,7 @@ PY
         return
     fi
 
-    printf '%s\n' "$HOME/.defenseclaw/plugins"
+    printf '%s\n' "$DC_HOME/plugins"
 }
 
 get_runtime_plugin_dirs() {
@@ -732,7 +738,7 @@ find_runtime_plugin_path() {
 
 find_quarantined_plugin_path() {
     local name="$1"
-    local root="$HOME/.defenseclaw/quarantine/plugins"
+    local root="$DC_HOME/quarantine/plugins"
     [ -n "$name" ] || return 1
     if [ -d "$root/$name" ]; then
         printf '%s\n' "$root/$name"
@@ -755,8 +761,8 @@ cleanup_skill_name() {
         [ -n "$dir" ] || continue
         rm -rf "$dir/$name" 2>/dev/null || true
     done < <(get_skill_dirs)
-    rm -rf "$HOME/.defenseclaw/quarantine/skills/$name" 2>/dev/null || true
-    rm -rf "$HOME/.defenseclaw/quarantine/skills"/*/"$name" 2>/dev/null || true
+    rm -rf "$DC_HOME/quarantine/skills/$name" 2>/dev/null || true
+    rm -rf "$DC_HOME/quarantine/skills"/*/"$name" 2>/dev/null || true
 }
 
 cleanup_plugin_name() {
@@ -765,8 +771,8 @@ cleanup_plugin_name() {
         [ -n "$dir" ] || continue
         rm -rf "$dir/$name" 2>/dev/null || true
     done < <(get_plugin_dirs)
-    rm -rf "$HOME/.defenseclaw/quarantine/plugins/$name" 2>/dev/null || true
-    rm -rf "$HOME/.defenseclaw/quarantine/plugins"/*/"$name" 2>/dev/null || true
+    rm -rf "$DC_HOME/quarantine/plugins/$name" 2>/dev/null || true
+    rm -rf "$DC_HOME/quarantine/plugins"/*/"$name" 2>/dev/null || true
 }
 
 skill_list_json() {
@@ -1237,7 +1243,7 @@ import os
 import yaml
 from pathlib import Path
 
-cfg_path = Path(os.path.expanduser("~/.defenseclaw/config.yaml"))
+cfg_path = Path(os.environ["DEFENSECLAW_HOME"]) / "config.yaml"
 if not cfg_path.exists():
     print("")
     raise SystemExit(0)
@@ -1256,7 +1262,7 @@ import os
 import yaml
 from pathlib import Path
 
-cfg_path = Path(os.path.expanduser("~/.defenseclaw/config.yaml"))
+cfg_path = Path(os.environ["DEFENSECLAW_HOME"]) / "config.yaml"
 if not cfg_path.exists():
     raise SystemExit("config.yaml not found")
 
@@ -1314,10 +1320,10 @@ cleanup_current_run_artifacts() {
         rm -rf "$dir"/"$E2E_PREFIX"* 2>/dev/null || true
     done < <(get_plugin_dirs)
 
-    rm -rf "$HOME/.defenseclaw/quarantine/skills"/"$E2E_PREFIX"* 2>/dev/null || true
-    rm -rf "$HOME/.defenseclaw/quarantine/plugins"/"$E2E_PREFIX"* 2>/dev/null || true
-    find "$HOME/.defenseclaw/quarantine/skills" -mindepth 2 -maxdepth 2 -name "$E2E_PREFIX*" -exec rm -rf {} + 2>/dev/null || true
-    find "$HOME/.defenseclaw/quarantine/plugins" -mindepth 2 -maxdepth 2 -name "$E2E_PREFIX*" -exec rm -rf {} + 2>/dev/null || true
+    rm -rf "$DC_HOME/quarantine/skills"/"$E2E_PREFIX"* 2>/dev/null || true
+    rm -rf "$DC_HOME/quarantine/plugins"/"$E2E_PREFIX"* 2>/dev/null || true
+    find "$DC_HOME/quarantine/skills" -mindepth 2 -maxdepth 2 -name "$E2E_PREFIX*" -exec rm -rf {} + 2>/dev/null || true
+    find "$DC_HOME/quarantine/plugins" -mindepth 2 -maxdepth 2 -name "$E2E_PREFIX*" -exec rm -rf {} + 2>/dev/null || true
     rm -rf "$HOME/.openclaw/extensions"/"$E2E_PREFIX"* 2>/dev/null || true
     rm -rf /tmp/"$E2E_PREFIX"* 2>/dev/null || true
     prune_openclaw_config_for_prefix
@@ -1333,7 +1339,7 @@ inspect_tool() {
 
 # dump_artifacts is invoked from an EXIT trap when
 # any phase records FAIL>0. The legacy implementation cat'd
-# ~/.defenseclaw/config.yaml and ~/.openclaw/openclaw.json directly
+# $DEFENSECLAW_HOME/config.yaml and ~/.openclaw/openclaw.json directly
 # and tail'd gateway.log / gateway.jsonl without redaction. The
 # DefenseClaw config schema permits inline llm.api_key,
 # splunk.hec_token, gateway.token, and OpenClaw gateway.auth.token
@@ -1368,20 +1374,20 @@ dump_artifacts() {
     echo "profile=$E2E_PROFILE"
     echo "run_id=$DEFENSECLAW_RUN_ID"
     echo "prefix=$E2E_PREFIX"
-    echo "--- ~/.defenseclaw/config.yaml (redacted) ---"
-    cat ~/.defenseclaw/config.yaml 2>/dev/null | _redact_secrets || echo "  (not found)"
+    echo "--- $DEFENSECLAW_HOME/config.yaml (redacted) ---"
+    cat "$DC_HOME/config.yaml" 2>/dev/null | _redact_secrets || echo "  (not found)"
     echo "--- .env key names (values redacted) ---"
-    grep -oP '^\w+(?==)' ~/.defenseclaw/.env 2>/dev/null || echo "  (none)"
+    grep -oP '^\w+(?==)' "$DC_HOME/.env" 2>/dev/null || echo "  (none)"
     echo "--- defenseclaw-gateway status ---"
     defenseclaw-gateway status 2>/dev/null | _redact_secrets || echo "  (not running)"
     echo "--- gateway.log (last 60 lines, redacted) ---"
-    tail -60 ~/.defenseclaw/gateway.log 2>/dev/null | _redact_secrets || echo "  (not found)"
+    tail -60 "$DC_HOME/gateway.log" 2>/dev/null | _redact_secrets || echo "  (not found)"
     echo "--- gateway.jsonl (last 60 lines, redacted) ---"
-    tail -60 ~/.defenseclaw/gateway.jsonl 2>/dev/null | _redact_secrets || echo "  (not found)"
+    tail -60 "$DC_HOME/gateway.jsonl" 2>/dev/null | _redact_secrets || echo "  (not found)"
     echo "--- SQLite direct event count (via Python) ---"
     python3 -c "
 import sqlite3, os
-db = os.path.expanduser('~/.defenseclaw/audit.db')
+db = os.path.join(os.environ['DEFENSECLAW_HOME'], 'audit.db')
 if not os.path.isfile(db):
     print('  audit.db not found')
     raise SystemExit(0)
@@ -1443,7 +1449,7 @@ phase_start() {
     local stale_skills stale_plugins stale_quarantine cfg_state
     stale_skills=$(snapshot_skill_paths | grep "/$E2E_PREFIX" || true)
     stale_plugins=$(snapshot_plugin_paths | grep "/$E2E_PREFIX" || true)
-    stale_quarantine=$(find "$HOME/.defenseclaw/quarantine" -mindepth 1 -maxdepth 3 -name "${E2E_PREFIX}*" 2>/dev/null || true)
+    stale_quarantine=$(find "$DC_HOME/quarantine" -mindepth 1 -maxdepth 3 -name "${E2E_PREFIX}*" 2>/dev/null || true)
     cfg_state=$(openclaw_config_state_json)
 
     if [ -z "$stale_skills" ]; then
@@ -1574,12 +1580,12 @@ phase_start() {
         GATEWAY_TOKEN_CACHE="__unset__"
     else
         fail "sidecar health endpoint reachable" "unhealthy after 3 attempts (60s each)"
-        echo "  --- last 100 lines of ~/.defenseclaw/gateway.log ---" >&2
-        tail -n 100 "$HOME/.defenseclaw/gateway.log" 2>&1 | sed 's/^/    /' >&2 || true
-        echo "  --- last 100 lines of ~/.defenseclaw/gateway.jsonl ---" >&2
-        tail -n 100 "$HOME/.defenseclaw/gateway.jsonl" 2>&1 | sed 's/^/    /' >&2 || true
-        echo "  --- last 40 lines of ~/.defenseclaw/watchdog.log ---" >&2
-        tail -n 40 "$HOME/.defenseclaw/watchdog.log" 2>&1 | sed 's/^/    /' >&2 || true
+        echo "  --- last 100 lines of $DEFENSECLAW_HOME/gateway.log ---" >&2
+        tail -n 100 "$DC_HOME/gateway.log" 2>&1 | sed 's/^/    /' >&2 || true
+        echo "  --- last 100 lines of $DEFENSECLAW_HOME/gateway.jsonl ---" >&2
+        tail -n 100 "$DC_HOME/gateway.jsonl" 2>&1 | sed 's/^/    /' >&2 || true
+        echo "  --- last 40 lines of $DEFENSECLAW_HOME/watchdog.log ---" >&2
+        tail -n 40 "$DC_HOME/watchdog.log" 2>&1 | sed 's/^/    /' >&2 || true
         echo "  --- defenseclaw / openclaw processes ---" >&2
         ps -eo pid,ppid,stat,etime,rss,vsz,cmd 2>&1 | grep -Ei 'defenseclaw|openclaw' | grep -v grep | sed 's/^/    /' >&2 || true
         echo "  --- listeners on 127.0.0.1:18789 and 127.0.0.1:18970 ---" >&2
@@ -1772,7 +1778,7 @@ phase_connector() {
     fi
 
     # ── 2B-2. Active Connector State ──
-    local state_file="$HOME/.defenseclaw/active_connector.json"
+    local state_file="$DC_HOME/active_connector.json"
     if is_full_live; then
         # Full-live should have an active connector configured.
         if [ -n "$active_name" ] && [ "$active_name" != "null" ] && [ "$active_name" != "unknown" ]; then
@@ -1829,8 +1835,8 @@ phase_connector() {
     fi
 
     # ── 2B-4. Hook Scripts & Shims ──
-    local hooks_dir="$HOME/.defenseclaw/hooks"
-    local shims_dir="$HOME/.defenseclaw/shims"
+    local hooks_dir="$DC_HOME/hooks"
+    local shims_dir="$DC_HOME/shims"
 
     if [ -d "$hooks_dir" ]; then
         pass "connector hooks: hooks directory exists"
@@ -1975,7 +1981,7 @@ phase_connector_artifact_matrix() {
 
     connector_names=$(echo "$connectors_resp" | jq -r '[.connectors[].name] | sort | join(" ")' 2>/dev/null || echo "")
 
-    local hook_dir="$HOME/.defenseclaw/hooks"
+    local hook_dir="$DC_HOME/hooks"
     if [ ! -d "$hook_dir" ]; then
         skip "phase 2C: hook dir absent" "no $hook_dir (guardrail not yet set up)"
         phase_timer_end "Phase 2C"
@@ -2477,7 +2483,7 @@ phase_quarantine() {
     fi
 
     local quarantine_root flat_quarantine_path connector_quarantine_path
-    quarantine_root="$HOME/.defenseclaw/quarantine/skills"
+    quarantine_root="$DC_HOME/quarantine/skills"
     flat_quarantine_path="$quarantine_root/$skill_name"
     connector_quarantine_path=$(find "$quarantine_root" -mindepth 2 -maxdepth 2 -type d -name "$skill_name" -print -quit 2>/dev/null || true)
     if [ -d "$flat_quarantine_path" ] || [ -n "$connector_quarantine_path" ]; then
@@ -3009,7 +3015,7 @@ providers_path = os.path.join(repo_root, "internal", "configs", "providers.json"
 if not os.path.exists(providers_path):
     # Fallback: check common paths
     for p in [
-        os.path.expanduser("~/.defenseclaw/providers.json"),
+        os.path.join(os.environ["DEFENSECLAW_HOME"], "providers.json"),
         "internal/configs/providers.json",
     ]:
         if os.path.exists(p):
@@ -3043,7 +3049,7 @@ import os
 repo_root = os.environ.get("REPO_ROOT", ".")
 candidates = [
     os.path.join(repo_root, "internal", "configs", "providers.json"),
-    os.path.expanduser("~/.defenseclaw/providers.json"),
+    os.path.join(os.environ["DEFENSECLAW_HOME"], "providers.json"),
     "internal/configs/providers.json",
 ]
 for p in candidates:
@@ -3845,10 +3851,10 @@ phase_recovery() {
         pass "recovery: sidecar restarted after stop"
     else
         fail "recovery: sidecar restarted after stop" "sidecar health endpoint did not recover"
-        echo "  --- last 100 lines of ~/.defenseclaw/gateway.log ---" >&2
-        tail -n 100 "$HOME/.defenseclaw/gateway.log" 2>&1 | sed 's/^/    /' >&2 || true
-        echo "  --- last 100 lines of ~/.defenseclaw/gateway.jsonl ---" >&2
-        tail -n 100 "$HOME/.defenseclaw/gateway.jsonl" 2>&1 | sed 's/^/    /' >&2 || true
+        echo "  --- last 100 lines of $DEFENSECLAW_HOME/gateway.log ---" >&2
+        tail -n 100 "$DC_HOME/gateway.log" 2>&1 | sed 's/^/    /' >&2 || true
+        echo "  --- last 100 lines of $DEFENSECLAW_HOME/gateway.jsonl ---" >&2
+        tail -n 100 "$DC_HOME/gateway.jsonl" 2>&1 | sed 's/^/    /' >&2 || true
         phase_timer_end "Phase 7C"
         return
     fi
@@ -4023,7 +4029,7 @@ phase_teardown() {
     defenseclaw-gateway status 2>/dev/null || true
 
     # Verify connector state before stopping.
-    local state_file="$HOME/.defenseclaw/active_connector.json"
+    local state_file="$DC_HOME/active_connector.json"
     if [ -f "$state_file" ]; then
         echo "  Active connector state at teardown: $(cat "$state_file" 2>/dev/null)"
     fi
@@ -4046,8 +4052,8 @@ phase_teardown() {
     fi
 
     # Verify connector teardown cleaned up stale artifacts.
-    local shims_dir="$HOME/.defenseclaw/shims"
-    local hooks_dir="$HOME/.defenseclaw/hooks"
+    local shims_dir="$DC_HOME/shims"
+    local hooks_dir="$DC_HOME/hooks"
     if [ -d "$shims_dir" ] && [ -n "$(ls -A "$shims_dir" 2>/dev/null)" ]; then
         echo "  [warn] shims directory still populated after stop — may need manual cleanup"
     fi


### PR DESCRIPTION
Standalone fix on exact `main` base `334e15d082c0f90f7ec2b1eede17e0b470984229`.

## Problem

Scheduled E2E run 31574327663 failed before either lane could install DefenseClaw. A prior interrupted source installation left an incomplete ownership tuple on the persistent runner, and the strict source-install preflight correctly refused to overwrite it.

Deleting the account-level installation is not a safe recovery strategy: that installation may be release-managed or developer-owned. The runner instead needs a private, recoverable DefenseClaw installation without allowing privileged cleanup to escape its selected slot.

## Current Situation

The scheduled workflow has two serialized jobs on one persistent self-hosted runner. DefenseClaw and OpenClaw previously shared the account home. A killed job could leave root-owned state, a partial source-install tuple, or an interrupted cleanup transaction.

`RUNNER_TEMP` cannot hold recovery state because the Actions runner empties it before every job. Removing the account's entire `~/.local/bin` from the source-install `PATH`, however, can also hide build tools installed there. Finally, validating a pathname and later running recursive privileged `chown` leaves a replacement window.

## Solution

Give Core and Full Live distinct, stable, marker-owned DefenseClaw slots directly under `RUNNER_WORKSPACE`. Keep account-level `HOME` and the intentionally shared OpenClaw service state unchanged, but bind the source install, DefenseClaw state, provider overlay, plugin configuration, and full-stack assertions to the selected slot.

Publication and retirement are crash-resumable. Permission recovery opens the state tree root-to-leaf with no-follow descriptors and mutates only verified open inodes. It skips links and special files, rejects multiply linked files, and clears special permission bits. The install command sees only its isolated bin plus bounded shims for required account-installed build tools (`go`, `node`, `npm`, and `uv`); unrelated account executables remain hidden.

```mermaid
flowchart LR
    A["Scheduled job"] --> B["Authenticate persistent slot or absence"]
    B --> C["Restore marked tombstone after interrupted retirement"]
    C --> D["Descriptor-pinned permission repair"]
    D --> E["Build marker-only staging directory"]
    E --> F["Atomically retire old owned slot"]
    F --> G["Atomically publish fresh slot"]
    G --> H["Install with isolated paths and bounded tool shims"]
    H --> I["Always-run authenticated cleanup"]
```

Unmarked, symlinked, or ambiguous canonical/transaction paths fail closed and are preserved. The active scheduled execution is never canceled; GitHub retains the newest pending execution, whose recovery reuses the stable slots. Full Live still waits for Core cleanup.

The persistent checkouts no longer store the Actions job token in `.git/config`. The OpenClaw extension honors an absolute `DEFENSECLAW_HOME` for `config.yaml` and `.env`; the full-live service receives that path plus the isolated custom-provider overlay. Relative or whitespace-only explicit paths fail closed, while an empty override retains the default-home contract.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `.github/workflows/e2e.yml` | Select persistent, distinct `RUNNER_WORKSPACE` slots; preserve the active schedule; disable checkout credential persistence; authorize, repair, transactionally prepare/clean each slot; propagate isolated DefenseClaw and provider paths. |
| `scripts/e2e-source-install.py` | Add marker-authenticated staging/tombstone recovery and bounded build-tool shims while filtering unrelated account executables. |
| `scripts/runner-cleanup.sh` | Honor `DEFENSECLAW_HOME`; reject path escapes; replace recursive pathname-based privileged repair with descriptor-rooted, no-follow inode repair. |
| `scripts/test-e2e-full-stack.sh` | Resolve DefenseClaw runtime, audit, quarantine, connector, log, and diagnostic paths from `DEFENSECLAW_HOME`. |
| `extensions/defenseclaw/src/sidecar-config.ts` | Resolve plugin config and dotenv from a validated absolute `DEFENSECLAW_HOME`. |
| `extensions/defenseclaw/src/__tests__/sidecar-config.test.ts` | Cover isolated config/dotenv reads, default empty-override behavior, and fail-closed invalid paths. |
| `cli/tests/test_e2e_workflow_cleanup.py` | Add workflow, crash-recovery, tool-filtering, permission-repair, symlink-preservation, credential, service-env, and persistent-install contracts; keep POSIX execution out of Windows shards. |

## Breaking Changes

None for users or operators. The scheduled E2E runner now uses job-owned DefenseClaw slots instead of the persistent account's DefenseClaw installation. Shared OpenClaw service state remains unchanged.

## Open Issues / Follow-ups

- #725 remains open until two consecutive post-merge scheduled E2E runs pass, as required by its acceptance criteria.

## Test Plan

Exact head: `08f3f510007d6f769302f16977d0cc7c540be85f`

Parent: `a375f1adb997b484a25a8c6508597c207731ed2b`

Base: `334e15d082c0f90f7ec2b1eede17e0b470984229`

Tree: `3264f7141686dc4cf66a4880d9e63bfd3f2862a3`

Tip parent-delta SHA-256: plain `0e7217391c6a912cac829442e9ad124b2eda11ef4ee1c395be1d03e5539f01b6`; full-index `315cf3512098fc169c6c582c0f84a888be4c3abe843c314df6596bf256945e33`.

Base-to-head SHA-256: plain `934e43484083c34b78d73058ac6ddb6722de950498d76241b179f64d182a2e7b`; full-index `3aad2e5d334c991448b21d0a600727c2e757e6f1daf9f0b91f29ad057c5402f9`.

- Stable patch IDs and range-diff are byte-equivalent across the rebase: `6268f9c2...` / `2aace758...`, both `=`. Merged #719/#720/#721/#722/#727/#731 paths do not overlap.
- Exact-head review repair: both persistent jobs publish the authenticated filtered runtime `PATH` through `GITHUB_ENV`, never inherit account-level `~/.local/bin`, and always install and invoke pinned OPA 1.14.1 from the isolated slot. Focused workflow suite: **51 passed**; Ruff lint/format, YAML parse, and diff check passed; independent delta audit and CodeRabbit review: **CLEAN**.
- Focused workflow/ownership/crash/symlink/tool suite: **51 passed** after the final rebase; pre-rebase suite repeated 20 times (**1,020/1,020**).
- Adjacent source release/publication contracts: **60 passed / 5 expected skipped** after the final rebase.
- Exact subset on connected Linux ARM64 and macOS ARM64: **51 passed each** before and after the merge-wave rebase.
- Native descriptor-repair probes on Linux ARM64 (Python 3.12.3) and macOS ARM64 (system Python 3.9.6): root-owned nested state repaired; special bits cleared; nested symlink target identity, permissions, and bytes preserved.
- Full OpenClaw extension suite: **20 files / 271 tests passed**; TypeScript build passed; production dependency audit found **0 vulnerabilities**. The sidecar suite passed **22/22** again after the final rebase.
- Ruff check/format, Python compile, Bash syntax, ShellCheck, YAML parse, and `git diff --check`: **passed**.
- Actionlint current-vs-parent comparison: **same 14 pre-existing diagnostics; no new diagnostic**.
- Local CodeRabbit found one special-mode restoration issue; it is fixed by re-reading mode after `fchown` and clearing setuid, setgid, and sticky bits. Hosted exact-head review found no further actionable issue.
- Independent exact-commit audit and final rebase-equivalence audit: **CLEAN**.
- Fresh exact-head hosted Windows/Linux/macOS CI and hosted CodeRabbit/Codex review are required after this rebase push.

Refs #725
Fixes #729
