### PR TITLE
fix(plugin): add onStartup activation to defenseclaw plugin

### DIFF
--- a/extensions/defenseclaw/openclaw.plugin.json
+++ b/extensions/defenseclaw/openclaw.plugin.json
@@ -3,6 +3,9 @@
   "name": "DefenseClaw Security",
   "version": "0.2.0",
   "enabledByDefault": true,
+  "activation": {
+    "onStartup": true
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,


### PR DESCRIPTION
Newer OpenClaw versions require `"activation": {"onStartup": true}` in the plugin manifest for the plugin to load at gateway startup. Without this, the plugin is not activated and the LLM fetch interceptor never installs — causing all LLM traffic to bypass the DefenseClaw guardrail proxy entirely.

<!--
Every future action item must have a GitHub issue before it appears in this PR
body. List linked issues under "Open Issues / Follow-ups". If there are no
follow-ups, write "None".
-->

## Problem

<!-- What user, operator, security, reliability, or maintenance problem does this PR solve? -->

## Current Situation

<!-- What exists today? Include relevant constraints, failing behavior, prior work, or base-branch context. -->

## Solution

<!-- Describe the implementation. For complex work, add focused subsections. -->

## Architecture Diagram

<!-- Include a diagram when it clarifies security posture, data flow, policy behavior, or reviewer risk. Write "N/A" if not useful. -->

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| <!-- path --> | <!-- change summary --> |

## Breaking Changes

<!-- Describe behavior/default/config/API/operator workflow changes. Write "None" if not applicable. -->

## Open Issues / Follow-ups

<!-- Every future action item here must link to a GitHub issue, e.g. "- #123 - follow-up summary". Write "None" if not applicable. -->

## Test Plan

<!-- Include exact commands and observed results. -->
