### PR TITLE
fix(tui): tolerate malformed SQLite detail reads

### DIFF
--- a/cli/defenseclaw/tui/panels/alerts.py
+++ b/cli/defenseclaw/tui/panels/alerts.py
@@ -1377,45 +1377,55 @@ def _coerce_alert_event(event: object) -> AlertEvent:
 def _list_findings_by_run_id(store: object | None, run_id: str) -> tuple[AlertFinding, ...]:
     if store is None or not run_id:
         return ()
-    if hasattr(store, "list_findings_by_run_id"):
-        return tuple(_coerce_finding(item) for item in store.list_findings_by_run_id(run_id))  # type: ignore[attr-defined]
-    db = getattr(store, "db", None)
-    if db is None:
-        return ()
-    rows = db.execute(
-        """SELECT id, scan_id, severity, title, description, location, remediation, scanner
-           FROM findings WHERE scan_id = ? ORDER BY severity DESC""",
-        (run_id,),
-    ).fetchall()
-    return tuple(
-        AlertFinding(
-            id=str(row[0]),
-            scan_id=str(row[1]),
-            severity=str(row[2]),
-            title=str(row[3]),
-            description=str(row[4] or ""),
-            location=str(row[5] or ""),
-            remediation=str(row[6] or ""),
-            scanner=str(row[7] or ""),
+    try:
+        if hasattr(store, "list_findings_by_run_id"):
+            return tuple(
+                _coerce_finding(item) for item in store.list_findings_by_run_id(run_id)  # type: ignore[attr-defined]
+            )
+        db = getattr(store, "db", None)
+        if db is None:
+            return ()
+        rows = db.execute(
+            """SELECT id, scan_id, severity, title, description, location, remediation, scanner
+               FROM findings WHERE scan_id = ? ORDER BY severity DESC""",
+            (run_id,),
+        ).fetchall()
+        return tuple(
+            AlertFinding(
+                id=str(row[0]),
+                scan_id=str(row[1]),
+                severity=str(row[2]),
+                title=str(row[3]),
+                description=str(row[4] or ""),
+                location=str(row[5] or ""),
+                remediation=str(row[6] or ""),
+                scanner=str(row[7] or ""),
+            )
+            for row in rows
         )
-        for row in rows
-    )
+    except Exception:  # noqa: BLE001 - detail enrichment must not hide the selected row.
+        return ()
 
 
 def _list_events_by_target(store: object | None, target: str, limit: int) -> tuple[AlertEvent, ...]:
     if store is None or not target:
         return ()
-    if hasattr(store, "list_events_by_target"):
-        return tuple(_coerce_alert_event(item) for item in store.list_events_by_target(target, limit))  # type: ignore[attr-defined]
-    db = getattr(store, "db", None)
-    if db is None:
+    try:
+        if hasattr(store, "list_events_by_target"):
+            return tuple(
+                _coerce_alert_event(item) for item in store.list_events_by_target(target, limit)  # type: ignore[attr-defined]
+            )
+        db = getattr(store, "db", None)
+        if db is None:
+            return ()
+        rows = db.execute(
+            """SELECT id, timestamp, action, target, actor, details, severity, run_id
+               FROM audit_events WHERE target = ? ORDER BY timestamp DESC LIMIT ?""",
+            (target, max(limit, 1)),
+        ).fetchall()
+        return tuple(_alert_event_from_row(row) for row in rows)
+    except Exception:  # noqa: BLE001 - detail enrichment must not hide the selected row.
         return ()
-    rows = db.execute(
-        """SELECT id, timestamp, action, target, actor, details, severity, run_id
-           FROM audit_events WHERE target = ? ORDER BY timestamp DESC LIMIT ?""",
-        (target, max(limit, 1)),
-    ).fetchall()
-    return tuple(_alert_event_from_row(row) for row in rows)
 
 
 def _get_alert_event_by_id(store: object | None, event_id: str) -> AlertEvent | None:

--- a/cli/defenseclaw/tui/panels/audit.py
+++ b/cli/defenseclaw/tui/panels/audit.py
@@ -810,43 +810,49 @@ def audit_severity_style_key(severity: str) -> str:
 def _list_findings_by_run_id(store: object | None, run_id: str) -> tuple[AuditFinding, ...]:
     if store is None or not run_id:
         return ()
-    db = getattr(store, "db", None)
-    if db is None:
-        return ()
-    rows = db.execute(
-        """SELECT id, scan_id, severity, title, description, location, remediation, scanner
-           FROM findings WHERE scan_id = ? ORDER BY severity DESC""",
-        (run_id,),
-    ).fetchall()
-    return tuple(
-        AuditFinding(
-            id=row[0],
-            scan_id=row[1],
-            severity=row[2],
-            title=row[3],
-            description=row[4] or "",
-            location=row[5] or "",
-            remediation=row[6] or "",
-            scanner=row[7],
+    try:
+        db = getattr(store, "db", None)
+        if db is None:
+            return ()
+        rows = db.execute(
+            """SELECT id, scan_id, severity, title, description, location, remediation, scanner
+               FROM findings WHERE scan_id = ? ORDER BY severity DESC""",
+            (run_id,),
+        ).fetchall()
+        return tuple(
+            AuditFinding(
+                id=row[0],
+                scan_id=row[1],
+                severity=row[2],
+                title=row[3],
+                description=row[4] or "",
+                location=row[5] or "",
+                remediation=row[6] or "",
+                scanner=row[7],
+            )
+            for row in rows
         )
-        for row in rows
-    )
+    except Exception:  # noqa: BLE001 - detail enrichment must not hide the selected row.
+        return ()
 
 
 def _list_events_by_target(store: object | None, target: str, limit: int) -> tuple[Event, ...]:
     if store is None or not target:
         return ()
-    if hasattr(store, "list_events_by_target"):
-        return tuple(store.list_events_by_target(target, limit))  # type: ignore[attr-defined]
-    db = getattr(store, "db", None)
-    if db is None:
+    try:
+        if hasattr(store, "list_events_by_target"):
+            return tuple(store.list_events_by_target(target, limit))  # type: ignore[attr-defined]
+        db = getattr(store, "db", None)
+        if db is None:
+            return ()
+        rows = db.execute(
+            """SELECT id, timestamp, action, target, actor, details, severity, run_id
+               FROM audit_events WHERE target = ? ORDER BY timestamp DESC LIMIT ?""",
+            (target, max(limit, 1)),
+        ).fetchall()
+        return tuple(_event_from_row(row) for row in rows)
+    except Exception:  # noqa: BLE001 - detail enrichment must not hide the selected row.
         return ()
-    rows = db.execute(
-        """SELECT id, timestamp, action, target, actor, details, severity, run_id
-           FROM audit_events WHERE target = ? ORDER BY timestamp DESC LIMIT ?""",
-        (target, max(limit, 1)),
-    ).fetchall()
-    return tuple(_event_from_row(row) for row in rows)
 
 
 def _get_event_by_id(store: object | None, event_id: str) -> Event | None:
@@ -862,15 +868,18 @@ def _get_event_by_id(store: object | None, event_id: str) -> Event | None:
 def _list_events_by_run_id(store: object | None, run_id: str, limit: int) -> tuple[Event, ...]:
     if store is None or not run_id:
         return ()
-    db = getattr(store, "db", None)
-    if db is None:
+    try:
+        db = getattr(store, "db", None)
+        if db is None:
+            return ()
+        rows = db.execute(
+            """SELECT id, timestamp, action, target, actor, details, severity, run_id
+               FROM audit_events WHERE run_id = ? ORDER BY timestamp DESC LIMIT ?""",
+            (run_id, max(limit, 1)),
+        ).fetchall()
+        return tuple(_event_from_row(row) for row in rows)
+    except Exception:  # noqa: BLE001 - detail enrichment must not hide the selected row.
         return ()
-    rows = db.execute(
-        """SELECT id, timestamp, action, target, actor, details, severity, run_id
-           FROM audit_events WHERE run_id = ? ORDER BY timestamp DESC LIMIT ?""",
-        (run_id, max(limit, 1)),
-    ).fetchall()
-    return tuple(_event_from_row(row) for row in rows)
 
 
 def _list_related_events(store: object | None, event: Event, limit: int) -> tuple[Event, ...]:

--- a/cli/tests/tui/test_alerts_panel.py
+++ b/cli/tests/tui/test_alerts_panel.py
@@ -12,7 +12,9 @@
 
 from __future__ import annotations
 
+import sqlite3
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
 import defenseclaw.tui.panels.alerts as alerts_panel
 from defenseclaw.tui.panels.alerts import (
@@ -175,6 +177,31 @@ def test_alert_detail_hydration_preserves_visible_non_info_promotion() -> None:
 
     assert detail is not None
     assert detail.event.severity == "HIGH"
+
+
+def test_alert_detail_survives_malformed_sqlite_history() -> None:
+    class CorruptDatabase:
+        def execute(self, *_args: object, **_kwargs: object) -> None:
+            raise sqlite3.DatabaseError("database disk image is malformed")
+
+    event = AlertEvent(
+        id="corrupt-db-alert",
+        severity="CRITICAL",
+        action="scan-finding",
+        target="claudecode:PostToolBatch",
+        run_id="run-1",
+    )
+    model = AlertsPanelModel(store=SimpleNamespace(db=CorruptDatabase()))
+    model.set_events([event])
+    model.toggle_expand_or_detail()
+
+    detail = model.get_detail_info()
+
+    assert detail is not None
+    assert detail.event == event
+    assert detail.findings == ()
+    assert detail.history == ()
+    assert "CRITICAL scan-finding" in model.detail_text()
 
 
 def test_humanize_alert_details_fast_paths_and_host_port() -> None:

--- a/cli/tests/tui/test_audit_panel.py
+++ b/cli/tests/tui/test_audit_panel.py
@@ -12,8 +12,10 @@
 
 from __future__ import annotations
 
+import sqlite3
 from datetime import datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 
 from defenseclaw.db import Store
 from defenseclaw.models import ActionState, Event
@@ -296,6 +298,32 @@ def test_audit_refresh_preserves_last_good_rows_when_database_is_locked() -> Non
     assert [event.id for event in panel.items] == ["cached"]
     assert [event.id for event in panel.filtered] == ["cached"]
     assert panel.error_message == "Audit refresh failed: database is locked"
+
+
+def test_audit_detail_survives_malformed_sqlite_history() -> None:
+    class CorruptDatabase:
+        def execute(self, *_args: object, **_kwargs: object) -> None:
+            raise sqlite3.DatabaseError("database disk image is malformed")
+
+    event = Event(
+        id="corrupt-db-event",
+        timestamp=datetime(2026, 4, 16, 12, 0, 0),
+        action="scan-finding",
+        target="claudecode:PostToolBatch",
+        severity="CRITICAL",
+        run_id="run-1",
+    )
+    panel = AuditPanelModel(SimpleNamespace(db=CorruptDatabase()))
+    panel.set_events([event])
+    panel.toggle_detail()
+
+    info = panel.get_detail_info()
+
+    assert info is not None
+    assert info.event == event
+    assert info.findings == ()
+    assert info.related == ()
+    assert ("Action", "scan-finding") in panel.detail_pairs()
 
 
 def test_audit_view_metadata_exposes_toolbar_rows_columns_and_styles() -> None:


### PR DESCRIPTION
Base: `main`. This PR is intentionally limited to the malformed-SQLite TUI detail crash fix; unrelated local gateway/OpenClaw changes are not included.

## Problem

Opening an alert detail can crash the Textual TUI when the audit SQLite database reports `sqlite3.DatabaseError: database disk image is malformed`.

The selected alert is already available for display, but synchronous findings/history enrichment performs additional raw SQLite queries. Those optional queries propagated database errors through `_render_chrome()` and terminated the key handler.

## Current Situation

The current `main` branch classifies and reports event-history SQLite failures in the Go runtime, but that health handling does not guard Python TUI detail reads or repair a malformed database.

Alerts and Audit both had unguarded optional enrichment queries, so either panel could fail while opening an otherwise renderable selected row.

## Solution

### Preserve core alert details

Treat alert findings and target-history enrichment as best-effort. If a store method or raw SQLite query fails, return empty enrichment and continue rendering the already-loaded alert.

### Apply the same resilience to Audit

Guard Audit findings, target-history, and run-history queries with the same behavior so malformed or temporarily unavailable SQLite data cannot crash Audit detail rendering.

### Keep recovery explicit

This change does not recreate, overwrite, or claim to repair a malformed database. It only prevents optional display enrichment from taking down the TUI.

```mermaid
flowchart LR
    A["Selected alert/event is already loaded"] --> B["Optional findings/history enrichment"]
    B --> C{"SQLite query succeeds?"}
    C -->|Yes| D["Render core detail plus enrichment"]
    C -->|No| E["Render core detail with empty enrichment"]
```

## What Changed (Where & How)

| Path | Change |
| --- | --- |
| `cli/defenseclaw/tui/panels/alerts.py` | Catch detail-enrichment failures for findings and target history while preserving the selected alert. |
| `cli/defenseclaw/tui/panels/audit.py` | Catch failures for findings, target history, and run history while preserving the selected event. |
| `cli/tests/tui/test_alerts_panel.py` | Reproduce the exact malformed-image `sqlite3.DatabaseError` and verify alert detail still renders. |
| `cli/tests/tui/test_audit_panel.py` | Verify Audit detail also survives malformed SQLite enrichment reads. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

```bash
./.venv/bin/pytest -q   cli/tests/tui/test_alerts_panel.py   cli/tests/tui/test_audit_panel.py   cli/tests/tui/test_v8_event_history.py
```

Observed: `50 passed`.

```bash
./.venv/bin/ruff check   cli/defenseclaw/tui/panels/alerts.py   cli/defenseclaw/tui/panels/audit.py   cli/tests/tui/test_alerts_panel.py   cli/tests/tui/test_audit_panel.py
```

Observed: `All checks passed!`.

```bash
git diff --check
```

Observed: completed successfully with no output.