### PR TITLE
fix(openclaw): reject structurally invalid tool verdicts

### DIFF
--- a/extensions/defenseclaw/src/__tests__/index.test.ts
+++ b/extensions/defenseclaw/src/__tests__/index.test.ts
@@ -65,6 +65,31 @@ vi.mock("../scanners/mcp-scanner.js", () => ({
 
 type EventHandler = (...args: unknown[]) => Promise<unknown> | unknown;
 
+type ToolVerdict = {
+  action: "allow" | "alert" | "confirm" | "block";
+  severity: "NONE" | "INFO" | "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+  reason: string;
+  mode: "action" | "observe";
+  raw_action?: "allow" | "alert" | "confirm" | "block";
+  approval_timeout_ms?: number;
+};
+
+const validToolVerdict = (
+  overrides: Partial<ToolVerdict> = {},
+): ToolVerdict => ({
+  action: "allow",
+  severity: "NONE",
+  reason: "",
+  mode: "action",
+  ...overrides,
+});
+
+const verdictResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
 function createMockContext() {
   const listeners: Record<string, EventHandler> = {};
   const commands: Record<string, { handler: (ctx: { args: Record<string, unknown> }) => Promise<{ text: string }> }> = {};
@@ -116,6 +141,7 @@ describe("DefenseClaw OpenClaw Plugin", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.DEFENSECLAW_TOOL_INSPECT_FAIL_OPEN;
     delete (globalThis as Record<string, unknown>).__defenseclawAwsHttp1ShimEvaluated;
     delete (globalThis as Record<string, unknown>).__defenseclawAwsHttp1GuardrailPatch;
     mockEnforcer.syncFromDaemon.mockResolvedValue(undefined);
@@ -146,29 +172,92 @@ describe("DefenseClaw OpenClaw Plugin", () => {
     });
   });
 
-  describe("before_tool_call approvals", () => {
-    it("returns native OpenClaw approval request when sidecar returns confirm", async () => {
-      const fetchMock = vi.fn().mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            action: "confirm",
-            raw_action: "confirm",
-            severity: "HIGH",
-            reason: "matched: CMD-ENV-DUMP:Environment variable dump",
-            mode: "action",
-            approval_timeout_ms: 30000,
-          }),
-          { status: 200, headers: { "content-type": "application/json" } },
-        ),
+  describe("before_tool_call verdict handling", () => {
+    const genericEvent = {
+      toolName: "exec",
+      params: { command: "printenv" },
+    };
+    const genericContext = {
+      sessionKey: "agent:main:main",
+      runId: "run-1",
+      toolName: "exec",
+    };
+
+    async function runGeneric(verdict: unknown) {
+      globalThis.fetch = vi.fn().mockResolvedValue(verdictResponse(verdict));
+      return listeners.before_tool_call(genericEvent, genericContext);
+    }
+
+    async function runMessage(verdict: unknown) {
+      globalThis.fetch = vi.fn().mockResolvedValue(verdictResponse(verdict));
+      return listeners.before_tool_call(
+        {
+          toolName: "message",
+          params: { to: "security@example.test", content: "status update" },
+        },
+        genericContext,
+      );
+    }
+
+    it.each([
+      ["allow", validToolVerdict({ action: "allow" })],
+      [
+        "informational",
+        validToolVerdict({
+          action: "allow",
+          severity: "INFO",
+          reason: "informational finding",
+        }),
+      ],
+      [
+        "alert",
+        validToolVerdict({
+          action: "alert",
+          severity: "LOW",
+          reason: "review recommended",
+        }),
+      ],
+      [
+        "observe",
+        validToolVerdict({
+          action: "allow",
+          raw_action: "block",
+          severity: "HIGH",
+          reason: "observed match",
+          mode: "observe",
+        }),
+      ],
+    ])("allows valid %s verdict", async (_name, verdict) => {
+      await expect(runGeneric(verdict)).resolves.toBeUndefined();
+      await expect(runMessage(verdict)).resolves.toBeUndefined();
+    });
+
+    it("returns native OpenClaw approval requests for valid confirm verdicts", async () => {
+      const verdict = validToolVerdict({
+        action: "confirm",
+        raw_action: "confirm",
+        severity: "HIGH",
+        reason: "matched: CMD-ENV-DUMP:Environment variable dump",
+        approval_timeout_ms: 30000,
+      });
+      const fetchMock = vi.fn().mockImplementation(async () =>
+        verdictResponse(verdict),
       );
       globalThis.fetch = fetchMock;
 
-      const result = await listeners.before_tool_call(
-        { toolName: "exec", params: { command: "printenv" } },
-        { sessionKey: "agent:main:main", runId: "run-1", toolName: "exec" },
+      const genericResult = await listeners.before_tool_call(
+        genericEvent,
+        genericContext,
+      );
+      const messageResult = await listeners.before_tool_call(
+        {
+          toolName: "message",
+          params: { to: "security@example.test", content: "status update" },
+        },
+        genericContext,
       );
 
-      expect(result).toMatchObject({
+      expect(genericResult).toMatchObject({
         requireApproval: {
           title: "DefenseClaw approval required",
           severity: "warning",
@@ -176,8 +265,21 @@ describe("DefenseClaw OpenClaw Plugin", () => {
           timeoutBehavior: "deny",
         },
       });
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-      const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+      expect(messageResult).toMatchObject({
+        requireApproval: {
+          title: "DefenseClaw approval required",
+          description: expect.stringContaining("outbound message"),
+          severity: "warning",
+          timeoutBehavior: "deny",
+        },
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const [requestUrl, requestInit] = fetchMock.mock.calls[0] as [
+        string,
+        RequestInit,
+      ];
+      expect(requestUrl).toMatch(/\/api\/v1\/inspect\/tool$/);
+      const body = JSON.parse(requestInit.body as string);
       expect(body).toMatchObject({
         tool: "exec",
         session_id: "agent:main:main",
@@ -185,26 +287,348 @@ describe("DefenseClaw OpenClaw Plugin", () => {
       });
     });
 
-    it("does not request approval in observe mode", async () => {
-      globalThis.fetch = vi.fn().mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            action: "allow",
-            raw_action: "confirm",
-            severity: "HIGH",
-            reason: "matched: CMD-ENV-DUMP:Environment variable dump",
-            mode: "observe",
-          }),
-          { status: 200, headers: { "content-type": "application/json" } },
+    it("keeps large sidecar bodies on the interceptor's URL/init path", async () => {
+      const verdict = validToolVerdict();
+      const fetchMock = vi.fn().mockResolvedValue(verdictResponse(verdict));
+      globalThis.fetch = fetchMock;
+      const command = "x".repeat(70 * 1024);
+
+      await expect(
+        listeners.before_tool_call(
+          { toolName: "exec", params: { command } },
+          genericContext,
         ),
+      ).resolves.toBeUndefined();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [requestUrl, requestInit] = fetchMock.mock.calls[0] as [
+        string,
+        RequestInit,
+      ];
+      expect(requestUrl).toBeTypeOf("string");
+      expect(requestInit.body).toBeTypeOf("string");
+      expect(new TextEncoder().encode(requestInit.body as string).byteLength)
+        .toBeGreaterThan(64 * 1024);
+      expect(JSON.parse(requestInit.body as string)).toMatchObject({
+        tool: "exec",
+        args: { command },
+      });
+    });
+
+    it("blocks generic and outbound message calls for a valid action-mode block", async () => {
+      const verdict = validToolVerdict({
+        action: "block",
+        raw_action: "block",
+        severity: "CRITICAL",
+        reason: "matched guardrail policy",
+      });
+
+      await expect(runGeneric(verdict)).resolves.toEqual({
+        block: true,
+        blockReason: "DefenseClaw: matched guardrail policy",
+      });
+      await expect(runMessage(verdict)).resolves.toEqual({
+        block: true,
+        blockReason:
+          "DefenseClaw: outbound blocked — matched guardrail policy",
+      });
+    });
+
+    it("accepts the gateway's fail-closed unsupported-confirmation verdict", async () => {
+      const verdict = validToolVerdict({
+        action: "block",
+        raw_action: "confirm",
+        severity: "HIGH",
+        reason: "human approval unsupported; failing closed",
+      });
+
+      await expect(runGeneric(verdict)).resolves.toEqual({
+        block: true,
+        blockReason:
+          "DefenseClaw: human approval unsupported; failing closed",
+      });
+      await expect(runMessage(verdict)).resolves.toEqual({
+        block: true,
+        blockReason:
+          "DefenseClaw: outbound blocked — human approval unsupported; failing closed",
+      });
+    });
+
+    it("treats a zero approval timeout as an omitted optional timeout", async () => {
+      const result = await runGeneric(
+        validToolVerdict({
+          action: "confirm",
+          severity: "HIGH",
+          reason: "approval required",
+          approval_timeout_ms: 0,
+        }),
       );
+
+      expect(result).toMatchObject({
+        requireApproval: {
+          timeoutBehavior: "deny",
+        },
+      });
+      expect(
+        (result as { requireApproval: { timeoutMs?: number } }).requireApproval
+          .timeoutMs,
+      ).toBeUndefined();
+    });
+
+    const invalidVerdicts: Array<[string, unknown]> = [
+      ["null", null],
+      ["array", []],
+      ["empty object", {}],
+      ["string", "allow"],
+      ["number", 1],
+      ["boolean", true],
+      ["missing action", { severity: "NONE", reason: "", mode: "action" }],
+      ["missing mode", { action: "allow", severity: "NONE", reason: "" }],
+      ["missing severity", { action: "allow", reason: "", mode: "action" }],
+      ["missing reason", { action: "allow", severity: "NONE", mode: "action" }],
+      ["unknown action", { ...validToolVerdict(), action: "pass" }],
+      ["unknown mode", { ...validToolVerdict(), mode: "enforce" }],
+      ["unknown severity", { ...validToolVerdict(), severity: "WARNING" }],
+      ["non-string action", { ...validToolVerdict(), action: true }],
+      ["non-string mode", { ...validToolVerdict(), mode: 1 }],
+      ["non-string severity", { ...validToolVerdict(), severity: null }],
+      ["non-string reason", { ...validToolVerdict(), reason: ["secret"] }],
+      ["non-string raw action", { ...validToolVerdict(), raw_action: 1 }],
+      ["unknown raw action", { ...validToolVerdict(), raw_action: "pass" }],
+      [
+        "contradictory action-mode raw action",
+        { ...validToolVerdict(), raw_action: "block" },
+      ],
+      [
+        "observe-mode effective block without raw action",
+        validToolVerdict({ action: "block", mode: "observe" }),
+      ],
+      [
+        "observe-mode effective block with raw action",
+        validToolVerdict({
+          action: "block",
+          raw_action: "block",
+          mode: "observe",
+        }),
+      ],
+      [
+        "observe-mode effective confirm without raw action",
+        validToolVerdict({ action: "confirm", mode: "observe" }),
+      ],
+      [
+        "observe-mode effective confirm with raw action",
+        validToolVerdict({
+          action: "confirm",
+          raw_action: "confirm",
+          mode: "observe",
+        }),
+      ],
+      [
+        "observe-mode effective alert",
+        validToolVerdict({
+          action: "alert",
+          raw_action: "alert",
+          mode: "observe",
+        }),
+      ],
+      [
+        "non-number approval timeout",
+        { ...validToolVerdict(), approval_timeout_ms: "30000" },
+      ],
+      [
+        "negative approval timeout",
+        { ...validToolVerdict(), approval_timeout_ms: -1 },
+      ],
+      [
+        "fractional approval timeout",
+        { ...validToolVerdict(), approval_timeout_ms: 1.5 },
+      ],
+      [
+        "unsafe approval timeout",
+        {
+          ...validToolVerdict(),
+          approval_timeout_ms: Number.MAX_SAFE_INTEGER + 1,
+        },
+      ],
+    ];
+
+    it.each(invalidVerdicts)(
+      "fails closed on an invalid %s verdict in generic and message paths",
+      async (_name, verdict) => {
+        await expect(runGeneric(verdict)).resolves.toMatchObject({
+          block: true,
+          blockReason: expect.stringContaining(
+            "sidecar returned invalid verdict",
+          ),
+        });
+        await expect(runMessage(verdict)).resolves.toMatchObject({
+          block: true,
+          blockReason: expect.stringContaining(
+            "sidecar returned invalid verdict",
+          ),
+        });
+      },
+    );
+
+    it("fails closed on a non-finite JSON approval timeout", async () => {
+      const responseBody =
+        '{"action":"allow","severity":"NONE","reason":"","mode":"action","approval_timeout_ms":1e10000}';
+      globalThis.fetch = vi
+        .fn()
+        .mockImplementation(async () => new Response(responseBody));
+
+      await expect(
+        listeners.before_tool_call(genericEvent, genericContext),
+      ).resolves.toMatchObject({ block: true });
+      await expect(
+        listeners.before_tool_call(
+          {
+            toolName: "message",
+            params: {
+              to: "security@example.test",
+              content: "status update",
+            },
+          },
+          genericContext,
+        ),
+      ).resolves.toMatchObject({ block: true });
+    });
+
+    it("does not expose response, argument, or credential data in diagnostics", async () => {
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          verdictResponse({
+            ...validToolVerdict(),
+            reason: ["sensitive-response-value"],
+          }),
+        )
+        .mockRejectedValueOnce(
+          new Error("synthetic-credential-value"),
+        );
+
+      try {
+        const invalidResponseResult = await listeners.before_tool_call(
+          {
+            toolName: "exec",
+            params: { command: "sensitive-tool-argument" },
+          },
+          genericContext,
+        );
+        const transportResult = await listeners.before_tool_call(
+          {
+            toolName: "exec",
+            params: { command: "sensitive-tool-argument" },
+          },
+          genericContext,
+        );
+        const visible = JSON.stringify({
+          invalidResponseResult,
+          transportResult,
+          logs: logSpy.mock.calls,
+          warnings: warnSpy.mock.calls,
+          errors: errorSpy.mock.calls,
+        });
+        expect(visible).not.toContain("sensitive-response-value");
+        expect(visible).not.toContain("sensitive-tool-argument");
+        expect(visible).not.toContain("synthetic-credential-value");
+      } finally {
+        logSpy.mockRestore();
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+      }
+    });
+
+    it("keeps invalid and malformed HTTP responses fail-closed under the availability override", async () => {
+      process.env.DEFENSECLAW_TOOL_INSPECT_FAIL_OPEN = "1";
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(verdictResponse({ action: "allow" }))
+        .mockResolvedValueOnce(new Response("not-json", { status: 200 }))
+        .mockResolvedValueOnce(new Response("unavailable", { status: 503 }));
+
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        await expect(
+          listeners.before_tool_call(genericEvent, genericContext),
+        ).resolves.toMatchObject({ block: true });
+      }
+    });
+
+    it("applies fail-open only to an unavailable transport", async () => {
+      process.env.DEFENSECLAW_TOOL_INSPECT_FAIL_OPEN = "1";
+      globalThis.fetch = vi
+        .fn()
+        .mockRejectedValue(new Error("sensitive-transport-value"));
+
+      await expect(
+        listeners.before_tool_call(genericEvent, genericContext),
+      ).resolves.toBeUndefined();
+    });
+
+    it("does not expose transport exception text when failing closed", async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockRejectedValue(new Error("sensitive-transport-value"));
 
       const result = await listeners.before_tool_call(
-        { toolName: "exec", params: { command: "printenv" } },
-        { sessionKey: "agent:main:main", runId: "run-1", toolName: "exec" },
+        genericEvent,
+        genericContext,
+      );
+      expect(JSON.stringify(result)).not.toContain("sensitive-transport-value");
+    });
+
+    it("keeps local request failures closed under the availability override", async () => {
+      process.env.DEFENSECLAW_TOOL_INSPECT_FAIL_OPEN = "1";
+      const fetchMock = vi.fn();
+      globalThis.fetch = fetchMock;
+      mockDaemonClient.buildOutboundHeaders.mockRejectedValueOnce(
+        new Error("header preparation failed"),
       );
 
-      expect(result).toBeUndefined();
+      await expect(
+        listeners.before_tool_call(genericEvent, genericContext),
+      ).resolves.toMatchObject({ block: true });
+
+      mockDaemonClient.buildOutboundHeaders.mockResolvedValue({});
+      await expect(
+        listeners.before_tool_call(
+          { toolName: "exec", params: { count: 1n } },
+          genericContext,
+        ),
+      ).resolves.toMatchObject({ block: true });
+
+      mockDaemonClient.buildOutboundHeaders.mockResolvedValueOnce({
+        "x-invalid-local-header": "value\nsmuggled",
+      });
+      await expect(
+        listeners.before_tool_call(genericEvent, genericContext),
+      ).resolves.toMatchObject({ block: true });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("fails closed repeatedly when transport is unavailable by default", async () => {
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error("offline"));
+
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        await expect(
+          listeners.before_tool_call(genericEvent, genericContext),
+        ).resolves.toMatchObject({ block: true });
+      }
+    });
+
+    it("fails closed on an invalid verdict from a legacy host without tool context", async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValue(verdictResponse({ action: "allow" }));
+
+      await expect(listeners.before_tool_call(genericEvent)).resolves.toEqual({
+        block: true,
+        blockReason:
+          "DefenseClaw: defenseclaw failing closed: sidecar returned invalid verdict",
+      });
     });
   });
 

--- a/extensions/defenseclaw/src/index.ts
+++ b/extensions/defenseclaw/src/index.ts
@@ -76,24 +76,77 @@ import { loadSidecarConfig } from "./sidecar-config.js";
 import { createFetchInterceptor } from "./fetch-interceptor.js";
 import { HealthMonitor } from "./health-monitor.js";
 
+const INSPECT_ACTIONS = new Set(["allow", "alert", "confirm", "block"]);
+const INSPECT_MODES = new Set(["action", "observe"]);
+const INSPECT_SEVERITIES = new Set([
+  "NONE",
+  "INFO",
+  "LOW",
+  "MEDIUM",
+  "HIGH",
+  "CRITICAL",
+]);
+
 type InspectVerdict = {
-  action: string;
-  raw_action?: string;
-  severity: string;
+  action: "allow" | "alert" | "confirm" | "block";
+  raw_action?: "allow" | "alert" | "confirm" | "block";
+  severity: "NONE" | "INFO" | "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
   reason: string;
-  mode: string;
+  mode: "action" | "observe";
   approval_timeout_ms?: number;
 };
 
-// when the sidecar cannot deliver a verdict we MUST
-// fail closed instead of returning {allow,observe}. The legacy
-// {allow,observe} fallback turned every sidecar outage, non-2xx
-// response, malformed JSON body, or fetch rejection into a tool-call
-// allow, because the caller only blocked on action==block && mode==action.
-//
-// Operators that explicitly opt into the legacy fail-open behavior can
-// set DEFENSECLAW_TOOL_INSPECT_FAIL_OPEN=1; the default is fail closed.
+function hasValidInspectActionContract(verdict: Record<string, unknown>): boolean {
+  if (verdict.mode === "observe" && verdict.action !== "allow") return false;
+
+  const rawAction = verdict.raw_action;
+  if (rawAction === undefined) return true;
+  if (typeof rawAction !== "string" || !INSPECT_ACTIONS.has(rawAction)) {
+    return false;
+  }
+  if (verdict.mode === "observe" || rawAction === verdict.action) return true;
+
+  // The gateway may turn an unsupported native confirmation into an effective
+  // block after applyMode(), while retaining "confirm" as the raw decision.
+  return verdict.action === "block" && rawAction === "confirm";
+}
+
+function isInspectVerdict(value: unknown): value is InspectVerdict {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const verdict = value as Record<string, unknown>;
+  return (
+    typeof verdict.action === "string" &&
+    INSPECT_ACTIONS.has(verdict.action) &&
+    typeof verdict.mode === "string" &&
+    INSPECT_MODES.has(verdict.mode) &&
+    typeof verdict.severity === "string" &&
+    INSPECT_SEVERITIES.has(verdict.severity) &&
+    typeof verdict.reason === "string" &&
+    hasValidInspectActionContract(verdict) &&
+    (verdict.approval_timeout_ms === undefined ||
+      (typeof verdict.approval_timeout_ms === "number" &&
+        Number.isSafeInteger(verdict.approval_timeout_ms) &&
+        verdict.approval_timeout_ms >= 0))
+  );
+}
+
+// A response that is present but unusable is never an availability failure:
+// non-2xx responses, malformed JSON, and invalid verdict envelopes all fail
+// closed even if the operator opted into transport fail-open behavior.
 function failClosedVerdict(reason: string): InspectVerdict {
+  return {
+    action: "block",
+    severity: "HIGH",
+    reason: `defenseclaw failing closed: ${reason}`,
+    mode: "action",
+  };
+}
+
+// The documented override applies only when no sidecar verdict is available
+// because the request itself failed (including timeout/abort).
+function unavailableVerdict(reason: string): InspectVerdict {
   const failOpen =
     (process.env.DEFENSECLAW_TOOL_INSPECT_FAIL_OPEN || "")
       .trim()
@@ -106,12 +159,7 @@ function failClosedVerdict(reason: string): InspectVerdict {
       mode: "observe",
     };
   }
-  return {
-    action: "block",
-    severity: "HIGH",
-    reason: `defenseclaw failing closed: ${reason}`,
-    mode: "action",
-  };
+  return failClosedVerdict(reason);
 }
 
 function approvalSeverity(severity: string): "info" | "warning" | "critical" {
@@ -125,7 +173,9 @@ function approvalDescription(toolName: string, verdict: InspectVerdict): string 
 
 function approvalTimeoutMs(verdict: InspectVerdict): number | undefined {
   const timeout = verdict.approval_timeout_ms;
-  return typeof timeout === "number" && Number.isFinite(timeout) && timeout > 0 ? timeout : undefined;
+  return typeof timeout === "number" && Number.isSafeInteger(timeout) && timeout > 0
+    ? timeout
+    : undefined;
 }
 
 function buildApprovalRequest(toolName: string, verdict: InspectVerdict) {
@@ -378,12 +428,40 @@ export default function (api: DefenseClawPluginHost) {
       const bodyPayload = sessionId
         ? { ...payload, session_id: sessionId, approval_surface: "native" }
         : { ...payload, approval_surface: "native" };
-      const res = await fetch(`${SIDECAR_API}/api/v1/inspect/tool`, {
+      const body = JSON.stringify(bodyPayload);
+      // Construct the complete request before entering the availability
+      // catch. Node validates the URL and headers here, so malformed local
+      // configuration cannot be mistaken for a transport outage and allowed
+      // by DEFENSECLAW_TOOL_INSPECT_FAIL_OPEN.
+      const request = new Request(`${SIDECAR_API}/api/v1/inspect/tool`, {
         method: "POST",
         headers,
-        body: JSON.stringify(bodyPayload),
+        body,
         signal: controller.signal,
       });
+      let res: Response;
+      try {
+        // Keep the intercepted call in URL/init form. The interceptor can
+        // inspect this string body synchronously; passing the Request would
+        // clone its stream and can wait indefinitely for tee cancellation
+        // when the payload exceeds the bounded body-peek cap.
+        res = await fetch(request.url, {
+          method: request.method,
+          headers: request.headers,
+          body,
+          signal: request.signal,
+        });
+      } catch {
+        const duration_ms = Math.round(performance.now() - started);
+        logOutboundRequest({
+          runId: toolCtx?.runId,
+          sessionId,
+          agentId: identityCache?.agentId ?? "unknown",
+          status_code: 0,
+          duration_ms,
+        });
+        return unavailableVerdict("sidecar unreachable");
+      }
       daemonClient.applyStickyFromHttpResponse(res);
       const duration_ms = Math.round(performance.now() - started);
       logOutboundRequest({
@@ -397,7 +475,10 @@ export default function (api: DefenseClawPluginHost) {
         return failClosedVerdict(`sidecar returned ${res.status}`);
       }
       try {
-        return (await res.json()) as InspectVerdict;
+        const verdict: unknown = await res.json();
+        return isInspectVerdict(verdict)
+          ? verdict
+          : failClosedVerdict("sidecar returned invalid verdict");
       } catch {
         return failClosedVerdict("sidecar returned malformed verdict");
       }
@@ -410,8 +491,7 @@ export default function (api: DefenseClawPluginHost) {
         status_code: 0,
         duration_ms,
       });
-      const msg = err instanceof Error ? err.message : String(err);
-      return failClosedVerdict(`sidecar unreachable: ${msg}`);
+      return failClosedVerdict("tool inspection failed");
     } finally {
       clearTimeout(timer);
     }


### PR DESCRIPTION
> Standalone change targeting `main` at audited base `9436470a6abb914c0dfcaec8305ea59a4f968c2f`. Frozen head: `3c4424e7e32a925ccf8b79ac5701ad80126410e5`.

## Problem

The embedded OpenClaw plugin accepted any syntactically valid JSON returned by `POST /api/v1/inspect/tool` as a tool verdict. A structurally invalid response such as `{"action":"allow"}` therefore reached the hook consumers with required fields missing. Because those consumers only enforce `block` and `confirm` decisions when `mode === "action"`, a malformed or compromised loopback sidecar response could become an implicit allow.

## Current Situation

- Malformed JSON and transport failures already entered a fallback path, but successful JSON responses were cast directly to `InspectVerdict` without runtime validation.
- Generic tool calls and outbound `message` calls share this verdict path.
- `DEFENSECLAW_TOOL_INSPECT_FAIL_OPEN=1` is an explicit availability override. It must not turn a received-but-invalid verdict, an HTTP error, or a local request-construction/configuration failure into an allow.
- The gateway supports `INFO` verdict severity and observe-mode raw decisions, plus an intentional action-mode `block` / raw-`confirm` result when native approval cannot be delivered.
- The installed LLM fetch interceptor peeks `Request` bodies through a cloned stream. Passing a sidecar inspection body larger than its 64 KiB cap as a `Request` can wait indefinitely on tee-branch cancellation before the downstream fetch starts.
- Current OpenClaw callback shape and context-less legacy callback shape both need to remain supported.

## Solution

Validate the complete verdict envelope and its action/mode relationships before either OpenClaw hook consumer can act on it, construct and validate the complete request before entering the transport-only override boundary, and distinguish actual transport unavailability from every other failure class.

### Strict verdict validation

Require a non-array object with all required fields and shipped enum values:

- `action`: `allow`, `alert`, `confirm`, or `block`
- `mode`: `action` or `observe`
- `severity`: `NONE`, `INFO`, `LOW`, `MEDIUM`, `HIGH`, or `CRITICAL`
- `reason`: string

Optional `raw_action` must be one of the shipped action values. Observe mode requires effective `action: "allow"` while retaining any original decision in `raw_action`. In action mode, a present raw action must match the effective action, except for the gateway's intentional fail-closed `action: "block", raw_action: "confirm"` result when approval is unavailable.

Optional `approval_timeout_ms` must be a non-negative safe integer; negative, fractional, non-finite, overflow, and non-number values invalidate the whole verdict and fail closed. Zero retains the Go wire format's omitted/default timeout semantics and still produces a native confirmation.

### Narrow availability override

The plugin constructs the complete `Request` before entering the fetch availability catch. URL parsing, header validation, payload serialization, and header preparation therefore remain in the fail-closed outer path. Only a rejection or abort after a valid `Request` reaches `fetch` can use the documented fail-open override.

Invalid JSON, invalid verdict shapes, non-2xx responses, and other local failures remain fail-closed.

### Bounded interceptor path

After the complete `Request` has validated the local URL, headers, method, body, and signal, the plugin invokes the intercepted fetch with the validated URL/method/headers/signal and the original string body in URL/init form. This retains the pre-transport validation boundary while keeping the interceptor on its synchronous, bounded string-body inspection path instead of cloning a request stream.

### Safe diagnostics and compatibility

Fallback reasons use fixed, non-sensitive messages. Response values, tool arguments, credentials, and transport exception text are not copied into diagnostics. The same validation and enforcement behavior covers generic tools, outbound message tools, repeated calls, and legacy callbacks without tool context.

## Architecture Diagram

```mermaid
flowchart LR
    A["OpenClaw tool callback"] --> B["Build headers and JSON body"]
    B --> C{"Construct valid Request?"}
    C -- "No: URL, header, or local error" --> F["Action-mode block"]
    C -- "Yes" --> D{"Transport delivered a response?"}
    D -- "No" --> E{"Explicit fail-open override?"}
    E -- "Yes" --> G["Observe-mode allow"]
    E -- "No" --> F
    D -- "Yes" --> H{"HTTP 2xx + valid JSON + strict verdict contract?"}
    H -- "No" --> F
    H -- "Yes" --> I["Apply allow / alert / confirm / block semantics"]
```

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `extensions/defenseclaw/src/index.ts` | Adds strict runtime verdict, cross-field action/mode, raw-action, and timeout validation; constructs a validated `Request` outside the transport-only catch; sends the validated sidecar call in bounded URL/init form; separates unavailable transport from fail-closed response/local failures; and removes sensitive exception details from fallback reasons. |
| `extensions/defenseclaw/src/__tests__/index.test.ts` | Covers all valid verdict decisions and severities; invalid shapes, types, enums, cross-field combinations, and timeout domains; real local request validation failure; a >64 KiB URL/init sidecar payload; generic and message paths; override boundaries; repetition; diagnostic redaction; and context-less legacy callbacks. |

## Breaking Changes

`DEFENSECLAW_TOOL_INSPECT_FAIL_OPEN=1` now applies only after a valid request reaches `fetch` and the transport rejects or aborts. Invalid local configuration/request construction, received invalid verdicts, malformed bodies, non-2xx responses, invalid action/mode relationships, and invalid optional values always fail closed. These are intentional security corrections; valid gateway verdict behavior is unchanged.

## Open Issues / Follow-ups

- #732 tracks the generic interceptor's Request-input tee-cancellation deadlock. This PR removes DefenseClaw's own sidecar call from that path without widening issue #715's two-file scope.

## Test Plan

- Focused regression repeated 10 times:
  ```sh
  cd extensions/defenseclaw
  set -e
  for run in {1..10}; do
    npm test -- --run src/__tests__/index.test.ts --silent
  done
  ```
  Observed: all 10 runs passed, 62/62 each.
- `make plugin` → TypeScript build passed.
- `make ts-test` → 20/20 files and 311/311 tests passed.
- `npm audit --omit=dev --audit-level=high` → 0 production vulnerabilities.
- Focused Go endpoint parity:
  ```sh
  go test ./internal/gateway -count=1 -run '^(TestInspectTool(SafeCommand|DangerousShell|MessageOutbound|MessageClean|HILTUnsupportedFailsClosed|HILTNativeSurfaceReturnsConfirm|ObserveModeNeverBlocks|ActionModeDowngradeOff)|TestOpenClawInspectConfirmNativeSurfaceLeavesConfirm)$' -v
  ```
  Observed: passed in 2.007s.
- The same endpoint selection with `go test -race` → passed in 21.713s; the exact-head independent audit reran the focused race gate and passed.
- OpenClaw connector compatibility:
  ```sh
  go test ./internal/gateway/connector -count=1 -run '^(TestOpenClaw_(Setup_InstallsExtensionAndPatchesConfig|Setup_IsIdempotent|Setup_HILTEnablesPluginApprovalForwarding|Setup_HILTDefaultsPluginApprovalMode|Route|Route_PassthroughNonChat)|TestOpenClawHookWriter_WritesGenericHooksOnly)$'
  ```
  Observed: passed in 1.046s.
- `make check VERIFY_OBSERVABILITY_BASELINE_ANCESTRY=1` → all repository schema/parity gates passed.
- `make lint` → Ruff passed; documented `go vet ./...` fallback passed because `golangci-lint` was unavailable; Python compile check passed.
- Local CodeRabbit final retry reached the review service but did not emit a terminal result; hosted exact-head CodeRabbit remains required.
- Real interceptor regression probe: the prior 70,060-byte Request-input call remained pending past 1 second despite aborting after 25 ms; the validated 70,037-byte URL/init sidecar call completed with HTTP 200 in 3 ms and delivered the full body.
- Independent exact-head frozen audit → identity and hashes matched; worktree and diff check clean; focused 62/62 ×10, full 311/311, TypeScript build, production dependency audit, gateway contract, and focused race gates passed; all verdict, timeout, diagnostic, availability, and large-body boundaries verified; 0 findings.

Live OpenClaw-plus-gateway E2E was not runnable because the `openclaw` executable is unavailable on the connected hosts. The current-context and context-less legacy callback shapes are covered directly in the plugin suite.

Frozen evidence: tree `554230e1daa02540b692e38644a894f24c765e9a`; stable patch ID `e27c5164bcdb1e16cf30f85ab1e0b6271182be3a`; binary diff SHA-256 `600ca84c76e4210a2a8023f0c9d89338a46ad0f7df6a62eabdbb9dcc4f40a943`.

Fixes #715
