### PR TITLE
fix(ci): classify connector radar report failures

### DIFF
--- a/cli/tests/test_live_connector_upgrade_harness.py
+++ b/cli/tests/test_live_connector_upgrade_harness.py
@@ -8,6 +8,7 @@ import runpy
 import shutil
 import stat
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -54,6 +55,73 @@ def _bash(script: str, *, env: dict[str, str] | None = None) -> subprocess.Compl
         capture_output=True,
         check=False,
     )
+
+
+def _write_report_artifact(
+    results_dir: Path,
+    name: str,
+    *,
+    connector: str,
+    classification: str,
+    baseline_status: str,
+    candidate_status: str,
+    rows: list[dict],
+    baseline_version: str = "1.0.0",
+    candidate_version: str = "1.1.0",
+) -> Path:
+    artifact = results_dir / name
+    artifact.mkdir()
+    (artifact / "classification.json").write_text(
+        json.dumps(
+            {
+                "connector": connector,
+                "classification": classification,
+                "baseline_version": baseline_version,
+                "candidate_version": candidate_version,
+                "baseline_status": baseline_status,
+                "candidate_status": candidate_status,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (artifact / "results.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+    return artifact
+
+
+def _write_unclassified_radar_artifact(
+    results_dir: Path,
+    name: str,
+    rows: list[dict],
+) -> Path:
+    artifact = results_dir / name
+    artifact.mkdir()
+    (artifact / "results.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+    return artifact
+
+
+def _run_report(
+    report_module: dict,
+    monkeypatch: pytest.MonkeyPatch,
+    results_dir: Path,
+    *,
+    open_issue: bool,
+) -> tuple[int, list[tuple[str, str]]]:
+    issue_calls: list[tuple[str, str]] = []
+    report_module["main"].__globals__["open_or_update_issue"] = lambda body, run_url: issue_calls.append(
+        (body, run_url)
+    )
+    argv = [str(REPORT), "--results-dir", str(results_dir), "--run-url", "https://example.test/run"]
+    if open_issue:
+        argv.append("--open-issue")
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.setattr(sys, "argv", argv)
+    return report_module["main"](), issue_calls
 
 
 def test_harness_cli_exposes_workflow_contract() -> None:
@@ -289,6 +357,7 @@ def test_report_prefers_candidate_version_over_known_good_baseline() -> None:
 def test_report_issue_rows_only_include_candidate_regressions(tmp_path: Path) -> None:
     report_module = runpy.run_path(str(REPORT))
     load_candidate_regression_results = report_module["load_candidate_regression_results"]
+    load_classifications = report_module["load_classifications"]
     summarize = report_module["summarize"]
 
     candidate = tmp_path / "connector-version-radar-codex-0.144.1"
@@ -296,11 +365,29 @@ def test_report_issue_rows_only_include_candidate_regressions(tmp_path: Path) ->
     candidate.mkdir()
     auth_failure.mkdir()
     (candidate / "classification.json").write_text(
-        json.dumps({"classification": "candidate_regression"}),
+        json.dumps(
+            {
+                "connector": "codex",
+                "classification": "candidate_regression",
+                "baseline_version": "0.142.5",
+                "candidate_version": "0.144.1",
+                "baseline_status": "pass",
+                "candidate_status": "fail",
+            }
+        ),
         encoding="utf-8",
     )
     (auth_failure / "classification.json").write_text(
-        json.dumps({"classification": "auth_failure"}),
+        json.dumps(
+            {
+                "connector": "claudecode",
+                "classification": "auth_failure",
+                "baseline_version": "2.1.208",
+                "candidate_version": "2.1.209",
+                "baseline_status": "fail",
+                "candidate_status": "not_run",
+            }
+        ),
         encoding="utf-8",
     )
     (candidate / "results.jsonl").write_text(
@@ -332,10 +419,725 @@ def test_report_issue_rows_only_include_candidate_regressions(tmp_path: Path) ->
         encoding="utf-8",
     )
 
-    rows = load_candidate_regression_results(tmp_path)
+    rows = load_candidate_regression_results(load_classifications(tmp_path))
     _cells, versions, failures = summarize(rows)
 
     assert versions[("codex", "macos")] == "0.144.1"
     assert failures == [
         ("codex", "macos", "candidate-upgrade:tool-block:enforced", "block verdict missing")
     ]
+
+
+def test_report_auth_only_failure_is_rendered_as_lab_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_report_artifact(
+        tmp_path,
+        "connector-version-radar-codex-1.1.0",
+        connector="codex",
+        classification="auth_failure",
+        baseline_status="fail",
+        candidate_status="not_run",
+        rows=[
+            {
+                "connector": "codex",
+                "os": "macos",
+                "event": "baseline:lifecycle:agent",
+                "status": "fail",
+                "version": "1.0.0",
+                "detail": "login expired",
+            }
+        ],
+    )
+
+    rc, issue_calls = _run_report(
+        runpy.run_path(str(REPORT)),
+        monkeypatch,
+        tmp_path,
+        open_issue=False,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert not issue_calls
+    assert "Operational lab failures (not candidate regressions)" in captured.out
+    assert "auth_failure" in captured.out
+    assert "Lab failure events (not candidate regressions)" in captured.out
+    assert "login expired" not in captured.out
+    assert "regression issue body" not in captured.err
+    assert "login expired" not in captured.err
+
+
+def test_report_candidate_only_failure_keeps_regression_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_report_artifact(
+        tmp_path,
+        "connector-version-radar-codex-1.1.0",
+        connector="codex",
+        classification="candidate_regression",
+        baseline_status="pass",
+        candidate_status="fail",
+        rows=[
+            {
+                "connector": "codex",
+                "os": "macos",
+                "event": "baseline:lifecycle:fires",
+                "status": "pass",
+                "version": "1.0.0",
+                "detail": "",
+            },
+            {
+                "connector": "codex",
+                "os": "macos",
+                "event": "candidate-upgrade:lifecycle:fires",
+                "status": "fail",
+                "version": "1.1.0",
+                "detail": "candidate hook missing",
+            },
+        ],
+    )
+
+    rc, issue_calls = _run_report(
+        runpy.run_path(str(REPORT)),
+        monkeypatch,
+        tmp_path,
+        open_issue=True,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert len(issue_calls) == 1
+    assert "Candidate regression events" in captured.out
+    assert "Operational lab failures" not in captured.out
+    assert "regression issue body" in captured.err
+    assert "candidate-upgrade:lifecycle:fires" in issue_calls[0][0]
+    assert "candidate hook missing" in issue_calls[0][0]
+
+
+def test_report_mixed_failures_separates_lab_and_candidate_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_report_artifact(
+        tmp_path,
+        "connector-version-radar-codex-1.1.0",
+        connector="codex",
+        classification="candidate_regression",
+        baseline_status="pass",
+        candidate_status="fail",
+        rows=[
+            {
+                "connector": "codex",
+                "os": "macos",
+                "event": "candidate-upgrade:tool-block:enforced",
+                "status": "fail",
+                "version": "1.1.0",
+                "detail": "candidate block verdict missing",
+            }
+        ],
+    )
+    _write_report_artifact(
+        tmp_path,
+        "connector-version-radar-claudecode-2.1.0",
+        connector="claudecode",
+        classification="auth_failure",
+        baseline_status="fail",
+        candidate_status="not_run",
+        baseline_version="2.0.0",
+        candidate_version="2.1.0",
+        rows=[
+            {
+                "connector": "claudecode",
+                "os": "macos",
+                "event": "baseline:lifecycle:agent",
+                "status": "fail",
+                "version": "2.0.0",
+                "detail": "baseline login expired",
+            }
+        ],
+    )
+
+    rc, issue_calls = _run_report(
+        runpy.run_path(str(REPORT)),
+        monkeypatch,
+        tmp_path,
+        open_issue=True,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert len(issue_calls) == 1
+    assert "auth_failure" in captured.out
+    assert "baseline:lifecycle:agent" in captured.out
+    assert "candidate-upgrade:tool-block:enforced" in captured.out
+    issue_body = issue_calls[0][0]
+    assert "candidate-upgrade:tool-block:enforced" in issue_body
+    assert "candidate block verdict missing" in issue_body
+    assert "claudecode" not in issue_body
+    assert "baseline login expired" not in issue_body
+    assert "baseline login expired" not in captured.err
+
+
+def test_report_auth_classification_never_calls_issue_api_without_failed_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_report_artifact(
+        tmp_path,
+        "connector-version-radar-codex-1.1.0",
+        connector="codex",
+        classification="auth_failure",
+        baseline_status="not_run",
+        candidate_status="not_run",
+        rows=[],
+    )
+
+    rc, issue_calls = _run_report(
+        runpy.run_path(str(REPORT)),
+        monkeypatch,
+        tmp_path,
+        open_issue=True,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert not issue_calls
+    assert "auth_failure" in captured.out
+    assert "no candidate-regression failures to file" in captured.err
+    assert "regression issue body" not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("classification", "baseline_status", "candidate_status"),
+    [
+        ("baseline_failure", "fail", "not_run"),
+        ("infrastructure_failure", "not_run", "not_run"),
+    ],
+)
+def test_report_other_operational_classifications_stay_red_without_raw_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    classification: str,
+    baseline_status: str,
+    candidate_status: str,
+) -> None:
+    _write_report_artifact(
+        tmp_path,
+        f"connector-version-radar-codex-{classification}",
+        connector="codex",
+        classification=classification,
+        baseline_status=baseline_status,
+        candidate_status=candidate_status,
+        rows=[],
+    )
+
+    rc, issue_calls = _run_report(
+        runpy.run_path(str(REPORT)),
+        monkeypatch,
+        tmp_path,
+        open_issue=True,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert not issue_calls
+    assert classification in captured.out
+    assert "not candidate regressions" in captured.out
+    assert "regression issue body" not in captured.err
+
+
+def test_report_contradictory_candidate_evidence_cannot_enter_regression_content(
+    tmp_path: Path,
+) -> None:
+    artifact = _write_report_artifact(
+        tmp_path,
+        "connector-version-radar-codex-1.1.0",
+        connector="codex",
+        classification="candidate_regression",
+        baseline_status="fail",
+        candidate_status="fail",
+        rows=[
+            {
+                "connector": "codex",
+                "os": "macos",
+                "event": "candidate-upgrade:lifecycle:fires",
+                "status": "fail",
+                "version": "1.1.0",
+                "detail": "must remain lab evidence",
+            }
+        ],
+    )
+    assert artifact.is_dir()
+
+    report_module = runpy.run_path(str(REPORT))
+    classifications = report_module["load_classifications"](tmp_path)
+    rows = report_module["load_candidate_regression_results"](classifications)
+
+    assert rows == []
+    assert len(classifications) == 1
+    assert classifications[0].is_lab_failure
+    assert not classifications[0].is_candidate_regression
+
+
+def test_report_failed_baseline_row_cannot_enter_regression_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_report_artifact(
+        tmp_path,
+        "connector-version-radar-codex-1.1.0",
+        connector="codex",
+        classification="candidate_regression",
+        baseline_status="pass",
+        candidate_status="fail",
+        rows=[
+            {
+                "connector": "codex",
+                "os": "macos",
+                "event": "baseline:lifecycle:fires",
+                "status": "fail",
+                "version": "1.0.0",
+                "detail": "sensitive contradictory baseline detail",
+            },
+            {
+                "connector": "codex",
+                "os": "macos",
+                "event": "candidate-upgrade:lifecycle:fires",
+                "status": "fail",
+                "version": "1.1.0",
+                "detail": "sensitive candidate detail",
+            },
+        ],
+    )
+
+    rc, issue_calls = _run_report(
+        runpy.run_path(str(REPORT)),
+        monkeypatch,
+        tmp_path,
+        open_issue=True,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert not issue_calls
+    assert "candidate-regression evidence contains a failed baseline row" in captured.out
+    assert "Operational lab failures (not candidate regressions)" in captured.out
+    assert "regression issue body" not in captured.err
+    assert "sensitive contradictory baseline detail" not in captured.out
+    assert "sensitive contradictory baseline detail" not in captured.err
+    assert "sensitive candidate detail" not in captured.out
+    assert "sensitive candidate detail" not in captured.err
+
+
+def test_report_malformed_candidate_result_row_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    artifact = _write_report_artifact(
+        tmp_path,
+        "connector-version-radar-codex-1.1.0",
+        connector="codex",
+        classification="candidate_regression",
+        baseline_status="pass",
+        candidate_status="fail",
+        rows=[
+            {
+                "connector": "codex",
+                "os": "macos",
+                "event": "baseline:lifecycle:fires",
+                "status": "pass",
+                "version": "1.0.0",
+                "detail": "",
+            },
+            {
+                "connector": "codex",
+                "os": "macos",
+                "event": "candidate-upgrade:lifecycle:fires",
+                "status": "fail",
+                "version": "1.1.0",
+                "detail": "sensitive candidate detail",
+            },
+        ],
+    )
+    results = artifact / "results.jsonl"
+    results.write_text(
+        results.read_text(encoding="utf-8") + '{"event":"baseline:truncated"',
+        encoding="utf-8",
+    )
+
+    rc, issue_calls = _run_report(
+        runpy.run_path(str(REPORT)),
+        monkeypatch,
+        tmp_path,
+        open_issue=True,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert not issue_calls
+    assert "candidate-regression result evidence is unreadable or malformed" in captured.out
+    assert "Operational lab failures (not candidate regressions)" in captured.out
+    assert "regression issue body" not in captured.err
+    assert "sensitive candidate detail" not in captured.out
+    assert "sensitive candidate detail" not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid_value"),
+    [
+        ("os", []),
+        ("detail", {"secret": "sensitive structured detail"}),
+    ],
+)
+def test_report_structurally_invalid_candidate_result_row_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    field: str,
+    invalid_value: object,
+) -> None:
+    candidate_row = {
+        "connector": "codex",
+        "os": "macos",
+        "event": "candidate-upgrade:lifecycle:fires",
+        "status": "fail",
+        "version": "1.1.0",
+        "detail": "sensitive candidate detail",
+    }
+    candidate_row[field] = invalid_value
+    _write_report_artifact(
+        tmp_path,
+        "connector-version-radar-codex-1.1.0",
+        connector="codex",
+        classification="candidate_regression",
+        baseline_status="pass",
+        candidate_status="fail",
+        rows=[candidate_row],
+    )
+
+    rc, issue_calls = _run_report(
+        runpy.run_path(str(REPORT)),
+        monkeypatch,
+        tmp_path,
+        open_issue=True,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert not issue_calls
+    assert "candidate-regression result evidence is unreadable or malformed" in captured.out
+    assert "Operational lab failures (not candidate regressions)" in captured.out
+    assert "regression issue body" not in captured.err
+    assert "sensitive candidate detail" not in captured.out
+    assert "sensitive candidate detail" not in captured.err
+    assert "sensitive structured detail" not in captured.out
+    assert "sensitive structured detail" not in captured.err
+
+
+@pytest.mark.parametrize(
+    "raw_row",
+    [
+        '{"event":"truncated"',
+        json.dumps(["not", "an", "object"]),
+        json.dumps(
+            {
+                "connector": "codex",
+                "os": [],
+                "event": "pass:invalid",
+                "status": "pass",
+                "version": "1.1.0",
+                "detail": "sensitive pass detail",
+            }
+        ),
+    ],
+)
+def test_report_invalid_pass_result_evidence_stays_red(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    raw_row: str,
+) -> None:
+    artifact = _write_report_artifact(
+        tmp_path,
+        "connector-version-radar-codex-1.1.0",
+        connector="codex",
+        classification="pass",
+        baseline_status="pass",
+        candidate_status="pass",
+        rows=[],
+    )
+    (artifact / "results.jsonl").write_text(raw_row + "\n", encoding="utf-8")
+
+    rc, issue_calls = _run_report(
+        runpy.run_path(str(REPORT)),
+        monkeypatch,
+        tmp_path,
+        open_issue=True,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert not issue_calls
+    assert "pass (invalid evidence)" in captured.out
+    assert "classified radar result evidence is unreadable or malformed" in captured.out
+    assert "Operational lab failures (not candidate regressions)" in captured.out
+    assert "regression issue body" not in captured.err
+    assert "sensitive pass detail" not in captured.out
+    assert "sensitive pass detail" not in captured.err
+
+
+def test_report_candidate_connector_must_match_artifact_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_report_artifact(
+        tmp_path,
+        "connector-version-radar-codex-1.1.0",
+        connector="claudecode",
+        classification="candidate_regression",
+        baseline_status="pass",
+        candidate_status="fail",
+        rows=[
+            {
+                "connector": "claudecode",
+                "os": "macos",
+                "event": "candidate-upgrade:lifecycle:fires",
+                "status": "fail",
+                "version": "1.1.0",
+                "detail": "must not escape the swapped artifact",
+            }
+        ],
+    )
+
+    rc, issue_calls = _run_report(
+        runpy.run_path(str(REPORT)),
+        monkeypatch,
+        tmp_path,
+        open_issue=True,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert not issue_calls
+    assert "does not match its artifact identity" in captured.out
+    assert "regression issue body" not in captured.err
+    assert "must not escape the swapped artifact" not in captured.err
+
+
+def test_report_candidate_version_must_match_artifact_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_report_artifact(
+        tmp_path,
+        "connector-version-radar-codex-9.9.9",
+        connector="codex",
+        classification="candidate_regression",
+        baseline_status="pass",
+        candidate_status="fail",
+        candidate_version="1.1.0",
+        rows=[
+            {
+                "connector": "codex",
+                "os": "macos",
+                "event": "candidate-upgrade:lifecycle:fires",
+                "status": "fail",
+                "version": "1.1.0",
+                "detail": "must not escape the renamed artifact",
+            }
+        ],
+    )
+
+    rc, issue_calls = _run_report(
+        runpy.run_path(str(REPORT)),
+        monkeypatch,
+        tmp_path,
+        open_issue=True,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert not issue_calls
+    assert "does not match its artifact identity" in captured.out
+    assert "regression issue body" not in captured.err
+    assert "must not escape the renamed artifact" not in captured.err
+
+
+def test_report_malformed_classification_is_lab_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    artifact = tmp_path / "connector-version-radar-codex-1.1.0"
+    artifact.mkdir()
+    (artifact / "classification.json").write_text("{malformed", encoding="utf-8")
+    (artifact / "results.jsonl").write_text("", encoding="utf-8")
+
+    rc, issue_calls = _run_report(
+        runpy.run_path(str(REPORT)),
+        monkeypatch,
+        tmp_path,
+        open_issue=True,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert not issue_calls
+    assert "(invalid evidence)" in captured.out
+    assert "unreadable or malformed" in captured.out
+    assert "regression issue body" not in captured.err
+
+
+def test_report_all_missing_radar_classifications_fail_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_unclassified_radar_artifact(
+        tmp_path,
+        "connector-version-radar-codex-1.1.0",
+        [
+            {
+                "connector": "codex",
+                "os": "macos",
+                "event": "candidate-upgrade:lifecycle:fires",
+                "status": "fail",
+                "version": "1.1.0",
+                "detail": "must not become regression content",
+            }
+        ],
+    )
+
+    rc, issue_calls = _run_report(
+        runpy.run_path(str(REPORT)),
+        monkeypatch,
+        tmp_path,
+        open_issue=True,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert not issue_calls
+    assert "invalid_classification (invalid evidence)" in captured.out
+    assert "classification evidence is missing" in captured.out
+    assert "Lab failure events (not candidate regressions)" in captured.out
+    assert "regression issue body" not in captured.err
+    assert "must not become regression content" not in captured.err
+
+
+def test_report_mixed_missing_classification_stays_out_of_candidate_issue(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_report_artifact(
+        tmp_path,
+        "connector-version-radar-codex-1.1.0",
+        connector="codex",
+        classification="candidate_regression",
+        baseline_status="pass",
+        candidate_status="fail",
+        rows=[
+            {
+                "connector": "codex",
+                "os": "macos",
+                "event": "candidate-upgrade:lifecycle:fires",
+                "status": "fail",
+                "version": "1.1.0",
+                "detail": "candidate regression detail",
+            }
+        ],
+    )
+    _write_unclassified_radar_artifact(
+        tmp_path,
+        "connector-version-radar-claudecode-2.1.0",
+        [
+            {
+                "connector": "claudecode",
+                "os": "macos",
+                "event": "candidate-upgrade:lifecycle:fires",
+                "status": "fail",
+                "version": "2.1.0",
+                "detail": "missing classification detail",
+            }
+        ],
+    )
+
+    rc, issue_calls = _run_report(
+        runpy.run_path(str(REPORT)),
+        monkeypatch,
+        tmp_path,
+        open_issue=True,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert len(issue_calls) == 1
+    assert "classification evidence is missing" in captured.out
+    assert "claudecode" in captured.out
+    issue_body = issue_calls[0][0]
+    assert "candidate regression detail" in issue_body
+    assert "claudecode" not in issue_body
+    assert "missing classification detail" not in issue_body
+    assert "missing classification detail" not in captured.err
+
+
+def test_report_preserves_unclassified_live_e2e_issue_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / "results.jsonl").write_text(
+        json.dumps(
+            {
+                "connector": "codex",
+                "os": [],
+                "event": "invalid:row",
+                "status": "fail",
+                "version": "1.1.0",
+                "detail": "invalid legacy detail",
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "connector": "codex",
+                "os": "linux",
+                "event": "tool-block:enforced",
+                "status": "fail",
+                "version": "1.1.0",
+                "detail": "block verdict missing",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rc, issue_calls = _run_report(
+        runpy.run_path(str(REPORT)),
+        monkeypatch,
+        tmp_path,
+        open_issue=True,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert len(issue_calls) == 1
+    assert "## Failing events" in captured.out
+    assert "Operational lab failures" not in captured.out
+    assert "tool-block:enforced" in issue_calls[0][0]
+    assert "invalid:row" not in captured.out
+    assert "invalid legacy detail" not in captured.out
+    assert "invalid legacy detail" not in captured.err

--- a/scripts/live-connector-e2e/report.py
+++ b/scripts/live-connector-e2e/report.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import argparse
 import collections
+import dataclasses
 import datetime
 import json
 import os
@@ -39,6 +40,53 @@ from pathlib import Path
 
 ISSUE_LABEL = "connector-regression"
 ISSUE_TITLE = "Connector live E2E regression"
+RADAR_ARTIFACT_PREFIX = "connector-version-radar-"
+RADAR_DETECTION_ARTIFACT = f"{RADAR_ARTIFACT_PREFIX}detection"
+LAB_FAILURE_ACTIONS = {
+    "auth_failure": "Refresh the connector login, then rerun the known-good baseline.",
+    "baseline_failure": "Repair or revalidate the known-good baseline before testing a candidate.",
+    "infrastructure_failure": "Repair the connector lab infrastructure, then rerun the comparison.",
+}
+LAB_FAILURE_CLASSIFICATIONS = frozenset(LAB_FAILURE_ACTIONS)
+KNOWN_CLASSIFICATIONS = LAB_FAILURE_CLASSIFICATIONS | {
+    "candidate_regression",
+    "pass",
+}
+RESULT_ROW_STRING_FIELDS = (
+    "connector",
+    "os",
+    "event",
+    "status",
+    "version",
+    "detail",
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class Classification:
+    root: Path
+    connector: str
+    classification: str
+    baseline_version: str
+    candidate_version: str
+    baseline_status: str
+    candidate_status: str
+    evidence_error: str = ""
+    result_rows: tuple[dict, ...] = dataclasses.field(
+        default=(), repr=False, compare=False
+    )
+
+    @property
+    def is_failure(self) -> bool:
+        return bool(self.evidence_error) or self.classification != "pass"
+
+    @property
+    def is_candidate_regression(self) -> bool:
+        return self.classification == "candidate_regression" and not self.evidence_error
+
+    @property
+    def is_lab_failure(self) -> bool:
+        return bool(self.evidence_error) or self.classification in LAB_FAILURE_CLASSIFICATIONS
 
 
 def _path_under(path: Path, root: Path) -> bool:
@@ -49,43 +97,222 @@ def _path_under(path: Path, root: Path) -> bool:
         return False
 
 
-def load_results(results_dir: Path, *, roots: list[Path] | None = None) -> list[dict]:
+def _is_result_row(row: object) -> bool:
+    return isinstance(row, dict) and all(
+        isinstance(row.get(field), str) for field in RESULT_ROW_STRING_FIELDS
+    )
+
+
+def _load_results_with_integrity(
+    results_dir: Path, *, roots: list[Path] | None = None
+) -> tuple[list[dict], bool]:
     rows: list[dict] = []
+    evidence_error = False
     for path in sorted(results_dir.rglob("*.jsonl")):
         if roots is not None and not any(_path_under(path, root) for root in roots):
             continue
         try:
             with path.open(encoding="utf-8") as f:
-                for line in f:
-                    line = line.strip()
+                for line_number, raw_line in enumerate(f, start=1):
+                    line = raw_line.strip()
                     if not line:
                         continue
                     try:
-                        rows.append(json.loads(line))
+                        row = json.loads(line)
                     except json.JSONDecodeError:
+                        evidence_error = True
+                        print(
+                            f"[report] ignored malformed JSON result row in {path}:{line_number}.",
+                            file=sys.stderr,
+                        )
                         continue
-        except OSError:
+                    if _is_result_row(row):
+                        rows.append(row)
+                    else:
+                        evidence_error = True
+                        print(
+                            f"[report] ignored structurally invalid result row in {path}:{line_number}.",
+                            file=sys.stderr,
+                        )
+        except (OSError, UnicodeError) as exc:
+            evidence_error = True
+            print(f"[report] could not read result file {path}: {exc}", file=sys.stderr)
             continue
+    return rows, evidence_error
+
+
+def load_results(results_dir: Path, *, roots: list[Path] | None = None) -> list[dict]:
+    rows, _evidence_error = _load_results_with_integrity(results_dir, roots=roots)
     return rows
 
 
-def candidate_regression_roots(results_dir: Path) -> list[Path]:
-    roots: list[Path] = []
-    for path in sorted(results_dir.rglob("classification.json")):
-        try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+def classification_paths(results_dir: Path) -> list[Path]:
+    return sorted(results_dir.rglob("classification.json"))
+
+
+def radar_artifact_roots(results_dir: Path) -> list[Path]:
+    roots = {path.parent for path in classification_paths(results_dir)}
+    candidates = [results_dir, *results_dir.rglob(f"{RADAR_ARTIFACT_PREFIX}*")]
+    roots.update(
+        path
+        for path in candidates
+        if path.is_dir()
+        and path.name.startswith(RADAR_ARTIFACT_PREFIX)
+        and path.name != RADAR_DETECTION_ARTIFACT
+    )
+    return sorted(roots)
+
+
+def _matches_candidate_failure(row: dict, item: Classification) -> bool:
+    return (
+        row.get("connector") == item.connector
+        and row.get("status") == "fail"
+        and str(row.get("event", "")).startswith("candidate-")
+        and str(row.get("version") or "unknown") == item.candidate_version
+    )
+
+
+def _contradicts_candidate_regression(row: dict) -> bool:
+    return row.get("status") == "fail" and str(row.get("event", "")).startswith(
+        "baseline"
+    )
+
+
+def load_classifications(results_dir: Path) -> list[Classification]:
+    classifications: list[Classification] = []
+    paths_by_root = {path.parent: path for path in classification_paths(results_dir)}
+    for root in radar_artifact_roots(results_dir):
+        path = paths_by_root.get(root)
+        if path is None:
+            result_rows = tuple(load_results(root))
+            connectors = {
+                connector.strip()
+                for row in result_rows
+                if isinstance((connector := row.get("connector")), str)
+                and connector.strip()
+                and connector.strip() != "unknown"
+            }
+            connector = next(iter(connectors)) if len(connectors) == 1 else root.name
+            classifications.append(
+                Classification(
+                    root=root,
+                    connector=connector,
+                    classification="invalid_classification",
+                    baseline_version="unknown",
+                    candidate_version="unknown",
+                    baseline_status="unknown",
+                    candidate_status="unknown",
+                    evidence_error="classification evidence is missing",
+                    result_rows=result_rows,
+                )
+            )
             continue
-        if payload.get("classification") == "candidate_regression":
-            roots.append(path.parent)
-    return roots
+
+        evidence_error = ""
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            loaded = {}
+            evidence_error = "classification evidence is unreadable or malformed"
+
+        if not isinstance(loaded, dict):
+            payload: dict = {}
+            evidence_error = evidence_error or "classification evidence is not a JSON object"
+        else:
+            payload = loaded
+
+        classification = payload.get("classification")
+        if not isinstance(classification, str) or classification not in KNOWN_CLASSIFICATIONS:
+            classification = "invalid_classification"
+            evidence_error = evidence_error or "classification evidence has an unknown outcome"
+
+        connector = payload.get("connector")
+        if not isinstance(connector, str) or not connector.strip():
+            connector = path.parent.name
+        else:
+            connector = connector.strip()
+
+        baseline_version = str(payload.get("baseline_version") or "unknown")
+        candidate_version = str(payload.get("candidate_version") or "unknown")
+        baseline_status = str(payload.get("baseline_status") or "unknown")
+        candidate_status = str(payload.get("candidate_status") or "unknown")
+
+        # A candidate regression is the only classification that may promote
+        # raw JSONL failures into regression issue content. Require the
+        # harness's proof that the baseline passed and the candidate failed;
+        # stale or contradictory metadata must fail closed as a lab problem.
+        if classification == "candidate_regression" and (
+            baseline_status != "pass" or candidate_status != "fail" or candidate_version == "unknown"
+        ):
+            evidence_error = "candidate-regression evidence contradicts the harness contract"
+        if classification == "candidate_regression" and not evidence_error:
+            expected_artifact = (
+                f"{RADAR_ARTIFACT_PREFIX}{connector}-{candidate_version}"
+            )
+            if root.name != expected_artifact:
+                evidence_error = (
+                    "candidate-regression evidence does not match its artifact identity"
+                )
+
+        result_rows: tuple[dict, ...] = ()
+        if not evidence_error:
+            loaded_rows, result_evidence_error = _load_results_with_integrity(path.parent)
+            if classification == "candidate_regression":
+                result_rows = tuple(loaded_rows)
+            if result_evidence_error:
+                kind = (
+                    "candidate-regression"
+                    if classification == "candidate_regression"
+                    else "classified radar"
+                )
+                evidence_error = f"{kind} result evidence is unreadable or malformed"
+
+        item = Classification(
+            root=path.parent,
+            connector=connector,
+            classification=classification,
+            baseline_version=baseline_version,
+            candidate_version=candidate_version,
+            baseline_status=baseline_status,
+            candidate_status=candidate_status,
+            evidence_error=evidence_error,
+            result_rows=result_rows,
+        )
+        if (
+            item.classification == "candidate_regression"
+            and not item.evidence_error
+            and any(_contradicts_candidate_regression(row) for row in item.result_rows)
+        ):
+            item = dataclasses.replace(
+                item,
+                evidence_error="candidate-regression evidence contains a failed baseline row",
+            )
+        if (
+            item.classification == "candidate_regression"
+            and not item.evidence_error
+            and not any(_matches_candidate_failure(row, item) for row in item.result_rows)
+        ):
+            item = dataclasses.replace(
+                item,
+                evidence_error="candidate-regression evidence has no matching failed candidate row",
+            )
+        classifications.append(item)
+    return classifications
 
 
-def load_candidate_regression_results(results_dir: Path) -> list[dict]:
-    roots = candidate_regression_roots(results_dir)
-    if not roots:
-        return []
-    return load_results(results_dir, roots=roots)
+def candidate_regression_roots(results_dir: Path) -> list[Path]:
+    return [item.root for item in load_classifications(results_dir) if item.is_candidate_regression]
+
+
+def load_candidate_regression_results(classifications: list[Classification]) -> list[dict]:
+    rows: list[dict] = []
+    for item in classifications:
+        if not item.is_candidate_regression:
+            continue
+        # Classification metadata and row evidence must agree before a
+        # failure can enter candidate-regression content.
+        rows.extend(row for row in item.result_rows if _matches_candidate_failure(row, item))
+    return rows
 
 
 def summarize(rows: list[dict]):
@@ -117,7 +344,45 @@ def summarize(rows: list[dict]):
     return cells, versions, failures
 
 
-def render_summary(cells, versions) -> str:
+def _markdown_cell(value: object) -> str:
+    return str(value).replace("\r", " ").replace("\n", " ").replace("|", "\\|")
+
+
+def _render_lab_failures(classifications: list[Classification]) -> list[str]:
+    lab_failures = [item for item in classifications if item.is_lab_failure]
+    if not lab_failures:
+        return []
+
+    lines = [
+        "## Operational lab failures (not candidate regressions)",
+        "",
+        "| Connector | Classification | Baseline | Candidate | Required action |",
+        "|---|---|---|---|---|",
+    ]
+    for item in sorted(lab_failures, key=lambda value: (value.connector, value.root)):
+        if item.evidence_error:
+            classification = f"{item.classification} (invalid evidence)"
+            action = item.evidence_error
+        else:
+            classification = item.classification
+            action = LAB_FAILURE_ACTIONS[item.classification]
+        connector = _markdown_cell(item.connector)
+        classification = _markdown_cell(classification)
+        baseline = _markdown_cell(item.baseline_version)
+        candidate = _markdown_cell(item.candidate_version)
+        action = _markdown_cell(action)
+        lines.append(f"| {connector} | {classification} | {baseline} | {candidate} | {action} |")
+    lines.append("")
+    return lines
+
+
+def render_summary(
+    cells,
+    versions,
+    *,
+    classifications: list[Classification] | None = None,
+    candidate_failures: list[tuple[str, str, str, str]] | None = None,
+) -> str:
     lines = ["# Connector live E2E results", ""]
     lines.append("| Connector | OS | Version | Result | Events (pass/fail/skip) |")
     lines.append("|---|---|---|---|---|")
@@ -132,17 +397,30 @@ def render_summary(cells, versions) -> str:
             f"{n_pass}/{n_fail}/{n_skip} |"
         )
     lines.append("")
-    failing_events = [
-        (c, o, e)
-        for (c, o), events in cells.items()
-        for e, s in events.items()
-        if s == "fail"
-    ]
-    if failing_events:
-        lines.append("## Failing events")
+    failing_events = {(c, o, e) for (c, o), events in cells.items() for e, s in events.items() if s == "fail"}
+    if classifications is None:
+        if failing_events:
+            lines.append("## Failing events")
+            lines.append("")
+            for c, o, e in sorted(failing_events):
+                lines.append(f"- `{c}` / `{o}` / `{e}`")
+            lines.append("")
+        return "\n".join(lines)
+
+    lines.extend(_render_lab_failures(classifications))
+    candidate_events = {(connector, os_, event) for connector, os_, event, _detail in (candidate_failures or [])}
+    lab_events = failing_events - candidate_events
+    if lab_events:
+        lines.append("## Lab failure events (not candidate regressions)")
         lines.append("")
-        for c, o, e in sorted(failing_events):
-            lines.append(f"- `{c}` / `{o}` / `{e}`")
+        for connector, os_, event in sorted(lab_events):
+            lines.append(f"- `{connector}` / `{os_}` / `{event}`")
+        lines.append("")
+    if candidate_events:
+        lines.append("## Candidate regression events")
+        lines.append("")
+        for connector, os_, event in sorted(candidate_events):
+            lines.append(f"- `{connector}` / `{os_}` / `{event}`")
         lines.append("")
     return "\n".join(lines)
 
@@ -249,13 +527,25 @@ def main() -> int:
               file=sys.stderr)
         return 0
 
+    radar_roots = radar_artifact_roots(args.results_dir)
+    classifications = load_classifications(args.results_dir) if radar_roots else []
     rows = load_results(args.results_dir)
-    if not rows:
+    if not rows and not radar_roots:
         print("[report] no result rows found; nothing to report.", file=sys.stderr)
         return 0
 
     cells, versions, failures = summarize(rows)
-    summary = render_summary(cells, versions)
+    issue_failures = failures
+    issue_versions = versions
+    if radar_roots:
+        issue_rows = load_candidate_regression_results(classifications)
+        _issue_cells, issue_versions, issue_failures = summarize(issue_rows)
+    summary = render_summary(
+        cells,
+        versions,
+        classifications=classifications if radar_roots else None,
+        candidate_failures=issue_failures if radar_roots else None,
+    )
     print(summary)
     if args.summary_file:
         try:
@@ -264,18 +554,19 @@ def main() -> int:
         except OSError as exc:
             print(f"[report] could not write summary: {exc}", file=sys.stderr)
 
-    if failures:
-        issue_failures = failures
-        issue_versions = versions
-        if args.open_issue:
-            issue_rows = load_candidate_regression_results(args.results_dir)
-            _issue_cells, issue_versions, issue_failures = summarize(issue_rows)
-        body = build_issue_body(issue_failures, issue_versions, args.run_url)
-        print("\n----- regression issue body -----\n" + body, file=sys.stderr)
-        if args.open_issue and issue_failures:
-            open_or_update_issue(body, args.run_url)
-        elif args.open_issue:
-            print("[report] no candidate-regression failures to file.", file=sys.stderr)
+    classification_failures = [item for item in classifications if item.is_failure]
+    if failures or classification_failures:
+        if issue_failures:
+            body = build_issue_body(issue_failures, issue_versions, args.run_url)
+            print("\n----- regression issue body -----\n" + body, file=sys.stderr)
+            if args.open_issue:
+                open_or_update_issue(body, args.run_url)
+        elif radar_roots:
+            action = "file" if args.open_issue else "report"
+            print(
+                f"[report] no candidate-regression failures to {action}.",
+                file=sys.stderr,
+            )
         return 1
 
     print("[report] all cells green.")


### PR DESCRIPTION
Base note: this is a single-commit change based on `main` at `c181ba4f13d05ac84273560b1ae43fb54ed5c34d`. The independently audited head is `f5098d719ac2968058edbe98b58e2103ad0daee7` (tree `9340f7e521879768d16123233a6c7295b194c187`).

## Problem

The Connector Version Radar aggregate reporter correctly returns a failing status for authentication, known-good baseline, and infrastructure failures. However, its candidate-regression presentation was only narrowed when `--open-issue` was passed. An auth-only radar run, where the workflow intentionally omits that flag, therefore printed every raw failing row under a misleading `regression issue body` with candidate-remediation guidance.

Missing, malformed, unreadable, structurally invalid, or contradictory classification/result evidence also needed to fail closed. Otherwise, incomplete radar artifacts could be mistaken for the separate unclassified connector-live-E2E format, or a nominally passing classification could remain green despite corrupt result evidence.

## Current Situation

Scheduled run [31588250030](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/31588250030) ran from exact `main` commit `9436470a6abb914c0dfcaec8305ea59a4f968c2f`. All three known-good baselines failed before candidate execution:

- Codex: stale refresh token prevented baseline gateway startup.
- Claude Code: the known-good baseline was logged out.
- Antigravity: the known-good baseline required authentication.

Each cell was correctly red with `auth_failure`, and no issue API call occurred, but the aggregate reporter rendered the baseline failures as a candidate regression.

## Solution

### Make radar reporting classification-aware

The reporter now recognizes version-radar artifact roots independently from the presence of `classification.json`, parses each classification once, and separates candidate regressions from operational lab failures. `auth_failure`, `baseline_failure`, and `infrastructure_failure` receive explicit operator actions and retain a red aggregate exit.

### Fail closed at the issue boundary

Every classified radar artifact must have readable, structurally valid result evidence. Only a coherent `candidate_regression` classification with a passing baseline, failed candidate, known candidate version, no failed baseline row, a matching failed candidate row, correct artifact connector/version identity, and fully readable JSONL objects whose six required fields are strings may enter the regression body or issue writer.

Malformed, non-object, structurally invalid, unreadable, missing, unknown, contradictory, identity-mismatched, and candidate-row-mismatched evidence remains red as an invalid lab result. This validation also applies to nominally passing classifications, preventing corrupt evidence from producing a green aggregate result. Operational raw details are not copied into summaries or candidate issue content.

### Preserve standalone live-E2E behavior

The separate connector-live-E2E workflow does not use version-radar artifact roots. Its existing unclassified failure and issue-writing contract remains unchanged, including tolerant handling of malformed legacy rows.

```mermaid
flowchart TD
    A["Downloaded result artifacts"] --> B{"Version-radar artifact root?"}
    B -->|No| L["Preserve standalone live-E2E reporting"]
    B -->|Yes| C["Load classification and result evidence"]
    C --> D{"Evidence valid and classification coherent?"}
    D -->|No| J["Render operational or invalid-evidence lab failure"]
    J --> K["Red exit; no regression body or issue call"]
    D -->|Yes| M{"Candidate regression?"}
    M -->|No| N["Render classified outcome"]
    M -->|Yes| E["Select matching failed candidate rows only"]
    E --> F["Render candidate regression body"]
    F --> G{"Issue flag enabled?"}
    G -->|Yes| H["Open or update regression issue"]
    G -->|No| I["Report only"]
```

## What Changed (Where & How)

| Path | Change |
|---|---|
| `scripts/live-connector-e2e/report.py` | Adds classification-aware radar-root discovery, integrity-aware classified-result loading, operational lab summaries, coherent candidate-row filtering, missing/invalid/contradictory evidence handling, detail-safe rendering, and red exit preservation. |
| `cli/tests/test_live_connector_upgrade_harness.py` | Adds auth-only, candidate-only, mixed, no-issue-call, baseline/infrastructure, malformed/contradictory, failed-baseline-row, malformed/non-object/structurally-invalid result-row, pass-classification integrity, artifact-identity mismatch, all-missing, mixed-missing, detail-redaction, and legacy compatibility coverage. |

## Breaking Changes

None. The aggregate job remains red for every failed cell. Only the report classification and issue-content boundary change: operational lab failures and invalid classified evidence are no longer presented as upstream candidate regressions.

## Open Issues / Follow-ups

- #741 tracks hardening the separate workflow privilege boundary so candidate-execution artifacts cannot authorize a later job's repository issue write. This PR keeps #737 scoped to fail-closed reporting and issue-content selection.

## Test Plan

Immutable review ledger:

- Patch serialization environment: `git version 2.50.1 (Apple Git-155)`
- Base: `c181ba4f13d05ac84273560b1ae43fb54ed5c34d`
- Head: `f5098d719ac2968058edbe98b58e2103ad0daee7`
- Tree: `9340f7e521879768d16123233a6c7295b194c187`
- `git diff HEAD^ HEAD --binary --no-ext-diff` SHA-256: `908685ebbd008734c53bd0c8df81ce9168e2a31d9d4b9575970ae15717f3e0c7`
- `git diff HEAD^ HEAD --binary --full-index --no-ext-diff` SHA-256: `d66e90141cf23aa5af2dac6a2d7917d6328d1b6665ea9ddebd5f9691d240279d`
- `scripts/live-connector-e2e/report.py` SHA-256: `ad5d8433ab4e638f720be7f752c80a31398298807ddb4b0e3b26be45099b552a`
- `cli/tests/test_live_connector_upgrade_harness.py` SHA-256: `9d696aabd2ca6ec68d8229b23aec704c7d1a22acbdcae7ed10a112ada2868b9b`
- Stable patch ID: `e621a7ae195df59557b6cd3066dc216b1eb5aea9`

Commands and observed results:

```sh
/Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/pytest -q \
  cli/tests/test_live_connector_upgrade_harness.py \
  cli/tests/test_connector_version_radar.py
# 43 passed

/Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/pytest -q \
  cli/tests/test_live_connector_upgrade_harness.py
# 32 passed

/Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/ruff check \
  scripts/live-connector-e2e/report.py \
  cli/tests/test_live_connector_upgrade_harness.py
# All checks passed

/Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/python -m py_compile \
  scripts/live-connector-e2e/report.py \
  cli/tests/test_live_connector_upgrade_harness.py
# passed

/Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/ruff check \
  --select PLW2901,SIM102,PERF401 \
  scripts/live-connector-e2e/report.py
# All checks passed

git diff HEAD^ HEAD --check
# passed
```

Production-evidence replay of run `31588250030`: expected exit `1`; three `auth_failure` lab rows rendered; zero issue-writer calls with `--open-issue`; no regression body; none of 16 non-empty raw result details appeared in stdout or stderr.

Independent immutable audit of the exact frozen commit: **CLEAN** with zero correctness or security findings. It independently reproduced 43/43 focused tests, 32/32 changed-module tests, and 33 direct adversarial scenarios. Coverage includes malformed, non-object, structurally invalid, unreadable, mixed-valid-and-malformed, and valid result evidence for passing classifications; all operational classifications; candidate-only and mixed runs; failed-baseline-row contradictions; malformed/missing/unknown/contradictory classification evidence; connector/event/version mismatches; all-missing and mixed-missing radar roots; detection-artifact and path-prefix boundaries; standalone live-E2E compatibility; issue-writer input; exit status; and detail disclosure. Missing or empty pass result files remain green because the source contract does not require a minimum result-row count.

Local CodeRabbit completed two pre-freeze review passes and all reported issues were addressed. The exact-final-head retry could not start because the CLI reported `rate_limit` and no assigned `cisco-ai-defense` seat for this Git provider account. Hosted reviews of earlier PR heads identified artifact connector/version identity, failed-baseline-row contradiction, malformed-result integrity, invalid-field structure, and pass-classification result-integrity gaps; this exact head fixes each with dedicated fail-closed tests. The separate workflow issue-write trust boundary is tracked in #741. Fresh hosted reviews of this replacement head are requested.

Fixes #737
