### PR TITLE
fix(observability): recover sticky SQLite event-history health

### DIFF
--- a/bundles/llm/model_catalog.json
+++ b/bundles/llm/model_catalog.json
@@ -109,9 +109,7 @@
       "models": [
         "openai/gpt-oss-120b",
         "openai/gpt-oss-20b",
-        "qwen/qwen3.6-27b",
-        "llama-3.3-70b-versatile",
-        "llama-3.1-8b-instant"
+        "qwen/qwen3.6-27b"
       ]
     },
     {

--- a/internal/audit/alert_acknowledgement_projection_test.go
+++ b/internal/audit/alert_acknowledgement_projection_test.go
@@ -130,8 +130,8 @@ type closingAlertHealthReporter struct {
 	errs  chan error
 }
 
-func (reporter *closingAlertHealthReporter) ReportEventHistoryHealth(code EventHistoryHealthCode) {
-	reporter.codes <- code
+func (reporter *closingAlertHealthReporter) ReportEventHistoryHealth(transition EventHistoryHealthTransition) {
+	reporter.codes <- transition.Code
 	reporter.errs <- reporter.store.Close()
 }
 

--- a/internal/audit/event_history_v8.go
+++ b/internal/audit/event_history_v8.go
@@ -30,6 +30,7 @@ import (
 	"io"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -111,8 +112,54 @@ const (
 	EventHistoryHealthWriteFailed        EventHistoryHealthCode = "sqlite_write_failed"
 )
 
+// EventHistoryHealthState distinguishes a bounded failure observation from a
+// later proof that the same persistence rail recovered.
+type EventHistoryHealthState string
+
+const (
+	EventHistoryHealthFailed    EventHistoryHealthState = "failed"
+	EventHistoryHealthRecovered EventHistoryHealthState = "recovered"
+)
+
+// EventHistorySQLiteClass is a deliberately coarse SQLite diagnostic. It is
+// safe to expose in health output; arbitrary driver text and extended result
+// codes never cross this boundary.
+type EventHistorySQLiteClass string
+
+const (
+	EventHistorySQLiteBusyLocked        EventHistorySQLiteClass = "busy_locked"
+	EventHistorySQLiteDeadline          EventHistorySQLiteClass = "deadline"
+	EventHistorySQLiteFull              EventHistorySQLiteClass = "full"
+	EventHistorySQLiteIO                EventHistorySQLiteClass = "io"
+	EventHistorySQLiteReadOnlyCantOpen  EventHistorySQLiteClass = "readonly_cantopen"
+	EventHistorySQLiteConstraintCorrupt EventHistorySQLiteClass = "constraint_corrupt"
+	EventHistorySQLiteUnavailable       EventHistorySQLiteClass = "unavailable"
+	EventHistorySQLiteOther             EventHistorySQLiteClass = "other"
+)
+
+// EventHistoryHealthTransition is immutable, bounded health state. Generation
+// identifies its runtime writer; Sequence is the writer-local outcome
+// linearization order assigned when a failure is staged or a commit succeeds,
+// independently of callback arrival.
+type EventHistoryHealthTransition struct {
+	Generation        uint64
+	Sequence          uint64
+	State             EventHistoryHealthState
+	Code              EventHistoryHealthCode
+	OccurredAt        time.Time
+	SQLiteClass       EventHistorySQLiteClass
+	SQLitePrimaryCode uint8
+}
+
 type EventHistoryHealthReporter interface {
-	ReportEventHistoryHealth(EventHistoryHealthCode)
+	ReportEventHistoryHealth(EventHistoryHealthTransition)
+}
+
+// EventHistoryHealthGenerationBinder is an optional runtime integration hook.
+// It is invoked only from the new graph component's Activate path, after the
+// graph has been published; candidate preparation never advances health state.
+type EventHistoryHealthGenerationBinder interface {
+	BindEventHistoryHealthGeneration(uint64)
 }
 
 type eventHistoryWriteError struct{ cause error }
@@ -145,8 +192,9 @@ func (err *eventHistoryHealthError) Unwrap() error {
 }
 
 type eventHistoryAppendOutcome struct {
-	signed   bool
-	unsigned bool
+	mandatory bool
+	signed    bool
+	unsigned  bool
 }
 
 func eventHistoryFailure(code EventHistoryHealthCode, err error) error {
@@ -234,19 +282,25 @@ func cloneLocalProjectionProfiles(
 // EventHistoryWriter appends immutable v8 log projections to audit_events. A
 // nil signer is valid and produces an explicitly unsigned row.
 type EventHistoryWriter struct {
-	store            *Store
-	signer           ProjectionIntegritySigner
-	healthReporter   EventHistoryHealthReporter
-	localProfiles    map[observability.Bucket]observabilityredaction.Profile
-	projectionEngine *observabilityredaction.Engine
-	graphDigest      string
-	appendCommitMu   sync.Mutex
-	healthMu         sync.Mutex
-	healthQueue      []EventHistoryHealthCode
-	healthPending    map[EventHistoryHealthCode]bool
-	healthDraining   bool
-	healthActive     EventHistoryHealthCode
-	unsignedReported bool
+	store              *Store
+	signer             ProjectionIntegritySigner
+	healthReporter     EventHistoryHealthReporter
+	localProfiles      map[observability.Bucket]observabilityredaction.Profile
+	projectionEngine   *observabilityredaction.Engine
+	graphDigest        string
+	generation         uint64
+	healthSequence     atomic.Uint64
+	appendCommitMu     sync.Mutex
+	healthMu           sync.Mutex
+	healthQueue        []EventHistoryHealthTransition
+	healthDraining     bool
+	healthActive       EventHistoryHealthTransition
+	writeHealthKnown   bool
+	writeHealthState   EventHistoryHealthState
+	writeHealthSeq     uint64
+	writeHealthClass   EventHistorySQLiteClass
+	writeHealthPrimary uint8
+	unsignedReported   bool
 }
 
 // NewEventHistoryWriter snapshots the compiled runtime graph's complete local
@@ -258,10 +312,22 @@ func NewEventHistoryWriter(
 	healthReporter EventHistoryHealthReporter,
 	binding LocalProjectionBinding,
 ) (*EventHistoryWriter, error) {
+	return NewEventHistoryWriterForGeneration(store, signer, healthReporter, binding, 1)
+}
+
+// NewEventHistoryWriterForGeneration binds health transitions to the same
+// immutable runtime generation that owns this writer.
+func NewEventHistoryWriterForGeneration(
+	store *Store,
+	signer ProjectionIntegritySigner,
+	healthReporter EventHistoryHealthReporter,
+	binding LocalProjectionBinding,
+	generation uint64,
+) (*EventHistoryWriter, error) {
 	if store == nil || store.db == nil || !store.Ready() {
 		return nil, fmt.Errorf("audit: ready v8 event-history store is required")
 	}
-	if binding == nil {
+	if binding == nil || generation == 0 {
 		return nil, fmt.Errorf("audit: local projection binding is required")
 	}
 	snapshot := binding.eventHistoryProjectionBinding()
@@ -279,7 +345,7 @@ func NewEventHistoryWriter(
 	}
 	return &EventHistoryWriter{
 		store: store, signer: signer, healthReporter: healthReporter, localProfiles: profiles,
-		projectionEngine: snapshot.engine, graphDigest: snapshot.graphDigest,
+		projectionEngine: snapshot.engine, graphDigest: snapshot.graphDigest, generation: generation,
 	}, nil
 }
 
@@ -290,6 +356,17 @@ func (writer *EventHistoryWriter) GraphDigest() string {
 		return ""
 	}
 	return writer.graphDigest
+}
+
+// ActivateHealthGeneration binds the reporter to this published writer's
+// generation before its component begins accepting records.
+func (writer *EventHistoryWriter) ActivateHealthGeneration() {
+	if writer == nil || writer.healthReporter == nil {
+		return
+	}
+	if binder, ok := writer.healthReporter.(EventHistoryHealthGenerationBinder); ok {
+		binder.BindEventHistoryHealthGeneration(writer.generation)
+	}
 }
 
 // Append persists exactly one local event-history row using a background
@@ -321,7 +398,7 @@ func (writer *EventHistoryWriter) AppendContext(
 	}
 	release, err := writer.store.acquireReady()
 	if err != nil {
-		writer.reportHealth(EventHistoryHealthWriteFailed)
+		writer.reportHealthFailure(EventHistoryHealthWriteFailed, err, EventHistorySQLiteUnavailable)
 		return err
 	}
 	released := false
@@ -334,8 +411,9 @@ func (writer *EventHistoryWriter) AppendContext(
 	defer releaseReady()
 	tx, err := writer.store.db.BeginTx(ctx, nil)
 	if err != nil {
+		writer.stageHealthFailure(EventHistoryHealthWriteFailed, err, "")
 		releaseReady()
-		writer.reportHealth(EventHistoryHealthWriteFailed)
+		writer.flushHealth()
 		return fmt.Errorf("audit: begin v8 event-history write: %w", err)
 	}
 	defer tx.Rollback() //nolint:errcheck
@@ -345,8 +423,9 @@ func (writer *EventHistoryWriter) AppendContext(
 		// same single-connection Store. End this transaction before invoking
 		// external code so failure reporting cannot self-deadlock.
 		_ = tx.Rollback()
+		writer.stageAppendError(err)
 		releaseReady()
-		writer.reportAppendError(err)
+		writer.flushHealth()
 		return err
 	}
 	if err := writer.commitAppendTransaction(tx, outcome); err != nil {
@@ -434,7 +513,9 @@ func (writer *EventHistoryWriter) appendContextTxResolvedProfile(
 		}
 		return eventHistoryAppendOutcome{}, eventHistoryFailure(EventHistoryHealthSigningFailed, err)
 	}
-	outcome := eventHistoryAppendOutcome{signed: !unsigned, unsigned: unsigned}
+	outcome := eventHistoryAppendOutcome{
+		mandatory: record.Mandatory(), signed: !unsigned, unsigned: unsigned,
+	}
 
 	correlation := record.Correlation()
 	provenance := record.Provenance()
@@ -656,11 +737,15 @@ func exactObservationTopology(traceID, spanID string) (string, string) {
 }
 
 func (writer *EventHistoryWriter) reportAppendError(err error) {
+	writer.stageAppendError(err)
+	writer.flushHealth()
+}
+
+func (writer *EventHistoryWriter) stageAppendError(err error) {
 	var healthErr *eventHistoryHealthError
 	if errors.As(err, &healthErr) {
-		writer.enqueueHealth(healthErr.code)
+		writer.stageHealthFailure(healthErr.code, err, "")
 	}
-	writer.flushHealth()
 }
 
 // commitAppendTransaction serializes commit order with signed/unsigned health
@@ -676,14 +761,19 @@ func (writer *EventHistoryWriter) commitAppendTransaction(
 	writer.appendCommitMu.Lock()
 	defer writer.appendCommitMu.Unlock()
 	if err := tx.Commit(); err != nil {
-		writer.enqueueHealth(EventHistoryHealthWriteFailed)
+		writer.enqueueHealthFailure(
+			writer.nextHealthSequence(), EventHistoryHealthWriteFailed, err, "",
+		)
 		return err
 	}
-	writer.stageAppendOutcome(outcome)
+	writer.stageAppendOutcome(outcome, writer.nextHealthSequence())
 	return nil
 }
 
-func (writer *EventHistoryWriter) stageAppendOutcome(outcome eventHistoryAppendOutcome) {
+func (writer *EventHistoryWriter) stageAppendOutcome(
+	outcome eventHistoryAppendOutcome,
+	sequence uint64,
+) {
 	if writer == nil {
 		return
 	}
@@ -691,6 +781,11 @@ func (writer *EventHistoryWriter) stageAppendOutcome(outcome eventHistoryAppendO
 	defer writer.healthMu.Unlock()
 	if outcome.signed {
 		writer.unsignedReported = false
+		if outcome.mandatory {
+			writer.enqueueHealthTransitionLocked(writer.healthTransition(
+				sequence, EventHistoryHealthRecovered, EventHistoryHealthWriteFailed, "", 0,
+			))
+		}
 		return
 	}
 	if outcome.unsigned && !writer.unsignedReported {
@@ -698,44 +793,152 @@ func (writer *EventHistoryWriter) stageAppendOutcome(outcome eventHistoryAppendO
 		// A signed commit can restore health while an earlier unsigned
 		// transition is still being reported. Preserve one later unsigned
 		// transition behind the active callback instead of dropping it.
-		writer.enqueueHealthLocked(EventHistoryHealthUnsigned, true)
+		writer.enqueueHealthTransitionLocked(writer.healthTransition(
+			sequence, EventHistoryHealthFailed, EventHistoryHealthUnsigned, "", 0,
+		))
 	}
 }
 
-func (writer *EventHistoryWriter) reportHealth(code EventHistoryHealthCode) {
-	writer.enqueueHealth(code)
+func (writer *EventHistoryWriter) nextHealthSequence() uint64 {
+	if writer == nil {
+		return 0
+	}
+	return writer.healthSequence.Add(1)
+}
+
+func (writer *EventHistoryWriter) healthTransition(
+	sequence uint64,
+	state EventHistoryHealthState,
+	code EventHistoryHealthCode,
+	sqliteClass EventHistorySQLiteClass,
+	primary uint8,
+) EventHistoryHealthTransition {
+	return EventHistoryHealthTransition{
+		Generation: writer.generation, Sequence: sequence, State: state, Code: code,
+		OccurredAt: time.Now().UTC(), SQLiteClass: sqliteClass, SQLitePrimaryCode: primary,
+	}
+}
+
+func (writer *EventHistoryWriter) reportHealthFailure(
+	code EventHistoryHealthCode,
+	err error,
+	classOverride EventHistorySQLiteClass,
+) {
+	writer.stageHealthFailure(code, err, classOverride)
 	writer.flushHealth()
 }
 
-func (writer *EventHistoryWriter) enqueueHealth(code EventHistoryHealthCode) {
+func (writer *EventHistoryWriter) stageHealthFailure(
+	code EventHistoryHealthCode,
+	err error,
+	classOverride EventHistorySQLiteClass,
+) {
+	if writer == nil {
+		return
+	}
+	writer.appendCommitMu.Lock()
+	writer.enqueueHealthFailure(writer.nextHealthSequence(), code, err, classOverride)
+	writer.appendCommitMu.Unlock()
+}
+
+func (writer *EventHistoryWriter) enqueueHealthFailure(
+	sequence uint64,
+	code EventHistoryHealthCode,
+	err error,
+	classOverride EventHistorySQLiteClass,
+) {
 	if writer == nil || writer.healthReporter == nil {
 		return
 	}
+	var sqliteClass EventHistorySQLiteClass
+	var primary uint8
+	if code == EventHistoryHealthWriteFailed {
+		sqliteClass, primary = classifyEventHistorySQLiteFailure(err)
+		if classOverride != "" {
+			sqliteClass = classOverride
+			// An override describes a lifecycle boundary rather than the
+			// driver's exact result. Do not pair it with a primary code whose
+			// meaning belongs to the discarded driver-derived class.
+			primary = 0
+		}
+	}
+	transition := writer.healthTransition(
+		sequence, EventHistoryHealthFailed, code, sqliteClass, primary,
+	)
 	writer.healthMu.Lock()
 	defer writer.healthMu.Unlock()
-	writer.enqueueHealthLocked(code, false)
+	writer.enqueueHealthTransitionLocked(transition)
 }
 
-func (writer *EventHistoryWriter) enqueueHealthLocked(
-	code EventHistoryHealthCode,
-	allowAfterActive bool,
+func (writer *EventHistoryWriter) enqueueHealthTransitionLocked(
+	transition EventHistoryHealthTransition,
 ) {
-	if writer.healthReporter == nil || code == "" || (code == writer.healthActive && !allowAfterActive) {
+	if writer.healthReporter == nil || !validEventHistoryHealthTransition(transition) {
 		return
 	}
-	if writer.healthPending == nil {
-		writer.healthPending = make(map[EventHistoryHealthCode]bool, 4)
+	if transition.Code == EventHistoryHealthWriteFailed {
+		if transition.Sequence <= writer.writeHealthSeq {
+			return
+		}
+		previousState := writer.writeHealthState
+		previousClass := writer.writeHealthClass
+		previousPrimary := writer.writeHealthPrimary
+		writer.writeHealthSeq = transition.Sequence
+		writer.writeHealthState = transition.State
+		writer.writeHealthClass = transition.SQLiteClass
+		writer.writeHealthPrimary = transition.SQLitePrimaryCode
+		if writer.writeHealthKnown && previousState == transition.State &&
+			(transition.State == EventHistoryHealthRecovered ||
+				previousClass == transition.SQLiteClass && previousPrimary == transition.SQLitePrimaryCode) {
+			return
+		}
+		writer.writeHealthKnown = true
 	}
-	if writer.healthPending[code] {
+	if transition.Code == EventHistoryHealthWriteFailed {
+		// Preserve the latest failed diagnostic immediately before a following
+		// recovery while another callback is active. A newer failure supersedes
+		// both; a newer recovery supersedes only an older recovery. The sidecar
+		// therefore learns the last bounded SQLite class even when the final
+		// state delivered from this drain is recovered.
+		keptFailure := false
+		queue := writer.healthQueue[:0]
+		for _, pending := range writer.healthQueue {
+			if pending.Code != EventHistoryHealthWriteFailed {
+				queue = append(queue, pending)
+				continue
+			}
+			if transition.State == EventHistoryHealthRecovered &&
+				pending.State == EventHistoryHealthFailed && !keptFailure {
+				queue = append(queue, pending)
+				keptFailure = true
+			}
+		}
+		writer.healthQueue = queue
+		if len(writer.healthQueue) >= 5 {
+			return
+		}
+		writer.healthQueue = append(writer.healthQueue, transition)
 		return
 	}
-	// The vocabulary has four values. Coalescing one pending transition per
-	// code makes the queue bounded even if a reporter re-enters this writer.
-	if len(writer.healthQueue) >= 4 {
+
+	// The active callback is separate. Behind it, retain only the latest
+	// failure for each non-write code. Moving the replacement to the tail
+	// preserves its actual outcome order relative to other codes.
+	for index := len(writer.healthQueue) - 1; index >= 0; index-- {
+		pending := writer.healthQueue[index]
+		if pending.Code != transition.Code {
+			continue
+		}
+		if pending.Generation > transition.Generation ||
+			pending.Generation == transition.Generation && pending.Sequence >= transition.Sequence {
+			return
+		}
+		writer.healthQueue = append(writer.healthQueue[:index], writer.healthQueue[index+1:]...)
+	}
+	if len(writer.healthQueue) >= 5 {
 		return
 	}
-	writer.healthPending[code] = true
-	writer.healthQueue = append(writer.healthQueue, code)
+	writer.healthQueue = append(writer.healthQueue, transition)
 }
 
 func (writer *EventHistoryWriter) flushHealth() {
@@ -753,23 +956,119 @@ func (writer *EventHistoryWriter) flushHealth() {
 	for {
 		writer.healthMu.Lock()
 		if len(writer.healthQueue) == 0 {
-			writer.healthActive = ""
+			writer.healthActive = EventHistoryHealthTransition{}
 			writer.healthDraining = false
 			writer.healthMu.Unlock()
 			return
 		}
-		code := writer.healthQueue[0]
+		transition := writer.healthQueue[0]
 		writer.healthQueue = writer.healthQueue[1:]
-		delete(writer.healthPending, code)
-		writer.healthActive = code
+		writer.healthActive = transition
 		writer.healthMu.Unlock()
 
-		writer.healthReporter.ReportEventHistoryHealth(code)
+		writer.healthReporter.ReportEventHistoryHealth(transition)
 
 		writer.healthMu.Lock()
-		writer.healthActive = ""
+		writer.healthActive = EventHistoryHealthTransition{}
 		writer.healthMu.Unlock()
 	}
+}
+
+func validEventHistoryHealthTransition(transition EventHistoryHealthTransition) bool {
+	if transition.Generation == 0 || transition.Sequence == 0 || transition.OccurredAt.IsZero() {
+		return false
+	}
+	switch transition.Code {
+	case EventHistoryHealthProjectionRejected, EventHistoryHealthUnsigned,
+		EventHistoryHealthSigningFailed, EventHistoryHealthWriteFailed:
+	default:
+		return false
+	}
+	if transition.State == EventHistoryHealthRecovered {
+		return transition.Code == EventHistoryHealthWriteFailed && transition.SQLiteClass == "" &&
+			transition.SQLitePrimaryCode == 0
+	}
+	if transition.State != EventHistoryHealthFailed {
+		return false
+	}
+	if transition.Code != EventHistoryHealthWriteFailed {
+		return transition.SQLiteClass == "" && transition.SQLitePrimaryCode == 0
+	}
+	return validEventHistorySQLiteDiagnostic(transition.SQLiteClass, transition.SQLitePrimaryCode)
+}
+
+// ValidEventHistoryHealthTransition validates the complete bounded transition
+// contract at package boundaries. Consumers use this instead of independently
+// reconstructing class/primary-code pairings that could drift.
+func ValidEventHistoryHealthTransition(transition EventHistoryHealthTransition) bool {
+	return validEventHistoryHealthTransition(transition)
+}
+
+func validEventHistorySQLiteDiagnostic(class EventHistorySQLiteClass, primary uint8) bool {
+	switch class {
+	case EventHistorySQLiteBusyLocked:
+		return primary == 5 || primary == 6
+	case EventHistorySQLiteDeadline:
+		return primary == 0 || primary == 9
+	case EventHistorySQLiteFull:
+		return primary == 13
+	case EventHistorySQLiteIO:
+		return primary == 10
+	case EventHistorySQLiteReadOnlyCantOpen:
+		return primary == 8 || primary == 14
+	case EventHistorySQLiteConstraintCorrupt:
+		return primary == 11 || primary == 19 || primary == 26
+	case EventHistorySQLiteUnavailable:
+		return primary == 0
+	case EventHistorySQLiteOther:
+		return primary == 0 || primary >= 1 && primary <= 28 &&
+			primary != 5 && primary != 6 && primary != 8 && primary != 9 &&
+			primary != 10 && primary != 11 && primary != 13 && primary != 14 &&
+			primary != 19 && primary != 26
+	default:
+		return false
+	}
+}
+
+func classifyEventHistorySQLiteFailure(err error) (EventHistorySQLiteClass, uint8) {
+	if errors.Is(err, context.DeadlineExceeded) {
+		primary := sqlitePrimaryCode(err)
+		if primary != 9 {
+			primary = 0
+		}
+		return EventHistorySQLiteDeadline, primary
+	}
+	primary := sqlitePrimaryCode(err)
+	switch primary {
+	case 5, 6:
+		return EventHistorySQLiteBusyLocked, primary
+	case 9:
+		return EventHistorySQLiteDeadline, primary
+	case 13:
+		return EventHistorySQLiteFull, primary
+	case 10:
+		return EventHistorySQLiteIO, primary
+	case 8, 14:
+		return EventHistorySQLiteReadOnlyCantOpen, primary
+	case 11, 19, 26:
+		return EventHistorySQLiteConstraintCorrupt, primary
+	default:
+		return EventHistorySQLiteOther, primary
+	}
+}
+
+func sqlitePrimaryCode(err error) uint8 {
+	var coded sqliteCoded
+	if !errors.As(err, &coded) {
+		return 0
+	}
+	primary := coded.Code() & 0xff
+	// SQLite currently defines primary result codes 1 through 28. Never
+	// expose an arbitrary driver-provided integer outside that allowlist.
+	if primary < 1 || primary > 28 {
+		return 0
+	}
+	return uint8(primary)
 }
 
 func projectedCompatibilityTarget(projection observabilityredaction.Projection) string {

--- a/internal/audit/event_history_v8.go
+++ b/internal/audit/event_history_v8.go
@@ -327,8 +327,11 @@ func NewEventHistoryWriterForGeneration(
 	if store == nil || store.db == nil || !store.Ready() {
 		return nil, fmt.Errorf("audit: ready v8 event-history store is required")
 	}
-	if binding == nil || generation == 0 {
+	if binding == nil {
 		return nil, fmt.Errorf("audit: local projection binding is required")
+	}
+	if generation == 0 {
+		return nil, fmt.Errorf("audit: event-history writer generation is required")
 	}
 	snapshot := binding.eventHistoryProjectionBinding()
 	if !observability.IsStableToken(snapshot.graphDigest) || snapshot.engine == nil ||

--- a/internal/audit/event_history_v8.go
+++ b/internal/audit/event_history_v8.go
@@ -294,7 +294,6 @@ type EventHistoryWriter struct {
 	healthMu           sync.Mutex
 	healthQueue        []EventHistoryHealthTransition
 	healthDraining     bool
-	healthActive       EventHistoryHealthTransition
 	writeHealthKnown   bool
 	writeHealthState   EventHistoryHealthState
 	writeHealthSeq     uint64
@@ -959,21 +958,15 @@ func (writer *EventHistoryWriter) flushHealth() {
 	for {
 		writer.healthMu.Lock()
 		if len(writer.healthQueue) == 0 {
-			writer.healthActive = EventHistoryHealthTransition{}
 			writer.healthDraining = false
 			writer.healthMu.Unlock()
 			return
 		}
 		transition := writer.healthQueue[0]
 		writer.healthQueue = writer.healthQueue[1:]
-		writer.healthActive = transition
 		writer.healthMu.Unlock()
 
 		writer.healthReporter.ReportEventHistoryHealth(transition)
-
-		writer.healthMu.Lock()
-		writer.healthActive = EventHistoryHealthTransition{}
-		writer.healthMu.Unlock()
 	}
 }
 

--- a/internal/audit/event_history_v8_test.go
+++ b/internal/audit/event_history_v8_test.go
@@ -87,11 +87,13 @@ type testProjectionSigner struct {
 }
 
 type testEventHistoryHealthReporter struct {
-	codes []EventHistoryHealthCode
+	codes       []EventHistoryHealthCode
+	transitions []EventHistoryHealthTransition
 }
 
-func (reporter *testEventHistoryHealthReporter) ReportEventHistoryHealth(code EventHistoryHealthCode) {
-	reporter.codes = append(reporter.codes, code)
+func (reporter *testEventHistoryHealthReporter) ReportEventHistoryHealth(transition EventHistoryHealthTransition) {
+	reporter.codes = append(reporter.codes, transition.Code)
+	reporter.transitions = append(reporter.transitions, transition)
 }
 
 type queryingEventHistoryHealthReporter struct {
@@ -100,6 +102,24 @@ type queryingEventHistoryHealthReporter struct {
 	codes       []EventHistoryHealthCode
 	errors      []error
 	closeErrors []error
+}
+
+type reentrantEventHistoryHealthReporter struct {
+	once        sync.Once
+	writer      *EventHistoryWriter
+	record      observability.Record
+	projection  observabilityredaction.Projection
+	transitions []EventHistoryHealthTransition
+	appendErr   error
+}
+
+func (reporter *reentrantEventHistoryHealthReporter) ReportEventHistoryHealth(
+	transition EventHistoryHealthTransition,
+) {
+	reporter.transitions = append(reporter.transitions, transition)
+	reporter.once.Do(func() {
+		reporter.appendErr = reporter.writer.Append(reporter.record, reporter.projection)
+	})
 }
 
 type toggleProjectionSigner struct {
@@ -125,18 +145,21 @@ func (signer *toggleProjectionSigner) HMACSHA256(
 }
 
 type blockingEventHistoryHealthReporter struct {
-	started chan EventHistoryHealthCode
-	release chan struct{}
-	once    sync.Once
-	mu      sync.Mutex
-	codes   []EventHistoryHealthCode
+	started     chan EventHistoryHealthCode
+	release     chan struct{}
+	once        sync.Once
+	mu          sync.Mutex
+	codes       []EventHistoryHealthCode
+	transitions []EventHistoryHealthTransition
 }
 
 func (reporter *blockingEventHistoryHealthReporter) ReportEventHistoryHealth(
-	code EventHistoryHealthCode,
+	transition EventHistoryHealthTransition,
 ) {
+	code := transition.Code
 	reporter.mu.Lock()
 	reporter.codes = append(reporter.codes, code)
+	reporter.transitions = append(reporter.transitions, transition)
 	reporter.mu.Unlock()
 	reporter.once.Do(func() {
 		reporter.started <- code
@@ -150,7 +173,14 @@ func (reporter *blockingEventHistoryHealthReporter) snapshot() []EventHistoryHea
 	return append([]EventHistoryHealthCode(nil), reporter.codes...)
 }
 
-func (reporter *queryingEventHistoryHealthReporter) ReportEventHistoryHealth(code EventHistoryHealthCode) {
+func (reporter *blockingEventHistoryHealthReporter) transitionSnapshot() []EventHistoryHealthTransition {
+	reporter.mu.Lock()
+	defer reporter.mu.Unlock()
+	return append([]EventHistoryHealthTransition(nil), reporter.transitions...)
+}
+
+func (reporter *queryingEventHistoryHealthReporter) ReportEventHistoryHealth(transition EventHistoryHealthTransition) {
+	code := transition.Code
 	reporter.codes = append(reporter.codes, code)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -248,6 +278,48 @@ func newV8HistoryRecordAt(t *testing.T, id, message string, timestamp time.Time)
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	return record
+}
+
+func newMandatoryV8HistoryRecord(t *testing.T, id string) observability.Record {
+	t.Helper()
+	builder, err := observability.NewRecordBuilder(
+		observability.ClockFunc(func() time.Time {
+			return time.Date(2026, 7, 3, 15, 0, 0, 0, time.UTC)
+		}),
+		observability.OccurrenceIDGeneratorFunc(func() (string, error) { return id, nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := builder.BuildClassifiedLog(observability.ClassifiedLogInput{
+		ProducerKind: observability.ProducerGatewayEvent,
+		ProducerKey:  "activity",
+		ClassificationContext: observability.ClassificationContext{
+			Bucket:      observability.BucketComplianceActivity,
+			EventName:   "config.change.applied",
+			RawSeverity: "WARN",
+			MandatoryFacts: observability.MandatoryFacts{
+				ControlPlaneMutation: true,
+			},
+		},
+		Source: observability.SourceOperatorAPI, Action: "config.change", Phase: "apply",
+		Outcome: observability.OutcomeApplied,
+		Provenance: observability.Provenance{
+			Producer: "operator_api", BinaryVersion: "v8.0.0-test",
+			RegistrySchemaVersion: 1, ConfigGeneration: 24,
+		},
+		Body: map[string]any{"target": "observability.routes", "reason": "approved change"},
+		FieldClasses: map[string]observability.FieldClass{
+			"/target": observability.FieldClassPath, "/reason": observability.FieldClassReason,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !record.Mandatory() {
+		t.Fatal("mandatory fixture was not classified as mandatory")
 	}
 	return record
 }
@@ -1485,6 +1557,272 @@ func TestEventHistoryWriterReportsBoundedProjectionUnsignedAndWriteHealth(t *tes
 	}
 }
 
+func TestEventHistoryWriterRecoversOnlyAfterMandatorySignedCommit(t *testing.T) {
+	store := newV8HistoryStore(t)
+	health := &testEventHistoryHealthReporter{}
+	writer, err := NewEventHistoryWriterForGeneration(
+		store,
+		&testProjectionSigner{keyID: "integrity-key-v1", key: bytes.Repeat([]byte{0x31}, 32)},
+		health,
+		testLocalProfileResolver{profile: observabilityredaction.ProfileNone},
+		7,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`CREATE TRIGGER reject_recovery_fixture BEFORE INSERT ON audit_events
+		WHEN NEW.id = 'history-recovery-failure' BEGIN SELECT RAISE(ABORT, 'private path'); END`); err != nil {
+		t.Fatal(err)
+	}
+	failed := newV8HistoryRecord(t, "history-recovery-failure", "private")
+	if err := writer.Append(failed, projectV8HistoryRecord(t, failed, observabilityredaction.ProfileNone)); err == nil {
+		t.Fatal("write failure was hidden")
+	}
+	optional := newV8HistoryRecord(t, "history-recovery-optional", "private")
+	if optional.Mandatory() {
+		t.Fatal("optional fixture became mandatory")
+	}
+	if err := writer.Append(optional, projectV8HistoryRecord(t, optional, observabilityredaction.ProfileNone)); err != nil {
+		t.Fatal(err)
+	}
+	if len(health.transitions) != 1 {
+		t.Fatalf("optional signed commit recovered write health: %+v", health.transitions)
+	}
+	mandatory := newMandatoryV8HistoryRecord(t, "history-recovery-mandatory")
+	if err := writer.Append(mandatory, projectV8HistoryRecord(t, mandatory, observabilityredaction.ProfileNone)); err != nil {
+		t.Fatal(err)
+	}
+	if len(health.transitions) != 2 {
+		t.Fatalf("health transitions = %+v", health.transitions)
+	}
+	failure, recovery := health.transitions[0], health.transitions[1]
+	if failure.Generation != 7 || failure.State != EventHistoryHealthFailed ||
+		failure.Code != EventHistoryHealthWriteFailed ||
+		failure.SQLiteClass != EventHistorySQLiteConstraintCorrupt || failure.SQLitePrimaryCode != 19 ||
+		failure.OccurredAt.IsZero() || failure.OccurredAt.Location() != time.UTC {
+		t.Fatalf("failure transition = %+v", failure)
+	}
+	if recovery.Generation != 7 || recovery.State != EventHistoryHealthRecovered ||
+		recovery.Code != EventHistoryHealthWriteFailed || recovery.Sequence <= failure.Sequence ||
+		recovery.SQLiteClass != "" || recovery.SQLitePrimaryCode != 0 || recovery.OccurredAt.IsZero() {
+		t.Fatalf("recovery transition = %+v after %+v", recovery, failure)
+	}
+}
+
+func TestEventHistoryWriterUnsignedMandatoryCommitDoesNotRecoverWriteHealth(t *testing.T) {
+	store := newV8HistoryStore(t)
+	health := &testEventHistoryHealthReporter{}
+	writer, err := NewEventHistoryWriterForGeneration(
+		store, nil, health,
+		testLocalProfileResolver{profile: observabilityredaction.ProfileNone}, 3,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`CREATE TRIGGER reject_unsigned_recovery BEFORE INSERT ON audit_events
+		WHEN NEW.id = 'history-unsigned-failure' BEGIN SELECT RAISE(ABORT, 'private'); END`); err != nil {
+		t.Fatal(err)
+	}
+	failed := newV8HistoryRecord(t, "history-unsigned-failure", "private")
+	if err := writer.Append(failed, projectV8HistoryRecord(t, failed, observabilityredaction.ProfileNone)); err == nil {
+		t.Fatal("write failure was hidden")
+	}
+	mandatory := newMandatoryV8HistoryRecord(t, "history-unsigned-mandatory")
+	if err := writer.Append(mandatory, projectV8HistoryRecord(t, mandatory, observabilityredaction.ProfileNone)); err != nil {
+		t.Fatal(err)
+	}
+	for _, transition := range health.transitions {
+		if transition.State == EventHistoryHealthRecovered {
+			t.Fatalf("unsigned commit recovered write health: %+v", health.transitions)
+		}
+	}
+}
+
+func TestEventHistoryWriterKeepsNewestWriteFailureBehindBlockedCallback(t *testing.T) {
+	store := newV8HistoryStore(t)
+	reporter := &blockingEventHistoryHealthReporter{
+		started: make(chan EventHistoryHealthCode, 1), release: make(chan struct{}),
+	}
+	writer, err := NewEventHistoryWriterForGeneration(
+		store,
+		&testProjectionSigner{keyID: "integrity-key-v1", key: bytes.Repeat([]byte{0x42}, 32)},
+		reporter,
+		testLocalProfileResolver{profile: observabilityredaction.ProfileNone}, 9,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`CREATE TRIGGER reject_blocked_failures BEFORE INSERT ON audit_events
+		WHEN NEW.id IN ('history-blocked-failure-1','history-blocked-failure-3')
+		BEGIN SELECT RAISE(ABORT, 'private'); END`); err != nil {
+		t.Fatal(err)
+	}
+	first := newV8HistoryRecord(t, "history-blocked-failure-1", "private")
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- writer.Append(first, projectV8HistoryRecord(t, first, observabilityredaction.ProfileNone))
+	}()
+	select {
+	case code := <-reporter.started:
+		if code != EventHistoryHealthWriteFailed {
+			t.Fatalf("first code = %q", code)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("failure callback did not start")
+	}
+	mandatory := newMandatoryV8HistoryRecord(t, "history-blocked-recovery-2")
+	if err := writer.Append(mandatory, projectV8HistoryRecord(t, mandatory, observabilityredaction.ProfileNone)); err != nil {
+		t.Fatal(err)
+	}
+	newer := newV8HistoryRecord(t, "history-blocked-failure-3", "private")
+	if err := writer.Append(newer, projectV8HistoryRecord(t, newer, observabilityredaction.ProfileNone)); err == nil {
+		t.Fatal("newer write failure was hidden")
+	}
+	close(reporter.release)
+	if err := <-firstDone; err == nil {
+		t.Fatal("first write failure was hidden")
+	}
+	transitions := reporter.transitionSnapshot()
+	if len(transitions) != 2 || transitions[0].State != EventHistoryHealthFailed ||
+		transitions[1].State != EventHistoryHealthFailed ||
+		transitions[1].Sequence <= transitions[0].Sequence {
+		t.Fatalf("blocked transition sequence = %+v", transitions)
+	}
+}
+
+func TestEventHistoryWriterPreservesFailureDiagnosticBeforePendingRecovery(t *testing.T) {
+	store := newV8HistoryStore(t)
+	reporter := &blockingEventHistoryHealthReporter{
+		started: make(chan EventHistoryHealthCode, 1), release: make(chan struct{}),
+	}
+	writer, err := NewEventHistoryWriterForGeneration(
+		store,
+		&testProjectionSigner{keyID: "integrity-key-v1", key: bytes.Repeat([]byte{0x43}, 32)},
+		reporter,
+		testLocalProfileResolver{profile: observabilityredaction.ProfileNone}, 10,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Block an unrelated callback so neither the write failure nor its recovery
+	// has been delivered when both are queued.
+	unrelatedDone := make(chan struct{})
+	go func() {
+		writer.reportHealthFailure(EventHistoryHealthProjectionRejected, errors.New("private"), "")
+		close(unrelatedDone)
+	}()
+	select {
+	case code := <-reporter.started:
+		if code != EventHistoryHealthProjectionRejected {
+			t.Fatalf("blocked code = %q", code)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("unrelated callback did not start")
+	}
+	if _, err := store.db.Exec(`CREATE TRIGGER reject_pending_failure BEFORE INSERT ON audit_events
+		WHEN NEW.id = 'history-pending-failure' BEGIN SELECT RAISE(ABORT, 'private'); END`); err != nil {
+		t.Fatal(err)
+	}
+	failed := newV8HistoryRecord(t, "history-pending-failure", "private")
+	if err := writer.Append(failed, projectV8HistoryRecord(t, failed, observabilityredaction.ProfileNone)); err == nil {
+		t.Fatal("pending failure was hidden")
+	}
+	mandatory := newMandatoryV8HistoryRecord(t, "history-pending-recovery")
+	if err := writer.Append(mandatory, projectV8HistoryRecord(t, mandatory, observabilityredaction.ProfileNone)); err != nil {
+		t.Fatal(err)
+	}
+	close(reporter.release)
+	select {
+	case <-unrelatedDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("health drain did not finish")
+	}
+	transitions := reporter.transitionSnapshot()
+	if len(transitions) != 3 || transitions[1].State != EventHistoryHealthFailed ||
+		transitions[1].Code != EventHistoryHealthWriteFailed ||
+		transitions[1].SQLiteClass != EventHistorySQLiteConstraintCorrupt ||
+		transitions[2].State != EventHistoryHealthRecovered ||
+		transitions[2].Sequence <= transitions[1].Sequence {
+		t.Fatalf("pending failure/recovery transitions = %+v", transitions)
+	}
+}
+
+type eventHistoryTestCodedError struct {
+	code int
+	text string
+}
+
+func (err eventHistoryTestCodedError) Error() string { return err.text }
+func (err eventHistoryTestCodedError) Code() int     { return err.code }
+
+func TestClassifyEventHistorySQLiteFailureIsBounded(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		class   EventHistorySQLiteClass
+		primary uint8
+	}{
+		{name: "busy extended", err: eventHistoryTestCodedError{code: 5 | 12<<8, text: "/secret/busy"}, class: EventHistorySQLiteBusyLocked, primary: 5},
+		{name: "locked", err: eventHistoryTestCodedError{code: 6, text: "secret"}, class: EventHistorySQLiteBusyLocked, primary: 6},
+		{name: "deadline", err: context.DeadlineExceeded, class: EventHistorySQLiteDeadline},
+		{
+			name: "deadline with unrelated coded cause",
+			err: errors.Join(
+				context.DeadlineExceeded,
+				eventHistoryTestCodedError{code: 5, text: "/secret/busy"},
+			),
+			class: EventHistorySQLiteDeadline,
+		},
+		{name: "full", err: eventHistoryTestCodedError{code: 13, text: "secret"}, class: EventHistorySQLiteFull, primary: 13},
+		{name: "io", err: eventHistoryTestCodedError{code: 10, text: "secret"}, class: EventHistorySQLiteIO, primary: 10},
+		{name: "readonly", err: eventHistoryTestCodedError{code: 8, text: "secret"}, class: EventHistorySQLiteReadOnlyCantOpen, primary: 8},
+		{name: "cantopen", err: eventHistoryTestCodedError{code: 14, text: "secret"}, class: EventHistorySQLiteReadOnlyCantOpen, primary: 14},
+		{name: "constraint", err: eventHistoryTestCodedError{code: 19, text: "secret"}, class: EventHistorySQLiteConstraintCorrupt, primary: 19},
+		{name: "unknown", err: eventHistoryTestCodedError{code: 255, text: "/secret/unknown"}, class: EventHistorySQLiteOther},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			class, primary := classifyEventHistorySQLiteFailure(test.err)
+			if class != test.class || primary != test.primary {
+				t.Fatalf("classification = %q/%d, want %q/%d", class, primary, test.class, test.primary)
+			}
+			transition := EventHistoryHealthTransition{
+				Generation: 1, Sequence: 1, State: EventHistoryHealthFailed,
+				Code: EventHistoryHealthWriteFailed, OccurredAt: time.Now().UTC(),
+				SQLiteClass: class, SQLitePrimaryCode: primary,
+			}
+			if !validEventHistoryHealthTransition(transition) {
+				t.Fatalf("classifier emitted an invalid transition: %+v", transition)
+			}
+			encoded, err := json.Marshal(transition)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bytes.Contains(encoded, []byte("secret")) {
+				t.Fatalf("bounded transition leaked driver text: %s", encoded)
+			}
+		})
+	}
+}
+
+func TestEventHistoryWriterClassOverrideClearsDriverPrimaryCode(t *testing.T) {
+	health := &testEventHistoryHealthReporter{}
+	writer := &EventHistoryWriter{healthReporter: health, generation: 1}
+	writer.reportHealthFailure(
+		EventHistoryHealthWriteFailed,
+		eventHistoryTestCodedError{code: 5, text: "/secret/busy"},
+		EventHistorySQLiteUnavailable,
+	)
+	if len(health.transitions) != 1 {
+		t.Fatalf("health transitions = %+v", health.transitions)
+	}
+	transition := health.transitions[0]
+	if transition.SQLiteClass != EventHistorySQLiteUnavailable || transition.SQLitePrimaryCode != 0 ||
+		!validEventHistoryHealthTransition(transition) {
+		t.Fatalf("overridden diagnostic = %+v", transition)
+	}
+}
+
 func TestEventHistoryWriterReportsHealthOnlyAfterTransactionEnds(t *testing.T) {
 	store := newV8HistoryStore(t)
 	health := &queryingEventHistoryHealthReporter{
@@ -1549,6 +1887,120 @@ func TestEventHistoryWriterReportsHealthOnlyAfterTransactionEnds(t *testing.T) {
 	}
 	if len(health.closeErrors) != 1 || health.closeErrors[0] != nil {
 		t.Fatalf("health callback could not close store after lifecycle release: %#v", health.closeErrors)
+	}
+}
+
+func TestEventHistoryWriterHealthCallbackCanReenterSameWriter(t *testing.T) {
+	store := newV8HistoryStore(t)
+	reporter := &reentrantEventHistoryHealthReporter{}
+	writer, err := NewEventHistoryWriterForGeneration(
+		store,
+		&testProjectionSigner{keyID: "integrity-key-v1", key: bytes.Repeat([]byte{0x22}, 32)},
+		reporter,
+		testLocalProfileResolver{profile: observabilityredaction.ProfileNone}, 11,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reporter.writer = writer
+	reporter.record = newMandatoryV8HistoryRecord(t, "history-reentrant-recovery")
+	reporter.projection = projectV8HistoryRecord(
+		t, reporter.record, observabilityredaction.ProfileNone,
+	)
+	if _, err := store.db.Exec(`CREATE TRIGGER reject_reentrant_initial BEFORE INSERT ON audit_events
+		WHEN NEW.id = 'history-reentrant-failure' BEGIN SELECT RAISE(ABORT, 'private'); END`); err != nil {
+		t.Fatal(err)
+	}
+	failed := newV8HistoryRecord(t, "history-reentrant-failure", "private")
+	done := make(chan error, 1)
+	go func() {
+		done <- writer.Append(failed, projectV8HistoryRecord(t, failed, observabilityredaction.ProfileNone))
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("initial failure was hidden")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("reentrant callback deadlocked the writer")
+	}
+	if reporter.appendErr != nil {
+		t.Fatalf("reentrant append: %v", reporter.appendErr)
+	}
+	if len(reporter.transitions) != 2 ||
+		reporter.transitions[0].State != EventHistoryHealthFailed ||
+		reporter.transitions[1].State != EventHistoryHealthRecovered ||
+		reporter.transitions[1].Sequence <= reporter.transitions[0].Sequence {
+		t.Fatalf("reentrant transitions = %+v", reporter.transitions)
+	}
+	var count int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM audit_events WHERE id=?`, reporter.record.RecordID()).Scan(&count); err != nil || count != 1 {
+		t.Fatalf("reentrant committed rows = %d, err=%v", count, err)
+	}
+}
+
+func TestEventHistoryWriterReportsClosedStoreAsUnavailable(t *testing.T) {
+	store := newV8HistoryStore(t)
+	health := &testEventHistoryHealthReporter{}
+	writer, err := NewEventHistoryWriterForGeneration(
+		store,
+		&testProjectionSigner{keyID: "integrity-key-v1", key: bytes.Repeat([]byte{0x24}, 32)},
+		health, testLocalProfileResolver{profile: observabilityredaction.ProfileNone}, 12,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	record := newV8HistoryRecord(t, "history-closed-store", "private")
+	if err := writer.Append(record, projectV8HistoryRecord(t, record, observabilityredaction.ProfileNone)); err == nil {
+		t.Fatal("closed store append succeeded")
+	}
+	if len(health.transitions) != 1 {
+		t.Fatalf("closed store transitions = %+v", health.transitions)
+	}
+	transition := health.transitions[0]
+	if transition.State != EventHistoryHealthFailed || transition.Code != EventHistoryHealthWriteFailed ||
+		transition.SQLiteClass != EventHistorySQLiteUnavailable || transition.SQLitePrimaryCode != 0 {
+		t.Fatalf("closed store transition = %+v", transition)
+	}
+}
+
+func TestEventHistoryWriterBeginFailureReportsAfterStoreRelease(t *testing.T) {
+	store := newV8HistoryStore(t)
+	health := &queryingEventHistoryHealthReporter{
+		store: store, closeOnCode: EventHistoryHealthWriteFailed,
+	}
+	writer, err := NewEventHistoryWriterForGeneration(
+		store,
+		&testProjectionSigner{keyID: "integrity-key-v1", key: bytes.Repeat([]byte{0x25}, 32)},
+		health, testLocalProfileResolver{profile: observabilityredaction.ProfileNone}, 13,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Close the underlying pool without changing Store.Ready so Append reaches
+	// BeginTx and proves its failure callback runs after lifecycle release.
+	if err := store.db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	record := newV8HistoryRecord(t, "history-begin-failure", "private")
+	done := make(chan error, 1)
+	go func() {
+		done <- writer.Append(record, projectV8HistoryRecord(t, record, observabilityredaction.ProfileNone))
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("closed database BeginTx succeeded")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("BeginTx failure callback held Store lifecycle lock")
+	}
+	if len(health.codes) != 1 || health.codes[0] != EventHistoryHealthWriteFailed ||
+		len(health.closeErrors) != 1 || health.closeErrors[0] != nil {
+		t.Fatalf("BeginTx health callback = codes:%+v close:%+v", health.codes, health.closeErrors)
 	}
 }
 

--- a/internal/audit/event_history_v8_test.go
+++ b/internal/audit/event_history_v8_test.go
@@ -559,6 +559,36 @@ func TestStoreInitFailsWhenMandatoryV8EventHistoryColumnIsMissing(t *testing.T) 
 	}
 }
 
+func TestEventHistoryWriterForGenerationRejectsMissingIdentityInputs(t *testing.T) {
+	store := newV8HistoryStore(t)
+	tests := []struct {
+		name       string
+		binding    LocalProjectionBinding
+		generation uint64
+		want       string
+	}{
+		{
+			name:       "missing binding",
+			generation: 7,
+			want:       "audit: local projection binding is required",
+		},
+		{
+			name:       "missing generation",
+			binding:    testLocalProfileResolver{profile: observabilityredaction.ProfileNone},
+			generation: 0,
+			want:       "audit: event-history writer generation is required",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := NewEventHistoryWriterForGeneration(store, nil, nil, test.binding, test.generation)
+			if err == nil || err.Error() != test.want {
+				t.Fatalf("NewEventHistoryWriterForGeneration error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestEventHistoryWriterPersistsExactCanonicalProjectionAndLegacyView(t *testing.T) {
 	store := newV8HistoryStore(t)
 	writer, err := NewEventHistoryWriter(store, nil, nil, testLocalProfileResolver{profile: observabilityredaction.ProfileNone})

--- a/internal/audit/event_history_v8_test.go
+++ b/internal/audit/event_history_v8_test.go
@@ -1808,6 +1808,9 @@ func TestClassifyEventHistorySQLiteFailureIsBounded(t *testing.T) {
 		{name: "readonly", err: eventHistoryTestCodedError{code: 8, text: "secret"}, class: EventHistorySQLiteReadOnlyCantOpen, primary: 8},
 		{name: "cantopen", err: eventHistoryTestCodedError{code: 14, text: "secret"}, class: EventHistorySQLiteReadOnlyCantOpen, primary: 14},
 		{name: "constraint", err: eventHistoryTestCodedError{code: 19, text: "secret"}, class: EventHistorySQLiteConstraintCorrupt, primary: 19},
+		{name: "corrupt", err: eventHistoryTestCodedError{code: 11, text: "secret"}, class: EventHistorySQLiteConstraintCorrupt, primary: 11},
+		{name: "notadb", err: eventHistoryTestCodedError{code: 26, text: "secret"}, class: EventHistorySQLiteConstraintCorrupt, primary: 26},
+		{name: "generic error", err: eventHistoryTestCodedError{code: 1, text: "/secret/sql"}, class: EventHistorySQLiteOther, primary: 1},
 		{name: "unknown", err: eventHistoryTestCodedError{code: 255, text: "/secret/unknown"}, class: EventHistorySQLiteOther},
 	}
 	for _, test := range tests {
@@ -1832,6 +1835,14 @@ func TestClassifyEventHistorySQLiteFailureIsBounded(t *testing.T) {
 				t.Fatalf("bounded transition leaked driver text: %s", encoded)
 			}
 		})
+	}
+}
+
+func TestValidEventHistorySQLiteDiagnosticRejectsMismatchedPairs(t *testing.T) {
+	if validEventHistorySQLiteDiagnostic(EventHistorySQLiteUnavailable, 5) ||
+		validEventHistorySQLiteDiagnostic(EventHistorySQLiteFull, 10) ||
+		validEventHistorySQLiteDiagnostic(EventHistorySQLiteOther, 19) {
+		t.Fatal("validator accepted a mismatched class/primary pair")
 	}
 }
 

--- a/internal/gateway/health.go
+++ b/internal/gateway/health.go
@@ -24,6 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/defenseclaw/defenseclaw/internal/audit"
 	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
 	"github.com/defenseclaw/defenseclaw/internal/observability"
 	"github.com/defenseclaw/defenseclaw/internal/observability/delivery"
@@ -47,6 +48,20 @@ type observabilityV8FailureObservation struct {
 	generation uint64
 	code       string
 	occurredAt time.Time
+}
+
+type observabilityV8EventHistoryObservation struct {
+	generation         uint64
+	sequence           uint64
+	active             bool
+	lastFailureClass   string
+	lastFailurePrimary uint8
+}
+
+type observabilityV8EventHistorySnapshot struct {
+	activeCode         string
+	lastFailureClass   string
+	lastFailurePrimary uint8
 }
 
 type SubsystemState string
@@ -107,25 +122,26 @@ type HealthSnapshot struct {
 }
 
 type SidecarHealth struct {
-	mu                                 sync.RWMutex
-	gateway                            SubsystemHealth
-	watcher                            SubsystemHealth
-	config                             SubsystemHealth
-	api                                SubsystemHealth
-	guardrail                          SubsystemHealth
-	telemetry                          SubsystemHealth
-	aiDiscovery                        SubsystemHealth
-	applicationProtection              SubsystemHealth
-	sandbox                            *SubsystemHealth
-	startedAt                          time.Time
-	observabilityV8Source              observabilityV8HealthSource
-	observabilityV8ActiveGeneration    uint64
-	observabilityV8Failures            map[string]observabilityV8FailureObservation
-	observabilityV8RetentionState      string
-	observabilityV8RetentionFailure    string
-	observabilityV8RetentionDays       int64
-	observabilityV8EventHistoryFailure string
-	managed                            *SubsystemHealth
+	mu                                    sync.RWMutex
+	gateway                               SubsystemHealth
+	watcher                               SubsystemHealth
+	config                                SubsystemHealth
+	api                                   SubsystemHealth
+	guardrail                             SubsystemHealth
+	telemetry                             SubsystemHealth
+	aiDiscovery                           SubsystemHealth
+	applicationProtection                 SubsystemHealth
+	sandbox                               *SubsystemHealth
+	startedAt                             time.Time
+	observabilityV8Source                 observabilityV8HealthSource
+	observabilityV8ActiveGeneration       uint64
+	observabilityV8Failures               map[string]observabilityV8FailureObservation
+	observabilityV8RetentionState         string
+	observabilityV8RetentionFailure       string
+	observabilityV8RetentionDays          int64
+	observabilityV8EventHistoryGeneration uint64
+	observabilityV8EventHistory           map[string]observabilityV8EventHistoryObservation
+	managed                               *SubsystemHealth
 
 	// subscribers receive a non-blocking notification after every Set*
 	// call, so long-lived consumers (like the IPC GetHealth stream)
@@ -323,6 +339,8 @@ func (h *SidecarHealth) clearObservabilityV8HealthSource() {
 		h.observabilityV8Source = nil
 		h.observabilityV8ActiveGeneration = 0
 		h.observabilityV8Failures = nil
+		h.observabilityV8EventHistoryGeneration = 0
+		h.observabilityV8EventHistory = nil
 		h.telemetry = SubsystemHealth{State: StateStopped, Since: time.Now()}
 		changed = true
 	}
@@ -405,14 +423,87 @@ func validObservabilityV8RetentionFailure(failure string) bool {
 	}
 }
 
-func (h *SidecarHealth) setObservabilityV8EventHistoryFailure(code string) {
-	if h == nil || !validObservabilityV8EventHistoryFailure(code) {
+func (h *SidecarHealth) observeObservabilityV8EventHistory(
+	transition audit.EventHistoryHealthTransition,
+) {
+	if h == nil || !validObservabilityV8EventHistoryTransition(transition) {
 		return
 	}
 	h.mu.Lock()
-	h.observabilityV8EventHistoryFailure = code
+	if transition.Generation < h.observabilityV8EventHistoryGeneration {
+		h.mu.Unlock()
+		return
+	}
+	if transition.Generation > h.observabilityV8EventHistoryGeneration {
+		h.observabilityV8EventHistoryGeneration = transition.Generation
+	}
+	if h.observabilityV8EventHistory == nil {
+		h.observabilityV8EventHistory = make(map[string]observabilityV8EventHistoryObservation, 4)
+	}
+	code := string(transition.Code)
+	current := h.observabilityV8EventHistory[code]
+	if transition.Generation < current.generation ||
+		transition.Generation == current.generation && transition.Sequence <= current.sequence {
+		h.mu.Unlock()
+		return
+	}
+	observation := observabilityV8EventHistoryObservation{
+		generation: transition.Generation, sequence: transition.Sequence,
+		active:           transition.State == audit.EventHistoryHealthFailed,
+		lastFailureClass: current.lastFailureClass, lastFailurePrimary: current.lastFailurePrimary,
+	}
+	if observation.active && transition.Code == audit.EventHistoryHealthWriteFailed {
+		observation.lastFailureClass = string(transition.SQLiteClass)
+		observation.lastFailurePrimary = transition.SQLitePrimaryCode
+	}
+	h.observabilityV8EventHistory[code] = observation
 	h.mu.Unlock()
 	h.notifySubscribers()
+}
+
+func (h *SidecarHealth) bindObservabilityV8EventHistoryGeneration(generation uint64) {
+	if h == nil || generation == 0 {
+		return
+	}
+	changed := false
+	h.mu.Lock()
+	if generation > h.observabilityV8EventHistoryGeneration {
+		h.observabilityV8EventHistoryGeneration = generation
+		changed = true
+	}
+	h.mu.Unlock()
+	if changed {
+		h.notifySubscribers()
+	}
+}
+
+func snapshotObservabilityV8EventHistory(
+	generation uint64,
+	observations map[string]observabilityV8EventHistoryObservation,
+) observabilityV8EventHistorySnapshot {
+	result := observabilityV8EventHistorySnapshot{}
+	var activeGeneration uint64
+	var activeSequence uint64
+	write := observations[string(audit.EventHistoryHealthWriteFailed)]
+	if write.generation != 0 && write.generation <= generation {
+		result.lastFailureClass = write.lastFailureClass
+		result.lastFailurePrimary = write.lastFailurePrimary
+	}
+	for code, observation := range observations {
+		if observation.generation == 0 || observation.generation > generation || !observation.active ||
+			observation.generation < activeGeneration ||
+			observation.generation == activeGeneration && observation.sequence < activeSequence {
+			continue
+		}
+		activeGeneration = observation.generation
+		activeSequence = observation.sequence
+		result.activeCode = code
+	}
+	return result
+}
+
+func validObservabilityV8EventHistoryTransition(transition audit.EventHistoryHealthTransition) bool {
+	return audit.ValidEventHistoryHealthTransition(transition)
 }
 
 func validObservabilityV8EventHistoryFailure(code string) bool {
@@ -700,7 +791,14 @@ func (h *SidecarHealth) Snapshot() HealthSnapshot {
 	retentionState := h.observabilityV8RetentionState
 	retentionFailure := h.observabilityV8RetentionFailure
 	retentionDays := h.observabilityV8RetentionDays
-	eventHistoryFailure := h.observabilityV8EventHistoryFailure
+	eventHistoryGeneration := h.observabilityV8EventHistoryGeneration
+	eventHistoryObservations := make(
+		map[string]observabilityV8EventHistoryObservation,
+		len(h.observabilityV8EventHistory),
+	)
+	for code, observation := range h.observabilityV8EventHistory {
+		eventHistoryObservations[code] = observation
+	}
 
 	if len(h.connStats) > 0 {
 		names := make([]string, 0, len(h.connStats))
@@ -734,19 +832,34 @@ func (h *SidecarHealth) Snapshot() HealthSnapshot {
 		cancel()
 		if ok {
 			failures = h.reconcileObservabilityV8Failures(live)
+			eventHistory := h.reconcileObservabilityV8EventHistory(live.Generation)
 			snap.Telemetry = renderObservabilityV8Health(
 				snap.Telemetry.Since, live, failures,
-				retentionState, retentionFailure, retentionDays, eventHistoryFailure,
+				retentionState, retentionFailure, retentionDays, eventHistory,
 			)
 		} else {
+			eventHistory := snapshotObservabilityV8EventHistory(
+				eventHistoryGeneration, eventHistoryObservations,
+			)
 			snap.Telemetry = renderObservabilityV8HealthUnavailable(
 				snap.Telemetry.Since,
-				retentionState, retentionFailure, retentionDays, eventHistoryFailure,
+				retentionState, retentionFailure, retentionDays, eventHistory,
 			)
 		}
 	}
 
 	return snap
+}
+
+func (h *SidecarHealth) reconcileObservabilityV8EventHistory(
+	generation uint64,
+) observabilityV8EventHistorySnapshot {
+	h.bindObservabilityV8EventHistoryGeneration(generation)
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return snapshotObservabilityV8EventHistory(
+		h.observabilityV8EventHistoryGeneration, h.observabilityV8EventHistory,
+	)
 }
 
 func (h *SidecarHealth) reconcileObservabilityV8Failures(
@@ -793,7 +906,7 @@ func renderObservabilityV8HealthUnavailable(
 	retentionState string,
 	retentionFailure string,
 	retentionDays int64,
-	eventHistoryFailure string,
+	eventHistory observabilityV8EventHistorySnapshot,
 ) SubsystemHealth {
 	// The source error and recovered panic value may contain destination
 	// endpoints, credentials, or payload fragments. Expose only one stable
@@ -806,9 +919,7 @@ func renderObservabilityV8HealthUnavailable(
 			details["retention_failure"] = retentionFailure
 		}
 	}
-	if eventHistoryFailure != "" && validObservabilityV8EventHistoryFailure(eventHistoryFailure) {
-		details["event_history_failure"] = eventHistoryFailure
-	}
+	appendObservabilityV8EventHistoryDetails(details, eventHistory)
 	return SubsystemHealth{
 		State:     StateError,
 		Since:     since,
@@ -824,7 +935,7 @@ func renderObservabilityV8Health(
 	retentionState string,
 	retentionFailure string,
 	retentionDays int64,
-	eventHistoryFailure string,
+	eventHistory observabilityV8EventHistorySnapshot,
 ) SubsystemHealth {
 	details := make(map[string]interface{}, 6)
 	details["generation"] = snapshot.Generation
@@ -949,13 +1060,26 @@ func renderObservabilityV8Health(
 			aggregate = StateError
 		}
 	}
-	if eventHistoryFailure != "" {
+	if eventHistory.activeCode != "" {
 		aggregate = StateError
-		if validObservabilityV8EventHistoryFailure(eventHistoryFailure) {
-			details["event_history_failure"] = eventHistoryFailure
+	}
+	appendObservabilityV8EventHistoryDetails(details, eventHistory)
+	return SubsystemHealth{State: aggregate, Since: since, Details: details}
+}
+
+func appendObservabilityV8EventHistoryDetails(
+	details map[string]interface{},
+	eventHistory observabilityV8EventHistorySnapshot,
+) {
+	if eventHistory.activeCode != "" && validObservabilityV8EventHistoryFailure(eventHistory.activeCode) {
+		details["event_history_failure"] = eventHistory.activeCode
+	}
+	if eventHistory.lastFailureClass != "" {
+		details["event_history_last_sqlite_class"] = eventHistory.lastFailureClass
+		if eventHistory.lastFailurePrimary != 0 {
+			details["event_history_last_sqlite_primary_code"] = eventHistory.lastFailurePrimary
 		}
 	}
-	return SubsystemHealth{State: aggregate, Since: since, Details: details}
 }
 
 func renderObservabilityV8Queue(

--- a/internal/gateway/health_test.go
+++ b/internal/gateway/health_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/defenseclaw/defenseclaw/internal/audit"
 	"github.com/defenseclaw/defenseclaw/internal/config"
 	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
 	"github.com/defenseclaw/defenseclaw/internal/observability"
@@ -390,7 +391,7 @@ func TestObservabilityV8HealthOnlyExposesValidRetentionFailures(t *testing.T) {
 				"degraded",
 				test.failure,
 				30,
-				"",
+				observabilityV8EventHistorySnapshot{},
 			)
 			failure, published := health.Details["retention_failure"]
 			if published != test.wantPublished {
@@ -416,7 +417,7 @@ func TestObservabilityV8HealthHidesInvalidEventHistoryFailureButFailsClosed(t *t
 		"healthy",
 		"",
 		30,
-		"secret_internal_failure",
+		observabilityV8EventHistorySnapshot{activeCode: "secret_internal_failure"},
 	)
 	if health.State != StateError {
 		t.Fatalf("telemetry state = %q, want %q", health.State, StateError)
@@ -454,6 +455,309 @@ func TestObservabilityV8HealthRejectsStaleFailureAcrossReload(t *testing.T) {
 	rows = health.Snapshot().Telemetry.Details["destinations"].([]map[string]interface{})
 	if rows[0]["failure"] != nil || rows[0]["generation"] != uint64(9) {
 		t.Fatalf("stale transition contaminated successor: %+v", rows[0])
+	}
+}
+
+func eventHistoryTransition(
+	generation, sequence uint64,
+	state audit.EventHistoryHealthState,
+	code audit.EventHistoryHealthCode,
+	class audit.EventHistorySQLiteClass,
+	primary uint8,
+) audit.EventHistoryHealthTransition {
+	return audit.EventHistoryHealthTransition{
+		Generation: generation, Sequence: sequence, State: state, Code: code,
+		OccurredAt:  time.Date(2026, 8, 12, 12, 0, int(sequence), 0, time.UTC),
+		SQLiteClass: class, SQLitePrimaryCode: primary,
+	}
+}
+
+func TestObservabilityV8EventHistoryFailureRecoversAndKeepsBoundedHistory(t *testing.T) {
+	source := &fakeObservabilityV8HealthSource{snapshot: observabilityruntime.DestinationHealthSnapshot{
+		Generation: 4,
+	}}
+	health := NewSidecarHealth()
+	health.bindObservabilityV8HealthSource(source)
+	health.bindObservabilityV8EventHistoryGeneration(4)
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		4, 1, audit.EventHistoryHealthFailed, audit.EventHistoryHealthWriteFailed,
+		audit.EventHistorySQLiteBusyLocked, 5,
+	))
+	failed := health.Snapshot().Telemetry
+	if failed.State != StateError || failed.Details["event_history_failure"] != "sqlite_write_failed" ||
+		failed.Details["event_history_last_sqlite_class"] != "busy_locked" ||
+		failed.Details["event_history_last_sqlite_primary_code"] != uint8(5) {
+		t.Fatalf("failed health = %+v", failed)
+	}
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		4, 2, audit.EventHistoryHealthRecovered, audit.EventHistoryHealthWriteFailed, "", 0,
+	))
+	recovered := health.Snapshot().Telemetry
+	if recovered.State != StateRunning {
+		t.Fatalf("recovered health = %+v", recovered)
+	}
+	if _, active := recovered.Details["event_history_failure"]; active {
+		t.Fatalf("recovered health retained active failure: %+v", recovered.Details)
+	}
+	if recovered.Details["event_history_last_sqlite_class"] != "busy_locked" ||
+		recovered.Details["event_history_last_sqlite_primary_code"] != uint8(5) {
+		t.Fatalf("recovery lost bounded failure history: %+v", recovered.Details)
+	}
+	// A delayed older callback cannot relatch the cleared failure.
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		4, 1, audit.EventHistoryHealthFailed, audit.EventHistoryHealthWriteFailed,
+		audit.EventHistorySQLiteFull, 13,
+	))
+	if stale := health.Snapshot().Telemetry; stale.State != StateRunning {
+		t.Fatalf("stale failure relatched health: %+v", stale)
+	}
+}
+
+func TestObservabilityV8EventHistoryBlockedDeliveryRetainsFailureClassAfterRecovery(t *testing.T) {
+	source := &fakeObservabilityV8HealthSource{snapshot: observabilityruntime.DestinationHealthSnapshot{Generation: 14}}
+	health := NewSidecarHealth()
+	health.bindObservabilityV8HealthSource(source)
+	health.bindObservabilityV8EventHistoryGeneration(14)
+	// These are the ordered transitions emitted after an unrelated reporter
+	// callback unblocks: the bounded failure diagnostic must arrive before its
+	// recovery even though Snapshot observes only the final active state.
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		14, 2, audit.EventHistoryHealthFailed, audit.EventHistoryHealthWriteFailed,
+		audit.EventHistorySQLiteFull, 13,
+	))
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		14, 3, audit.EventHistoryHealthRecovered, audit.EventHistoryHealthWriteFailed, "", 0,
+	))
+	snapshot := health.Snapshot().Telemetry
+	if snapshot.State != StateRunning {
+		t.Fatalf("final recovered state = %+v", snapshot)
+	}
+	if _, active := snapshot.Details["event_history_failure"]; active ||
+		snapshot.Details["event_history_last_sqlite_class"] != "full" ||
+		snapshot.Details["event_history_last_sqlite_primary_code"] != uint8(13) {
+		t.Fatalf("recovered state lost queued failure diagnostic: %+v", snapshot.Details)
+	}
+}
+
+func TestObservabilityV8EventHistoryNewerFailureBeatsStaleRecovery(t *testing.T) {
+	source := &fakeObservabilityV8HealthSource{snapshot: observabilityruntime.DestinationHealthSnapshot{Generation: 5}}
+	health := NewSidecarHealth()
+	health.bindObservabilityV8HealthSource(source)
+	health.bindObservabilityV8EventHistoryGeneration(5)
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		5, 3, audit.EventHistoryHealthFailed, audit.EventHistoryHealthWriteFailed,
+		audit.EventHistorySQLiteIO, 10,
+	))
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		5, 2, audit.EventHistoryHealthRecovered, audit.EventHistoryHealthWriteFailed, "", 0,
+	))
+	snapshot := health.Snapshot().Telemetry
+	if snapshot.State != StateError || snapshot.Details["event_history_failure"] != "sqlite_write_failed" ||
+		snapshot.Details["event_history_last_sqlite_class"] != "io" {
+		t.Fatalf("stale recovery cleared newer failure: %+v", snapshot)
+	}
+}
+
+func TestObservabilityV8EventHistoryRecoveryLeavesUnrelatedFailureActive(t *testing.T) {
+	source := &fakeObservabilityV8HealthSource{snapshot: observabilityruntime.DestinationHealthSnapshot{Generation: 6}}
+	health := NewSidecarHealth()
+	health.bindObservabilityV8HealthSource(source)
+	health.bindObservabilityV8EventHistoryGeneration(6)
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		6, 1, audit.EventHistoryHealthFailed, audit.EventHistoryHealthProjectionRejected, "", 0,
+	))
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		6, 2, audit.EventHistoryHealthFailed, audit.EventHistoryHealthWriteFailed,
+		audit.EventHistorySQLiteFull, 13,
+	))
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		6, 3, audit.EventHistoryHealthRecovered, audit.EventHistoryHealthWriteFailed, "", 0,
+	))
+	snapshot := health.Snapshot().Telemetry
+	if snapshot.State != StateError || snapshot.Details["event_history_failure"] != "projection_rejected" {
+		t.Fatalf("write recovery cleared unrelated failure: %+v", snapshot)
+	}
+}
+
+func TestObservabilityV8EventHistoryGenerationCarriesFailureAndRejectsRetiredCallbacks(t *testing.T) {
+	source := &fakeObservabilityV8HealthSource{snapshot: observabilityruntime.DestinationHealthSnapshot{Generation: 1}}
+	health := NewSidecarHealth()
+	health.bindObservabilityV8HealthSource(source)
+	_ = health.Snapshot()
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		1, 7, audit.EventHistoryHealthFailed, audit.EventHistoryHealthWriteFailed,
+		audit.EventHistorySQLiteBusyLocked, 5,
+	))
+	source.snapshot = observabilityruntime.DestinationHealthSnapshot{Generation: 2}
+	carried := health.Snapshot().Telemetry
+	if carried.State != StateError || carried.Details["event_history_failure"] != "sqlite_write_failed" {
+		t.Fatalf("reload cleared unproven failure: %+v", carried)
+	}
+	for _, retired := range []audit.EventHistoryHealthTransition{
+		eventHistoryTransition(1, 8, audit.EventHistoryHealthRecovered, audit.EventHistoryHealthWriteFailed, "", 0),
+		eventHistoryTransition(1, 9, audit.EventHistoryHealthFailed, audit.EventHistoryHealthWriteFailed, audit.EventHistorySQLiteIO, 10),
+	} {
+		health.observeObservabilityV8EventHistory(retired)
+	}
+	if stale := health.Snapshot().Telemetry; stale.Details["event_history_last_sqlite_class"] != "busy_locked" {
+		t.Fatalf("retired callback contaminated generation two: %+v", stale)
+	}
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		2, 1, audit.EventHistoryHealthRecovered, audit.EventHistoryHealthWriteFailed, "", 0,
+	))
+	if recovered := health.Snapshot().Telemetry; recovered.State != StateRunning {
+		t.Fatalf("generation two proof did not recover inherited failure: %+v", recovered)
+	}
+}
+
+func TestObservabilityV8EventHistoryReloadPreservesCrossCodeOrder(t *testing.T) {
+	source := &fakeObservabilityV8HealthSource{snapshot: observabilityruntime.DestinationHealthSnapshot{Generation: 1}}
+	health := NewSidecarHealth()
+	health.bindObservabilityV8HealthSource(source)
+	_ = health.Snapshot()
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		1, 1, audit.EventHistoryHealthFailed, audit.EventHistoryHealthWriteFailed,
+		audit.EventHistorySQLiteBusyLocked, 5,
+	))
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		1, 2, audit.EventHistoryHealthFailed, audit.EventHistoryHealthSigningFailed, "", 0,
+	))
+	source.snapshot = observabilityruntime.DestinationHealthSnapshot{Generation: 2}
+	for index := 0; index < 20; index++ {
+		snapshot := health.Snapshot().Telemetry
+		if snapshot.State != StateError || snapshot.Details["event_history_failure"] != "integrity_signing_failed" {
+			t.Fatalf("reload snapshot %d lost cross-code order: %+v", index, snapshot)
+		}
+	}
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		2, 1, audit.EventHistoryHealthRecovered, audit.EventHistoryHealthWriteFailed, "", 0,
+	))
+	for index := 0; index < 20; index++ {
+		snapshot := health.Snapshot().Telemetry
+		if snapshot.State != StateError || snapshot.Details["event_history_failure"] != "integrity_signing_failed" {
+			t.Fatalf("write recovery %d cleared unrelated health: %+v", index, snapshot)
+		}
+	}
+}
+
+func TestObservabilityV8EventHistoryNewGenerationCallbackPreservesOtherCodesBeforeBind(t *testing.T) {
+	source := &fakeObservabilityV8HealthSource{snapshot: observabilityruntime.DestinationHealthSnapshot{Generation: 1}}
+	health := NewSidecarHealth()
+	health.bindObservabilityV8HealthSource(source)
+	_ = health.Snapshot()
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		1, 1, audit.EventHistoryHealthFailed, audit.EventHistoryHealthWriteFailed,
+		audit.EventHistorySQLiteBusyLocked, 5,
+	))
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		1, 2, audit.EventHistoryHealthFailed, audit.EventHistoryHealthProjectionRejected, "", 0,
+	))
+	// A generation-two callback may arrive after graph publication but before
+	// owner.reload returns and explicitly advances the health generation floor.
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		2, 1, audit.EventHistoryHealthFailed, audit.EventHistoryHealthSigningFailed, "", 0,
+	))
+	health.mu.RLock()
+	if len(health.observabilityV8EventHistory) != 3 {
+		health.mu.RUnlock()
+		t.Fatalf("new generation callback erased inherited failures: %+v", health.observabilityV8EventHistory)
+	}
+	health.mu.RUnlock()
+	health.observeObservabilityV8EventHistory(eventHistoryTransition(
+		2, 2, audit.EventHistoryHealthRecovered, audit.EventHistoryHealthWriteFailed, "", 0,
+	))
+	health.bindObservabilityV8EventHistoryGeneration(2)
+	source.snapshot = observabilityruntime.DestinationHealthSnapshot{Generation: 2}
+	snapshot := health.Snapshot().Telemetry
+	if snapshot.State != StateError || snapshot.Details["event_history_failure"] != "integrity_signing_failed" {
+		t.Fatalf("write recovery erased unrelated inherited failure: %+v", snapshot)
+	}
+	health.mu.RLock()
+	projection := health.observabilityV8EventHistory[string(audit.EventHistoryHealthProjectionRejected)]
+	health.mu.RUnlock()
+	if !projection.active || projection.generation != 1 {
+		t.Fatalf("inherited projection failure was not preserved: %+v", projection)
+	}
+}
+
+func TestObservabilityV8EventHistoryActivationRejectsDelayedRetiredCallback(t *testing.T) {
+	health := NewSidecarHealth()
+	health.bindObservabilityV8EventHistoryGeneration(1)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		close(started)
+		<-release
+		health.observeObservabilityV8EventHistory(eventHistoryTransition(
+			1, 1, audit.EventHistoryHealthFailed, audit.EventHistoryHealthWriteFailed,
+			audit.EventHistorySQLiteBusyLocked, 5,
+		))
+		close(done)
+	}()
+	<-started
+	// This is the local component Activate-time bind performed immediately
+	// after graph publication, while retirement may still be waiting on a
+	// generation-one lease and its delayed callback.
+	health.bindObservabilityV8EventHistoryGeneration(2)
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("delayed callback did not return")
+	}
+	health.mu.RLock()
+	defer health.mu.RUnlock()
+	if len(health.observabilityV8EventHistory) != 0 ||
+		health.observabilityV8EventHistoryGeneration != 2 {
+		t.Fatalf("retired callback crossed activation boundary: generation=%d observations=%+v",
+			health.observabilityV8EventHistoryGeneration, health.observabilityV8EventHistory)
+	}
+}
+
+func TestObservabilityV8EventHistoryRejectsMismatchedSQLiteDiagnostics(t *testing.T) {
+	tests := []struct {
+		name    string
+		class   audit.EventHistorySQLiteClass
+		primary uint8
+	}{
+		{name: "busy with arbitrary code", class: audit.EventHistorySQLiteBusyLocked, primary: 255},
+		{name: "busy with io code", class: audit.EventHistorySQLiteBusyLocked, primary: 10},
+		{name: "unavailable with driver code", class: audit.EventHistorySQLiteUnavailable, primary: 28},
+		{name: "full without full code", class: audit.EventHistorySQLiteFull, primary: 0},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			health := NewSidecarHealth()
+			health.bindObservabilityV8EventHistoryGeneration(1)
+			health.observeObservabilityV8EventHistory(eventHistoryTransition(
+				1, 1, audit.EventHistoryHealthFailed, audit.EventHistoryHealthWriteFailed,
+				test.class, test.primary,
+			))
+			health.mu.RLock()
+			defer health.mu.RUnlock()
+			if len(health.observabilityV8EventHistory) != 0 {
+				t.Fatalf("mismatched diagnostic was accepted: %+v", health.observabilityV8EventHistory)
+			}
+		})
+	}
+}
+
+func TestObservabilityV8EventHistoryStateDoesNotSurviveSidecarRestart(t *testing.T) {
+	source := &fakeObservabilityV8HealthSource{snapshot: observabilityruntime.DestinationHealthSnapshot{Generation: 1}}
+	failed := NewSidecarHealth()
+	failed.bindObservabilityV8HealthSource(source)
+	failed.observeObservabilityV8EventHistory(eventHistoryTransition(
+		1, 1, audit.EventHistoryHealthFailed, audit.EventHistoryHealthWriteFailed,
+		audit.EventHistorySQLiteOther, 0,
+	))
+	if failed.Snapshot().Telemetry.State != StateError {
+		t.Fatal("failure fixture did not latch")
+	}
+	restarted := NewSidecarHealth()
+	restarted.bindObservabilityV8HealthSource(source)
+	if snapshot := restarted.Snapshot().Telemetry; snapshot.State != StateRunning {
+		t.Fatalf("new sidecar inherited process-local latch: %+v", snapshot)
 	}
 }
 
@@ -495,7 +799,11 @@ func TestObservabilityV8HealthSnapshotFailureIsBoundedAndFailClosed(t *testing.T
 			health := NewSidecarHealth()
 			health.bindObservabilityV8HealthSource(test.source)
 			health.setObservabilityV8Retention("degraded", 30, "scheduler_failed")
-			health.setObservabilityV8EventHistoryFailure("sqlite_write_failed")
+			health.observeObservabilityV8EventHistory(audit.EventHistoryHealthTransition{
+				Generation: 1, Sequence: 1, State: audit.EventHistoryHealthFailed,
+				Code: audit.EventHistoryHealthWriteFailed, OccurredAt: time.Now().UTC(),
+				SQLiteClass: audit.EventHistorySQLiteOther,
+			})
 
 			snapshot := health.Snapshot()
 			if snapshot.Telemetry.State != StateError {

--- a/internal/gateway/sidecar_observability_v8_bootstrap.go
+++ b/internal/gateway/sidecar_observability_v8_bootstrap.go
@@ -953,13 +953,20 @@ func (observer sidecarV8RetentionObserver) ReportRetentionController(
 
 type sidecarV8EventHistoryObserver struct{ s *Sidecar }
 
+func (observer sidecarV8EventHistoryObserver) BindEventHistoryHealthGeneration(generation uint64) {
+	if observer.s == nil || observer.s.health == nil {
+		return
+	}
+	observer.s.health.bindObservabilityV8EventHistoryGeneration(generation)
+}
+
 func (observer sidecarV8EventHistoryObserver) ReportEventHistoryHealth(
-	code audit.EventHistoryHealthCode,
+	transition audit.EventHistoryHealthTransition,
 ) {
 	if observer.s == nil || observer.s.health == nil {
 		return
 	}
-	observer.s.health.setObservabilityV8EventHistoryFailure(string(code))
+	observer.s.health.observeObservabilityV8EventHistory(transition)
 }
 
 func newSidecarObservabilityV8BootstrapError(

--- a/internal/observability/runtime/local.go
+++ b/internal/observability/runtime/local.go
@@ -77,11 +77,12 @@ func (factory *localLogFactory) Prepare(
 	if err != nil {
 		return nil, &localFactoryError{}
 	}
-	writer, err := audit.NewEventHistoryWriter(
+	writer, err := audit.NewEventHistoryWriterForGeneration(
 		factory.store,
 		factory.signer,
 		factory.healthReporter,
 		binding,
+		input.Generation,
 	)
 	if err != nil {
 		return nil, &localFactoryError{}
@@ -157,6 +158,7 @@ func (component *localLogComponent) applyAlertAcknowledgement(
 
 func (component *localLogComponent) Activate() {
 	if component != nil && !component.closed.Load() {
+		component.history.ActivateHealthGeneration()
 		component.active.Store(true)
 	}
 }

--- a/internal/observability/runtime/runtime_test.go
+++ b/internal/observability/runtime/runtime_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -43,6 +44,51 @@ type runtimeTestDependencies struct {
 	retentionReaper     *fakeRetentionReaper
 	retentionController *RetentionController
 	retentionScheduler  *scriptedRetentionScheduler
+}
+
+type generationBindingHealthReporter struct {
+	mu          sync.Mutex
+	generations []uint64
+	transitions []audit.EventHistoryHealthTransition
+	bound       chan uint64
+}
+
+func (reporter *generationBindingHealthReporter) ReportEventHistoryHealth(
+	transition audit.EventHistoryHealthTransition,
+) {
+	reporter.mu.Lock()
+	latest := uint64(0)
+	if len(reporter.generations) > 0 {
+		latest = reporter.generations[len(reporter.generations)-1]
+	}
+	if transition.Generation >= latest {
+		reporter.transitions = append(reporter.transitions, transition)
+	}
+	reporter.mu.Unlock()
+}
+
+func (reporter *generationBindingHealthReporter) BindEventHistoryHealthGeneration(generation uint64) {
+	reporter.mu.Lock()
+	reporter.generations = append(reporter.generations, generation)
+	reporter.mu.Unlock()
+	if reporter.bound != nil {
+		select {
+		case reporter.bound <- generation:
+		default:
+		}
+	}
+}
+
+func (reporter *generationBindingHealthReporter) transitionSnapshot() []audit.EventHistoryHealthTransition {
+	reporter.mu.Lock()
+	defer reporter.mu.Unlock()
+	return append([]audit.EventHistoryHealthTransition(nil), reporter.transitions...)
+}
+
+func (reporter *generationBindingHealthReporter) snapshot() []uint64 {
+	reporter.mu.Lock()
+	defer reporter.mu.Unlock()
+	return append([]uint64(nil), reporter.generations...)
 }
 
 func newRuntimeTestDependencies(t *testing.T) runtimeTestDependencies {
@@ -315,6 +361,101 @@ func TestRuntimeRetentionOnlyReloadReplacesGraphAndReusesStore(t *testing.T) {
 	newLocal := newComponent.(*localLogComponent)
 	if newLocal == oldLocal || newLocal.store != dependencies.store || oldLocal.store != dependencies.store {
 		t.Fatal("retention reload did not replace only generation state around the stable store")
+	}
+}
+
+func TestRuntimeBindsEventHistoryGenerationOnlyWhenGraphActivates(t *testing.T) {
+	dependencies := newRuntimeTestDependencies(t)
+	reporter := &generationBindingHealthReporter{}
+	options := dependencies.options()
+	options.EventHistoryHealthReporter = reporter
+	initialPlan := runtimeTestPlan(t, dependencies.storePath, dependencies.judgePath, 90, nil)
+	runtime, err := New(t.Context(), runtimegraph.ConfigFromPlan(initialPlan, false), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = runtime.Close(t.Context()) })
+	if got := reporter.snapshot(); !reflect.DeepEqual(got, []uint64{1}) {
+		t.Fatalf("initial generation bindings = %+v", got)
+	}
+	// Rejected candidates are prepared off-path but must not advance the health
+	// generation. An applied replacement binds from its Activate call, before
+	// Reload waits for retirement of the old graph.
+	invalid := runtimegraph.ConfigFromPlan(initialPlan, false)
+	invalid.LocalPath = filepath.Join(t.TempDir(), "wrong.db")
+	if _, reloadErr := runtime.Reload(t.Context(), invalid); reloadErr == nil {
+		t.Fatal("invalid reload was applied")
+	}
+	if got := reporter.snapshot(); !reflect.DeepEqual(got, []uint64{1}) {
+		t.Fatalf("rejected candidate bound generation: %+v", got)
+	}
+	candidate := runtimeTestPlan(t, dependencies.storePath, dependencies.judgePath, 30, nil)
+	result, reloadErr := runtime.Reload(t.Context(), runtimegraph.ConfigFromPlan(candidate, false))
+	if reloadErr != nil || result.Status() != runtimegraph.ReloadApplied {
+		t.Fatalf("reload = %s/%v", result.Status(), reloadErr)
+	}
+	if got := reporter.snapshot(); !reflect.DeepEqual(got, []uint64{1, 2}) {
+		t.Fatalf("activation generation bindings = %+v", got)
+	}
+}
+
+func TestRuntimeActivationBindsBeforeOldGenerationRetires(t *testing.T) {
+	dependencies := newRuntimeTestDependencies(t)
+	reporter := &generationBindingHealthReporter{bound: make(chan uint64, 2)}
+	options := dependencies.options()
+	options.EventHistoryHealthReporter = reporter
+	initialPlan := runtimeTestPlan(t, dependencies.storePath, dependencies.judgePath, 90, nil)
+	runtime, err := New(t.Context(), runtimegraph.ConfigFromPlan(initialPlan, false), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = runtime.Close(t.Context()) })
+	<-reporter.bound // generation one Activate
+	oldLease, leaseErr := runtime.manager.Acquire(t.Context())
+	if leaseErr != nil {
+		t.Fatal(leaseErr)
+	}
+	type reloadOutcome struct {
+		result runtimegraph.ReloadResult
+		err    *runtimegraph.Error
+	}
+	reloadDone := make(chan reloadOutcome, 1)
+	candidate := runtimeTestPlan(t, dependencies.storePath, dependencies.judgePath, 30, nil)
+	go func() {
+		result, reloadErr := runtime.Reload(t.Context(), runtimegraph.ConfigFromPlan(candidate, false))
+		reloadDone <- reloadOutcome{result: result, err: reloadErr}
+	}()
+	select {
+	case generation := <-reporter.bound:
+		if generation != 2 {
+			t.Fatalf("activated generation = %d", generation)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("generation two did not activate while old lease was held")
+	}
+	select {
+	case outcome := <-reloadDone:
+		t.Fatalf("reload returned before old generation retirement: %+v", outcome)
+	default:
+	}
+	// This represents a delayed callback admitted under the still-held old
+	// graph lease. The activation-time floor must already reject it.
+	reporter.ReportEventHistoryHealth(audit.EventHistoryHealthTransition{
+		Generation: 1, Sequence: 99, State: audit.EventHistoryHealthFailed,
+		Code: audit.EventHistoryHealthWriteFailed, OccurredAt: time.Now().UTC(),
+		SQLiteClass: audit.EventHistorySQLiteBusyLocked, SQLitePrimaryCode: 5,
+	})
+	if got := reporter.transitionSnapshot(); len(got) != 0 {
+		t.Fatalf("retired callback crossed generation activation: %+v", got)
+	}
+	oldLease.Release()
+	select {
+	case outcome := <-reloadDone:
+		if outcome.err != nil || outcome.result.Status() != runtimegraph.ReloadApplied {
+			t.Fatalf("reload = %s/%v", outcome.result.Status(), outcome.err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("reload did not finish after old lease release")
 	}
 }
 

--- a/internal/observability/runtime/runtime_test.go
+++ b/internal/observability/runtime/runtime_test.go
@@ -438,8 +438,10 @@ func TestRuntimeActivationBindsBeforeOldGenerationRetires(t *testing.T) {
 		t.Fatalf("reload returned before old generation retirement: %+v", outcome)
 	default:
 	}
-	// This represents a delayed callback admitted under the still-held old
-	// graph lease. The activation-time floor must already reject it.
+	// Invoke the generationBindingHealthReporter test double directly to prove
+	// activation ordering while the old lease is still held. The production
+	// SidecarHealth rejection path is covered by
+	// TestObservabilityV8EventHistoryActivationRejectsDelayedRetiredCallback.
 	reporter.ReportEventHistoryHealth(audit.EventHistoryHealthTransition{
 		Generation: 1, Sequence: 99, State: audit.EventHistoryHealthFailed,
 		Code: audit.EventHistoryHealthWriteFailed, OccurredAt: time.Now().UTC(),


### PR DESCRIPTION
Base note: this change is based on exact `main` commit `79c67cc5e485bfb494e34e9fec42bd4939bc8158`. It closes #723.

## Problem

An event-history SQLite write failure latched `Telemetry: ERROR` for the lifetime of the gateway process. Later successful mandatory writes did not clear the error, so recovered storage continued to look broken until restart. The health surface also discarded the underlying SQLite failure category, leaving operators unable to distinguish bounded classes such as contention, deadline, disk-full, I/O, or read-only/open failures.

## Current Situation

The writer reported only a failure code. The sidecar stored that code as process-global sticky state with no recovery transition or ordering identity. A naive clear callback would be unsafe: a delayed success could erase a newer failure, an old runtime generation could contaminate a replacement graph, and an ordinary optional or unsigned write is not proof that mandatory signed event history recovered.

## Solution

### Publish ordered, bounded health transitions

Event-history writers now report generation-bound failure and recovery transitions with a monotonic outcome sequence. SQLite diagnostics cross the boundary only as an allowlisted class and primary code; raw error text, paths, SQL, and record content never do.

### Recover only from durable proof

Only a committed, mandatory, signed event-history row emits `sqlite_write_failed` recovery. Optional commits, unsigned commits, failed commits, projection failures, and unrelated health codes cannot clear the SQLite failure.

### Preserve state safely across reloads

The replacement local component advances the accepted generation during graph activation, before old-generation retirement completes. Delayed retired callbacks are rejected, active failures survive configuration reload, and the first valid new-generation recovery can clear only the inherited SQLite write failure.

### Keep delivery bounded and ordered

Reporter callbacks remain outside SQLite transaction and store ownership. The bounded queue preserves the latest SQLite failure diagnostic immediately before a following recovery, coalesces superseded states, and retains independent failure codes.

### Keep the required catalog gate current

The base branch crossed the published retirement date for two Groq picker suggestions while this PR was under review. Those two deprecated suggestions are removed so the required catalog gate can evaluate this change; arbitrary model IDs remain supported.

```mermaid
flowchart TD
    A["SQLite event-history outcome"] --> B{"Failure or committed mandatory signed success?"}
    B -->|"Failure"| C["Bounded failed transition"]
    B -->|"Verified success"| D["SQLite recovery transition"]
    B -->|"Optional, unsigned, or uncommitted"| E["No recovery proof"]
    C --> F["Generation + sequence gate"]
    D --> F
    F --> G{"Current and newer than this code's state?"}
    G -->|"No"| H["Ignore stale callback"]
    G -->|"Yes"| I["Update only that health code"]
    I --> J["Active error or recovered health; retain bounded last SQLite class"]
```

## What Changed (Where & How)

| Path | Change |
|---|---|
| `internal/audit/event_history_v8.go` | Adds typed generation/sequence health transitions, bounded SQLite classification, commit-qualified recovery, ordered bounded callback delivery, and distinct writer-generation validation. |
| `internal/audit/event_history_v8_test.go` | Covers recovery proof, unsigned/optional/failed commits, concurrent ordering, callback re-entry, queue coalescing, and diagnostic privacy. |
| `internal/audit/alert_acknowledgement_projection_test.go` | Adapts acknowledgement health fixtures to the typed transition contract. |
| `internal/observability/runtime/local.go` | Binds each writer to its runtime generation and advances health state from component activation. |
| `internal/observability/runtime/runtime_test.go` | Proves rejected candidates do not bind and a replacement binds before old-generation retirement completes. |
| `internal/gateway/health.go` | Tracks per-code active state and watermarks, rejects stale generations, renders recovered state, and retains bounded last SQLite diagnostics. |
| `internal/gateway/health_test.go` | Covers recovery, reload carryover, cross-code ordering, delayed callbacks, restart, and invalid diagnostic pairs. |
| `internal/gateway/sidecar_observability_v8_bootstrap.go` | Bridges activation and typed transitions into sidecar health. |
| `bundles/llm/model_catalog.json` | Removes two Groq suggestions that became deprecated on 2026-08-16 and broke the required base-branch catalog gate. |

## Breaking Changes

No API or configuration breakage.

Telemetry health intentionally changes after recovery: `event_history_failure: sqlite_write_failed` is removed only after a verified mandatory signed commit. The bounded `event_history_last_sqlite_class` and optional primary code remain available for diagnosis.

The setup picker no longer suggests two retired Groq model IDs. Operators can still type arbitrary model IDs, so existing configured models and runtime routing are unchanged.

## Open Issues / Follow-ups

None.

## Test Plan

Validated on exact head `f07966817a6c4a4a3445696994a9c8a42c2eeccf`, base `79c67cc5e485bfb494e34e9fec42bd4939bc8158`, binary diff SHA-256 `dd5af79f494beb721e652df2198b22deddba446760004c2feab4bbca72a7cd1c` (9 files, +1477/-107):

```text
git diff --check origin/main...HEAD
PASS

go test ./internal/audit ./internal/observability/runtime -count=1 -timeout=10m
PASS (audit 19.949s; runtime 18.961s)

go test ./internal/gateway -run 'TestObservabilityV8EventHistory|TestHealth.*EventHistory|TestSidecar.*EventHistory' -count=25 -timeout=10m
PASS (gateway 1.142s)

go test -race ./internal/audit -run 'Test(ClassifyEventHistorySQLiteFailureIsBounded|ValidEventHistorySQLiteDiagnosticRejectsMismatchedPairs|EventHistoryWriterKeepsNewestWriteFailureBehindBlockedCallback|EventHistoryWriterPreservesFailureDiagnosticBeforePendingRecovery|EventHistoryWriterHealthCallbackCanReenterSameWriter|EventHistoryWriterSerializesSignedUnsignedTransitionsWhileReporterBlocked)' -count=25 -timeout=10m
PASS (audit 252.897s)

go vet ./internal/audit ./internal/observability/runtime ./internal/gateway
PASS

uv run pytest cli/tests/test_llm_catalog.py -q
PASS (9 tests)

python -m json.tool bundles/llm/model_catalog.json
PASS

Focused event-history, recovery/queue/privacy, and activation/reload tests at count=100; review-fix tests at count=25
PASS
```

The preceding feature head also passed the full gateway package and broader focused race suite. An independent exact-head audit verified byte-identical range-diff preservation, queue/reentrancy safety, non-vacuous diagnostic tests, and compatibility with the intervening observability changes on `main`, then returned CLEAN.

Closes #723.
