### PR TITLE
spec(001-windows-deterministic-build): Workstream E — deterministic-build support for AVC

### DIFF
--- a/docs/WINDOWS-AVC-PACKAGING-HANDOFF.md
+++ b/docs/WINDOWS-AVC-PACKAGING-HANDOFF.md
@@ -1,0 +1,69 @@
+# Windows AVC packaging handoff — feasibility check
+
+**Ask.** Can AVC run the three steps below inside the Windows managed_enterprise signing pipeline? Reply yes / no per item.
+
+---
+
+## What DefenseClaw hands you
+
+A single build kit (tarball or zip):
+
+```
+windows-enterprise-buildkit-<version>/
+├── payload/                          # you sign these five files
+│   ├── defenseclaw.exe               # unsigned
+│   ├── defenseclaw-gateway.exe       # unsigned
+│   ├── defenseclaw-hook.exe          # unsigned
+│   ├── install-enterprise.ps1        # unsigned
+│   └── DefenseClawEnterprise.psm1    # unsigned
+├── source/                           # everything `go build` needs
+│   ├── cmd/defenseclaw-enterprise-setup/
+│   ├── internal/…                    # trimmed import graph
+│   ├── vendor/                       # `go mod vendor`, offline-buildable
+│   ├── go.mod
+│   └── go.sum
+├── assemble.sh                       # or assemble.ps1 — one entry point
+├── payload-metadata.json
+└── README-AVC.md                     # ~20-line runbook
+```
+
+Estimated kit size: **~150–250 MB** (dominated by the vendored Go module cache).
+
+---
+
+## Steps you run
+
+```
+# 1. Sign the unsigned inner files:
+signtool sign /f <cert> ... payload/*.exe
+Set-AuthenticodeSignature -FilePath payload/*.ps1 ...
+
+# 2. Assemble the outer Setup EXE:
+./assemble.sh          # or: pwsh -File assemble.ps1
+
+# 3. Sign the outer Setup EXE:
+signtool sign /f <cert> ... out/DefenseClawSetup-Enterprise-x64.exe
+```
+
+Final release artifact: `DefenseClawSetup-Enterprise-x64.exe` + `.sha256` + `.provenance.json`.
+
+---
+
+## What AVC needs to confirm
+
+Please tick each:
+
+- [ ] **Go toolchain available** in the pipeline (Go 1.24.x, matching the version pinned in `go.mod`). Bundling the toolchain into the build kit is possible if preferred — please indicate.
+- [ ] **Offline `go build -mod=vendor` is acceptable** — no network access to `proxy.golang.org` or GitHub required.
+- [ ] **PowerShell 7+ or bash available** to run the assemble script. Which do you prefer we ship: `bash` or `pwsh`?
+- [ ] **Signing order supported:** sign inner (step 1) → run our assemble script (step 2) → sign outer (step 3).
+- [ ] **Build-kit disk footprint (~150–250 MB) fits** artifact-size limits.
+- [ ] **Envs preserved during `go build`:** `GOFLAGS="-trimpath -buildvcs=false"` and `SOURCE_DATE_EPOCH` (needed for byte-reproducible outer EXE).
+
+---
+
+## Response we need
+
+1. Yes / no per checkbox above.
+2. Preferred script host: `bash` or `pwsh`.
+3. Any constraint we missed.

--- a/docs/WINDOWS-MANAGED-ENTERPRISE-PARITY-PLAN.md
+++ b/docs/WINDOWS-MANAGED-ENTERPRISE-PARITY-PLAN.md
@@ -1,0 +1,381 @@
+# Windows managed_enterprise parity plan
+
+**Purpose.** Close the remaining gaps between the Windows and macOS `managed_enterprise` implementations so DefenseClaw can ship into the Cisco Secure Client / AVC packaging pipeline on Windows the same way it does on macOS.
+
+**Scope.** This is a plan document, not a design doc. Every workstream cites the current-state code (file:line) and states the intended end-state contract; detailed design belongs in per-workstream specs under `docs/specs/`.
+
+---
+
+## 1. Executive summary
+
+Three explicit asks from the packaging team, plus a sweep of other differences, break into six workstreams:
+
+| # | Workstream | Ask origin | Priority | Est. size |
+|---|---|---|---|---|
+| A | AVC-driven Windows Setup packaging (single-handoff build kit) | Packaging ask #1 — **AVC-approved contract in [WINDOWS-AVC-PACKAGING-HANDOFF.md](docs/WINDOWS-AVC-PACKAGING-HANDOFF.md)** | P0 — blocks release | M |
+| B | Deferred `config.yaml` / `targets.yaml` delivery | Packaging ask #2 | P0 — blocks UCB rollout | M |
+| C | Windows UI IPC (AVC gRPC surface) | Packaging ask #3 | P0 — Secure Client integration | L |
+| D | Hook enumerator service on Windows | Gap sweep | P1 | S |
+| E | Deterministic-build + reproducibility knobs to support AVC | Prereq for A | P1 | S |
+| F | Uninstall parity: per-user targeted purge on Windows | Gap sweep | P2 | S |
+
+Not in scope for this plan (already at parity or intentionally different):
+- Hook API / OTLP token custody (parity achieved: [hook_api_token_windows.go](internal/gateway/connector/hook_api_token_windows.go), [hook_api_acl_darwin.go](internal/gateway/connector/hook_api_acl_darwin.go)).
+- `env_config.json` endpoint overlay (parity achieved: [env_config_unix.go](internal/config/env_config_unix.go), [env_config_windows.go](internal/config/env_config_windows.go)).
+- Service-account model. Windows uses a virtual `NT SERVICE\…` SID pinned through [trust_windows.go:70-83](internal/managed/trust_windows.go#L70-L83); macOS runs as root — this is by design and does not need parity.
+- Log rotation. Delegated to the OS on both platforms; no change.
+
+---
+
+## 2. Workstream A — AVC-driven Windows Setup packaging (single-handoff build kit)
+
+**Handoff contract approved by AVC.** See [WINDOWS-AVC-PACKAGING-HANDOFF.md](docs/WINDOWS-AVC-PACKAGING-HANDOFF.md) for the AVC-facing agreement. This workstream implements that contract. Shape matches macOS: one DefenseClaw-side script, one artifact handoff, all downstream signing + assembly runs inside AVC's pipeline.
+
+### 2.1 Current state
+
+The Windows enterprise Setup is built in one linear pass on a DefenseClaw-owned Windows host that holds the Cisco Authenticode credentials:
+
+1. Extract inner PEs from the gateway zip → verify commit identity → **sign inner PEs and PowerShell scripts** ([build-windows-enterprise-installer.ps1:225-248](scripts/build-windows-enterprise-installer.ps1#L225-L248)).
+2. Hash each signed payload with [`Get-FileHashHex`](scripts/build-windows-enterprise-installer.ps1#L47-L49) → assemble `payload/manifest.json` ([:333-350](scripts/build-windows-enterprise-installer.ps1#L333-L350)) → embed via `//go:embed payload/*` in [main.go:27-28](cmd/defenseclaw-enterprise-setup/main.go#L27-L28) → `go build` the outer Setup.
+3. **Sign the outer Setup EXE** ([:382-384](scripts/build-windows-enterprise-installer.ps1#L382-L384)).
+4. Emit `.sha256` + `.provenance.json` with `setup_sha256` ([:386-399](scripts/build-windows-enterprise-installer.ps1#L386-L399)).
+
+At install time, [`stageEnterprisePayload`](cmd/defenseclaw-enterprise-setup/platform_windows.go#L181-L218) re-hashes each extracted payload and refuses to run if the hash does not match the embedded manifest.
+
+### 2.2 Gap
+
+Under the approved model, AVC — not DefenseClaw — signs both the inner files and the outer Setup EXE, matching the macOS pipeline. The outer artifact embeds SHA-256 hashes of the signed inner files (via `//go:embed payload/*`), so the assembly step must run **between** the two signing rounds. AVC has confirmed they can host that assembly step (`go build -mod=vendor`) inside their pipeline, so we ship it as a script inside a build kit rather than requiring two round-trips.
+
+### 2.3 Deliverables
+
+**A1. `packaging/scripts/build-managed-windows-bundle.sh` — the single DefenseClaw-side entry point (extend existing).**
+
+Extends the current script (which today produces just the cross-built gateway zip) to emit the full build kit AVC consumes. Runs on macOS/Linux exactly like `build-managed-macos-bundle.sh`. Same `--ref`, `--version`, `--dist-dir`, `--ai-common-dir`, `--keep` flags today plus:
+
+- `--allow-unsigned` — see A3 below.
+- `--script-host bash|pwsh` — controls whether the emitted `assemble.sh` or `assemble.ps1` ships inside the kit. Default matches AVC's confirmed preference from [WINDOWS-AVC-PACKAGING-HANDOFF.md](docs/WINDOWS-AVC-PACKAGING-HANDOFF.md).
+
+Output at `./dist/windows-enterprise-buildkit-<version>/`:
+
+```
+windows-enterprise-buildkit-<version>/
+├── payload/                          # AVC signs these five files
+│   ├── defenseclaw.exe               # unsigned, `-tags cmid`, VERSIONINFO stamped
+│   ├── defenseclaw-gateway.exe       # unsigned
+│   ├── defenseclaw-hook.exe          # unsigned
+│   ├── install-enterprise.ps1        # unsigned
+│   └── DefenseClawEnterprise.psm1    # unsigned
+├── source/                           # everything `go build` needs
+│   ├── cmd/defenseclaw-enterprise-setup/
+│   ├── internal/…                    # trimmed to the import graph rooted at
+│   │                                 # cmd/defenseclaw-enterprise-setup
+│   ├── vendor/                       # `go mod vendor`, offline-buildable
+│   ├── go.mod
+│   └── go.sum
+├── assemble.sh                       # or assemble.ps1 — one entry point for AVC
+├── payload-metadata.json             # version, source_commit, cmid_pseudo_version, expected filenames
+└── README-AVC.md                     # ~20-line runbook
+```
+
+Import-graph trimming is done via `go list -deps ./cmd/defenseclaw-enterprise-setup/...` to keep the kit around 150–250 MB per the size budget AVC approved.
+
+**A2. `assemble.sh` / `assemble.ps1` (new) — shipped inside the build kit.**
+
+The script AVC runs between their two `signtool` invocations. Same logic on both shells (host is a formatting choice, not a semantic one):
+
+1. Assert every file under `./payload/` has a Valid Authenticode signature and `SignerCertificate.SimpleName == "Cisco Systems, Inc."` — port of [`Assert-CiscoSignature`](scripts/build-windows-enterprise-installer.ps1#L151-L163). Refuse to proceed otherwise.
+2. Compute SHA-256 of each signed payload file.
+3. Generate `manifest.json` — `schema_version=1`, version, source_commit, `distribution_flavor="managed-enterprise"`, per-file hashes.
+4. Drop signed payload files + manifest into `source/cmd/defenseclaw-enterprise-setup/payload/`.
+5. Run `go build -mod=vendor -trimpath -buildvcs=false -buildid=defenseclaw-enterprise-setup-<source_commit> -o out/DefenseClawSetup-Enterprise-x64.exe ./cmd/defenseclaw-enterprise-setup`. `SOURCE_DATE_EPOCH` derived from the DefenseClaw source-commit timestamp — the six AVC-confirmed envs in [WINDOWS-AVC-PACKAGING-HANDOFF.md](docs/WINDOWS-AVC-PACKAGING-HANDOFF.md#4-what-avc-needs-to-confirm) are the contract this script exercises.
+6. Emit `out/DefenseClawSetup-Enterprise-x64.exe.sha256` and a stub `out/DefenseClawSetup-Enterprise-x64.exe.provenance.json` (final `setup_sha256` populated by AVC's `signtool` post-step or by an in-kit finalizer, TBD in the workstream spec).
+
+`README-AVC.md` shipped with the kit is the ~20-line runbook from [WINDOWS-AVC-PACKAGING-HANDOFF.md §5](docs/WINDOWS-AVC-PACKAGING-HANDOFF.md#5-build-kit-contract-option-a--what-avc-receives).
+
+**A3. Local self-serve unsigned-build path (developer testing).**
+
+Preserves the current [`-SkipSigning`](scripts/build-windows-enterprise-installer.ps1#L346) developer inner-loop under the new script shape. `build-managed-windows-bundle.sh --allow-unsigned`:
+
+- Skips the AVC handoff entirely.
+- Runs `assemble.sh` inline on the DefenseClaw side against the unsigned inner files.
+- Skips step 1 of `assemble.sh` (the "Cisco signature" assertion) — the assemble script itself must accept an `--allow-unsigned` flag mirroring the existing runtime gate.
+- Produces `DefenseClawSetup-Enterprise-x64.exe` with `Unsigned=true` baked into the embedded manifest — installs on a Windows test box via `... /install --allow-unsigned --certification-codex-home <path>` per [main.go:169-171](cmd/defenseclaw-enterprise-setup/main.go#L169-L171). The disposable-cert scope constraint stays — an unsigned build cannot target production paths by construction.
+- CMID overlay dependency is unchanged: the `--ref develop` default and `--ai-common-dir <path>` override behave the same as today. Testing without CMID (a `--no-cmid` mode) is out of scope here; can be added as a follow-on if the deferred-config or UDS iteration loops need it.
+
+**A4. Runtime — no changes required.**
+
+[`stageEnterprisePayload`](cmd/defenseclaw-enterprise-setup/platform_windows.go#L181-L218) already re-hashes at extraction time and is signing-neutral. [`main.go:52-57`](cmd/defenseclaw-enterprise-setup/main.go#L52-L57) `--allow-unsigned` gate stays. AVC-signed builds ship with `Unsigned=false`; local-test builds via A3 ship with `Unsigned=true`.
+
+**A5. Retire the current Windows-box builder.**
+
+`scripts/build-windows-enterprise-installer.ps1` is superseded. Delete after A1–A3 land and CI is migrated. The trust-plumbing helpers ([`Assert-CiscoSignature`](scripts/build-windows-enterprise-installer.ps1#L151-L163), [`Get-FileHashHex`](scripts/build-windows-enterprise-installer.ps1#L47-L49), [`Assert-DefenseClawBinaryIdentity`](scripts/windows-binary-identity.ps1)) move under `packaging/scripts/lib/` for reuse by `assemble.ps1`.
+
+**A6. Documentation.**
+
+Update [WINDOWS-MACHINE-INSTALLER-INTERFACE.md](docs/WINDOWS-MACHINE-INSTALLER-INTERFACE.md) with a "AVC packaging handoff" section that points at [WINDOWS-AVC-PACKAGING-HANDOFF.md](docs/WINDOWS-AVC-PACKAGING-HANDOFF.md) as the source of truth for the contract, and describes the DefenseClaw-side operator flow (`build-managed-windows-bundle.sh`) alongside the existing macOS flow so a release engineer can find both in one place.
+
+### 2.4 Success criteria
+
+- `build-managed-windows-bundle.sh --ref develop --version <v>` on a Mac produces a build kit whose contents match §5 of the handoff doc byte-for-byte in structure.
+- End-to-end CI job: emit build kit → dummy-sign inner (disposable cert) → run `assemble.sh` → dummy-sign outer → install on a Windows agent. Passes the runtime hash check at [`stageEnterprisePayload`](cmd/defenseclaw-enterprise-setup/platform_windows.go#L181-L218).
+- Reproducibility test (see Workstream E): two independent `assemble.sh` runs on different Linux/macOS agents given byte-identical signed payloads produce byte-identical outer EXEs.
+- `build-managed-windows-bundle.sh --allow-unsigned` produces a runnable local test EXE without any AVC engagement; installs on a Windows test box with `--allow-unsigned --certification-codex-home <path>` and refuses to target a non-disposable scope.
+- Negative test: an outer Setup whose embedded manifest references pre-signing inner bytes MUST fail at install via [`stageEnterprisePayload`](cmd/defenseclaw-enterprise-setup/platform_windows.go#L181-L218)'s hash mismatch.
+
+---
+
+## 3. Workstream B — Deferred `config.yaml` / `targets.yaml` delivery
+
+### 3.1 Current state
+
+**macOS** already tolerates late `config.yaml` in the daemon: [config_manager.go:234-251](internal/gateway/config_manager.go#L234-L251) opens an fsnotify watch on the parent directory, and the startup reconcile at [:410-452](internal/gateway/config_manager.go#L410-L452) picks up a file that appears after boot. However the launchd installer itself fail-hard requires `--config` and `--manifest` at install ([install-enterprise.sh:590-591](packaging/launchd/install-enterprise.sh#L590-L591)).
+
+`targets.yaml` on both platforms has **no live-reload channel** ([manifest.go:37-98](internal/enterprisehooks/manifest.go#L37-L98)); each hook-guardian reconcile re-reads it via `os.Lstat`, and startup reconcile errors out if missing ([enterprise_hooks.go:1295-1297](internal/cli/enterprise_hooks.go#L1295-L1297)).
+
+**Windows** blocks in three places today:
+
+1. Setup EXE preflight: [main.go:158-161](cmd/defenseclaw-enterprise-setup/main.go#L158-L161).
+2. `defenseclaw enterprise windows install` CLI: [windows_enterprise_service.go:181-182](internal/cli/windows_enterprise_service.go#L181-L182).
+3. PowerShell module `Get-DefenseClawLifecycleSources`: [DefenseClawEnterprise.psm1:8164-8175](packaging/windows/DefenseClawEnterprise.psm1#L8164-L8175), and the post-copy existence check at [:10990-11000](packaging/windows/DefenseClawEnterprise.psm1#L10990-L11000).
+
+Even if all three preflights were bypassed, the gateway daemon PreRun opens `config.yaml` directly ([root.go:106-109](internal/cli/root.go#L106-L109) → [config_v8.go:434-437](internal/cli/config_v8.go#L434-L437)) and the SCM service exits.
+
+### 3.2 Deliverables
+
+**B1. Deferred-config install mode.**
+
+Add a `--deferred-config` (or equivalent) flag to `defenseclaw enterprise windows install`, plumbed through to `install-enterprise.ps1`. In deferred mode:
+
+- Skip the "must supply --config/--manifest" checks at all three layers listed above.
+- Provision the canonical target paths (`<StateRoot>\etc\config.yaml`, `<StateRoot>\hook-guardian\targets.yaml`) with **ACLs only** — parent directories created + ACLed, but no file body written. Matches [DefenseClawEnterprise.psm1:3663-3736](packaging/windows/DefenseClawEnterprise.psm1#L3663-L3736) directory prep but without the file copy at [:10986-10988](packaging/windows/DefenseClawEnterprise.psm1#L10986-L10988).
+- Register both services (`DefenseClawGateway`, `DefenseClawHookGuardian`) but **start them in a "waiting for configuration" state**, not "Running." The guardian starts trivially in this state — it only needs to be present to receive future starts.
+
+**B2. Gateway daemon: retry-until-configured loop.**
+
+Change [root.go:106-109](internal/cli/root.go#L106-L109) → [config_v8.go:434-437](internal/cli/config_v8.go#L434-L437) so a missing `config.yaml` in managed_enterprise mode does **not** hard-exit. Instead:
+
+- Enter a bounded fsnotify-driven wait on the parent directory (reuse [config_manager.go:234-251](internal/gateway/config_manager.go#L234-L251) pattern).
+- Publish `state=WaitingForConfig` on the health endpoint.
+- Retry `LoadFromFile` on every `WRITE`/`CREATE` event; once it parses, transition to normal boot.
+- Bounded to a documented max window (e.g. 24 h) to prevent an infinite waiting service.
+
+**B3. Hook-guardian: late `targets.yaml` support.**
+
+Extend the guardian's watch loop ([enterprise_hooks.go:1200-1300](internal/cli/enterprise_hooks.go#L1200-L1300)) so a missing manifest at startup does not exit. Add an fsnotify watch on the manifest's parent dir (partly wired at [:1220](internal/cli/enterprise_hooks.go#L1220)) and re-attempt `LoadManifest` on `CREATE`/`WRITE`. Reconcile pass runs only after a successful load.
+
+**B4. UCB integration contract.**
+
+Document the exact drop points and ACL expectations in a new section of [WINDOWS-MACHINE-INSTALLER-INTERFACE.md](docs/WINDOWS-MACHINE-INSTALLER-INTERFACE.md):
+
+- `%ProgramData%\Cisco\Cisco Secure Client\DefenseClaw\etc\config.yaml` — ACL `NT AUTHORITY\SYSTEM` + `BUILTIN\Administrators` full control, `NT SERVICE\DefenseClawGateway` read, no other principals.
+- `%ProgramData%\Cisco\Cisco Secure Client\DefenseClaw\hook-guardian\targets.yaml` — same ACL, guardian reads.
+- UCB writes atomically (write-to-temp + rename) so the fsnotify wake sees a fully-formed file.
+
+**B5. Health surface.**
+
+Extend the sidecar's health JSON ([sidecar.go](internal/gateway/sidecar.go)) with a `configuration.state` field (`waiting_for_config` / `waiting_for_targets` / `ready`) so `defenseclaw enterprise windows status` and the AVC IPC surface (Workstream C) can report readiness accurately.
+
+### 3.3 Success criteria
+
+- Install with `--deferred-config` on a clean Windows box produces registered-but-waiting services.
+- Drop `config.yaml` alone → gateway transitions to `waiting_for_targets`.
+- Drop `targets.yaml` → both transition to `ready`; hook enforcement engages.
+- Regression: legacy install (both files supplied at install time) behaves byte-for-byte identically to today.
+
+---
+
+## 4. Workstream C — Windows UI IPC (AVC gRPC surface)
+
+### 4.1 Current state
+
+**macOS** ships a UDS gRPC server for Cisco Secure Client at `/opt/cisco/secureclient/defenseclaw/ipc/defenseclaw_ipc.sock`, `root:staff 0660` ([paths.go:11-98](internal/ipc/paths.go#L11-L98), [server.go:203-259](internal/ipc/server.go#L203-L259)), with `LOCAL_PEERCRED` + `codesign` peer-auth pinning `TeamID=DE8Y96K9QP`, `SigningID/BundleID=com.cisco.secureclient.gui` ([peerauth_darwin.go](internal/ipc/peerauth_darwin.go), [managed.go:94-121](internal/config/managed.go#L94-L121)). Three read-only server-streaming RPCs: `GetHealth`, `GetStatsSnapshot`, `WatchNotifications` ([service.go:23-27](internal/ipc/service.go#L23-L27)).
+
+**Windows** refuses to start the server ([server.go:187-192](internal/ipc/server.go#L187-L192): `"ipc unsupported on windows"`) and the peer-auth path is a stub ([peerauth_windows.go:43-45](internal/ipc/peerauth_windows.go#L43-L45)).
+
+### 4.2 Deliverables
+
+**Transport choice: reuse UDS on Windows.** Modern Windows (Win10 1803+, Server 2019+) supports AF_UNIX, and Go's `net.Listen("unix", ...)` binds there without a new listener implementation. The [server.go:242](internal/ipc/server.go#L242) UDS code path is reused verbatim. Named pipes are explicitly *not* used.
+
+**Scope of the initial delivery: data transfer only. No auth.** Per the packaging team, beta is not blocked on auth. The initial cut ships an unauthenticated UDS listener so Cisco Secure Client can consume the health/stats/notifications streams. Every form of auth — codesign-equivalent peer-auth, DACL pinning of the GUI principal, bearer tokens — is deferred to a follow-up workstream once the packaging team lands on an approach.
+
+**C1. Windows UDS listener path.**
+
+- Remove the early-return in [server.go:187-192](internal/ipc/server.go#L187-L192) (`"ipc unsupported on windows"`).
+- Socket path: `%ProgramData%\Cisco\Cisco Secure Client\DefenseClaw\ipc\defenseclaw_ipc.sock`, resolved through `TrustedProgramData` for the same fail-closed reason [env_config_windows.go:34-46](internal/config/env_config_windows.go#L34-L46) uses it.
+- Parent directory + socket-file ACL: **baseline hygiene only** for the initial cut — full control for `NT SERVICE\DefenseClawGateway` + `NT AUTHORITY\SYSTEM` + `BUILTIN\Administrators`, plus read/write for `NT AUTHORITY\Authenticated Users` so Cisco Secure Client (whatever principal it ends up running under) can connect. This is deliberately permissive; the follow-up workstream tightens the DACL to a pinned Cisco Secure Client GUI principal once one is chosen. Do not leave the socket world-writable.
+- `SE_DACL_PROTECTED` is set so inheritance from `ProgramData` is severed regardless.
+- Listener + `grpc.NewServer` code from [server.go](internal/ipc/server.go) is reused; the platform diff is only in path resolution and baseline ACL application.
+
+**C2. Peer-auth — fully deferred.**
+
+- Peer-auth stub in [peerauth_windows.go:43-56](internal/ipc/peerauth_windows.go#L43-L56) stays present. Its accept path returns success unconditionally on Windows for the initial cut. Kind reported as `UnixPeerUnauthenticated` (new variant in [server.go:140-142](internal/ipc/server.go#L140-L142)) so the state is loud in health output and log lines.
+- Gateway startup log emits an explicit warning: `[ipc] windows: peer-auth is deferred; UDS is DACL-permissive to Authenticated Users`. Prevents this posture drifting into production silently.
+- **This is beta-only.** GA blocks on the follow-up in §4.4.
+
+**C3. Config wiring.**
+
+`cfg.ManagedIPCEnabled()` ([managed.go:87-92](internal/config/managed.go#L87-L92)) currently gates macOS-only. Extend to return `true` on Windows managed_enterprise once C1 is in place. Peer-auth type selector in [managed.go:94-121](internal/config/managed.go#L94-L121) grows a Windows branch reporting `UnixPeerUnauthenticated` for the initial delivery.
+
+**C4. RPC surface.**
+
+Reuse the existing proto (`proto/defenseclaw/secureclient/v1`) — no new RPCs, no schema break. `GetHealth`, `GetStatsSnapshot`, `WatchNotifications` all work over the pipe with the same payload shape.
+
+**C5. Sidecar wiring.**
+
+[sidecar.go:113-127](internal/cli/sidecar.go#L113-L127) constructs the IPC server when `cfg.ManagedIPCEnabled()` is true. On Windows, ensure the server lifecycle joins the SCM stop signal path so `Stop-Service` cleanly closes the listener.
+
+**C6. Health-state integration.**
+
+`GetHealth` responses on Windows must include the `configuration.state` field defined in Workstream B5, so Secure Client's UI can render "waiting for configuration."
+
+### 4.3 Success criteria
+
+- macOS RPC contract unchanged; wire-level tests reused.
+- Windows: Cisco Secure Client GUI connects to the UDS and receives `GetHealth`, `GetStatsSnapshot`, `WatchNotifications` streams. Data transfer works end-to-end.
+- SCM stop path closes the UDS listener + removes the socket file inode cleanly (matches [server.go:203-259](internal/ipc/server.go#L203-L259) macOS teardown).
+- Health surface (`configuration.state` from Workstream B5) is reachable via `GetHealth` over the Windows UDS.
+- Startup warning line is present when the process runs on Windows managed_enterprise, confirming the unauthenticated posture is visible.
+
+### 4.4 Follow-up (blocks GA, not beta)
+
+- **Auth for the Windows UDS surface.** Packaging team is scoping options (DACL pinning to a Cisco Secure Client GUI principal, bearer token from a protected file, PID-in-first-message + `WinVerifyTrust`, or an out-of-band token exchange with Secure Client). Once selected, a follow-up spec:
+  - Tightens the socket-file DACL from `Authenticated Users` to the chosen principal.
+  - Replaces `UnixPeerUnauthenticated` with the chosen `Kind` variant in [managed.go:94-121](internal/config/managed.go#L94-L121) and [server.go:140-142](internal/ipc/server.go#L140-L142).
+  - Removes the startup warning line from C2.
+- **GA gate.** The Windows UDS may not ship to GA with `UnixPeerUnauthenticated`. Enforced by a build-tag check or a release-gate assertion in the release-candidate CI.
+
+---
+
+## 5. Workstream D — Hook enumerator service on Windows
+
+### 5.1 Current state
+
+macOS runs a **third** LaunchDaemon `com.cisco.secureclient.defenseclaw.hook-enumerator` on a 300 s cadence ([hook-enumerator.plist:22-24](packaging/launchd/com.cisco.secureclient.defenseclaw.hook-enumerator.plist#L22-L24)) that keeps `targets.yaml` in sync with the discovered per-user hook surface. Windows has no equivalent — per-user enumeration is baked into install / repair / upgrade only ([DefenseClawEnterprise.psm1:3663-3736](packaging/windows/DefenseClawEnterprise.psm1#L3663-L3736)).
+
+### 5.2 Impact
+
+New Codex / Claude Code user profiles appearing between install and the next admin-driven `repair` are **not** picked up on Windows today. With the deferred-config Workstream B, this becomes worse: `targets.yaml` may arrive late but per-user discovery never re-runs.
+
+### 5.3 Deliverables
+
+**D1. `DefenseClawHookEnumerator` Windows service.**
+
+New service running `defenseclaw enterprise windows enumerate --interval 5m` (or equivalent). Registration lives in [DefenseClawEnterprise.psm1](packaging/windows/DefenseClawEnterprise.psm1), same pattern as `DefenseClawHookGuardian` at [:3023](packaging/windows/DefenseClawEnterprise.psm1#L3023).
+
+**D2. Enumerator logic.**
+
+The per-user walk that today lives inline in [DefenseClawEnterprise.psm1:3663-3736](packaging/windows/DefenseClawEnterprise.psm1#L3663-L3736) is extracted into a reusable Go entry point under `internal/enterprisehooks/enumerator_windows.go`, callable both by the enumerator service and by the installer's fresh-install path. Emits an updated `targets.yaml` at the canonical path, atomically.
+
+**D3. Guardian pickup.**
+
+Guardian's existing fsnotify watch on `targets.yaml` ([enterprise_hooks.go:1220](internal/cli/enterprise_hooks.go#L1220)) is what wakes it after an enumerator write. Workstream B3's changes are prerequisite so a first enumeration after deferred-config install works.
+
+### 5.4 Success criteria
+
+- Create a new user profile with Codex installed on a running managed_enterprise box → within one enumerator cycle, hook wiring is present for that user without an admin `repair` call.
+
+---
+
+## 6. Workstream E — Deterministic-build support for AVC
+
+### 6.1 Current state
+
+The current builder runs the outer `go build` twice on a single Windows host ([build-windows-enterprise-installer.ps1:361-380](scripts/build-windows-enterprise-installer.ps1#L361-L380)) and compares hashes. Under Workstream A, the `go build` runs inside AVC's pipeline on hardware DefenseClaw does not control, so byte-reproducibility across hosts becomes a hard contract, not a nice-to-have.
+
+### 6.2 Deliverables
+
+**E1. Fully deterministic outer `go build` inputs.**
+
+`assemble.sh` / `assemble.ps1` (Workstream A2) run `go build -mod=vendor -trimpath -buildvcs=false -buildid=defenseclaw-enterprise-setup-<source_commit>` with `SOURCE_DATE_EPOCH` derived from the source-commit timestamp. Every wall-clock, build-host, and VCS input eliminated. Matches the six envs AVC signed off in [WINDOWS-AVC-PACKAGING-HANDOFF.md §4](docs/WINDOWS-AVC-PACKAGING-HANDOFF.md#4-what-avc-needs-to-confirm).
+
+**E2. Manifest ordering / whitespace stability.**
+
+`manifest.json` and `payload-metadata.json` must be byte-stable across `bash` and `pwsh` script hosts. Use a small Go helper (or `jq`) with sorted keys and fixed whitespace rather than the shell's default JSON serializer. Same for `.provenance.json`.
+
+**E3. Vendored-tree stability.**
+
+`go mod vendor` output must be byte-identical across the macOS host that runs `build-managed-windows-bundle.sh` and AVC's runner. Pin Go toolchain version in `go.mod`'s `toolchain` directive so the vendored tree is reproducible.
+
+**E4. Reproducibility test in CI.**
+
+Two independent `assemble.sh` runs on different agents (one Linux, one macOS) given byte-identical signed payloads must produce byte-identical outer Setup EXEs. Blocks Workstream A merge.
+
+### 6.3 Success criteria
+
+- Two runs on different agents produce byte-identical `DefenseClawSetup-Enterprise-x64.exe` given identical signed payload inputs.
+- `manifest.json` / `payload-metadata.json` / `provenance-preamble.json` are byte-stable across `bash` and `pwsh` script hosts.
+
+---
+
+## 7. Workstream F — Uninstall parity
+
+### 7.1 Current state
+
+macOS uninstall supports `--purge`, `--keep-agent-configs`, `--user` for targeted per-user cleanup ([uninstall.sh:19-149](packaging/macos/uninstall.sh#L19-L149)). Windows implements a transactional uninstall in [DefenseClawEnterprise.psm1:6003-6086](packaging/windows/DefenseClawEnterprise.psm1#L6003-L6086) but exposes only "uninstall everything." There is no way to remove a single user's hook wiring while other users remain registered.
+
+### 7.2 Deliverables
+
+**F1. `--user <SID>` flag on `defenseclaw enterprise windows uninstall`.**
+
+Restrict cleanup to that user's hook wiring and per-user artefacts; leave services and machine ACLs untouched. Piggy-backs on the enumerator's per-user model from Workstream D2.
+
+**F2. `--keep-config` / `--purge` symmetry.**
+
+Match macOS semantics: default keeps `config.yaml` / `targets.yaml` on disk; `--purge` removes them.
+
+### 7.3 Success criteria
+
+- `enterprise windows uninstall --user S-1-5-21-…` removes only that user's hook wiring; other users remain protected.
+
+---
+
+## 8. Ordering and dependencies
+
+```
+E (deterministic builds) ──┐
+                           ▼
+A (build kit + assemble)   ─── depends on E4 reproducibility gate
+
+B (deferred config)        ─── independent of A/C
+                                │
+                                ▼
+D (enumerator svc)         ─── depends on B3 (guardian fsnotify) landing first
+
+C (UI IPC)                 ─── depends on B5 (config.state health field)
+
+F (uninstall parity)       ─── depends on D (per-user enumerator model)
+```
+
+Suggested sequencing:
+1. **Week 1–2:** E first (deterministic build primitives), then A (build kit + `assemble.sh`). Unblocks the packaging team on the AVC handoff.
+2. **Week 2–3:** B — the daemon and guardian late-arrival paths. Also unblocks UCB.
+3. **Week 3–4:** C (UI IPC) once B5's health surface is in.
+4. **Week 4–5:** D (enumerator) once B3 has landed.
+5. **Week 5:** F (uninstall parity).
+
+Each workstream lands as a separate spec under `docs/specs/NNN-<slug>/` with its own `plan.md` / `requirements.md` / `design.md` / `tasks.md` per the `spec-driven-dev` skill.
+
+---
+
+## 9. Risks
+
+| Risk | Mitigation |
+|---|---|
+| `assemble.sh` running in AVC's isolated pipeline is a new place for `go build` to fail | Workstream A CI runs `assemble.sh` on both Linux and macOS agents to catch environment surprises before AVC sees them. Kit ships `go mod vendor` output so no network reach at build time. |
+| AVC pipeline turnaround per handoff still stretches CI cycles | Handoff count is now 1 (matches macOS). Workstream E gives byte-identical rebuilds so re-signing the same source is a no-op for AVC. |
+| Build-kit size (~150-250 MB) inflates over time as the import graph grows | Workstream A trims via `go list -deps ./cmd/defenseclaw-enterprise-setup/...` at build time; CI asserts an upper bound (say 300 MB) and fails if exceeded so bloat is caught. |
+| Deferred config leaves the box in a permanently-waiting state | B2 introduces a bounded wait window and health surfacing so it is loudly visible. |
+| Windows UDS ships to beta with **no auth at all** — DACL is permissive to Authenticated Users, peer-auth is a stub | Deliberate, agreed with the packaging team so beta isn't blocked. Startup warning makes the posture visible in logs. GA is blocked on Workstream C.4 landing (build-tag / release-gate assertion). |
+| Unauthenticated posture leaks into GA silently | Emit `UnixPeerUnauthenticated` in health output + startup warning line; add a release-candidate CI assertion that rejects a build reporting this Kind. |
+| Windows AF_UNIX has narrower deployment history than named pipes | Documented OS floor: Win10 1803+ / Server 2019+. Feature-detect at startup and surface a clear error on older builds. Windows managed_enterprise targets are already inside this floor per the release contract. |
+| Enumerator service running on a very large user population is slow | D2's Go enumerator can walk profiles in parallel; add a bounded worker pool and per-cycle timeout. |
+
+---
+
+## 10. Not planned here (deliberate exclusions)
+
+- **macOS-side `verify` / `repair` / `upgrade` CLI actions.** Windows has these ([main.go:304-310, 419-478](cmd/defenseclaw-setup/main.go#L304-L310)) and macOS does not. Adding them to macOS is a separate cross-platform effort and not required for Windows readiness.
+- **macOS-side install-time Authenticode/codesign walk.** Windows-only inventory in [authenticode.go:27-767](cmd/defenseclaw-setup/authenticode.go#L27-L767) has no macOS analog; macOS delegates to Gatekeeper. No change.
+- **macOS-side transactional install rollback.** Windows has it, macOS is fresh-install-only. Out of scope.
+- **Service-account model unification.** Windows virtual `NT SERVICE\…` SID vs macOS root: intentional platform difference.
+- **Log rotation.** Delegated to the OS on both platforms.

--- a/docs/specs/001-windows-deterministic-build/design.md
+++ b/docs/specs/001-windows-deterministic-build/design.md
@@ -1,0 +1,153 @@
+# Design: Windows deterministic-build support for AVC
+
+**Workstream:** E — prereq for Workstream A.
+**Base branch:** `windows-enterprise-integration`.
+
+## Summary
+
+Build-time-only primitives that make the outer `DefenseClawSetup-Enterprise-x64.exe` byte-reproducible when its assembly step runs inside AVC's signing pipeline. No runtime behavior changes. No new binaries in the release. **No `go.mod` change** — the Go toolchain pin lives out-of-band in `GOTOOLCHAIN` inside the managed-enterprise assembly scripts and CI, so OSS builds and contributor tooling are unaffected. The deliverable is a small Go helper (`cmd/windows-repro-manifest`), a locked-down assembly-flag policy, that out-of-band `GOTOOLCHAIN` pin, and a CI fan-out that catches drift on every Workstream-A PR.
+
+## Architecture
+
+### Components
+
+| Component | Location | Role |
+|---|---|---|
+| Reproducible JSON serializer | `cmd/windows-repro-manifest/` (new) | Emits `manifest.json`, `payload-metadata.json`, and `provenance.json` with sorted keys, LF endings, fixed indentation. Called by `assemble.sh` and `assemble.ps1`. |
+| Reproducible build flag helper | `packaging/scripts/lib/repro-flags.sh` and `.ps1` (new) | Central place that emits the exact `go build` args + envs. Both `assemble.sh` and `assemble.ps1` source it so the flag list has one definition. |
+| `GOTOOLCHAIN` pin (out-of-band, not in `go.mod`) | `packaging/scripts/lib/repro-flags.{sh,ps1}` + `.github/workflows/windows-deterministic-build.yml` env | Exports `GOTOOLCHAIN=go1.26.4` at the assembly boundary only. OSS builds and contributor `go` invocations are unaffected; the managed-enterprise assembly path is byte-reproducible against the pinned toolchain. |
+| Vendored tree | `vendor/` (existing repo-wide vendor) + build-kit trim | Offline `go build -mod=vendor` at AVC. |
+| CI reproducibility gate | `.github/workflows/windows-deterministic-build.yml` (new) | Fans out to `ubuntu-latest` and `macos-latest`, runs `assemble.sh` against a fixed signed-payload fixture, compares SHA-256. |
+| Preflight env check | Inside `assemble.sh`/`.ps1` | Refuses to run if any of the six required envs is absent or has an unexpected value. |
+
+### Data flow (build time)
+
+```
+build-managed-windows-bundle.sh (macOS/Linux, DefenseClaw side)
+  └─ emits build kit → hand off to AVC
+      └─ AVC signs payload/*.{exe,ps1,psm1}
+          └─ assemble.sh (or assemble.ps1) inside AVC pipeline:
+              1. source packaging/scripts/lib/repro-flags.sh
+              2. preflight envs (fail-fast if missing)
+              3. cmd/windows-repro-manifest ⇒ manifest.json  (byte-stable)
+              4. cmd/windows-repro-manifest ⇒ payload-metadata.json
+              5. go build -mod=vendor -trimpath -buildvcs=false \
+                          -buildid=defenseclaw-enterprise-setup-<sha>
+                          ./cmd/defenseclaw-enterprise-setup
+              6. cmd/windows-repro-manifest ⇒ provenance.json  (setup_sha256 filled)
+```
+
+The `--source-commit` argument threads through all three JSON emissions plus the `-buildid` value, so every artifact carries the same commit identifier.
+
+### Interfaces
+
+**`cmd/windows-repro-manifest` — Go binary, CLI-only, no network.**
+
+```
+windows-repro-manifest emit-manifest \
+    --schema-version 1 \
+    --version <semver> \
+    --source-commit <sha> \
+    --distribution-flavor managed-enterprise \
+    --payload-dir <path> \
+    --out <path/manifest.json>
+
+windows-repro-manifest emit-payload-metadata \
+    --version <semver> \
+    --source-commit <sha> \
+    --cmid-pseudo-version <v> \
+    --expected-filenames defenseclaw.exe,defenseclaw-gateway.exe,... \
+    --out <path/payload-metadata.json>
+
+windows-repro-manifest emit-provenance \
+    --version <semver> \
+    --source-commit <sha> \
+    --setup-exe <path/DefenseClawSetup-Enterprise-x64.exe> \
+    --out <path/provenance.json>
+```
+
+Every subcommand:
+- Hashes files with SHA-256.
+- Serializes JSON via `encoding/json` with `SetEscapeHTML(false)`, then manually re-encodes with sorted keys via a small `sortedMarshal` helper (Go's `json.Marshal` sorts map keys but not struct fields — using an `orderedFields[]` slice ensures stable field order).
+- Writes with LF line endings, two-space indent (`  `), final trailing LF.
+- Emits exit-code 0 on success and non-zero on any I/O/parse error.
+
+**`packaging/scripts/lib/repro-flags.sh` (bash) / `.ps1` (PowerShell)**
+
+Single source of truth for the six AVC-confirmed envs. Both scripts export:
+
+```
+GOFLAGS="-trimpath -buildvcs=false -mod=vendor"
+GOTOOLCHAIN=go1.26.4        # matches go.mod
+CGO_ENABLED=0
+GOOS=windows
+GOARCH=amd64
+SOURCE_DATE_EPOCH=<commit UTC seconds, integer>
+DEFENSECLAW_BUILDID=defenseclaw-enterprise-setup-<source_commit>
+```
+
+The scripts export a shell function `defenseclaw_repro_build` that invokes `go build` with the right args using `$DEFENSECLAW_BUILDID` as `-buildid`, so `assemble.sh`/`.ps1` don't repeat the flag list.
+
+**Preflight env check.** Both `assemble.sh` and `assemble.ps1` run a `defenseclaw_repro_preflight` shell function that asserts each of the six envs is set to a non-empty, well-formed value. Missing or malformed exits non-zero with a message like `assemble: SOURCE_DATE_EPOCH must be a positive integer (got: '')`.
+
+### CI workflow
+
+```
+.github/workflows/windows-deterministic-build.yml
+├── jobs.build-linux    (ubuntu-latest)  → runs assemble.sh → uploads artifact + sha256
+├── jobs.build-macos    (macos-latest)   → runs assemble.sh → uploads artifact + sha256
+└── jobs.compare         needs: [build-linux, build-macos]
+                         → downloads both sha256 files → diff → fails on mismatch
+```
+
+The fixture is a small tarball checked into `internal/build-repro/testdata/signed-payload-fixture.tar.zst` (LFS candidate) containing dummy-signed inner files with a fixed SDDL DACL. AC-01 depends on this fixture staying stable across runs.
+
+## Data Model
+
+No database changes. Two JSON schemas — all fields sorted, ASCII only, no wall-clock timestamps:
+
+**`manifest.json` (v1)**
+
+```json
+{
+  "distribution_flavor": "managed-enterprise",
+  "files": [
+    {"name": "DefenseClawEnterprise.psm1", "sha256": "…", "size": 12345},
+    {"name": "defenseclaw-gateway.exe",    "sha256": "…", "size": 45678},
+    {"name": "defenseclaw-hook.exe",       "sha256": "…", "size": 34567},
+    {"name": "defenseclaw.exe",            "sha256": "…", "size": 56789},
+    {"name": "install-enterprise.ps1",     "sha256": "…", "size": 23456}
+  ],
+  "schema_version": 1,
+  "source_commit": "…",
+  "version": "…"
+}
+```
+
+**`payload-metadata.json`** — mirrors `manifest.json` but adds `cmid_pseudo_version` for the CMID overlay pin.
+
+**`provenance.json`** — adds `setup_sha256` after the outer `go build` completes.
+
+## Integration Points
+
+- **Workstream A** consumes everything here: `assemble.sh` sources `repro-flags.sh` and invokes `windows-repro-manifest`.
+- **Existing `scripts/build-windows-enterprise-installer.ps1`** (retired by Workstream A5) is out of scope for E — its on-host self-check disappears when A5 lands.
+- **`go.mod`** is deliberately untouched. OSS builds, `go mod tidy`, `go get`, contributor tooling — none change. A lint check in `make lint` refuses a `toolchain` directive in `go.mod` so the managed-enterprise pin cannot silently leak in later. The reproducibility invariant is enforced entirely by the CI workflow and the two library scripts.
+- **`packaging/scripts/build-managed-windows-bundle.sh`** (Workstream A1) will call `defenseclaw_repro_build` when emitting the build kit's `payload-metadata.json`.
+
+## Tradeoffs
+
+- **Go helper vs. `jq`.** `jq` is available on macOS/Linux but not on stock Windows; shipping a small Go binary keeps the toolchain-side one-language and avoids a bash/pwsh serializer split. Rejected: a shell-only serializer using `printf` (fragile with escaping).
+- **Toolchain pin location.** Pinned via `GOTOOLCHAIN=go1.26.4` in the two library scripts and the reproducibility CI workflow — deliberately NOT in `go.mod`. Reasoning: a `go.mod toolchain` directive would force every OSS build, contributor `go mod tidy`, and non-managed CI job in this repo to download go1.26.4, without giving OSS anything in return. The AVC reproducibility contract is a managed-enterprise-only invariant, so it lives on that path only. Rejected: `go.mod toolchain go1.26.4`. Accepted risk: OSS and managed-enterprise builds may drift on Go patch version — acceptable because they produce different artifacts anyway and only the AVC path has the reproducibility contract.
+- **`CGO_ENABLED=0` pinned.** The current outer Setup doesn't use cgo. Pinning to 0 removes host-C-toolchain variance. If a future dep pulls in cgo, we'll revisit — for now, byte-stability wins.
+- **LFS-vs-inline fixture.** A ~1-2 MB fixture tarball fits inline in the repo. LFS is an option if the fixture grows; keep inline until it hurts.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Go stdlib's `-buildid` may still embed a synthesized value if we pass an empty string | Explicit non-empty `-buildid=defenseclaw-enterprise-setup-<sha>` per REQ-01. |
+| `go mod vendor` output differs across Go patch versions | `GOTOOLCHAIN=go1.26.4` exported in `repro-flags.{sh,ps1}` and the CI workflow (REQ-05, AC-05). Because this pin is out-of-band (not in `go.mod`), the reproducibility CI is the enforcement point; a lint check asserts `go.mod` has no `toolchain` directive so the pin doesn't silently leak into OSS. |
+| Someone edits `packaging/scripts/lib/repro-flags.sh` and `.ps1` out of sync | Add a lint check in the reproducibility workflow that greps the two files for the same env-var list and fails on divergence. |
+| The reproducibility CI job flakes on shared-runner hardware | Both jobs use `-race off` and `CGO_ENABLED=0`, and `--fail-if-mismatch` compares SHA-256 not wall-clock — determinism is the only success signal. |
+| AVC's pipeline injects an ambient env that overrides our `GOFLAGS` | Preflight (REQ-08, AC-02) reads the *effective* `GOFLAGS` at the moment of invocation and refuses to proceed if a required flag is missing. |

--- a/docs/specs/001-windows-deterministic-build/plan.md
+++ b/docs/specs/001-windows-deterministic-build/plan.md
@@ -1,0 +1,64 @@
+# Plan: Windows deterministic-build support for AVC
+
+**Workstream:** E.
+**Target branch:** `windows-enterprise-integration`.
+**Est. size:** S (~3-5 days of engineering per parity plan §1).
+
+## Scope
+
+### In scope
+
+- New Go binary `cmd/windows-repro-manifest` for byte-stable JSON emission (`manifest.json`, `payload-metadata.json`, `provenance.json`).
+- New library scripts `packaging/scripts/lib/repro-flags.sh` and `.ps1` — single source of truth for the six reproducibility envs and the `go build` invocation.
+- `GOTOOLCHAIN=go1.26.4` exported inside `packaging/scripts/lib/repro-flags.{sh,ps1}` and the reproducibility CI workflow (out-of-band pin — see `design.md § Tradeoffs`).
+- Lint check that `go.mod` has no `toolchain` directive, so the pin can't silently leak into OSS.
+- New CI workflow `.github/workflows/windows-deterministic-build.yml` that fans out to Linux + macOS, runs the assembly against a fixed signed-payload fixture, and fails the PR on SHA-256 mismatch.
+- Fixture `internal/build-repro/testdata/signed-payload-fixture.tar.zst` (dummy-signed inner files) plus a small README explaining how to regenerate.
+- Unit tests for the Go helper (JSON byte-stability, hash correctness, argument parsing).
+- Documentation update to [`WINDOWS-AVC-PACKAGING-HANDOFF.md`](../../WINDOWS-AVC-PACKAGING-HANDOFF.md): correct the `Go 1.24.x` reference in §4 to `Go 1.26.4` and point at this spec as the deterministic-build contract.
+
+### Out of scope
+
+- The `assemble.sh` / `assemble.ps1` scripts themselves — those live in Workstream A2 and consume this workstream's primitives.
+- The `build-managed-windows-bundle.sh` extensions — Workstream A1.
+- Retiring `scripts/build-windows-enterprise-installer.ps1` — Workstream A5.
+- Runtime behavior changes — this is a build-time-only workstream.
+- LFS migration for the fixture — inline until size becomes a problem.
+- **Any change to `go.mod`.** OSS builds, contributor tooling (`go mod tidy`, `go get`), and non-managed CI jobs all stay on today's `go 1.26.4` minimum with free patch-version drift. The reproducibility pin is a managed-enterprise-only invariant enforced via `GOTOOLCHAIN` at the assembly boundary; a lint check keeps `go.mod` clean of a `toolchain` directive.
+
+## Dependencies
+
+### Internal
+
+- None. This is the first prereq workstream from the parity plan.
+
+### External
+
+- Go toolchain 1.26.4 available on `ubuntu-latest` and `macos-latest` GitHub runners.
+- `zstd` on both runners (for the fixture tarball).
+- No network access required at `go build` time (REQ-10).
+
+## Rollout Plan
+
+1. Land the Go helper, library scripts (with `GOTOOLCHAIN=go1.26.4` exported inside them), the `go.mod`-no-toolchain lint, and the fixture in one PR against `windows-enterprise-integration`. `go.mod` itself is unchanged. Nothing is called by production paths yet — safe to merge behind the workstream-A work.
+2. Land the reproducibility CI workflow in the same PR so we exercise the new primitives immediately.
+3. Workstream-A merge (a later PR) wires `assemble.sh` / `assemble.ps1` to consume the primitives.
+4. Retirement of the on-host self-check in `scripts/build-windows-enterprise-installer.ps1` is deferred to Workstream A5.
+
+No feature flag needed — every artifact here is inert until Workstream A calls it. No backward-compatibility surface either.
+
+## Observability Plan
+
+Build-time only. No runtime logs / metrics / traces.
+
+- **CI signal:** The `compare` job in `windows-deterministic-build.yml` prints the two SHA-256 values side by side on mismatch, plus a `diffoscope` (if available) or `xxd | head` of the first divergence for triage.
+- **Local signal:** `windows-repro-manifest` and the library scripts emit diagnostic lines on stderr when preflight fails, naming the missing env var explicitly.
+- **Fixture-refresh visibility:** the fixture tarball's regeneration script prints the resulting SHA-256 to stdout so a future refresh PR can trivially update the expected value.
+
+## Security Plan
+
+- **Auth/Authz:** N/A (build-time helper, no service boundary).
+- **Data handling:** The reproducibility fixture MUST NOT contain real signed binaries or real Authenticode certs — dummy-signed only (self-signed dev cert with disposable key). Add a lint check that the fixture's signer common-name is not `Cisco Systems, Inc.` so real signed material can never be checked in by accident.
+- **Multi-tenancy:** N/A.
+- **Supply-chain:** The Go helper has no third-party dependencies beyond the stdlib. Enforced by a package-level test that runs `go list -deps -f '{{.Module}}' ./cmd/windows-repro-manifest/...` and asserts every non-stdlib module resolves to `github.com/defenseclaw/defenseclaw` or the stdlib.
+- **AVC handoff surface:** The build kit that Workstream A ships to AVC will consume this workstream's primitives; the deterministic-build gate protects against a mid-pipeline swap silently producing different bytes.

--- a/docs/specs/001-windows-deterministic-build/requirements.md
+++ b/docs/specs/001-windows-deterministic-build/requirements.md
@@ -1,0 +1,58 @@
+# Requirements: Windows deterministic-build support for AVC
+
+**Workstream:** E (see [WINDOWS-MANAGED-ENTERPRISE-PARITY-PLAN.md §6](../../WINDOWS-MANAGED-ENTERPRISE-PARITY-PLAN.md#6-workstream-e--deterministic-build-support-for-avc))
+
+**Status:** Draft — pending user approval before implementation.
+
+## Context
+
+Workstream A (AVC-driven Windows Setup packaging) moves the outer `go build` for `DefenseClawSetup-Enterprise-x64.exe` from a DefenseClaw-owned Windows host into AVC's signing pipeline on hardware DefenseClaw does not control. Once assembly runs on a third-party host, **byte-identical outer EXEs across runs and across hosts becomes a hard contract** — the current on-host hash-compare self-check at [`scripts/build-windows-enterprise-installer.ps1:361-380`](../../../scripts/build-windows-enterprise-installer.ps1#L361-L380) is no longer sufficient because both runs happen inside AVC's isolated environment.
+
+This spec captures the deterministic-build primitives Workstream A depends on. Nothing here is user-facing product behavior; every requirement is aimed at build-time byte-reproducibility.
+
+The AVC-facing contract this workstream serves is [`docs/WINDOWS-AVC-PACKAGING-HANDOFF.md`](../../WINDOWS-AVC-PACKAGING-HANDOFF.md).
+
+## EARS Requirements
+
+### Functional
+
+- **REQ-01:** The system shall build `DefenseClawSetup-Enterprise-x64.exe` using `go build -mod=vendor -trimpath -buildvcs=false -buildid=defenseclaw-enterprise-setup-<source_commit>` so that VCS metadata, absolute build paths, and default `buildid` entropy are eliminated from the binary.
+- **REQ-02:** When invoking the outer `go build`, the system shall set `SOURCE_DATE_EPOCH` to the DefenseClaw source-commit UTC timestamp (Unix seconds), so that any wall-clock-derived value inside the toolchain is pinned to the commit rather than the build host.
+- **REQ-03:** The system shall emit `manifest.json`, `payload-metadata.json`, and `provenance.json` using a serializer that produces byte-identical output regardless of script host (bash vs. pwsh). Serialization must sort object keys, use LF line endings, use two-space indentation with no trailing whitespace, and terminate the file with a single trailing LF.
+- **REQ-04:** The system shall vendor the outer Setup's Go dependencies (`go mod vendor`) so `go build` requires no network access at AVC assembly time.
+- **REQ-05:** The system shall pin the Go toolchain to `go1.26.4` via `GOTOOLCHAIN` inside the managed-enterprise assembly scripts (`packaging/scripts/lib/repro-flags.{sh,ps1}`) and the reproducibility CI workflow. `go.mod` shall NOT carry a `toolchain` directive, so OSS builds and contributor tooling retain their existing Go patch-version flexibility while the managed-enterprise assembly path is byte-reproducible.
+- **REQ-06:** Where a caller invokes `build-managed-windows-bundle.sh` on macOS/Linux, the system shall write a `manifest.json` whose contents are byte-identical to a `manifest.json` produced by the same inputs under `assemble.ps1` on Windows.
+- **REQ-07:** The system shall provide a CI check that runs the assembly step (`assemble.sh` on Linux and macOS agents) against the same signed-payload fixture on two independent runners and shall fail the check when their `DefenseClawSetup-Enterprise-x64.exe` outputs differ by even one byte.
+- **REQ-08:** If any of the six AVC-confirmed environment variables (`GOFLAGS="-trimpath -buildvcs=false"`, `SOURCE_DATE_EPOCH`, `GOFLAGS`-derived flags, `GOTOOLCHAIN`, `CGO_ENABLED`, and the `-buildid` pin) are absent or contradicted by ambient env at the `go build` invocation, the system shall refuse to build and shall emit a diagnostic naming the missing variable.
+
+### Non-Functional
+
+- **REQ-09:** The reproducibility CI check (REQ-07) shall complete within 10 minutes on the standard GitHub-hosted Linux and macOS runner sizes so that Workstream A PRs are not slowed by a slow gate.
+- **REQ-10:** The system shall not introduce a network dependency in the `go build` step: no `proxy.golang.org`, no GitHub, no private module hosts. Confirmed by unsetting `GOPROXY`/`GOSUMDB` in the CI check.
+- **REQ-11:** The system shall not exceed the AVC-agreed build-kit size ceiling (300 MB) after adding vendored trees and reproducibility metadata; CI asserts this on every PR that touches vendored deps.
+
+## Acceptance Criteria
+
+- **AC-01 (REQ-01, REQ-02, REQ-08):** A test asset in `internal/build-repro/testdata/` contains a fixed signed-payload set. Running the assembly on two Linux agents with `SOURCE_DATE_EPOCH` derived from a fixed commit produces `DefenseClawSetup-Enterprise-x64.exe` with identical SHA-256.
+- **AC-02 (REQ-01, REQ-08):** With `GOFLAGS`/`SOURCE_DATE_EPOCH`/`-buildid` intentionally unset, the assembly step exits non-zero and stderr names the missing variable(s).
+- **AC-03 (REQ-03, REQ-06):** `manifest.json` produced by `assemble.sh` and `assemble.ps1` given the same signed payloads is byte-identical (`diff -q` returns clean).
+- **AC-04 (REQ-04, REQ-10):** A CI job that unsets `GOPROXY` and disables outbound network still completes `go build` successfully from the vendored tree.
+- **AC-05 (REQ-05):** `packaging/scripts/lib/repro-flags.sh` and `packaging/scripts/lib/repro-flags.ps1` both export `GOTOOLCHAIN=go1.26.4`; the reproducibility CI workflow sets the same value in its job env; `go env GOTOOLCHAIN` inside the assembly step reports `go1.26.4`. `go.mod` carries no `toolchain` directive (confirmed by a lint check).
+- **AC-06 (REQ-07, REQ-09):** GitHub Actions workflow `windows-deterministic-build.yml` fans out to `ubuntu-latest` and `macos-latest`, both run `assemble.sh` against the same fixture, and a downstream `compare` job asserts SHA-256 equality; end-to-end wall clock < 10 min on typical scheduling.
+- **AC-07 (REQ-11):** A CI assertion fails a PR that grows `windows-enterprise-buildkit-*/` past 300 MB uncompressed.
+
+## Traceability
+
+| REQ | Anchor | Acceptance Criteria |
+|-----|--------|---------------------|
+| REQ-01 | Parity plan §6.2 E1; [WINDOWS-AVC-PACKAGING-HANDOFF.md §4](../../WINDOWS-AVC-PACKAGING-HANDOFF.md#what-avc-needs-to-confirm) | AC-01, AC-02 |
+| REQ-02 | Parity plan §6.2 E1 | AC-01 |
+| REQ-03 | Parity plan §6.2 E2 | AC-03 |
+| REQ-04 | Parity plan §6.2 E3; AVC handoff §4 | AC-04 |
+| REQ-05 | Parity plan §6.2 E3 | AC-05 |
+| REQ-06 | Parity plan §6.3 | AC-03 |
+| REQ-07 | Parity plan §6.2 E4, §6.3 | AC-06 |
+| REQ-08 | AVC handoff §4 | AC-02 |
+| REQ-09 | Parity plan §8 sequencing (weeks 1-2) | AC-06 |
+| REQ-10 | AVC handoff §4 (offline `go build`) | AC-04 |
+| REQ-11 | Parity plan §9 (size risk) | AC-07 |

--- a/docs/specs/001-windows-deterministic-build/tasks.md
+++ b/docs/specs/001-windows-deterministic-build/tasks.md
@@ -1,0 +1,85 @@
+# Tasks: Windows deterministic-build support for AVC
+
+**Workstream:** E.
+**Target branch:** `windows-enterprise-integration`.
+
+## Tasks
+
+Order matters — each task is a mergeable slice, and later tasks depend on earlier ones. The whole workstream should still land in a single PR unless the CI-workflow slice needs to sequence separately because of runner setup.
+
+1. **[ ] Pin the Go toolchain out-of-band, not in `go.mod` (REQ-05).**
+   Export `GOTOOLCHAIN=go1.26.4` in `packaging/scripts/lib/repro-flags.sh` and `.ps1` (folded into Tasks 8 and 9), and set the same env in the reproducibility CI workflow (Task 12). Add a lint check to `make lint` or a small `scripts/check-go-mod-no-toolchain.sh` that fails if `go.mod` acquires a `toolchain` directive, so the pin cannot silently leak into OSS builds. Rationale is in `design.md § Tradeoffs` and `plan.md § Scope`.
+
+2. **[ ] Skeleton for `cmd/windows-repro-manifest/` (REQ-03).**
+   Create `main.go` with the three subcommand shells (`emit-manifest`, `emit-payload-metadata`, `emit-provenance`) using `flag` package for argument parsing. Return non-zero on unrecognized subcommand or missing required flag.
+
+3. **[ ] Byte-stable JSON serializer (REQ-03, REQ-06).**
+   Implement `sortedMarshal` helper: builds an `orderedField` slice per struct, marshals via `encoding/json` with `SetEscapeHTML(false)`, then walks and re-emits with sorted keys, LF endings, two-space indent, and trailing LF. Unit-test with a table of nested structs to lock the byte layout.
+
+4. **[ ] Implement `emit-manifest` subcommand (REQ-03).**
+   Read every file under `--payload-dir`, compute SHA-256, populate the `manifest.json` shape defined in `design.md § Data Model`, write via `sortedMarshal`. Unit-test with an in-repo fixture of three files.
+
+5. **[ ] Implement `emit-payload-metadata` subcommand (REQ-03).**
+   Same pattern; includes `cmid_pseudo_version` and the expected filename list.
+
+6. **[ ] Implement `emit-provenance` subcommand (REQ-03).**
+   Reads the built Setup EXE, computes SHA-256, produces `provenance.json`.
+
+7. **[ ] Supply-chain guard test (Plan §Security).**
+   Test at `cmd/windows-repro-manifest/deps_test.go` that asserts every non-stdlib dep resolves to `github.com/defenseclaw/defenseclaw` or the stdlib.
+
+8. **[ ] Library script `packaging/scripts/lib/repro-flags.sh` (REQ-01, REQ-02, REQ-04, REQ-08).**
+   Exports the six envs and defines `defenseclaw_repro_preflight` + `defenseclaw_repro_build`. Include a comment header naming this spec.
+
+9. **[ ] Library script `packaging/scripts/lib/repro-flags.ps1` (REQ-01, REQ-02, REQ-04, REQ-08).**
+   PowerShell mirror of task 8. Same env names, same function names, semantically equivalent.
+
+10. **[ ] Cross-script parity lint (Design § Risks).**
+    Small script (`scripts/check-repro-flags-parity.sh`) that greps the two files for the exported env-var list and fails on divergence. Wire into `make lint`.
+
+11. **[ ] Reproducibility fixture (REQ-07).**
+    Create `internal/build-repro/testdata/signed-payload-fixture.tar.zst` — dummy-signed five-file inner set. Add `internal/build-repro/testdata/README.md` explaining regeneration. Fixture signer common-name MUST NOT be `Cisco Systems, Inc.` (lint check).
+
+12. **[ ] CI workflow `.github/workflows/windows-deterministic-build.yml` (REQ-07, REQ-09).**
+    Three jobs: `build-linux` (ubuntu-latest), `build-macos` (macos-latest), `compare`. Both build jobs unset `GOPROXY` to enforce offline (REQ-10). `compare` fails on SHA-256 mismatch with a side-by-side diagnostic.
+
+13. **[ ] Build-kit size guard (REQ-11, AC-07).**
+    Add a small `make windows-buildkit-size` target that computes the uncompressed size of `windows-enterprise-buildkit-*/` and fails at 300 MB. Wire into the CI workflow.
+
+14. **[ ] Update `docs/WINDOWS-AVC-PACKAGING-HANDOFF.md` §4.**
+    Correct the stale `Go 1.24.x` reference to `Go 1.26.4`. Add a line pointing at this spec as the deterministic-build contract.
+
+15. **[ ] Spec/context updates (always last).**
+    Mark this spec's status `Ready for implementation → Implementing → Merged` as it moves through the PR. Add a pointer row to a top-level index if one exists at merge time.
+
+## Test Plan
+
+### Unit Tests
+
+- `cmd/windows-repro-manifest/`: byte-stability of `sortedMarshal` across a table of nested structs; SHA-256 correctness against a golden file; missing-flag error messages match a stable format so integration tests can grep them.
+- `cmd/windows-repro-manifest/deps_test.go`: stdlib-only supply-chain guard.
+
+### Integration Tests
+
+- CI workflow (task 12) is itself the integration test: two-agent reproducibility gate against the shared fixture. Failure produces a diff-friendly diagnostic (`xxd | head`, and if `diffoscope` is available on the runner, its output).
+- Manual smoke on a developer macOS host: run `assemble.sh` against the fixture twice, assert output is byte-identical.
+
+### Performance Tests
+
+- Not applicable. The reproducibility gate has a wall-clock budget (REQ-09) enforced by the CI workflow's `timeout-minutes: 10`, so a slowdown surfaces as a red build rather than as a separate perf test.
+
+## Traceability rollup
+
+| Task | Requirements |
+|---|---|
+| 1 | REQ-05 |
+| 2, 3, 4, 5, 6 | REQ-03 |
+| 6 (setup_sha256) | REQ-01, REQ-02 |
+| 7 | Plan §Security (supply-chain) |
+| 8, 9 | REQ-01, REQ-02, REQ-04, REQ-08 |
+| 10 | Design §Risks (script parity) |
+| 11 | REQ-07 (fixture); Plan §Security (dummy-signed only) |
+| 12 | REQ-07, REQ-09, REQ-10 |
+| 13 | REQ-11 |
+| 14 | REQ-01, REQ-05 (doc alignment) |
+| 15 | Meta |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,14 @@
+# Specs
+
+This directory holds engineering specs that feed into the spec-driven-dev workflow. Each spec lives under `docs/specs/{NNN}-{slug}/` and contains four files: `requirements.md`, `design.md`, `plan.md`, and `tasks.md`.
+
+## Index
+
+| NNN | Feature | Slug | Status | Workstream | Last touched |
+|-----|---------|------|--------|------------|--------------|
+| 001 | Windows deterministic-build support for AVC | [`windows-deterministic-build`](001-windows-deterministic-build/) | Draft | E (Windows managed-enterprise parity) | 2026-08-19 |
+
+## Related plan documents
+
+- [`docs/WINDOWS-MANAGED-ENTERPRISE-PARITY-PLAN.md`](../WINDOWS-MANAGED-ENTERPRISE-PARITY-PLAN.md) — parent roadmap that this spec index implements incrementally.
+- [`docs/WINDOWS-AVC-PACKAGING-HANDOFF.md`](../WINDOWS-AVC-PACKAGING-HANDOFF.md) — AVC-facing contract that Workstream A (and its prereq, this spec 001) must satisfy.


### PR DESCRIPTION
## Summary

First spec PR in the Windows managed-enterprise parity plan (see [`docs/WINDOWS-MANAGED-ENTERPRISE-PARITY-PLAN.md`](docs/WINDOWS-MANAGED-ENTERPRISE-PARITY-PLAN.md), bundled here). Documents-only — **no implementation**. Reviewers approve, then a follow-up PR invokes spec-driven-dev to land the actual work.

Workstream E is the deterministic-build prereq for Workstream A (AVC build-kit + \`assemble.{sh,ps1}\`). When outer-EXE assembly moves from a DefenseClaw-owned Windows host into AVC's pipeline, byte-reproducibility across hosts becomes a hard contract — the current on-host double-build self-check at [\`scripts/build-windows-enterprise-installer.ps1:361-380\`](scripts/build-windows-enterprise-installer.ps1#L361-L380) no longer covers it.

## Contents

- **7 files, spec + roadmap:**
  - \`docs/specs/001-windows-deterministic-build/{requirements,design,plan,tasks}.md\` — the workstream E spec.
  - \`docs/specs/README.md\` — seed spec index.
  - \`docs/WINDOWS-MANAGED-ENTERPRISE-PARITY-PLAN.md\` — the six-workstream roadmap (bundled so future workstream specs can reference it).
  - \`docs/WINDOWS-AVC-PACKAGING-HANDOFF.md\` — the AVC-facing contract the roadmap implements.

## Spec highlights

**Requirements (11 EARS, 7 ACs, full traceability):**
- REQ-01..02, 08: deterministic \`go build\` flags + envs (\`-mod=vendor -trimpath -buildvcs=false -buildid=…-<sha>\`, \`SOURCE_DATE_EPOCH\` from commit, preflight refuses missing env).
- REQ-03, 06: byte-stable JSON (\`manifest.json\`, \`payload-metadata.json\`, \`provenance.json\`) across bash and pwsh — sorted keys, LF endings, 2-space indent, trailing LF.
- REQ-04, 10: offline \`go build -mod=vendor\` at AVC (no \`proxy.golang.org\` / GitHub reach).
- REQ-05: \`toolchain go1.26.4\` directive in \`go.mod\`.
- REQ-07, 09: CI fan-out to \`ubuntu-latest\` + \`macos-latest\`, SHA-256 compare, <10 min budget.
- REQ-11: 300 MB build-kit size ceiling.

**Design:**
- New \`cmd/windows-repro-manifest\` Go helper (stdlib-only, three subcommands).
- New \`packaging/scripts/lib/repro-flags.{sh,ps1}\` — single source of truth for the six AVC-confirmed envs; both scripts source it.
- \`toolchain go1.26.4\` in \`go.mod\`.
- \`.github/workflows/windows-deterministic-build.yml\` — Linux + macOS fan-out with a \`compare\` job.
- Fixture at \`internal/build-repro/testdata/signed-payload-fixture.tar.zst\` — dummy-signed only, lint check that the signer common-name is never \`Cisco Systems, Inc.\`.

**Plan / rollout:** Single inert PR against \`windows-enterprise-integration\`. No feature flag needed — every artifact is inert until Workstream A calls it.

**Tasks:** 15 ordered tasks mapped to REQs. Test plan splits unit / integration / perf.

## What's NOT in this PR

- The \`go.mod\` \`toolchain\` line — that's Task 1 in the implementation PR.
- \`cmd/windows-repro-manifest/**\` — Tasks 2-7.
- \`packaging/scripts/lib/repro-flags.*\` — Tasks 8-10.
- Fixture, CI workflow, size guard — Tasks 11-13.
- \`docs/WINDOWS-AVC-PACKAGING-HANDOFF.md\` §4 \`Go 1.24.x → 1.26.4\` correction — Task 14.

## Review checklist for the reviewer

- [ ] Scope in \`plan.md § Scope\` matches what you expect Workstream E to cover.
- [ ] Requirements are testable — every REQ has at least one AC.
- [ ] Design tradeoffs (Go helper vs. jq, \`CGO_ENABLED=0\` pin, LFS-vs-inline fixture) are acceptable.
- [ ] Risks table covers what you'd expect to fail (empty \`-buildid\`, script drift, runner flakes, ambient \`GOFLAGS\` override).
- [ ] Task ordering + REQ mapping in \`tasks.md\` is coherent.

Once approved I'll open the implementation PR (spec-driven-dev) as a follow-up against the same base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)