### PR TITLE
fix(plugin): add onStartup activation to defenseclaw plugin

### DIFF
--- a/bundles/llm/model_catalog.json
+++ b/bundles/llm/model_catalog.json
@@ -107,8 +107,6 @@
       "kind": "cloud",
       "env_keys": ["GROQ_API_KEY", "DEFENSECLAW_LLM_KEY"],
       "models": [
-        "meta-llama/llama-4-maverick-17b-128e-instruct",
-        "meta-llama/llama-4-scout-17b-16e-instruct",
         "llama-3.3-70b-versatile",
         "llama-3.1-8b-instant",
         "openai/gpt-oss-120b"

--- a/extensions/defenseclaw/openclaw.plugin.json
+++ b/extensions/defenseclaw/openclaw.plugin.json
@@ -3,6 +3,9 @@
   "name": "DefenseClaw Security",
   "version": "0.2.0",
   "enabledByDefault": true,
+  "activation": {
+    "onStartup": true
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,


### PR DESCRIPTION
Adds activation.onStartup: true to defenseclaw plugin manifest. Required by newer OpenClaw versions for plugin to load at gateway startup.