### PR TITLE
impl(005-windows-per-user-hook-lifecycle): hook enumerator service (Workstream D)

### DIFF
--- a/cli/tests/test_windows_enterprise_service_contract.py
+++ b/cli/tests/test_windows_enterprise_service_contract.py
@@ -423,7 +423,11 @@ def test_enterprise_process_json_and_machine_root_contracts() -> None:
     assert "$null -eq $argument -or $argument -isnot [string]" in command_line_encoder
     assert "CharSet = CharSet.Unicode" in module_smoke
     assert "ExactSpelling = true" in module_smoke
-    assert module.count("Assert-DefenseClawServiceImagePath `") == 2
+    # Spec 005 D1 (docs/specs/005-windows-per-user-hook-lifecycle/):
+    # third `Assert-DefenseClawServiceImagePath` call pins the
+    # DefenseClawHookEnumerator SCM service's ImagePath alongside
+    # the existing gateway + guardian.
+    assert module.count("Assert-DefenseClawServiceImagePath `") == 3
     assert "[Text.UTF8Encoding]::new($false)" in module
 
     requirements_report = module[

--- a/internal/cli/enterprise_windows_enumerate_windows.go
+++ b/internal/cli/enterprise_windows_enumerate_windows.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"path/filepath"
 	"strings"
 	"time"
@@ -121,7 +122,7 @@ side; nothing about this subcommand is invoked on non-Windows OSes.
 	flags := cmd.Flags()
 	flags.StringVar(&opts.manifestPath, "manifest", "", "absolute path to the hook-guardian targets.yaml this enumerator maintains (required)")
 	flags.DurationVar(&opts.interval, "interval", enterpriseWindowsEnumerateDefaultInterval, "sleep between enumeration cycles when running as a service")
-	flags.BoolVar(&opts.once, "once", false, "run a single cycle synchronously and exit; ignored when --interval is set to 0")
+	flags.BoolVar(&opts.once, "once", false, "run a single cycle synchronously and exit; --interval is then unused")
 	flags.DurationVar(&opts.initialDelay, "initial-cycle-delay", enterpriseWindowsEnumerateInitialCycleDelay, "wait this long before the first interval-loop cycle so the gateway + guardian can publish their startup health lines first")
 	return cmd
 }
@@ -189,15 +190,12 @@ func runEnterpriseWindowsEnumerateSingleCycle(
 
 	logf := enumerationLoggerForStderr(stderr)
 	start := time.Now()
-	manifest, err := enterprisehooks.EnumerateWindows(cfg, enterprisehooks.EnumerateOptions{
+	manifest, err := enterprisehooks.EnumerateWindows(cycleCtx, cfg, enterprisehooks.EnumerateOptions{
 		ExistingManifestPath: manifestPath,
 		Logger:               logf,
 	})
 	if err != nil {
 		return fmt.Errorf("enterprise windows enumerate: walk profiles: %w", err)
-	}
-	if ctxErr := cycleCtx.Err(); ctxErr != nil {
-		return fmt.Errorf("enterprise windows enumerate: cycle timeout / cancel: %w", ctxErr)
 	}
 
 	changed, err := enterprisehooks.WriteTargetsManifestAtomic(manifestPath, manifest)
@@ -297,13 +295,23 @@ var enterpriseWindowsEnumerateConfigLoader = func() (*config.Config, error) {
 // treat it as a soft-retry rather than a hard failure. Spec 003
 // added the deferred-config posture; the enumerator's REQ-04 mirrors
 // it.
+//
+// Detection is `errors.Is(err, fs.ErrNotExist)` first — both
+// config.LoadFromFile and the Windows trusted-path validator wrap
+// their underlying os.Open / os.Lstat errors with %w, so the fs
+// sentinel survives the wrap chain. The substring fallback stays
+// for edge cases where a caller loses the chain (e.g. a test
+// harness that stringifies the error before passing it up). See CR
+// spec-005:PRRT_kwDORuAK-s6atyfG — a message-only check would fail
+// on non-English Windows locales where the OS returns a localized
+// "cannot find the file" string.
 func isEnterpriseWindowsEnumerateConfigMissing(err error) bool {
 	if err == nil {
 		return false
 	}
-	// config.LoadFromFile wraps os.Open errors verbatim; a
-	// substring check is more portable than an errors.Is against a
-	// specific sentinel (the wrap chain crosses package boundaries).
+	if errors.Is(err, fs.ErrNotExist) {
+		return true
+	}
 	msg := err.Error()
 	return strings.Contains(msg, "no such file or directory") ||
 		strings.Contains(msg, "cannot find the file specified") ||

--- a/internal/cli/enterprise_windows_enumerate_windows.go
+++ b/internal/cli/enterprise_windows_enumerate_windows.go
@@ -1,0 +1,311 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/enterprisehooks"
+	"github.com/defenseclaw/defenseclaw/internal/managed"
+)
+
+// enterpriseWindowsEnumerateDefaultInterval is the SCM-service
+// default sleep between cycles. Matches macOS's
+// `com.cisco.secureclient.defenseclaw.hook-enumerator` LaunchDaemon
+// `StartInterval = 300` (5 minutes).
+const enterpriseWindowsEnumerateDefaultInterval = 5 * time.Minute
+
+// enterpriseWindowsEnumerateInitialCycleDelay bounds the "first
+// cycle" wait so a `--deferred-config` fresh-install install path
+// doesn't have to wait a full 5-minute interval before hooks appear.
+// Set to 30 s so the gateway + guardian services publish their
+// "starting" health lines FIRST (each takes ~5-10 s on a cold-boot);
+// the enumerator's first cycle then runs, and any hooked-in health
+// dashboard sees a coherent startup ordering.
+//
+// Spec 005 REQ-13. Tuneable in a follow-up if telemetry shows this
+// is too long / too short.
+const enterpriseWindowsEnumerateInitialCycleDelay = 30 * time.Second
+
+// enterpriseWindowsEnumerateCycleTimeout bounds a single enumeration
+// cycle so a wedged registry walk / IO can't starve subsequent
+// ticks. Spec 005 REQ-19.
+const enterpriseWindowsEnumerateCycleTimeout = 60 * time.Second
+
+// enterpriseWindowsEnumerateOptions carries the CLI flags for the
+// `enterprise windows enumerate` subcommand. Parsed in
+// `newEnterpriseWindowsEnumerateCommand`.
+type enterpriseWindowsEnumerateOptions struct {
+	manifestPath string
+	interval     time.Duration
+	once         bool
+	initialDelay time.Duration
+}
+
+// newEnterpriseWindowsEnumerateCommand wires the `enterprise windows
+// enumerate` cobra subcommand under the existing
+// `enterpriseWindowsCmd` group.
+//
+// Two modes:
+//
+//   - `--once`: runs a single enumeration cycle synchronously and
+//     exits. Used by the installer's fresh-install path (replaces
+//     the retired inline PowerShell walk at
+//     `DefenseClawEnterprise.psm1:3663-3736`).
+//   - default (no `--once`): enters the interval-loop the SCM
+//     service invokes at boot. Sleeps `--interval` (default 5m)
+//     between cycles; each cycle is bounded by
+//     `enterpriseWindowsEnumerateCycleTimeout`; ctx-cancel
+//     (SCM stop signal) returns within a bounded window.
+//
+// Spec 005 REQ-03, REQ-04, REQ-13, REQ-18, REQ-19.
+func newEnterpriseWindowsEnumerateCommand() *cobra.Command {
+	opts := &enterpriseWindowsEnumerateOptions{
+		interval:     enterpriseWindowsEnumerateDefaultInterval,
+		initialDelay: enterpriseWindowsEnumerateInitialCycleDelay,
+	}
+	cmd := &cobra.Command{
+		Use:   "enumerate",
+		Short: "Refresh targets.yaml from the current local user profile set",
+		Long: `Walk HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList to
+discover local user profiles, filter to interactive users (S-1-5-21-…), and
+regenerate the hook-guardian's targets.yaml so newly-created user profiles
+receive hooks without an administrator invoking 'enterprise windows repair'.
+
+Two modes:
+
+  * default: enter an interval-loop suitable for an SCM ImagePath.
+    Sleeps --interval (default 5m) between cycles; the first cycle
+    fires within 30 s of service start so a deferred-config install
+    does not wait a full interval for hooks to appear.
+
+  * --once: run a single cycle synchronously and exit. Used by the
+    fresh-install path to seed targets.yaml before the enumerator
+    service is up.
+
+The DACL discipline on targets.yaml is unchanged from spec 003 —
+the enumerator writes as LocalSystem via SYSTEM's inherited
+FullControl, matching the guardian's account model.
+
+Managed-enterprise Windows only. macOS's LaunchDaemon-based
+'hook-enumerator' + render-targets.sh already covers the darwin
+side; nothing about this subcommand is invoked on non-Windows OSes.
+`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return withExitCode(
+				runEnterpriseWindowsEnumerate(cmd.Context(), cmd, opts),
+				windowsEnterpriseFailureExitCode,
+			)
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVar(&opts.manifestPath, "manifest", "", "absolute path to the hook-guardian targets.yaml this enumerator maintains (required)")
+	flags.DurationVar(&opts.interval, "interval", enterpriseWindowsEnumerateDefaultInterval, "sleep between enumeration cycles when running as a service")
+	flags.BoolVar(&opts.once, "once", false, "run a single cycle synchronously and exit; ignored when --interval is set to 0")
+	flags.DurationVar(&opts.initialDelay, "initial-cycle-delay", enterpriseWindowsEnumerateInitialCycleDelay, "wait this long before the first interval-loop cycle so the gateway + guardian can publish their startup health lines first")
+	return cmd
+}
+
+// runEnterpriseWindowsEnumerate is the RunE for the subcommand.
+// Split out so unit tests can drive it with a fake context + fake
+// clock; the cobra command is a thin wrapper.
+func runEnterpriseWindowsEnumerate(
+	ctx context.Context,
+	cmd *cobra.Command,
+	opts *enterpriseWindowsEnumerateOptions,
+) error {
+	if opts == nil {
+		return errors.New("enterprise windows enumerate: nil options")
+	}
+	manifestPath := strings.TrimSpace(opts.manifestPath)
+	if manifestPath == "" {
+		return errors.New("enterprise windows enumerate: --manifest is required")
+	}
+	if !filepath.IsAbs(manifestPath) {
+		return fmt.Errorf("enterprise windows enumerate: --manifest must be absolute (got %q)", manifestPath)
+	}
+	if opts.interval <= 0 && !opts.once {
+		return errors.New("enterprise windows enumerate: --interval must be positive unless --once is set")
+	}
+
+	stderr := cmd.ErrOrStderr()
+	fmt.Fprintf(stderr, "[hook-enumerator] windows: manifest=%s interval=%s once=%t initial_delay=%s\n",
+		manifestPath, opts.interval, opts.once, opts.initialDelay)
+
+	if opts.once {
+		return runEnterpriseWindowsEnumerateSingleCycle(ctx, stderr, manifestPath)
+	}
+
+	return runEnterpriseWindowsEnumerateInterval(ctx, stderr, opts, manifestPath)
+}
+
+// runEnterpriseWindowsEnumerateSingleCycle runs one bounded cycle
+// and returns. Used by both `--once` and the interval-loop's
+// tick handler.
+func runEnterpriseWindowsEnumerateSingleCycle(
+	ctx context.Context,
+	stderr io.Writer,
+	manifestPath string,
+) error {
+	cycleCtx, cancel := context.WithTimeout(ctx, enterpriseWindowsEnumerateCycleTimeout)
+	defer cancel()
+
+	cfg, cfgErr := enterpriseWindowsEnumerateConfigLoader()
+	if cfgErr != nil {
+		// A missing config in managed_enterprise mode is a "waiting
+		// for configuration" state — logged, not fatal. Interval-loop
+		// callers retry next tick; --once callers exit non-zero so an
+		// installer can distinguish "no config yet" from "cycle wrote
+		// a manifest".
+		if isEnterpriseWindowsEnumerateConfigMissing(cfgErr) {
+			fmt.Fprintf(stderr, "[hook-enumerator] config.yaml unavailable; skipping cycle (waiting_for_config): %v\n", cfgErr)
+			return cfgErr
+		}
+		return fmt.Errorf("enterprise windows enumerate: load config: %w", cfgErr)
+	}
+	if !managed.IsManagedEnterprise(cfg.DeploymentMode) {
+		return fmt.Errorf("enterprise windows enumerate: deployment_mode=%q is not managed_enterprise; refusing to run", cfg.DeploymentMode)
+	}
+
+	logf := enumerationLoggerForStderr(stderr)
+	start := time.Now()
+	manifest, err := enterprisehooks.EnumerateWindows(cfg, enterprisehooks.EnumerateOptions{
+		ExistingManifestPath: manifestPath,
+		Logger:               logf,
+	})
+	if err != nil {
+		return fmt.Errorf("enterprise windows enumerate: walk profiles: %w", err)
+	}
+	if ctxErr := cycleCtx.Err(); ctxErr != nil {
+		return fmt.Errorf("enterprise windows enumerate: cycle timeout / cancel: %w", ctxErr)
+	}
+
+	changed, err := enterprisehooks.WriteTargetsManifestAtomic(manifestPath, manifest)
+	if err != nil {
+		return fmt.Errorf("enterprise windows enumerate: write manifest: %w", err)
+	}
+	elapsed := time.Since(start)
+
+	fmt.Fprintf(stderr, "[hook-enumerator] cycle complete users=%d targets=%d changed=%t elapsed=%s\n",
+		countDistinctSIDs(manifest.Targets), len(manifest.Targets), changed, elapsed)
+	if elapsed > 10*time.Second {
+		// Spec 005 REQ-19 documents a soft 10 s target on a 100-user
+		// fleet; log a WARN if a single cycle overshoots so operators
+		// see the degradation before the hard 60 s ceiling fires.
+		fmt.Fprintf(stderr, "[hook-enumerator] WARN cycle exceeded 10 s target: %s\n", elapsed)
+	}
+	return nil
+}
+
+// runEnterpriseWindowsEnumerateInterval is the interval-loop entry.
+// Runs the first cycle after `initial_delay` (per REQ-13), then
+// every `interval` thereafter. ctx-cancel (SCM stop) returns within
+// a bounded window.
+func runEnterpriseWindowsEnumerateInterval(
+	ctx context.Context,
+	stderr io.Writer,
+	opts *enterpriseWindowsEnumerateOptions,
+	manifestPath string,
+) error {
+	// Initial cycle after the configurable delay. REQ-13 default 30 s
+	// so gateway + guardian publish their startup lines first.
+	initial := time.NewTimer(opts.initialDelay)
+	defer initial.Stop()
+
+	select {
+	case <-ctx.Done():
+		return nil
+	case <-initial.C:
+	}
+	// First cycle: log the outcome but do NOT bail on a transient
+	// "config missing" error — the whole point of REQ-04 is to
+	// tolerate deferred-config boots.
+	if err := runEnterpriseWindowsEnumerateSingleCycle(ctx, stderr, manifestPath); err != nil {
+		if !isEnterpriseWindowsEnumerateConfigMissing(err) {
+			fmt.Fprintf(stderr, "[hook-enumerator] initial cycle failed: %v\n", err)
+		}
+	}
+
+	ticker := time.NewTicker(opts.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := runEnterpriseWindowsEnumerateSingleCycle(ctx, stderr, manifestPath); err != nil {
+				if !isEnterpriseWindowsEnumerateConfigMissing(err) {
+					fmt.Fprintf(stderr, "[hook-enumerator] cycle failed: %v\n", err)
+				}
+			}
+		}
+	}
+}
+
+// enumerationLoggerForStderr wraps the enumerator's per-drop logger
+// callback so drops surface on the same stderr the interval-loop
+// summary lines use.
+func enumerationLoggerForStderr(w io.Writer) enterprisehooks.EnumerationLogger {
+	return func(subject, reason string) {
+		fmt.Fprintf(w, "[hook-enumerator] skipped %s: %s\n", subject, reason)
+	}
+}
+
+// countDistinctSIDs is a small helper for the summary log — a cycle
+// emitting 10 targets across 5 users is more informative than "10
+// targets" alone.
+func countDistinctSIDs(targets []enterprisehooks.ManifestTarget) int {
+	seen := make(map[string]struct{})
+	for _, t := range targets {
+		if sid := strings.TrimSpace(t.SID); sid != "" {
+			seen[strings.ToUpper(sid)] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
+// enterpriseWindowsEnumerateConfigLoader is the config-load seam the
+// interval-loop uses. Points at the SAME administrator-owned config
+// path the gateway + guardian read, via the same helper spec 003
+// wired in. Test hooks reassign this to a fixture.
+var enterpriseWindowsEnumerateConfigLoader = func() (*config.Config, error) {
+	return enterpriseHooksWindowsConfigLoader()
+}
+
+// isEnterpriseWindowsEnumerateConfigMissing recognises the specific
+// "config.yaml is not on disk yet" error so the interval loop can
+// treat it as a soft-retry rather than a hard failure. Spec 003
+// added the deferred-config posture; the enumerator's REQ-04 mirrors
+// it.
+func isEnterpriseWindowsEnumerateConfigMissing(err error) bool {
+	if err == nil {
+		return false
+	}
+	// config.LoadFromFile wraps os.Open errors verbatim; a
+	// substring check is more portable than an errors.Is against a
+	// specific sentinel (the wrap chain crosses package boundaries).
+	msg := err.Error()
+	return strings.Contains(msg, "no such file or directory") ||
+		strings.Contains(msg, "cannot find the file specified") ||
+		strings.Contains(msg, "The system cannot find the file specified")
+}

--- a/internal/cli/enterprise_windows_enumerate_windows_test.go
+++ b/internal/cli/enterprise_windows_enumerate_windows_test.go
@@ -16,12 +16,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/spf13/cobra"
+	"time"
 
 	"github.com/defenseclaw/defenseclaw/internal/config"
 	"github.com/defenseclaw/defenseclaw/internal/enterprisehooks"
@@ -141,7 +139,6 @@ func TestRunEnterpriseWindowsEnumerateOnceRefusesNonManagedEnterprise(t *testing
 	if !strings.Contains(err.Error(), "managed_enterprise") {
 		t.Fatalf("error should cite managed_enterprise: %v", err)
 	}
-	_ = managed.DeploymentModeManagedEnterprise // ensure the import is used
 }
 
 // TestIsEnterpriseWindowsEnumerateConfigMissingRecognisesBothOSes
@@ -237,25 +234,27 @@ func TestEnterpriseWindowsEnumerateIntervalHonoursCtxCancel(t *testing.T) {
 
 	prev := enterpriseWindowsEnumerateConfigLoader
 	enterpriseWindowsEnumerateConfigLoader = func() (*config.Config, error) {
-		return &config.Config{DeploymentMode: string(config.DeploymentModeManagedEnterprise)}, nil
+		return &config.Config{DeploymentMode: managed.DeploymentModeManagedEnterprise}, nil
 	}
 	defer func() { enterpriseWindowsEnumerateConfigLoader = prev }()
 
-	// Register a fake writer so RunE writes go somewhere; the CLI
-	// call goes through the shared cobra.Command that
-	// runEnterpriseWindowsEnumerateInterval consults.
-	cmd := &cobra.Command{}
-	cmd.SetErr(new(bytes.Buffer))
+	stderr := new(bytes.Buffer)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	// Cancel immediately: the initial-delay timer sees ctx.Done()
 	// before it fires, and the loop returns nil.
 	cancel()
 
-	err := runEnterpriseWindowsEnumerateInterval(ctx, os.Stderr, &enterpriseWindowsEnumerateOptions{
+	err := runEnterpriseWindowsEnumerateInterval(ctx, stderr, &enterpriseWindowsEnumerateOptions{
 		manifestPath: manifest,
-		interval:     100, // never actually reached
-		initialDelay: 100,
+		// Both durations are explicit time.Millisecond values;
+		// they never actually fire because ctx is cancelled
+		// before the initial-delay timer, but the numeric shape
+		// documents intent (100ms, not 100ns) for a future maintainer
+		// who removes the pre-cancel. See CR
+		// spec-005:PRRT_kwDORuAK-s6atye4.
+		interval:     100 * time.Millisecond,
+		initialDelay: 100 * time.Millisecond,
 	}, manifest)
 	if err != nil {
 		t.Fatalf("ctx-cancelled interval-loop should return nil; got %v", err)

--- a/internal/cli/enterprise_windows_enumerate_windows_test.go
+++ b/internal/cli/enterprise_windows_enumerate_windows_test.go
@@ -1,0 +1,263 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/enterprisehooks"
+	"github.com/defenseclaw/defenseclaw/internal/managed"
+)
+
+// TestNewEnterpriseWindowsEnumerateCommandRegistersFlags pins the
+// public CLI surface — a maintainer who renames a flag in the
+// registrar breaks this test immediately, forcing them to think
+// about backwards compat (SCM ImagePath strings baked into installed
+// services).
+func TestNewEnterpriseWindowsEnumerateCommandRegistersFlags(t *testing.T) {
+	cmd := newEnterpriseWindowsEnumerateCommand()
+	if cmd.Use != "enumerate" {
+		t.Fatalf("cobra Use = %q, want %q", cmd.Use, "enumerate")
+	}
+	for _, name := range []string{"manifest", "interval", "once", "initial-cycle-delay"} {
+		if flag := cmd.Flags().Lookup(name); flag == nil {
+			t.Fatalf("flag %q not registered", name)
+		}
+	}
+}
+
+// TestRunEnterpriseWindowsEnumerateRejectsMissingManifest asserts
+// the CLI refuses to run without an explicit `--manifest` path. The
+// helper is invoked via cobra so the shape mirrors production.
+func TestRunEnterpriseWindowsEnumerateRejectsMissingManifest(t *testing.T) {
+	cmd := newEnterpriseWindowsEnumerateCommand()
+	cmd.SetOut(new(bytes.Buffer))
+	cmd.SetErr(new(bytes.Buffer))
+	err := runEnterpriseWindowsEnumerate(context.Background(), cmd, &enterpriseWindowsEnumerateOptions{})
+	if err == nil {
+		t.Fatal("empty --manifest: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "manifest") {
+		t.Fatalf("error should cite --manifest: %v", err)
+	}
+}
+
+// TestRunEnterpriseWindowsEnumerateRejectsRelativeManifest asserts a
+// relative --manifest path is refused — same discipline the
+// installer already uses for other file arguments (a service
+// ImagePath resolved against SCM's cwd could point at an
+// unexpected location).
+func TestRunEnterpriseWindowsEnumerateRejectsRelativeManifest(t *testing.T) {
+	cmd := newEnterpriseWindowsEnumerateCommand()
+	cmd.SetErr(new(bytes.Buffer))
+	err := runEnterpriseWindowsEnumerate(context.Background(), cmd, &enterpriseWindowsEnumerateOptions{
+		manifestPath: `relative\path\targets.yaml`,
+		once:         true,
+	})
+	if err == nil {
+		t.Fatal("relative --manifest: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "absolute") {
+		t.Fatalf("error should cite 'absolute': %v", err)
+	}
+}
+
+// TestRunEnterpriseWindowsEnumerateOnceHonoursMissingConfig asserts
+// the --once path returns the specific "config missing" error
+// upward so the installer's shell-out can distinguish "no config
+// yet" from "cycle wrote a manifest" — a distinguishable exit
+// signature.
+func TestRunEnterpriseWindowsEnumerateOnceHonoursMissingConfig(t *testing.T) {
+	dir := t.TempDir()
+	manifest := filepath.Join(dir, "targets.yaml")
+
+	prev := enterpriseWindowsEnumerateConfigLoader
+	enterpriseWindowsEnumerateConfigLoader = func() (*config.Config, error) {
+		return nil, errors.New("open C:\\ProgramData\\Cisco\\...\\config.yaml: The system cannot find the file specified.")
+	}
+	defer func() { enterpriseWindowsEnumerateConfigLoader = prev }()
+
+	cmd := newEnterpriseWindowsEnumerateCommand()
+	stderr := new(bytes.Buffer)
+	cmd.SetErr(stderr)
+	err := runEnterpriseWindowsEnumerate(context.Background(), cmd, &enterpriseWindowsEnumerateOptions{
+		manifestPath: manifest,
+		once:         true,
+	})
+	if err == nil {
+		t.Fatal("--once with missing config: want error, got nil")
+	}
+	if !isEnterpriseWindowsEnumerateConfigMissing(err) {
+		t.Fatalf("error not recognised as config-missing: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "waiting_for_config") {
+		t.Fatalf("stderr should mention waiting_for_config; got: %s", stderr.String())
+	}
+}
+
+// TestRunEnterpriseWindowsEnumerateOnceRefusesNonManagedEnterprise
+// pins the deploy-mode gate: the enumerator MUST NOT run on
+// non-managed-enterprise builds. If an operator points the CLI at a
+// dev/BYOD config the command errors out rather than silently
+// walking the local users.
+func TestRunEnterpriseWindowsEnumerateOnceRefusesNonManagedEnterprise(t *testing.T) {
+	dir := t.TempDir()
+	manifest := filepath.Join(dir, "targets.yaml")
+
+	prev := enterpriseWindowsEnumerateConfigLoader
+	enterpriseWindowsEnumerateConfigLoader = func() (*config.Config, error) {
+		return &config.Config{DeploymentMode: "unmanaged_byod"}, nil
+	}
+	defer func() { enterpriseWindowsEnumerateConfigLoader = prev }()
+
+	cmd := newEnterpriseWindowsEnumerateCommand()
+	cmd.SetErr(new(bytes.Buffer))
+	err := runEnterpriseWindowsEnumerate(context.Background(), cmd, &enterpriseWindowsEnumerateOptions{
+		manifestPath: manifest,
+		once:         true,
+	})
+	if err == nil {
+		t.Fatal("non-managed-enterprise deploy mode: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "managed_enterprise") {
+		t.Fatalf("error should cite managed_enterprise: %v", err)
+	}
+	_ = managed.DeploymentModeManagedEnterprise // ensure the import is used
+}
+
+// TestIsEnterpriseWindowsEnumerateConfigMissingRecognisesBothOSes
+// asserts the "config missing" detector recognises Windows'
+// "The system cannot find the file specified" AND Unix's
+// "no such file or directory" wording — both surface via
+// os.Open-wrapped errors depending on which OS we're compiled for.
+func TestIsEnterpriseWindowsEnumerateConfigMissingRecognisesBothOSes(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"windows", errors.New("open C:\\...\\config.yaml: The system cannot find the file specified."), true},
+		{"windows lowercase", errors.New("open C:\\...\\config.yaml: cannot find the file specified"), true},
+		{"unix", errors.New("open /etc/defenseclaw/config.yaml: no such file or directory"), true},
+		{"unrelated error", errors.New("open C:\\...\\config.yaml: access denied"), false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isEnterpriseWindowsEnumerateConfigMissing(tc.err); got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCountDistinctSIDsHandlesEmptyAndDuplicates asserts the summary-
+// log helper counts unique SIDs case-insensitively.
+func TestCountDistinctSIDsHandlesEmptyAndDuplicates(t *testing.T) {
+	cases := []struct {
+		name    string
+		targets []enterprisehooks.ManifestTarget
+		want    int
+	}{
+		{"empty", nil, 0},
+		{
+			"single user, two connectors",
+			[]enterprisehooks.ManifestTarget{
+				{SID: "S-1-5-21-1000-2000-3000-1001", Connector: "codex"},
+				{SID: "S-1-5-21-1000-2000-3000-1001", Connector: "claudecode"},
+			},
+			1,
+		},
+		{
+			"two users, one connector each",
+			[]enterprisehooks.ManifestTarget{
+				{SID: "S-1-5-21-1000-2000-3000-1001", Connector: "codex"},
+				{SID: "S-1-5-21-1000-2000-3000-1002", Connector: "codex"},
+			},
+			2,
+		},
+		{
+			"case difference is normalised",
+			[]enterprisehooks.ManifestTarget{
+				{SID: "S-1-5-21-1000-2000-3000-1001", Connector: "codex"},
+				{SID: "s-1-5-21-1000-2000-3000-1001", Connector: "claudecode"},
+			},
+			1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := countDistinctSIDs(tc.targets); got != tc.want {
+				t.Fatalf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEnumerationLoggerForStderrFormatsSubjectAndReason asserts the
+// per-drop log line format so a log-scraping oncall alert keyed on
+// "skipped SID X: Y" doesn't silently break if we tweak the string.
+func TestEnumerationLoggerForStderrFormatsSubjectAndReason(t *testing.T) {
+	buf := new(bytes.Buffer)
+	logf := enumerationLoggerForStderr(buf)
+	logf("S-1-5-21-1000-2000-3000-1001", "reparse point in ancestor chain")
+	got := buf.String()
+	if !strings.Contains(got, "[hook-enumerator] skipped S-1-5-21-1000-2000-3000-1001: reparse point in ancestor chain") {
+		t.Fatalf("logger output missing expected line: %q", got)
+	}
+}
+
+// TestEnterpriseWindowsEnumerateIntervalHonoursCtxCancel bounds the
+// interval-loop's shutdown behaviour: a ctx-cancel MUST return
+// within the initial delay + a small grace period. Uses a
+// deliberately-short initial-delay so the test wall-clock stays
+// under a second.
+func TestEnterpriseWindowsEnumerateIntervalHonoursCtxCancel(t *testing.T) {
+	dir := t.TempDir()
+	manifest := filepath.Join(dir, "targets.yaml")
+
+	prev := enterpriseWindowsEnumerateConfigLoader
+	enterpriseWindowsEnumerateConfigLoader = func() (*config.Config, error) {
+		return &config.Config{DeploymentMode: string(config.DeploymentModeManagedEnterprise)}, nil
+	}
+	defer func() { enterpriseWindowsEnumerateConfigLoader = prev }()
+
+	// Register a fake writer so RunE writes go somewhere; the CLI
+	// call goes through the shared cobra.Command that
+	// runEnterpriseWindowsEnumerateInterval consults.
+	cmd := &cobra.Command{}
+	cmd.SetErr(new(bytes.Buffer))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately: the initial-delay timer sees ctx.Done()
+	// before it fires, and the loop returns nil.
+	cancel()
+
+	err := runEnterpriseWindowsEnumerateInterval(ctx, os.Stderr, &enterpriseWindowsEnumerateOptions{
+		manifestPath: manifest,
+		interval:     100, // never actually reached
+		initialDelay: 100,
+	}, manifest)
+	if err != nil {
+		t.Fatalf("ctx-cancelled interval-loop should return nil; got %v", err)
+	}
+}

--- a/internal/cli/windows_enterprise_service.go
+++ b/internal/cli/windows_enterprise_service.go
@@ -169,6 +169,10 @@ func init() {
 	enterpriseWindowsCmd.AddCommand(newWindowsCodexRequirementsCommand())
 	enterpriseWindowsCmd.AddCommand(newWindowsManagedHooksTeardownCommand())
 	enterpriseWindowsCmd.AddCommand(newWindowsManagedHooksLifecycleCommand())
+	// Spec 005 D1: hook-enumerator subcommand. Windows-only; the
+	// whole file is //go:build windows so a non-Windows build never
+	// reaches this registration.
+	enterpriseWindowsCmd.AddCommand(newEnterpriseWindowsEnumerateCommand())
 	enterpriseCmd.AddCommand(enterpriseWindowsCmd)
 }
 

--- a/internal/enterprisehooks/enumerator_windows.go
+++ b/internal/enterprisehooks/enumerator_windows.go
@@ -35,7 +35,8 @@ import (
 // directory.
 //
 // See MS docs:
-//   https://learn.microsoft.com/en-us/windows/win32/win7appqual/user-profile-service---policy
+//
+//	https://learn.microsoft.com/en-us/windows/win32/win7appqual/user-profile-service---policy
 //
 // The macOS analogue is `dscl . -list /Users UniqueID`; the shape is
 // identical (one row per profile, keyed on SID vs. uid). Documented

--- a/internal/enterprisehooks/enumerator_windows.go
+++ b/internal/enterprisehooks/enumerator_windows.go
@@ -1,0 +1,630 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package enterprisehooks
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+	"gopkg.in/yaml.v3"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/winpath"
+)
+
+// profileListRegistryKey is the Windows registry key that holds one
+// subkey per local user profile. Each subkey's name IS a stringified
+// SID (e.g. "S-1-5-21-1234-567-89-1001"); its `ProfileImagePath`
+// REG_SZ / REG_EXPAND_SZ value is the profile's on-disk home
+// directory.
+//
+// See MS docs:
+//   https://learn.microsoft.com/en-us/windows/win32/win7appqual/user-profile-service---policy
+//
+// The macOS analogue is `dscl . -list /Users UniqueID`; the shape is
+// identical (one row per profile, keyed on SID vs. uid). Documented
+// stable across Windows XP → Windows 11 / Server 2025.
+const profileListRegistryKey = `SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList`
+
+// windowsHookConnectors is the closed set of hook-based connectors
+// the Windows per-user hook installer supports today. The enumerator
+// filters `cfg.Guardrail.Connector` + `cfg.Guardrail.Connectors` down
+// to this set: an operator can list "openclaw" or "zeptoclaw" in the
+// primary Connector field (they are proxy-only connectors) but the
+// enumerator has nothing to install per-user for those, so it drops
+// them.
+//
+// Kept in sync with the switch in
+// `internal/cli/enterprise_hooks_platform_windows.go:
+// windowsEnterpriseDesiredEnrollments` — if a third hook-based
+// connector appears there, add it here too.
+var windowsHookConnectors = map[string]struct{}{
+	"claudecode": {},
+	"codex":      {},
+}
+
+// EnumerationLogger receives one line per user profile the enumerator
+// dropped or annotated, so an operator can debug WHY a specific user
+// isn't getting hooked. Matches the macOS `_enumerate_users_warn`
+// shape. Nil is safe (drops are silent).
+type EnumerationLogger func(subject, reason string)
+
+// EnumerateOptions controls a single enumeration cycle. All fields
+// are optional.
+type EnumerateOptions struct {
+	// ExistingManifestPath, when non-empty, is loaded before
+	// enumeration so per-target `AgentVersion` + `Enabled` state
+	// carries over between cycles. This is the primary mechanism by
+	// which the enumerator preserves admin-supplied fields it has no
+	// independent way to discover: the enumerator DISCOVERS profile
+	// membership, but AgentVersion for a given (SID, Connector) is
+	// authoritative-in-file. If the file is unreadable / malformed /
+	// missing, enumeration proceeds and rows start with empty
+	// AgentVersion + `Enabled=false` (safe default — a new row
+	// without a discovered agent version does not auto-hook the
+	// user; the admin promotes it explicitly).
+	//
+	// Callers that want to force a from-scratch generation (e.g. F1
+	// targeted-uninstall regeneration after the target user's rows
+	// have been removed) leave this empty.
+	ExistingManifestPath string
+
+	// ExcludeSIDs is a list of SID strings to drop from the output.
+	// Used by spec 005 F1 targeted-uninstall to regenerate the
+	// manifest with a specific user excluded, without doing per-row
+	// surgery on the on-disk file.
+	ExcludeSIDs []string
+
+	// Logger receives one line per filter-drop / warn event. Nil
+	// silences all diagnostics.
+	Logger EnumerationLogger
+}
+
+// EnumerateWindows walks the local user profile registry, filters per
+// spec 005 REQ-08 + REQ-11, and produces a Manifest matching the
+// shape the hook-guardian's LoadManifest already accepts.
+//
+// Filter chain (each step drops the profile with a logf line if opts.Logger is set):
+//
+//  1. SID must be a syntactically-valid Windows SID string.
+//  2. SID must be an interactive-user SID: `S-1-5-21-…` (NT
+//     AUTHORITY, SECURITY_NT_NON_UNIQUE base RID) with at least 4
+//     sub-authorities so it can't be a bare domain SID. Refuses
+//     well-known SIDs (Everyone S-1-1-0, Anonymous S-1-5-7, SYSTEM
+//     S-1-5-18, Authenticated Users S-1-5-11, BUILTIN S-1-5-32-*,
+//     NT SERVICE S-1-5-80-*, etc.) by construction. Belt-and-braces
+//     on top of the CLI-input filter at spec 005 REQ-15.
+//  3. ProfileImagePath registry value must resolve to an absolute
+//     path under the local filesystem.
+//  4. Home directory must exist as a real directory (not a reparse
+//     point, junction, or symlink; `winpath.RejectReparseChain`
+//     walks the ancestor chain up to the volume root — a junction
+//     anywhere in the path is refused).
+//  5. `opts.ExcludeSIDs`: any SID listed here is dropped. Used by
+//     spec 005 F1's targeted uninstall.
+//
+// Deduplication (REQ-10): if two profiles have the same SID (e.g. a
+// re-created account whose registry entry conflicts with a stale
+// row), the enumerator prefers the one whose `ProfileImagePath`
+// mtime is newer.
+//
+// AgentVersion + Enabled preservation: for each (SID, Connector) row
+// that already exists in `opts.ExistingManifestPath` (if set), the
+// pre-existing AgentVersion + Enabled fields are carried over. New
+// rows — those discovered by the ProfileList walk that had no
+// counterpart in the file — start with `Enabled: false` and empty
+// AgentVersion so the guardian's LoadManifest skips schema-validation
+// (which requires AgentVersion ≥ Windows minimum on enabled rows).
+// An admin / UCB flow promotes the row to enabled by patching
+// targets.yaml with a real AgentVersion. This preserves the security
+// posture: a new user profile is DISCOVERED by the enumerator but
+// only receives hooks when the admin explicitly promotes it.
+//
+// Rows sorted by (SID, Connector) for deterministic YAML output —
+// the byte-identical-no-op-no-write invariant in
+// `WriteTargetsManifestAtomic` depends on stable serialisation.
+func EnumerateWindows(cfg *config.Config, opts EnumerateOptions) (Manifest, error) {
+	if cfg == nil {
+		return Manifest{}, fmt.Errorf("enterprise hooks: enumerate windows: nil config")
+	}
+	connectors := effectiveWindowsHookConnectors(cfg)
+	if len(connectors) == 0 {
+		// No enabled hook-based connector → no per-user rows to
+		// emit. Return an empty (but valid) manifest so the atomic
+		// write path lands a `version: 1\ntargets: []` document
+		// rather than a missing file — the guardian's LoadManifest
+		// accepts an empty target list, and this keeps the on-disk
+		// state well-defined during a mid-configuration window where
+		// the operator has disabled every connector.
+		return Manifest{Version: 1, Targets: []ManifestTarget{}}, nil
+	}
+
+	exclude := make(map[string]struct{}, len(opts.ExcludeSIDs))
+	for _, sid := range opts.ExcludeSIDs {
+		if canon := canonicalManifestTargetSID(sid); canon != "" {
+			exclude[canon] = struct{}{}
+		}
+	}
+
+	previous := loadPreviousManifestForEnumeration(opts.ExistingManifestPath, opts.Logger)
+
+	profiles, err := listWindowsUserProfiles(opts.Logger)
+	if err != nil {
+		return Manifest{}, err
+	}
+
+	targets := make([]ManifestTarget, 0, len(profiles)*len(connectors))
+	for _, profile := range profiles {
+		if _, skip := exclude[canonicalManifestTargetSID(profile.SID)]; skip {
+			logfSafely(opts.Logger, profile.SID, "excluded by caller (targeted uninstall)")
+			continue
+		}
+		for _, conn := range connectors {
+			dataDir := filepath.Join(filepath.Clean(profile.Home), ".defenseclaw")
+			row := ManifestTarget{
+				SID:       profile.SID,
+				UserHome:  filepath.Clean(profile.Home),
+				Connector: conn,
+				DataDir:   dataDir,
+			}
+			applyPreviousRowState(&row, previous, opts.Logger)
+			targets = append(targets, row)
+		}
+	}
+
+	sort.Slice(targets, func(i, j int) bool {
+		if targets[i].SID != targets[j].SID {
+			return targets[i].SID < targets[j].SID
+		}
+		return targets[i].Connector < targets[j].Connector
+	})
+
+	return Manifest{Version: 1, Targets: targets}, nil
+}
+
+// WriteTargetsManifestAtomic serialises `m` to YAML, compares it
+// byte-for-byte to the on-disk file at `path`, and — if the two
+// differ — writes the serialised bytes atomically via a
+// write-to-`.new` + `MoveFileEx(MOVEFILE_REPLACE_EXISTING |
+// MOVEFILE_WRITE_THROUGH)` swap.
+//
+// Returns `changed=false, err=nil` when the on-disk file is
+// byte-identical to the newly-serialised manifest. This is the
+// no-op-no-write invariant from spec 005 REQ-05: without it, every
+// 5-min interval tick on a stable box would fsnotify-wake the
+// guardian and force it to re-reconcile identical rows (288
+// wakes/day on a stable 50-user fleet).
+//
+// Returns `changed=true, err=nil` on a successful atomic replace.
+// Returns `changed=false, err=<non-nil>` on any failure; the on-disk
+// file is left untouched.
+//
+// The caller is responsible for the DACL on `path` — this function
+// only writes the bytes. Under spec 005 the enumerator service runs
+// as LocalSystem (matching guardian), so SYSTEM's inherited
+// FullControl via the existing `AdminFile` ACL (from spec 003) is
+// enough; no ACL mutation happens here.
+func WriteTargetsManifestAtomic(path string, m Manifest) (changed bool, err error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return false, fmt.Errorf("enterprise hooks: write targets manifest: empty path")
+	}
+	if !filepath.IsAbs(path) {
+		return false, fmt.Errorf("enterprise hooks: write targets manifest: path must be absolute: %s", path)
+	}
+
+	serialised, err := marshalTargetsManifest(m)
+	if err != nil {
+		return false, err
+	}
+
+	current, readErr := os.ReadFile(path)
+	if readErr == nil && bytes.Equal(current, serialised) {
+		// Byte-identical: skip the write entirely so the guardian's
+		// fsnotify watch does not wake. This is the primary
+		// steady-state code path — a stable box hits it every tick.
+		return false, nil
+	}
+	if readErr != nil && !os.IsNotExist(readErr) {
+		return false, fmt.Errorf("enterprise hooks: read existing manifest %s: %w", path, readErr)
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".defenseclaw-targets-*.new")
+	if err != nil {
+		return false, fmt.Errorf("enterprise hooks: create temp manifest under %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	// Best-effort cleanup on failure. If MoveFileEx succeeds the
+	// temp path is consumed, so os.Remove on a non-existent path is
+	// silently ignored below.
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, writeErr := tmp.Write(serialised); writeErr != nil {
+		_ = tmp.Close()
+		return false, fmt.Errorf("enterprise hooks: write temp manifest %s: %w", tmpPath, writeErr)
+	}
+	if closeErr := tmp.Close(); closeErr != nil {
+		return false, fmt.Errorf("enterprise hooks: close temp manifest %s: %w", tmpPath, closeErr)
+	}
+
+	fromPtr, err := windows.UTF16PtrFromString(tmpPath)
+	if err != nil {
+		return false, fmt.Errorf("enterprise hooks: encode temp manifest path: %w", err)
+	}
+	toPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return false, fmt.Errorf("enterprise hooks: encode manifest path: %w", err)
+	}
+	if err := windows.MoveFileEx(
+		fromPtr,
+		toPtr,
+		windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH,
+	); err != nil {
+		return false, fmt.Errorf("enterprise hooks: atomic replace %s: %w", path, err)
+	}
+	return true, nil
+}
+
+// marshalTargetsManifest serialises the manifest to YAML with
+// deterministic field ordering. yaml.Marshal is not guaranteed
+// stable across releases, but for a struct with tagged fields the
+// output is a function of the field-declaration order — which we
+// control. `Manifest.Targets` is pre-sorted by (SID, Connector) in
+// EnumerateWindows so this function is deterministic for the same
+// input.
+func marshalTargetsManifest(m Manifest) ([]byte, error) {
+	if m.Version == 0 {
+		m.Version = 1
+	}
+	if m.Targets == nil {
+		m.Targets = []ManifestTarget{}
+	}
+	raw, err := yaml.Marshal(&m)
+	if err != nil {
+		return nil, fmt.Errorf("enterprise hooks: marshal manifest: %w", err)
+	}
+	return raw, nil
+}
+
+// loadPreviousManifestForEnumeration reads the on-disk manifest at
+// `path`, returning a fast per-(SID, Connector) lookup that lets
+// EnumerateWindows preserve `AgentVersion` + `Enabled` fields for
+// rows that already exist. A missing file, a malformed body, and a
+// well-formed empty file all return a nil map — the caller falls
+// back to "new row" defaults for every discovered profile.
+func loadPreviousManifestForEnumeration(path string, logf EnumerationLogger) map[string]ManifestTarget {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	m, err := LoadManifest(path)
+	if err != nil {
+		// Not fatal — an operator-hand-edited targets.yaml that
+		// fails validation shouldn't crash the enumerator; we log
+		// and treat every discovered row as new.
+		logfSafely(logf, path, fmt.Sprintf("existing manifest failed to load; treating every row as new: %v", err))
+		return nil
+	}
+	previous := make(map[string]ManifestTarget, len(m.Targets))
+	for _, t := range m.Targets {
+		key := previousManifestKey(t.SID, t.Connector)
+		if key != "" {
+			previous[key] = t
+		}
+	}
+	return previous
+}
+
+// applyPreviousRowState copies AgentVersion + Enabled from the
+// existing manifest into `row` if a match is found. If no match, it
+// leaves both fields at their zero values — Enabled stays nil (the
+// default-enabled behaviour), but since AgentVersion is empty the
+// row cannot be enabled (LoadManifest's requireAgentVersion check
+// runs on enabled rows). To keep new rows well-formed in that state
+// we explicitly disable them so LoadManifest's per-row validation
+// skips them, avoiding a load-time reject.
+func applyPreviousRowState(row *ManifestTarget, previous map[string]ManifestTarget, logf EnumerationLogger) {
+	if row == nil {
+		return
+	}
+	key := previousManifestKey(row.SID, row.Connector)
+	if prev, ok := previous[key]; ok {
+		row.AgentVersion = prev.AgentVersion
+		row.Enabled = prev.Enabled
+		row.User = prev.User
+		row.UID = prev.UID
+		row.GID = prev.GID
+		return
+	}
+	// New (SID, Connector) row: keep AgentVersion empty and mark
+	// Enabled=false so LoadManifest's schema validation skips this
+	// target. An admin or UCB flow promotes it later by writing the
+	// AgentVersion + flipping Enabled=true. This preserves the
+	// security posture — a new user profile is DISCOVERED by the
+	// enumerator but does not auto-hook without operator intent.
+	disabled := false
+	row.Enabled = &disabled
+	logfSafely(logf, row.SID, fmt.Sprintf("newly-discovered (SID, %s) row emitted as disabled; admin must supply agent_version + enable", row.Connector))
+}
+
+func previousManifestKey(sid, connector string) string {
+	sid = canonicalManifestTargetSID(sid)
+	connector = strings.ToLower(strings.TrimSpace(connector))
+	if sid == "" || connector == "" {
+		return ""
+	}
+	return sid + "\x00" + connector
+}
+
+// windowsUserProfile is the trimmed view of a `ProfileList` subkey
+// the enumerator needs. Kept package-private so the filter chain can
+// vary without leaking implementation details into the exported API.
+type windowsUserProfile struct {
+	SID  string
+	Home string
+	// HomeMtime disambiguates duplicate-SID rows per REQ-10; the
+	// registry doesn't have direct time-of-registration for a
+	// profile, but the ProfileImagePath directory's mtime is a
+	// reasonable proxy (it changes whenever the profile is
+	// materialised / logged into).
+	HomeMtime int64
+}
+
+// listWindowsUserProfiles walks the ProfileList registry key and
+// returns one row per surviving profile. Profiles that fail any step
+// of the filter chain (parse, well-known-SID, path-not-absolute,
+// missing/reparse-point home) are dropped with a WARN via logf.
+//
+// Duplicate SIDs are deduplicated in-place — the newest
+// ProfileImagePath mtime wins, per REQ-10.
+func listWindowsUserProfiles(logf EnumerationLogger) ([]windowsUserProfile, error) {
+	rootKey, err := registry.OpenKey(
+		registry.LOCAL_MACHINE,
+		profileListRegistryKey,
+		registry.ENUMERATE_SUB_KEYS,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("enterprise hooks: open ProfileList registry: %w", err)
+	}
+	defer rootKey.Close()
+
+	subkeyNames, err := rootKey.ReadSubKeyNames(-1)
+	if err != nil {
+		return nil, fmt.Errorf("enterprise hooks: enumerate ProfileList subkeys: %w", err)
+	}
+
+	byCanonSID := make(map[string]windowsUserProfile, len(subkeyNames))
+	for _, name := range subkeyNames {
+		sid, err := windows.StringToSid(name)
+		if err != nil || sid == nil {
+			logfSafely(logf, name, fmt.Sprintf("not a syntactically-valid SID: %v", err))
+			continue
+		}
+		if !sidIsInteractiveUser(sid) {
+			logfSafely(logf, name, "not an interactive-user SID (S-1-5-21-…); refusing well-known / machine-scoped principals")
+			continue
+		}
+		home, err := readAndExpandProfileImagePath(name)
+		if err != nil {
+			logfSafely(logf, name, fmt.Sprintf("ProfileImagePath unresolvable: %v", err))
+			continue
+		}
+		if home == "" || !filepath.IsAbs(home) {
+			logfSafely(logf, name, "ProfileImagePath is empty or not absolute")
+			continue
+		}
+		info, err := os.Stat(home)
+		if err != nil {
+			logfSafely(logf, name, fmt.Sprintf("ProfileImagePath does not resolve to an existing directory: %v", err))
+			continue
+		}
+		if !info.IsDir() {
+			logfSafely(logf, name, "ProfileImagePath is not a directory")
+			continue
+		}
+		if err := winpath.RejectReparseChain(home); err != nil {
+			logfSafely(logf, name, fmt.Sprintf("ProfileImagePath contains a reparse point in its ancestor chain: %v", err))
+			continue
+		}
+		mtime := info.ModTime().UnixNano()
+
+		canon := canonicalManifestTargetSID(name)
+		if canon == "" {
+			logfSafely(logf, name, "SID canonicalisation returned empty")
+			continue
+		}
+		if prev, dup := byCanonSID[canon]; dup {
+			if mtime <= prev.HomeMtime {
+				logfSafely(logf, name, fmt.Sprintf("duplicate SID; older ProfileImagePath mtime %d ≤ existing %d — kept existing", mtime, prev.HomeMtime))
+				continue
+			}
+			logfSafely(logf, name, fmt.Sprintf("duplicate SID; newer ProfileImagePath mtime %d > existing %d — replacing", mtime, prev.HomeMtime))
+		}
+		byCanonSID[canon] = windowsUserProfile{
+			SID:       name,
+			Home:      filepath.Clean(home),
+			HomeMtime: mtime,
+		}
+	}
+
+	out := make([]windowsUserProfile, 0, len(byCanonSID))
+	for _, p := range byCanonSID {
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].SID < out[j].SID })
+	return out, nil
+}
+
+// readAndExpandProfileImagePath opens the per-SID ProfileList subkey
+// and reads its ProfileImagePath value, expanding any %SystemDrive%
+// prefix the OS may embed.
+//
+// Mirrors the shape of
+// `internal/cli/enterprise_hooks_platform_windows.go:
+// windowsEnterpriseHookSIDProfilePath` but does NOT re-parse the SID
+// (the caller already did) and does NOT enforce interactive-user
+// filtering (the caller applies that separately for consistent error
+// reporting).
+func readAndExpandProfileImagePath(sidString string) (string, error) {
+	key, err := registry.OpenKey(
+		registry.LOCAL_MACHINE,
+		profileListRegistryKey+`\`+sidString,
+		registry.QUERY_VALUE,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer key.Close()
+	profile, valueType, err := key.GetStringValue("ProfileImagePath")
+	if err != nil {
+		return "", err
+	}
+	if valueType == registry.EXPAND_SZ {
+		expanded, err := expandProfileImagePathSystemDrive(profile)
+		if err != nil {
+			return "", err
+		}
+		profile = expanded
+	}
+	profile = strings.TrimSpace(profile)
+	if profile == "" {
+		return "", fmt.Errorf("ProfileImagePath is empty")
+	}
+	return filepath.Clean(profile), nil
+}
+
+// expandProfileImagePathSystemDrive resolves a `%SystemDrive%`-
+// prefixed ProfileImagePath. Only that specific expansion is
+// permitted; anything else with a `%` in it is refused so a
+// malicious environment substitution cannot escape into an unrelated
+// volume.
+func expandProfileImagePathSystemDrive(profile string) (string, error) {
+	const systemDrive = `%SystemDrive%`
+	profile = strings.TrimSpace(profile)
+	if len(profile) < len(systemDrive) || !strings.EqualFold(profile[:len(systemDrive)], systemDrive) {
+		if strings.Contains(profile, "%") {
+			return "", fmt.Errorf("ProfileImagePath contains an unsupported environment expansion")
+		}
+		return profile, nil
+	}
+	systemDir, err := windows.GetSystemDirectory()
+	if err != nil {
+		return "", fmt.Errorf("resolve trusted Windows system directory: %w", err)
+	}
+	drive := filepath.VolumeName(filepath.Clean(systemDir))
+	if drive == "" {
+		return "", fmt.Errorf("resolve trusted Windows system drive from %q", systemDir)
+	}
+	expanded := drive + profile[len(systemDrive):]
+	if strings.Contains(expanded, "%") {
+		return "", fmt.Errorf("ProfileImagePath contains an unsupported environment expansion")
+	}
+	return expanded, nil
+}
+
+// sidIsInteractiveUser reports whether `sid` is an interactive local
+// or domain user SID — i.e. lives under NT AUTHORITY (identifier
+// authority 5) with SubAuthority[0] == SECURITY_NT_NON_UNIQUE (21)
+// and at least 4 sub-authorities so the SID names a specific user,
+// not the bare domain.
+//
+// Every well-known / machine-scoped principal (SYSTEM S-1-5-18,
+// Authenticated Users S-1-5-11, Everyone S-1-1-0, Anonymous
+// S-1-5-7, BUILTIN S-1-5-32-*, NT SERVICE S-1-5-80-*, LocalService
+// S-1-5-19, NetworkService S-1-5-20, IIS_IUSRS S-1-5-17, etc.) fails
+// the SubAuthority[0] == 21 check.
+//
+// Matches spec 005 REQ-11 and — together with the CLI-input
+// validator at spec 005 REQ-15 — provides belt-and-braces coverage.
+// Same discipline as spec 004's `sidIsNTService` (in
+// internal/ipc/acl_windows.go), inverted: this filter admits ONLY
+// interactive users; spec 004's admitted ONLY NT SERVICE principals.
+func sidIsInteractiveUser(sid *windows.SID) bool {
+	if sid == nil {
+		return false
+	}
+	if sid.IdentifierAuthority().Value != [6]byte{0, 0, 0, 0, 0, 5} {
+		return false
+	}
+	const securityNTNonUnique uint32 = 21
+	if sid.SubAuthorityCount() < 4 {
+		return false
+	}
+	return sid.SubAuthority(0) == securityNTNonUnique
+}
+
+// effectiveWindowsHookConnectors returns the connector names for
+// which the enumerator emits per-user rows. Filters the operator-
+// configured connector list down to those the Windows per-user
+// installer actually supports (see `windowsHookConnectors`),
+// deduplicating and dropping explicitly-disabled entries.
+//
+// Resolution order:
+//
+//  1. `cfg.Guardrail.Connectors` map — each key is a candidate; a
+//     PerConnectorGuardrailConfig with `Enabled != nil && !*Enabled`
+//     is dropped. This matches the boot-loop precedence in
+//     internal/gateway/config.go.
+//  2. `cfg.Guardrail.Connector` scalar — added if not already
+//     present in the map. Legacy single-connector configs surface
+//     here.
+//
+// Return value is sorted alphabetically for deterministic output.
+func effectiveWindowsHookConnectors(cfg *config.Config) []string {
+	seen := make(map[string]struct{})
+	ordered := make([]string, 0, len(cfg.Guardrail.Connectors)+1)
+	consider := func(name string, explicitlyDisabled bool) {
+		trimmed := strings.ToLower(strings.TrimSpace(name))
+		if trimmed == "" {
+			return
+		}
+		if _, ok := windowsHookConnectors[trimmed]; !ok {
+			return
+		}
+		if explicitlyDisabled {
+			return
+		}
+		if _, dup := seen[trimmed]; dup {
+			return
+		}
+		seen[trimmed] = struct{}{}
+		ordered = append(ordered, trimmed)
+	}
+	for name, perConn := range cfg.Guardrail.Connectors {
+		disabled := perConn.Enabled != nil && !*perConn.Enabled
+		consider(name, disabled)
+	}
+	consider(cfg.Guardrail.Connector, false)
+	sort.Strings(ordered)
+	return ordered
+}
+
+// logfSafely is a nil-safe wrapper around EnumerationLogger. The
+// enumerator's filter chain is peppered with logf calls; a single
+// nil check up front is easier to read than a nil check per call
+// site.
+func logfSafely(logf EnumerationLogger, subject, reason string) {
+	if logf != nil {
+		logf(subject, reason)
+	}
+}

--- a/internal/enterprisehooks/enumerator_windows.go
+++ b/internal/enterprisehooks/enumerator_windows.go
@@ -14,6 +14,7 @@ package enterprisehooks
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -105,12 +106,14 @@ type EnumerateOptions struct {
 //
 //  1. SID must be a syntactically-valid Windows SID string.
 //  2. SID must be an interactive-user SID: `S-1-5-21-…` (NT
-//     AUTHORITY, SECURITY_NT_NON_UNIQUE base RID) with at least 4
-//     sub-authorities so it can't be a bare domain SID. Refuses
-//     well-known SIDs (Everyone S-1-1-0, Anonymous S-1-5-7, SYSTEM
-//     S-1-5-18, Authenticated Users S-1-5-11, BUILTIN S-1-5-32-*,
-//     NT SERVICE S-1-5-80-*, etc.) by construction. Belt-and-braces
-//     on top of the CLI-input filter at spec 005 REQ-15.
+//     AUTHORITY, SECURITY_NT_NON_UNIQUE base RID) with at least 5
+//     sub-authorities so the SID names a specific user (the trailing
+//     RID), not the bare domain (`S-1-5-21-A-B-C` has 4 sub-auths
+//     and is rejected). Refuses well-known SIDs (Everyone S-1-1-0,
+//     Anonymous S-1-5-7, SYSTEM S-1-5-18, Authenticated Users
+//     S-1-5-11, BUILTIN S-1-5-32-*, NT SERVICE S-1-5-80-*, etc.) by
+//     construction. Belt-and-braces on top of the CLI-input filter
+//     at spec 005 REQ-15.
 //  3. ProfileImagePath registry value must resolve to an absolute
 //     path under the local filesystem.
 //  4. Home directory must exist as a real directory (not a reparse
@@ -140,9 +143,20 @@ type EnumerateOptions struct {
 // Rows sorted by (SID, Connector) for deterministic YAML output —
 // the byte-identical-no-op-no-write invariant in
 // `WriteTargetsManifestAtomic` depends on stable serialisation.
-func EnumerateWindows(cfg *config.Config, opts EnumerateOptions) (Manifest, error) {
+func EnumerateWindows(ctx context.Context, cfg *config.Config, opts EnumerateOptions) (Manifest, error) {
 	if cfg == nil {
 		return Manifest{}, fmt.Errorf("enterprise hooks: enumerate windows: nil config")
+	}
+	if ctx == nil {
+		// A nil context is a caller bug — every real call comes
+		// from the CLI subcommand that wraps a cycle in
+		// context.WithTimeout. Use context.Background() as a
+		// defensive fallback so we don't panic on a stray
+		// unit-test invocation.
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return Manifest{}, err
 	}
 	connectors := effectiveWindowsHookConnectors(cfg)
 	if len(connectors) == 0 {
@@ -165,13 +179,24 @@ func EnumerateWindows(cfg *config.Config, opts EnumerateOptions) (Manifest, erro
 
 	previous := loadPreviousManifestForEnumeration(opts.ExistingManifestPath, opts.Logger)
 
-	profiles, err := listWindowsUserProfiles(opts.Logger)
+	profiles, err := listWindowsUserProfiles(ctx, opts.Logger)
 	if err != nil {
+		return Manifest{}, err
+	}
+	if err := ctx.Err(); err != nil {
 		return Manifest{}, err
 	}
 
 	targets := make([]ManifestTarget, 0, len(profiles)*len(connectors))
 	for _, profile := range profiles {
+		// Fast-fail per row so a wedged cycle never runs to
+		// completion after ctx has been cancelled — spec 005
+		// REQ-19's 60 s cycle ceiling depends on this loop
+		// noticing the deadline. See CR
+		// spec-005:PRRT_kwDORuAK-s6atyfD.
+		if err := ctx.Err(); err != nil {
+			return Manifest{}, err
+		}
 		if _, skip := exclude[canonicalManifestTargetSID(profile.SID)]; skip {
 			logfSafely(opts.Logger, profile.SID, "excluded by caller (targeted uninstall)")
 			continue
@@ -398,7 +423,11 @@ type windowsUserProfile struct {
 //
 // Duplicate SIDs are deduplicated in-place — the newest
 // ProfileImagePath mtime wins, per REQ-10.
-func listWindowsUserProfiles(logf EnumerationLogger) ([]windowsUserProfile, error) {
+//
+// ctx bounds the walk: a per-subkey ctx.Err() check ensures a
+// wedged os.Stat on one profile cannot starve the interval-loop's
+// cycle timeout (spec 005 REQ-19).
+func listWindowsUserProfiles(ctx context.Context, logf EnumerationLogger) ([]windowsUserProfile, error) {
 	rootKey, err := registry.OpenKey(
 		registry.LOCAL_MACHINE,
 		profileListRegistryKey,
@@ -416,6 +445,9 @@ func listWindowsUserProfiles(logf EnumerationLogger) ([]windowsUserProfile, erro
 
 	byCanonSID := make(map[string]windowsUserProfile, len(subkeyNames))
 	for _, name := range subkeyNames {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		sid, err := windows.StringToSid(name)
 		if err != nil || sid == nil {
 			logfSafely(logf, name, fmt.Sprintf("not a syntactically-valid SID: %v", err))
@@ -546,8 +578,13 @@ func expandProfileImagePathSystemDrive(profile string) (string, error) {
 // sidIsInteractiveUser reports whether `sid` is an interactive local
 // or domain user SID — i.e. lives under NT AUTHORITY (identifier
 // authority 5) with SubAuthority[0] == SECURITY_NT_NON_UNIQUE (21)
-// and at least 4 sub-authorities so the SID names a specific user,
-// not the bare domain.
+// and at least 5 sub-authorities so the SID names a specific user
+// (the trailing RID), not the bare domain. A user SID has the shape
+// `S-1-5-21-A-B-C-RID` (five sub-authorities: 21, A, B, C, RID). The
+// bare domain SID without the RID (`S-1-5-21-A-B-C`) has four
+// sub-authorities and MUST be rejected — enumerating a bare domain
+// as an interactive user would emit garbage manifest rows. See
+// CR spec-005:PRRT_kwDORuAK-s6atyfL.
 //
 // Every well-known / machine-scoped principal (SYSTEM S-1-5-18,
 // Authenticated Users S-1-5-11, Everyone S-1-1-0, Anonymous
@@ -568,7 +605,7 @@ func sidIsInteractiveUser(sid *windows.SID) bool {
 		return false
 	}
 	const securityNTNonUnique uint32 = 21
-	if sid.SubAuthorityCount() < 4 {
+	if sid.SubAuthorityCount() < 5 {
 		return false
 	}
 	return sid.SubAuthority(0) == securityNTNonUnique
@@ -591,8 +628,23 @@ func sidIsInteractiveUser(sid *windows.SID) bool {
 //     here.
 //
 // Return value is sorted alphabetically for deterministic output.
+//
+// Precedence: an explicit `Connectors[name].Enabled=false` in the map
+// beats the scalar `Connector` field. A config that sets
+// `guardrail.connector: claudecode` together with
+// `guardrail.connectors.claudecode.enabled: false` emits ZERO
+// per-user rows for claudecode — the disabled map entry is
+// authoritative. See CR spec-005:PRRT_kwDORuAK-s6atyfM.
 func effectiveWindowsHookConnectors(cfg *config.Config) []string {
 	seen := make(map[string]struct{})
+	// disabledNames captures every name the operator explicitly
+	// disabled in cfg.Guardrail.Connectors. The scalar-connector
+	// pass then refuses to re-add any name in this set, so the
+	// map's `Enabled=false` decision cannot be silently reversed
+	// by a stale scalar. Populated only by the map pass — the
+	// scalar branch never adds to it, matching the semantic
+	// "map is authoritative for explicit disables".
+	disabledNames := make(map[string]struct{})
 	ordered := make([]string, 0, len(cfg.Guardrail.Connectors)+1)
 	consider := func(name string, explicitlyDisabled bool) {
 		trimmed := strings.ToLower(strings.TrimSpace(name))
@@ -603,6 +655,10 @@ func effectiveWindowsHookConnectors(cfg *config.Config) []string {
 			return
 		}
 		if explicitlyDisabled {
+			disabledNames[trimmed] = struct{}{}
+			return
+		}
+		if _, off := disabledNames[trimmed]; off {
 			return
 		}
 		if _, dup := seen[trimmed]; dup {

--- a/internal/enterprisehooks/enumerator_windows_test.go
+++ b/internal/enterprisehooks/enumerator_windows_test.go
@@ -14,6 +14,8 @@ package enterprisehooks
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,20 +27,27 @@ import (
 )
 
 // TestSIDIsInteractiveUserAcceptsRealUserSIDs pins the shape spec 005
-// REQ-11 requires: an S-1-5-21-… SID with at least 4 sub-authorities
-// is accepted; anything else is refused. The sub-authority count
-// covers the fabricated "S-1-5-21-1234" case (only 2 sub-authorities)
-// which would otherwise slip past a naive "starts with 5-21" check.
+// REQ-11 requires: an S-1-5-21-… SID with at least 5 sub-authorities
+// (21, A, B, C, RID) is accepted; anything else is refused. The
+// boundary case (`S-1-5-21-A-B-C`, 4 sub-authorities — the bare
+// domain SID without a trailing RID) MUST be rejected: enumerating a
+// bare domain as an interactive user would emit garbage manifest
+// rows. See CR spec-005:PRRT_kwDORuAK-s6atyfL.
 func TestSIDIsInteractiveUserAcceptsRealUserSIDs(t *testing.T) {
 	cases := []struct {
 		name string
 		raw  string
 		want bool
 	}{
-		{"typical local user", "S-1-5-21-1000-2000-3000-1001", true},
-		{"domain user with high RID", "S-1-5-21-1234567890-987654321-1111111111-4321", true},
-		{"bare domain SID (3 sub-auths)", "S-1-5-21-1000-2000-3000", false},
-		{"NT AUTHORITY too short", "S-1-5-21", false},
+		{"typical local user (5 sub-auths)", "S-1-5-21-1000-2000-3000-1001", true},
+		{"domain user with high RID (5 sub-auths)", "S-1-5-21-1234567890-987654321-1111111111-4321", true},
+		// Exact 5-sub-authority boundary — smallest legal user SID.
+		{"minimum accepted (exactly 5 sub-auths)", "S-1-5-21-0-0-0-500", true},
+		// The bare domain SID (`S-1-5-21-A-B-C`) has 4 sub-auths and
+		// MUST be rejected — this is the boundary the earlier
+		// `< 4` check missed.
+		{"bare domain SID (4 sub-auths)", "S-1-5-21-1000-2000-3000", false},
+		{"NT AUTHORITY too short (1 sub-auth)", "S-1-5-21", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -144,6 +153,24 @@ func TestEffectiveWindowsHookConnectorsFiltersUnsupported(t *testing.T) {
 				},
 			},
 			want: []string{"codex"},
+		},
+		{
+			// CR spec-005:PRRT_kwDORuAK-s6atyfM regression:
+			// a disabled map entry MUST beat the scalar
+			// re-declaration. A config that names claudecode
+			// both as the scalar Connector AND as an explicitly
+			// disabled Connectors[claudecode].Enabled=false must
+			// emit ZERO per-user rows for claudecode.
+			name: "map disable beats scalar re-declaration",
+			cfg: &config.Config{
+				Guardrail: config.GuardrailConfig{
+					Connector: "claudecode",
+					Connectors: map[string]config.PerConnectorGuardrailConfig{
+						"claudecode": {Enabled: &disabled},
+					},
+				},
+			},
+			want: []string{},
 		},
 		{
 			name: "map contains gemini (unsupported) alongside codex",
@@ -377,7 +404,7 @@ func TestMarshalTargetsManifestIsDeterministic(t *testing.T) {
 // config would panic on `cfg.Guardrail` deref if we didn't refuse it
 // up front.
 func TestEnumerateWindowsRejectsNilConfig(t *testing.T) {
-	_, err := EnumerateWindows(nil, EnumerateOptions{})
+	_, err := EnumerateWindows(context.Background(), nil, EnumerateOptions{})
 	if err == nil {
 		t.Fatal("EnumerateWindows(nil): want error, got nil")
 	}
@@ -388,7 +415,7 @@ func TestEnumerateWindowsRejectsNilConfig(t *testing.T) {
 // (not nil) so the on-disk YAML always has a well-defined shape.
 func TestEnumerateWindowsEmptyConnectorsReturnsEmptyManifest(t *testing.T) {
 	cfg := &config.Config{} // no guardrail.connector configured
-	m, err := EnumerateWindows(cfg, EnumerateOptions{})
+	m, err := EnumerateWindows(context.Background(), cfg, EnumerateOptions{})
 	if err != nil {
 		t.Fatalf("EnumerateWindows: %v", err)
 	}
@@ -400,5 +427,23 @@ func TestEnumerateWindowsEmptyConnectorsReturnsEmptyManifest(t *testing.T) {
 	}
 	if m.Targets == nil {
 		t.Fatal("Targets is nil; want non-nil empty slice for stable YAML shape")
+	}
+}
+
+// TestEnumerateWindowsHonoursCancelledContext asserts the cycle-
+// timeout invariant CR spec-005:PRRT_kwDORuAK-s6atyfD asks for: a
+// ctx that's already cancelled returns immediately without touching
+// the registry / filesystem. Belt-and-braces on top of the per-row
+// ctx.Err() checks; a cancelled ctx at ENTRY must never proceed.
+func TestEnumerateWindowsHonoursCancelledContext(t *testing.T) {
+	cfg := &config.Config{Guardrail: config.GuardrailConfig{Connector: "codex"}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := EnumerateWindows(ctx, cfg, EnumerateOptions{})
+	if err == nil {
+		t.Fatal("cancelled ctx: want error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled ctx: err = %v, want context.Canceled", err)
 	}
 }

--- a/internal/enterprisehooks/enumerator_windows_test.go
+++ b/internal/enterprisehooks/enumerator_windows_test.go
@@ -1,0 +1,404 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package enterprisehooks
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+)
+
+// TestSIDIsInteractiveUserAcceptsRealUserSIDs pins the shape spec 005
+// REQ-11 requires: an S-1-5-21-… SID with at least 4 sub-authorities
+// is accepted; anything else is refused. The sub-authority count
+// covers the fabricated "S-1-5-21-1234" case (only 2 sub-authorities)
+// which would otherwise slip past a naive "starts with 5-21" check.
+func TestSIDIsInteractiveUserAcceptsRealUserSIDs(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"typical local user", "S-1-5-21-1000-2000-3000-1001", true},
+		{"domain user with high RID", "S-1-5-21-1234567890-987654321-1111111111-4321", true},
+		{"bare domain SID (3 sub-auths)", "S-1-5-21-1000-2000-3000", false},
+		{"NT AUTHORITY too short", "S-1-5-21", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sid, err := windows.StringToSid(tc.raw)
+			if err != nil {
+				t.Fatalf("StringToSid(%q): %v", tc.raw, err)
+			}
+			if got := sidIsInteractiveUser(sid); got != tc.want {
+				t.Fatalf("sidIsInteractiveUser(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSIDIsInteractiveUserRejectsWellKnown pins REQ-11's exclusion
+// list. Every principal listed here is a well-known SID the CLI /
+// enumerator MUST refuse — accepting any of them would let a
+// misconfigured install rewrite the machine's SYSTEM / BUILTIN /
+// NT SERVICE hook wiring, which is nonsensical (those principals
+// don't run hook-based agents).
+func TestSIDIsInteractiveUserRejectsWellKnown(t *testing.T) {
+	wellKnown := []struct {
+		name string
+		raw  string
+	}{
+		{"Everyone", "S-1-1-0"},
+		{"Anonymous", "S-1-5-7"},
+		{"Authenticated Users", "S-1-5-11"},
+		{"LocalSystem", "S-1-5-18"},
+		{"LocalService", "S-1-5-19"},
+		{"NetworkService", "S-1-5-20"},
+		{"BUILTIN\\Administrators", "S-1-5-32-544"},
+		{"BUILTIN\\Users", "S-1-5-32-545"},
+		{"NT SERVICE\\TrustedInstaller", "S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464"},
+	}
+	for _, tc := range wellKnown {
+		t.Run(tc.name, func(t *testing.T) {
+			sid, err := windows.StringToSid(tc.raw)
+			if err != nil {
+				t.Fatalf("StringToSid(%q): %v", tc.raw, err)
+			}
+			if sidIsInteractiveUser(sid) {
+				t.Fatalf("sidIsInteractiveUser(%q) = true, want false — well-known SID leaked", tc.raw)
+			}
+		})
+	}
+}
+
+// TestEffectiveWindowsHookConnectorsFiltersUnsupported drives the
+// connector-list filter that decides which per-user rows the
+// enumerator emits. Coverage:
+//   - Unsupported connector ("openclaw", "gemini") is dropped.
+//   - Duplicate names (map + scalar overlap) are deduped.
+//   - `Enabled=false` in the per-connector map drops that connector.
+//   - Empty config → empty output.
+func TestEffectiveWindowsHookConnectorsFiltersUnsupported(t *testing.T) {
+	disabled := false
+	cases := []struct {
+		name string
+		cfg  *config.Config
+		want []string
+	}{
+		{
+			name: "empty",
+			cfg:  &config.Config{},
+			want: []string{},
+		},
+		{
+			name: "scalar only, supported",
+			cfg: &config.Config{
+				Guardrail: config.GuardrailConfig{Connector: "codex"},
+			},
+			want: []string{"codex"},
+		},
+		{
+			name: "scalar unsupported (openclaw) → dropped",
+			cfg: &config.Config{
+				Guardrail: config.GuardrailConfig{Connector: "openclaw"},
+			},
+			want: []string{},
+		},
+		{
+			name: "map with two supported entries, alphabetical order",
+			cfg: &config.Config{
+				Guardrail: config.GuardrailConfig{
+					Connector: "codex",
+					Connectors: map[string]config.PerConnectorGuardrailConfig{
+						"codex":      {},
+						"claudecode": {},
+					},
+				},
+			},
+			want: []string{"claudecode", "codex"},
+		},
+		{
+			name: "map contains explicitly-disabled connector",
+			cfg: &config.Config{
+				Guardrail: config.GuardrailConfig{
+					Connectors: map[string]config.PerConnectorGuardrailConfig{
+						"codex":      {},
+						"claudecode": {Enabled: &disabled},
+					},
+				},
+			},
+			want: []string{"codex"},
+		},
+		{
+			name: "map contains gemini (unsupported) alongside codex",
+			cfg: &config.Config{
+				Guardrail: config.GuardrailConfig{
+					Connectors: map[string]config.PerConnectorGuardrailConfig{
+						"codex":  {},
+						"gemini": {},
+					},
+				},
+			},
+			want: []string{"codex"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := effectiveWindowsHookConnectors(tc.cfg)
+			if len(got) != len(tc.want) {
+				t.Fatalf("length mismatch: got %v (len=%d), want %v (len=%d)", got, len(got), tc.want, len(tc.want))
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("index %d: got %q, want %q (full: got=%v want=%v)", i, got[i], tc.want[i], got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// TestWriteTargetsManifestAtomicNoOpNoWrite pins spec 005 REQ-05: a
+// byte-identical manifest must not touch the on-disk file. This is
+// the CORE property that prevents guardian fsnotify wakes every 5-min
+// tick on a stable box. If regressions land here, the test-fixture's
+// mtime check catches it.
+func TestWriteTargetsManifestAtomicNoOpNoWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "targets.yaml")
+
+	disabled := false
+	initial := Manifest{
+		Version: 1,
+		Targets: []ManifestTarget{
+			{
+				SID:       "S-1-5-21-1000-2000-3000-1001",
+				UserHome:  filepath.FromSlash(`C:\Users\alice`),
+				Connector: "codex",
+				DataDir:   filepath.FromSlash(`C:\Users\alice\.defenseclaw`),
+				Enabled:   &disabled,
+			},
+		},
+	}
+
+	// Round 1: write from scratch.
+	changed, err := WriteTargetsManifestAtomic(path, initial)
+	if err != nil {
+		t.Fatalf("initial WriteTargetsManifestAtomic: %v", err)
+	}
+	if !changed {
+		t.Fatal("initial write reported changed=false; want true")
+	}
+
+	firstInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after initial write: %v", err)
+	}
+	firstMtime := firstInfo.ModTime()
+	firstBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after initial write: %v", err)
+	}
+
+	// Round 2: write the same manifest. Must be a no-op no-write.
+	changed, err = WriteTargetsManifestAtomic(path, initial)
+	if err != nil {
+		t.Fatalf("second WriteTargetsManifestAtomic: %v", err)
+	}
+	if changed {
+		t.Fatal("second write reported changed=true on byte-identical input; want false")
+	}
+
+	secondInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after second write: %v", err)
+	}
+	if !secondInfo.ModTime().Equal(firstMtime) {
+		t.Fatalf("byte-identical write mutated mtime: was %v, now %v", firstMtime, secondInfo.ModTime())
+	}
+
+	secondBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after second write: %v", err)
+	}
+	if !bytes.Equal(firstBytes, secondBytes) {
+		t.Fatal("byte-identical write mutated file contents")
+	}
+}
+
+// TestWriteTargetsManifestAtomicReplacesOnDifference asserts the
+// atomic-replace half: a non-identical serialisation lands via
+// MoveFileEx REPLACE_EXISTING and the new bytes are on disk.
+func TestWriteTargetsManifestAtomicReplacesOnDifference(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "targets.yaml")
+
+	first := Manifest{
+		Version: 1,
+		Targets: []ManifestTarget{{SID: "S-1-5-21-1000-2000-3000-1001", UserHome: `C:\Users\alice`, Connector: "codex", DataDir: `C:\Users\alice\.defenseclaw`}},
+	}
+	changed, err := WriteTargetsManifestAtomic(path, first)
+	if err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if !changed {
+		t.Fatal("first write: changed=false, want true")
+	}
+
+	second := first
+	second.Targets = append(second.Targets, ManifestTarget{
+		SID: "S-1-5-21-1000-2000-3000-1002", UserHome: `C:\Users\bob`, Connector: "codex", DataDir: `C:\Users\bob\.defenseclaw`,
+	})
+	changed, err = WriteTargetsManifestAtomic(path, second)
+	if err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	if !changed {
+		t.Fatal("second write on distinct content: changed=false, want true")
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after distinct write: %v", err)
+	}
+	if !strings.Contains(string(raw), "S-1-5-21-1000-2000-3000-1002") {
+		t.Fatalf("second-row SID missing from on-disk file:\n%s", string(raw))
+	}
+}
+
+// TestApplyPreviousRowStatePreservesAgentVersion asserts the
+// AgentVersion + Enabled preservation invariant spec 005 REQ-08's
+// design says: a row that already exists in the file keeps its
+// agent_version + enabled state across enumeration cycles. A NEW
+// row starts with Enabled=false so LoadManifest's schema validation
+// skips it (avoiding a load-time reject on empty AgentVersion).
+func TestApplyPreviousRowStatePreservesAgentVersion(t *testing.T) {
+	enabled := true
+	previous := map[string]ManifestTarget{
+		previousManifestKey("S-1-5-21-1000-2000-3000-1001", "codex"): {
+			SID:          "S-1-5-21-1000-2000-3000-1001",
+			Connector:    "codex",
+			AgentVersion: "0.145.0",
+			Enabled:      &enabled,
+		},
+	}
+
+	// Match: preserve AgentVersion + Enabled.
+	matched := ManifestTarget{
+		SID:       "s-1-5-21-1000-2000-3000-1001", // deliberate case
+		Connector: "codex",
+	}
+	applyPreviousRowState(&matched, previous, nil)
+	if matched.AgentVersion != "0.145.0" {
+		t.Fatalf("existing-row AgentVersion not preserved: got %q, want %q", matched.AgentVersion, "0.145.0")
+	}
+	if matched.Enabled == nil || !*matched.Enabled {
+		t.Fatal("existing-row Enabled=true not preserved")
+	}
+
+	// No match: emit disabled with empty AgentVersion.
+	fresh := ManifestTarget{
+		SID:       "S-1-5-21-9999-8888-7777-1001",
+		Connector: "claudecode",
+	}
+	applyPreviousRowState(&fresh, previous, nil)
+	if fresh.AgentVersion != "" {
+		t.Fatalf("fresh row: AgentVersion should be empty; got %q", fresh.AgentVersion)
+	}
+	if fresh.Enabled == nil || *fresh.Enabled {
+		t.Fatal("fresh row: Enabled should be pointer-to-false")
+	}
+}
+
+// TestLoadPreviousManifestForEnumerationHandlesMissingFile asserts
+// that a missing existing manifest is not a hard error — enumeration
+// proceeds with a nil previous map (every row is treated as new).
+func TestLoadPreviousManifestForEnumerationHandlesMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "does-not-exist.yaml")
+	got := loadPreviousManifestForEnumeration(path, nil)
+	if got != nil {
+		t.Fatalf("missing file: got non-nil map (len=%d); want nil", len(got))
+	}
+}
+
+// TestLoadPreviousManifestForEnumerationHandlesEmptyPath asserts an
+// empty path (the target-uninstall regenerate-from-scratch case)
+// returns nil without an error.
+func TestLoadPreviousManifestForEnumerationHandlesEmptyPath(t *testing.T) {
+	got := loadPreviousManifestForEnumeration("", nil)
+	if got != nil {
+		t.Fatalf("empty path: got non-nil map (len=%d); want nil", len(got))
+	}
+}
+
+// TestMarshalTargetsManifestIsDeterministic asserts the byte-output
+// of `marshalTargetsManifest` is stable for the same input, which is
+// what the no-op-no-write invariant in WriteTargetsManifestAtomic
+// depends on.
+func TestMarshalTargetsManifestIsDeterministic(t *testing.T) {
+	disabled := false
+	m := Manifest{
+		Version: 1,
+		Targets: []ManifestTarget{
+			{SID: "S-1-5-21-1000-2000-3000-1001", UserHome: `C:\Users\alice`, Connector: "codex", DataDir: `C:\Users\alice\.defenseclaw`, Enabled: &disabled},
+			{SID: "S-1-5-21-1000-2000-3000-1002", UserHome: `C:\Users\bob`, Connector: "claudecode", DataDir: `C:\Users\bob\.defenseclaw`, Enabled: &disabled},
+		},
+	}
+	first, err := marshalTargetsManifest(m)
+	if err != nil {
+		t.Fatalf("first marshal: %v", err)
+	}
+	second, err := marshalTargetsManifest(m)
+	if err != nil {
+		t.Fatalf("second marshal: %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatalf("marshal not deterministic:\nfirst:  %q\nsecond: %q", first, second)
+	}
+}
+
+// TestEnumerateWindowsRejectsNilConfig pins the guard clause — a nil
+// config would panic on `cfg.Guardrail` deref if we didn't refuse it
+// up front.
+func TestEnumerateWindowsRejectsNilConfig(t *testing.T) {
+	_, err := EnumerateWindows(nil, EnumerateOptions{})
+	if err == nil {
+		t.Fatal("EnumerateWindows(nil): want error, got nil")
+	}
+}
+
+// TestEnumerateWindowsEmptyConnectorsReturnsEmptyManifest asserts
+// the no-connector-configured path emits `Version: 1, Targets: []`
+// (not nil) so the on-disk YAML always has a well-defined shape.
+func TestEnumerateWindowsEmptyConnectorsReturnsEmptyManifest(t *testing.T) {
+	cfg := &config.Config{} // no guardrail.connector configured
+	m, err := EnumerateWindows(cfg, EnumerateOptions{})
+	if err != nil {
+		t.Fatalf("EnumerateWindows: %v", err)
+	}
+	if m.Version != 1 {
+		t.Fatalf("Version = %d, want 1", m.Version)
+	}
+	if len(m.Targets) != 0 {
+		t.Fatalf("Targets = %v, want empty", m.Targets)
+	}
+	if m.Targets == nil {
+		t.Fatal("Targets is nil; want non-nil empty slice for stable YAML shape")
+	}
+}

--- a/internal/gateway/health.go
+++ b/internal/gateway/health.go
@@ -961,6 +961,12 @@ func (h *SidecarHealth) SetManaged(state SubsystemState, lastErr string, details
 // receiver and this method is a no-op via the Go zero-value
 // method-call semantics (receiver is a pointer, so a nil check up
 // front is enough).
+//
+// `details` is DEEP-COPIED before storage. A caller retaining a
+// reference to the input map cannot mutate the stored subsystem
+// health after the call returns — Snapshot() then serves an equally
+// independent copy so a JSON marshal path and a live setter cannot
+// race on the same map. See CR spec-005:PRRT_kwDORuAK-s6atyfQ.
 func (h *SidecarHealth) SetEnumerator(state SubsystemState, lastErr string, details map[string]interface{}) {
 	if h == nil {
 		return
@@ -970,10 +976,52 @@ func (h *SidecarHealth) SetEnumerator(state SubsystemState, lastErr string, deta
 		State:     state,
 		Since:     time.Now(),
 		LastError: lastErr,
-		Details:   details,
+		Details:   cloneSubsystemDetails(details),
 	}
 	h.mu.Unlock()
 	h.notifySubscribers()
+}
+
+// cloneSubsystemDetails is a shallow-deep hybrid: the top-level map
+// is copied; each value is copied by re-boxing (values are
+// primitives + occasional nested map[string]interface{}). Recurses
+// one level for nested maps — enough for the shapes SetEnumerator
+// callers pass today (cycle_count, elapsed_ms, error_reason,
+// last_success). Callers that need deeper nesting can extend the
+// recursion; the current contract keeps details flat.
+//
+// Returns nil for a nil input so the stored SubsystemHealth.Details
+// carries the same zero-value semantics — a Snapshot consumer sees
+// `"details": null` in JSON only when the caller explicitly wanted
+// that, not because of an internal allocation.
+func cloneSubsystemDetails(in map[string]interface{}) map[string]interface{} {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		if nested, ok := v.(map[string]interface{}); ok {
+			out[k] = cloneSubsystemDetails(nested)
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// cloneSubsystemHealth deep-copies a *SubsystemHealth pointer so
+// Snapshot() consumers cannot mutate internal state by holding onto
+// the returned pointer's fields. Returns nil for a nil input.
+func cloneSubsystemHealth(in *SubsystemHealth) *SubsystemHealth {
+	if in == nil {
+		return nil
+	}
+	return &SubsystemHealth{
+		State:     in.State,
+		Since:     in.Since,
+		LastError: in.LastError,
+		Details:   cloneSubsystemDetails(in.Details),
+	}
 }
 
 // Subscribe returns a channel that receives a non-blocking notification
@@ -1180,7 +1228,10 @@ func (h *SidecarHealth) Snapshot() HealthSnapshot {
 		ApplicationProtection: h.applicationProtection,
 		Sandbox:               h.sandbox,
 		Managed:               h.managed,
-		Enumerator:            h.enumerator,
+		// Enumerator is deep-cloned so a caller mutating the returned
+		// pointer's Details map cannot race with a concurrent
+		// SetEnumerator. See CR spec-005:PRRT_kwDORuAK-s6atyfQ.
+		Enumerator: cloneSubsystemHealth(h.enumerator),
 	}
 	// Deep-copy the configuration pointer under the read lock so a
 	// caller mutating the returned snapshot cannot race with a Set*

--- a/internal/gateway/health.go
+++ b/internal/gateway/health.go
@@ -156,6 +156,16 @@ type HealthSnapshot struct {
 	// serves the DefenseClaw ↔ AVC contract. Present only when the
 	// server has been started (managed_enterprise or managed.enabled).
 	Managed *SubsystemHealth `json:"managed,omitempty"`
+	// Enumerator reports the DefenseClawHookEnumerator SCM service's
+	// interval-loop state (spec 005 Workstream D). Present only on
+	// Windows managed_enterprise where the enumerator service runs.
+	// The three-state signal (`starting` / `running` / `error`) lets
+	// operators see whether new user profiles will actually get
+	// picked up on the next tick, distinct from the guardian's own
+	// health (guardian may be READY while enumerator is ERROR — the
+	// existing on-disk targets.yaml still drives reconciles, but new
+	// users won't appear until the enumerator recovers).
+	Enumerator *SubsystemHealth `json:"enumerator,omitempty"`
 	// Connector is the primary/active connector, retained for back-compat
 	// with single-connector clients. Connectors lists every active
 	// connector with its own live counters (multi-connector view).
@@ -184,6 +194,12 @@ type SidecarHealth struct {
 	observabilityV8EventHistoryGeneration uint64
 	observabilityV8EventHistory           map[string]observabilityV8EventHistoryObservation
 	managed                               *SubsystemHealth
+	// enumerator tracks the DefenseClawHookEnumerator SCM service
+	// (spec 005 Workstream D). Nil until SetEnumerator is called at
+	// least once — a nil pointer omits the "enumerator" block from
+	// the snapshot, which is the correct behaviour for every
+	// deployment mode other than managed_enterprise on Windows.
+	enumerator                            *SubsystemHealth
 
 	// configuration is the collapsed daemon+guardian state (spec 003).
 	// Nil until SetDaemonConfigLoaded is called at least once — a
@@ -925,6 +941,41 @@ func (h *SidecarHealth) SetManaged(state SubsystemState, lastErr string, details
 	h.notifySubscribers()
 }
 
+// SetEnumerator records the current state of the
+// DefenseClawHookEnumerator SCM service's interval loop (spec 005
+// Workstream D). Called from the enumerator CLI subcommand as it
+// moves through:
+//
+//   - Starting: service just booted, initial-cycle-delay running.
+//   - Running:  first successful cycle emitted; subsequent ticks
+//     replace this with the same Running state so the LastError
+//     field clears.
+//   - Error:    a cycle failed (registry unreadable, atomic-replace
+//     failed, YAML marshal error). LastError carries the specific
+//     reason. The interval loop keeps ticking; the state flips back
+//     to Running on the next successful cycle.
+//
+// Nil-safe: the enumerator subcommand may run standalone
+// (`--once` from an installer shell-out) with no SidecarHealth
+// wired; in that case the caller passes a nil *SidecarHealth
+// receiver and this method is a no-op via the Go zero-value
+// method-call semantics (receiver is a pointer, so a nil check up
+// front is enough).
+func (h *SidecarHealth) SetEnumerator(state SubsystemState, lastErr string, details map[string]interface{}) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	h.enumerator = &SubsystemHealth{
+		State:     state,
+		Since:     time.Now(),
+		LastError: lastErr,
+		Details:   details,
+	}
+	h.mu.Unlock()
+	h.notifySubscribers()
+}
+
 // Subscribe returns a channel that receives a non-blocking notification
 // (a single struct{} value, buffered depth 1) after every Set* call.
 // Consumers coalesce multiple rapid changes naturally: the channel
@@ -1129,6 +1180,7 @@ func (h *SidecarHealth) Snapshot() HealthSnapshot {
 		ApplicationProtection: h.applicationProtection,
 		Sandbox:               h.sandbox,
 		Managed:               h.managed,
+		Enumerator:            h.enumerator,
 	}
 	// Deep-copy the configuration pointer under the read lock so a
 	// caller mutating the returned snapshot cannot race with a Set*

--- a/internal/gateway/health.go
+++ b/internal/gateway/health.go
@@ -199,7 +199,7 @@ type SidecarHealth struct {
 	// least once — a nil pointer omits the "enumerator" block from
 	// the snapshot, which is the correct behaviour for every
 	// deployment mode other than managed_enterprise on Windows.
-	enumerator                            *SubsystemHealth
+	enumerator *SubsystemHealth
 
 	// configuration is the collapsed daemon+guardian state (spec 003).
 	// Nil until SetDaemonConfigLoaded is called at least once — a

--- a/internal/gateway/health_test.go
+++ b/internal/gateway/health_test.go
@@ -943,3 +943,49 @@ func TestSetEnumeratorJSONShape(t *testing.T) {
 		t.Fatalf("snapshot JSON missing `enumerator` key:\n%s", string(raw))
 	}
 }
+
+// TestSetEnumeratorDeepCopiesDetails is the regression pin CR
+// spec-005:PRRT_kwDORuAK-s6atyfQ asks for: mutating the caller's
+// input map after SetEnumerator MUST NOT mutate the stored
+// subsystem health; mutating the Snapshot()-returned pointer's
+// Details map MUST NOT mutate the stored subsystem health either.
+// Without the boundary-copy discipline, a concurrent JSON marshal
+// and a live setter race on the same map header.
+func TestSetEnumeratorDeepCopiesDetails(t *testing.T) {
+	h := NewSidecarHealth()
+
+	// Round 1: input-map mutation.
+	details := map[string]interface{}{"cycle_count": int64(1)}
+	h.SetEnumerator(StateRunning, "", details)
+	// Caller mutates the map they retained.
+	details["cycle_count"] = int64(99)
+	details["injected"] = "attacker-controlled"
+
+	got := h.Snapshot().Enumerator
+	if got == nil {
+		t.Fatal("Enumerator nil after SetEnumerator")
+	}
+	if got.Details["cycle_count"] != int64(1) {
+		t.Fatalf("input-map mutation leaked: cycle_count = %v, want int64(1)", got.Details["cycle_count"])
+	}
+	if _, present := got.Details["injected"]; present {
+		t.Fatalf("input-map mutation leaked: injected key present in stored details: %+v", got.Details)
+	}
+
+	// Round 2: snapshot-return mutation.
+	snap := h.Snapshot()
+	if snap.Enumerator == nil {
+		t.Fatal("second Snapshot() returned nil Enumerator")
+	}
+	snap.Enumerator.Details["cycle_count"] = int64(-1)
+	snap.Enumerator.Details["poisoned"] = true
+
+	// A fresh snapshot must still show the original value.
+	fresh := h.Snapshot()
+	if fresh.Enumerator.Details["cycle_count"] != int64(1) {
+		t.Fatalf("snapshot mutation leaked: cycle_count = %v, want int64(1)", fresh.Enumerator.Details["cycle_count"])
+	}
+	if _, present := fresh.Enumerator.Details["poisoned"]; present {
+		t.Fatalf("snapshot mutation leaked: poisoned key present: %+v", fresh.Enumerator.Details)
+	}
+}

--- a/internal/gateway/health_test.go
+++ b/internal/gateway/health_test.go
@@ -850,3 +850,96 @@ func stringContains(value, fragment string) bool {
 	}
 	return false
 }
+
+// TestSetEnumeratorPublishesSubsystem pins the wire contract spec 005
+// Workstream D introduces: SidecarHealth.Enumerator is nil until
+// SetEnumerator is called, then holds the last-published state +
+// LastError + Details verbatim. Snapshot() must surface the field
+// in the JSON payload so a Cisco Secure Client IPC consumer can
+// render "enumerator error: <reason>" alongside the gateway +
+// guardian tiles.
+func TestSetEnumeratorPublishesSubsystem(t *testing.T) {
+	h := NewSidecarHealth()
+
+	// Pre-call: enumerator absent from the snapshot (nil pointer
+	// omits the field in JSON via omitempty).
+	before := h.Snapshot()
+	if before.Enumerator != nil {
+		t.Fatalf("Enumerator should be nil before SetEnumerator; got %+v", before.Enumerator)
+	}
+
+	h.SetEnumerator(StateRunning, "", map[string]interface{}{"cycle_count": int64(3)})
+
+	after := h.Snapshot()
+	if after.Enumerator == nil {
+		t.Fatal("Enumerator should be non-nil after SetEnumerator")
+	}
+	if after.Enumerator.State != StateRunning {
+		t.Fatalf("Enumerator.State = %v, want %v", after.Enumerator.State, StateRunning)
+	}
+	if after.Enumerator.LastError != "" {
+		t.Fatalf("Enumerator.LastError = %q, want empty", after.Enumerator.LastError)
+	}
+	if v, ok := after.Enumerator.Details["cycle_count"].(int64); !ok || v != 3 {
+		t.Fatalf("Enumerator.Details[cycle_count] = %v, want int64(3)", after.Enumerator.Details["cycle_count"])
+	}
+
+	// Second call flips the state and clears LastError back to empty.
+	h.SetEnumerator(StateError, "walk profiles: registry unreadable", nil)
+	after2 := h.Snapshot()
+	if after2.Enumerator.State != StateError {
+		t.Fatalf("after second SetEnumerator: State = %v, want %v", after2.Enumerator.State, StateError)
+	}
+	if after2.Enumerator.LastError != "walk profiles: registry unreadable" {
+		t.Fatalf("LastError not surfaced: %q", after2.Enumerator.LastError)
+	}
+}
+
+// TestSetEnumeratorNilReceiverIsSafe asserts SetEnumerator can be
+// called against a nil *SidecarHealth without panicking. The
+// enumerator CLI subcommand may run standalone (`--once` from an
+// installer shell-out) with no sidecar wired; the CLI passes a
+// nil receiver in that case and expects a no-op.
+func TestSetEnumeratorNilReceiverIsSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("SetEnumerator on nil receiver panicked: %v", r)
+		}
+	}()
+	var h *SidecarHealth
+	h.SetEnumerator(StateStarting, "", nil)
+}
+
+// TestSetEnumeratorNotifiesSubscribers asserts the pub/sub wake-up
+// invariant SetEnumerator inherits from the pattern SetManaged /
+// SetGuardrail / etc. use — a change to the enumerator's state
+// wakes any registered subscriber exactly once.
+func TestSetEnumeratorNotifiesSubscribers(t *testing.T) {
+	h := NewSidecarHealth()
+	ch, cancel := h.Subscribe()
+	defer cancel()
+
+	h.SetEnumerator(StateStarting, "", nil)
+
+	select {
+	case <-ch:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("SetEnumerator did not wake subscriber within 500ms")
+	}
+}
+
+// TestSetEnumeratorJSONShape asserts the field appears in the
+// wire-level JSON payload as `enumerator` (lower-case, matches the
+// json tag) — a rename here would break every downstream dashboard
+// or CI check keyed on the field.
+func TestSetEnumeratorJSONShape(t *testing.T) {
+	h := NewSidecarHealth()
+	h.SetEnumerator(StateRunning, "", nil)
+	raw, err := json.Marshal(h.Snapshot())
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	if !stringContains(string(raw), `"enumerator":`) {
+		t.Fatalf("snapshot JSON missing `enumerator` key:\n%s", string(raw))
+	}
+}

--- a/packaging/windows/DefenseClawEnterprise.psm1
+++ b/packaging/windows/DefenseClawEnterprise.psm1
@@ -3116,6 +3116,19 @@ function Set-DefenseClawManagedServices {
     Assert-DefenseClawServiceImagePath `
         -Name $GuardianServiceName `
         -ExpectedImage $guardianImage
+    # Spec 005 D1 (CR PRRT_kwDORuAK-s6atyfV): authenticate an
+    # existing enumerator BEFORE reconfiguring it, mirroring the
+    # ownership check the uninstall path already does. Without this,
+    # a foreign process that pre-registered a service with the exact
+    # DefenseClawHookEnumerator name would have its ImagePath +
+    # ObjectName silently rewritten. Assert-DefenseClawOwnedService-
+    # OrAbsent refuses foreign ownership; a matching or absent
+    # service proceeds through the create-or-config branch below.
+    Assert-DefenseClawOwnedServiceOrAbsent `
+        -Name $enumeratorServiceName `
+        -ExpectedGatewayPath $GatewayPath `
+        -ExpectedManifestPath $ManifestPath `
+        -Enumerator
     if (Test-DefenseClawServiceExists -Name $enumeratorServiceName) {
         [void](Invoke-DefenseClawNative -File $script:ScExe -Arguments @(
             'config', $enumeratorServiceName,
@@ -3441,6 +3454,16 @@ function Get-DefenseClawTransactionServiceStates {
         [Parameter(Mandatory)][string]$GatewayServiceName,
         [Parameter(Mandatory)][string]$GuardianServiceName
     )
+    # Spec 005 D1 (CR PRRT_kwDORuAK-s6atyfZ): derive the enumerator's
+    # service name from the guardian's — same shape as the
+    # transaction-open snapshot builder above. Transaction snapshots
+    # written by pre-spec-005 psm1 versions have only 2 services;
+    # loading such a snapshot on a post-spec-005 host is expected
+    # during an upgrade window, so the "missing enumerator state"
+    # check below is a WARN (rather than throw) that treats the
+    # enumerator as absent. Post-upgrade transactions always carry
+    # all 3.
+    $enumeratorServiceName = Get-DefenseClawEnumeratorServiceName -GuardianServiceName $GuardianServiceName
     $states = @{}
     foreach ($service in @($Services)) {
         $nameProperty = $service.PSObject.Properties['name']
@@ -3453,7 +3476,8 @@ function Get-DefenseClawTransactionServiceStates {
         $name = [string]$nameProperty.Value
         $canonicalName = @(
             $GatewayServiceName,
-            $GuardianServiceName
+            $GuardianServiceName,
+            $enumeratorServiceName
         ) | Microsoft.PowerShell.Core\Where-Object {
             [string]::Equals(
                 $_,
@@ -3480,6 +3504,26 @@ function Get-DefenseClawTransactionServiceStates {
             throw "transaction is missing service state for $name"
         }
     }
+    # Enumerator is spec-005-new. A pre-spec-005 transaction snapshot
+    # will not carry it; synthesise an "absent" entry so callers
+    # (Restore-DefenseClawTransactionServiceStartModes) can iterate
+    # all three service names uniformly. Post-spec-005 snapshots
+    # always contain the entry, and Get-DefenseClawTransactionService-
+    # StartMode's absence guard already rejects a running-but-absent
+    # combination.
+    if (-not $states.ContainsKey($enumeratorServiceName)) {
+        $states[$enumeratorServiceName] = [pscustomobject]@{
+            service = [pscustomobject]@{
+                name = $enumeratorServiceName
+                existed = $false
+                running = $false
+                start_mode = 0
+            }
+            existed = $false
+            running = $false
+            start_mode = 0
+        }
+    }
     return $states
 }
 
@@ -3493,12 +3537,19 @@ function Restore-DefenseClawTransactionServiceStartModes {
         -Services $Services `
         -GatewayServiceName $GatewayServiceName `
         -GuardianServiceName $GuardianServiceName
-    # Activate the guardian's recorded boot policy first. A power loss during
-    # this sequence can therefore never leave the gateway automatic while the
-    # guardian is still demand-start because of this transaction.
-    foreach ($name in @($GuardianServiceName, $GatewayServiceName)) {
+    # Spec 005 D1 (CR PRRT_kwDORuAK-s6atyfZ): restore the enumerator's
+    # recorded start mode too, so a rollback returns all three
+    # services to their pre-transaction posture. Order: guardian →
+    # gateway (existing, preserves the boot-safety invariant that
+    # gateway cannot be automatic while guardian is demand-start)
+    # → enumerator LAST because enumerator's readiness depends on
+    # gateway + guardian being back to their target boot mode; a
+    # crash mid-restore leaves enumerator disabled which is a safe
+    # posture (no targets.yaml writes until the next transaction).
+    $enumeratorServiceName = Get-DefenseClawEnumeratorServiceName -GuardianServiceName $GuardianServiceName
+    foreach ($name in @($GuardianServiceName, $GatewayServiceName, $enumeratorServiceName)) {
         $state = $states[$name]
-        if ([bool]$state.existed) {
+        if ($null -ne $state -and [bool]$state.existed) {
             Set-DefenseClawServiceStartMode `
                 -Name $name `
                 -StartMode ([int]$state.start_mode)
@@ -4355,8 +4406,18 @@ function New-DefenseClawTransaction {
         -Root $Layout.StateRoot `
         -Label 'transaction directory'
     New-DefenseClawDirectory -Path $directory
+    # Spec 005 D1 (CR PRRT_kwDORuAK-s6atyfZ): transaction snapshots
+    # must record all THREE managed services. The enumerator's
+    # start-mode + running state travel with gateway + guardian so
+    # rollback restores them together — otherwise a failed transaction
+    # could leave the enumerator disabled while gateway + guardian are
+    # restored to auto-start, and new user profiles would stop getting
+    # picked up. Derive the enumerator's service name from the guardian's
+    # via the same helper Set-DefenseClawManagedServices uses so a
+    # certification-run cross-check is enforced.
+    $enumeratorServiceName = Get-DefenseClawEnumeratorServiceName -GuardianServiceName $GuardianServiceName
     $services = [Collections.Generic.List[object]]::new()
-    foreach ($name in @($GatewayServiceName, $GuardianServiceName)) {
+    foreach ($name in @($GatewayServiceName, $GuardianServiceName, $enumeratorServiceName)) {
         $service = Microsoft.PowerShell.Management\Get-Service `
             -Name $name `
             -ErrorAction SilentlyContinue
@@ -4409,7 +4470,12 @@ function New-DefenseClawTransaction {
         # Disabled start neutralizes boot activation and any failure restart
         # already queued by SCM. Gateway is disabled first so a crash cannot
         # leave it boot-active while guardian was demoted by this transaction.
-        foreach ($name in @($GatewayServiceName, $GuardianServiceName)) {
+        # Spec 005 D1 (CR PRRT_kwDORuAK-s6atyfZ): disable all THREE
+        # services during the quiesce phase. Enumerator disabled last
+        # so its final cycle (already in flight) can complete and drop
+        # a coherent targets.yaml before the transaction reads it as
+        # a preimage.
+        foreach ($name in @($GatewayServiceName, $GuardianServiceName, $enumeratorServiceName)) {
             $service = $services |
                 Microsoft.PowerShell.Core\Where-Object {
                     [string]::Equals(
@@ -4424,9 +4490,12 @@ function New-DefenseClawTransaction {
             }
         }
 
-        # Quiesce the only LocalSystem writer before reading any shared or
+        # Quiesce every LocalSystem writer before reading any shared or
         # managed file preimage. Stop-Service waits for process exit, so an
         # in-flight guardian reconciliation cannot straddle the snapshot.
+        # Enumerator first — it's the targets.yaml writer, stopping it
+        # first freezes the file the guardian's final reconcile pass reads.
+        Stop-DefenseClawService -Name $enumeratorServiceName
         Stop-DefenseClawService -Name $GuardianServiceName
         Stop-DefenseClawService -Name $GatewayServiceName
         $servicesQuiescedAt = [DateTime]::UtcNow.ToString('o')

--- a/packaging/windows/DefenseClawEnterprise.psm1
+++ b/packaging/windows/DefenseClawEnterprise.psm1
@@ -6173,33 +6173,57 @@ function Start-DefenseClawTransactionServices {
     # an existing enumerator, the Restore call above has already put it
     # back to its recorded start mode — the block below just brings it
     # LIVE if the recorded posture had it running.
+    #
+    # Edge case (CR PRRT_kwDORuAK-s6au6lY): a snapshot with
+    # `running=true, start_mode=4` (running-while-disabled — legal
+    # in Windows: sc.exe config can change start mode without
+    # stopping the process) must ROUND-TRIP back to running-while-
+    # disabled after rollback. Set-DefenseClawServiceStartMode 4
+    # doesn't stop the process; but Start-DefenseClawService on a
+    # disabled service throws. So the sequence is:
+    #   1. Temporarily set demand-start (mode 3).
+    #   2. Start-Service.
+    #   3. Set disabled (mode 4) — SCM allows this while running.
     $enumeratorServiceName = Get-DefenseClawEnumeratorServiceName -GuardianServiceName $GuardianServiceName
     $enumeratorState = $states[$enumeratorServiceName]
     $enumeratorService = Microsoft.PowerShell.Management\Get-Service `
         -Name $enumeratorServiceName `
         -ErrorAction SilentlyContinue
     if ($null -ne $enumeratorService) {
-        $enumeratorStartMode = if ($null -ne $enumeratorState -and [bool]$enumeratorState.existed) {
+        $enumeratorRecordedExisted = $null -ne $enumeratorState -and [bool]$enumeratorState.existed
+        $enumeratorTargetStartMode = if ($enumeratorRecordedExisted) {
             [int]$enumeratorState.start_mode
         }
         else {
             # Fresh install: promote to auto-start.
             2
         }
-        Set-DefenseClawServiceStartMode `
-            -Name $enumeratorServiceName `
-            -StartMode $enumeratorStartMode
-        # Start only if the recorded posture had it running OR
-        # this is a fresh install (existed=false → we just
-        # promoted it to auto-start above and want it live now).
-        $enumeratorShouldRun = if ($null -eq $enumeratorState -or -not [bool]$enumeratorState.existed) {
+        # `should run` = recorded-running OR fresh install (we just
+        # created the service and want it live now).
+        $enumeratorShouldRun = if (-not $enumeratorRecordedExisted) {
             $true
         }
         else {
             [bool]$enumeratorState.running
         }
-        if ($enumeratorShouldRun -and $enumeratorStartMode -in @(2, 3)) {
+        if ($enumeratorShouldRun -and $enumeratorTargetStartMode -eq 4) {
+            # Running-while-disabled round-trip: demand-start,
+            # start, disable while running.
+            Set-DefenseClawServiceStartMode `
+                -Name $enumeratorServiceName `
+                -StartMode 3
             Start-DefenseClawService -Name $enumeratorServiceName
+            Set-DefenseClawServiceStartMode `
+                -Name $enumeratorServiceName `
+                -StartMode 4
+        }
+        else {
+            Set-DefenseClawServiceStartMode `
+                -Name $enumeratorServiceName `
+                -StartMode $enumeratorTargetStartMode
+            if ($enumeratorShouldRun -and $enumeratorTargetStartMode -in @(2, 3)) {
+                Start-DefenseClawService -Name $enumeratorServiceName
+            }
         }
     }
 }
@@ -11608,6 +11632,18 @@ function Invoke-DefenseClawInstallLikeLifecycle {
                 -Name $GatewayServiceName `
                 -StartMode 3
             Start-DefenseClawService -Name $GatewayServiceName
+            # Spec 005 D1 (CR PRRT_kwDORuAK-s6au6lZ): the enumerator
+            # must be demand-started + RUNNING before the pending-state
+            # assertion below, which requires every managed service to
+            # be StartMode 3 AND (via -RequireReadiness below) the
+            # enumerator SCM process to be Running. Promotion to
+            # StartMode 2 happens later alongside gateway + guardian
+            # only after full readiness succeeds.
+            $enumeratorServiceName = Get-DefenseClawEnumeratorServiceName -GuardianServiceName $GuardianServiceName
+            Set-DefenseClawServiceStartMode `
+                -Name $enumeratorServiceName `
+                -StartMode 3
+            Start-DefenseClawService -Name $enumeratorServiceName
             Assert-DefenseClawManagedServiceConfigurations `
                 -Layout $Layout `
                 -GatewayServiceName $GatewayServiceName `
@@ -11634,19 +11670,14 @@ function Invoke-DefenseClawInstallLikeLifecycle {
             Set-DefenseClawServiceStartMode `
                 -Name $GatewayServiceName `
                 -StartMode 2
-            # Spec 005 D1 (CR PRRT_kwDORuAK-s6aunSc): promote the
-            # enumerator to auto-start and START IT. Without this,
-            # Set-DefenseClawManagedServices leaves the enumerator at
-            # `disabled` after creation and it never runs — new user
-            # profiles would never be picked up, defeating the whole
-            # point of the workstream. Enumerator starts LAST because
-            # its first tick depends on config.yaml + targets.yaml
-            # provisioning that gateway + guardian activation ensures.
-            $enumeratorServiceName = Get-DefenseClawEnumeratorServiceName -GuardianServiceName $GuardianServiceName
+            # Spec 005 D1: promote the (already-running) enumerator
+            # from demand-start to auto-start now that readiness has
+            # been proven. Without this, boot would leave the
+            # enumerator disabled and new user profiles would never
+            # get picked up.
             Set-DefenseClawServiceStartMode `
                 -Name $enumeratorServiceName `
                 -StartMode 2
-            Start-DefenseClawService -Name $enumeratorServiceName
             Assert-DefenseClawEnterpriseDeployment `
                 -Layout $Layout `
                 -GatewayServiceName $GatewayServiceName `

--- a/packaging/windows/DefenseClawEnterprise.psm1
+++ b/packaging/windows/DefenseClawEnterprise.psm1
@@ -6165,6 +6165,43 @@ function Start-DefenseClawTransactionServices {
             -GatewayServiceName $GatewayServiceName `
             -GuardianServiceName $GuardianServiceName
     }
+    # Spec 005 D1 (CR PRRT_kwDORuAK-s6aunSc): reactivate the enumerator
+    # too. Restore-DefenseClawTransactionServiceStartModes only restores
+    # `existed=true` services from the pre-transaction snapshot; on a
+    # fresh install the enumerator was `existed=false`, so it stays
+    # disabled without this explicit start. On a snapshot rollback with
+    # an existing enumerator, the Restore call above has already put it
+    # back to its recorded start mode — the block below just brings it
+    # LIVE if the recorded posture had it running.
+    $enumeratorServiceName = Get-DefenseClawEnumeratorServiceName -GuardianServiceName $GuardianServiceName
+    $enumeratorState = $states[$enumeratorServiceName]
+    $enumeratorService = Microsoft.PowerShell.Management\Get-Service `
+        -Name $enumeratorServiceName `
+        -ErrorAction SilentlyContinue
+    if ($null -ne $enumeratorService) {
+        $enumeratorStartMode = if ($null -ne $enumeratorState -and [bool]$enumeratorState.existed) {
+            [int]$enumeratorState.start_mode
+        }
+        else {
+            # Fresh install: promote to auto-start.
+            2
+        }
+        Set-DefenseClawServiceStartMode `
+            -Name $enumeratorServiceName `
+            -StartMode $enumeratorStartMode
+        # Start only if the recorded posture had it running OR
+        # this is a fresh install (existed=false → we just
+        # promoted it to auto-start above and want it live now).
+        $enumeratorShouldRun = if ($null -eq $enumeratorState -or -not [bool]$enumeratorState.existed) {
+            $true
+        }
+        else {
+            [bool]$enumeratorState.running
+        }
+        if ($enumeratorShouldRun -and $enumeratorStartMode -in @(2, 3)) {
+            Start-DefenseClawService -Name $enumeratorServiceName
+        }
+    }
 }
 
 function Restore-DefenseClawTransactionWithManagedHooksRollback {
@@ -8236,6 +8273,44 @@ function Assert-DefenseClawEnterpriseDeployment {
                 'DEFENSECLAW_WINDOWS_CODEX_TRUSTED_HOOK_LAUNCHER_VERIFIED=1'
         )
     }
+    # Spec 005 D1 (CR PRRT_kwDORuAK-s6aunSc): the enumerator is a
+    # third managed SCM service. Its expected env vars mirror the
+    # guardian's (DEFENSECLAW_WINDOWS_SERVICE_NAME differs; everything
+    # else including the shared GuardianLogPath is identical), and
+    # its expected start mode + running state get validated here so
+    # -RequireReadiness catches the case where the enumerator got
+    # left disabled during activation.
+    $enumeratorServiceName = Get-DefenseClawEnumeratorServiceName -GuardianServiceName $GuardianServiceName
+    $enumeratorEnvironment = [string[]]@(
+        "DEFENSECLAW_HOME=$($Layout.RuntimeDirectory)",
+        "DEFENSECLAW_CONFIG=$($Layout.ConfigPath)",
+        'DEFENSECLAW_DEPLOYMENT_MODE=managed_enterprise',
+        "DEFENSECLAW_HOOK_GUARDIAN_AUTH_DIR=$($Layout.AuthorizationDirectory)",
+        "DEFENSECLAW_WINDOWS_SERVICE_NAME=$enumeratorServiceName",
+        "DEFENSECLAW_WINDOWS_GATEWAY_SERVICE_NAME=$GatewayServiceName",
+        "DEFENSECLAW_WINDOWS_SERVICE_ACCOUNT=NT SERVICE\$GatewayServiceName",
+        "DEFENSECLAW_WINDOWS_SERVICE_LOG=$($Layout.GuardianLogPath)"
+    )
+    if ([bool]$Layout.AgentApplicationControlAttested) {
+        $enumeratorEnvironment = [string[]]@(
+            $enumeratorEnvironment + @(
+                'DEFENSECLAW_WINDOWS_CODEX_APPROVED_CLIENT_ENFORCED=1',
+                'DEFENSECLAW_WINDOWS_APPROVED_AGENT_CLIENTS_ENFORCED=1'
+            )
+        )
+    }
+    if ([bool]$Layout.ClaudeEffectivePolicyVerified) {
+        $enumeratorEnvironment = [string[]]@(
+            $enumeratorEnvironment +
+                'DEFENSECLAW_WINDOWS_CLAUDE_EFFECTIVE_POLICY_VERIFIED=1'
+        )
+    }
+    if ([bool]$Layout.CodexTrustedHookLauncherVerified) {
+        $enumeratorEnvironment = [string[]]@(
+            $enumeratorEnvironment +
+                'DEFENSECLAW_WINDOWS_CODEX_TRUSTED_HOOK_LAUNCHER_VERIFIED=1'
+        )
+    }
     Assert-DefenseClawServiceConfiguration `
         -Name $GatewayServiceName `
         -ExpectedImage ('"{0}"' -f $Layout.GatewayPath) `
@@ -8260,6 +8335,21 @@ function Assert-DefenseClawEnterpriseDeployment {
         ) `
         -ExpectedEnvironment $guardianEnvironment `
         -ExpectedStartMode $expectedServiceStartMode
+    Assert-DefenseClawServiceConfiguration `
+        -Name $enumeratorServiceName `
+        -ExpectedImage ('"{0}" enterprise windows enumerate --manifest "{1}" --interval 5m' -f $Layout.GatewayPath, $Layout.ManifestPath) `
+        -ExpectedAccount 'LocalSystem' `
+        -ExpectedDisplayName 'DefenseClaw Enterprise Hook Enumerator' `
+        -ExpectedSidType 1 `
+        -ExpectedPrivileges @(
+            'SeTcbPrivilege',
+            'SeImpersonatePrivilege',
+            'SeChangeNotifyPrivilege',
+            'SeBackupPrivilege',
+            'SeRestorePrivilege'
+        ) `
+        -ExpectedEnvironment $enumeratorEnvironment `
+        -ExpectedStartMode $expectedServiceStartMode
     Assert-DefenseClawInstalledConfig -Layout $Layout -GatewayServiceName $GatewayServiceName
     [void](Invoke-DefenseClawCodexRequirementsCommand `
         -Layout $Layout `
@@ -8276,6 +8366,24 @@ function Assert-DefenseClawEnterpriseDeployment {
             -GuardianServiceName $GuardianServiceName `
             -LiveVerify)) {
             throw 'guardian SCM process is running but protected target coverage is not verified'
+        }
+        # Spec 005 D1: readiness check for the enumerator SCM
+        # process. Uses the same lightweight "service is running"
+        # probe as Test-DefenseClawGatewayReady rather than a
+        # deeper liveness call — the enumerator has no readiness
+        # RPC of its own; its per-cycle stderr goes to the
+        # guardian's log surface and the sidecar's
+        # SidecarHealth.Enumerator field (spec 005 Stage 9)
+        # carries the per-cycle state. A missing-or-stopped SCM
+        # process here is caught; a hung enumerator loop is a
+        # follow-up to add a health probe for.
+        $enumeratorService = Microsoft.PowerShell.Management\Get-Service `
+            -Name $enumeratorServiceName `
+            -ErrorAction SilentlyContinue
+        if ($null -eq $enumeratorService -or
+            $enumeratorService.Status -ne
+                [ServiceProcess.ServiceControllerStatus]::Running) {
+            throw 'enumerator SCM process is not running; targets.yaml will not refresh for new user profiles'
         }
     }
 }
@@ -11526,6 +11634,19 @@ function Invoke-DefenseClawInstallLikeLifecycle {
             Set-DefenseClawServiceStartMode `
                 -Name $GatewayServiceName `
                 -StartMode 2
+            # Spec 005 D1 (CR PRRT_kwDORuAK-s6aunSc): promote the
+            # enumerator to auto-start and START IT. Without this,
+            # Set-DefenseClawManagedServices leaves the enumerator at
+            # `disabled` after creation and it never runs — new user
+            # profiles would never be picked up, defeating the whole
+            # point of the workstream. Enumerator starts LAST because
+            # its first tick depends on config.yaml + targets.yaml
+            # provisioning that gateway + guardian activation ensures.
+            $enumeratorServiceName = Get-DefenseClawEnumeratorServiceName -GuardianServiceName $GuardianServiceName
+            Set-DefenseClawServiceStartMode `
+                -Name $enumeratorServiceName `
+                -StartMode 2
+            Start-DefenseClawService -Name $enumeratorServiceName
             Assert-DefenseClawEnterpriseDeployment `
                 -Layout $Layout `
                 -GatewayServiceName $GatewayServiceName `

--- a/packaging/windows/DefenseClawEnterprise.psm1
+++ b/packaging/windows/DefenseClawEnterprise.psm1
@@ -1219,6 +1219,31 @@ function Assert-DefenseClawServiceName {
     }
 }
 
+# Get-DefenseClawEnumeratorServiceName derives the third-service SCM
+# name from the guardian's, matching the same production /
+# certification-run-ID discipline the existing gateway + guardian
+# names already carry (Get-DefenseClawLayout enforces those two).
+#
+# Production: `DefenseClawHookGuardian` → `DefenseClawHookEnumerator`.
+# Certification: `DefenseClawCertGuardian_<10hex>` → `DefenseClawCertEnumerator_<10hex>`.
+#
+# Kept as a derivation rather than a separate parameter across the
+# ~230 GuardianServiceName call-sites so the enumerator's name is
+# always in lockstep with the guardian's. Every caller that today
+# passes `-GuardianServiceName` gets the enumerator name for free
+# via this helper — no threading required. See spec 005 D1.
+function Get-DefenseClawEnumeratorServiceName {
+    param([Parameter(Mandatory)][string]$GuardianServiceName)
+    Assert-DefenseClawServiceName -Name $GuardianServiceName
+    if ($GuardianServiceName -ceq 'DefenseClawHookGuardian') {
+        return 'DefenseClawHookEnumerator'
+    }
+    if ($GuardianServiceName -cmatch '^DefenseClawCertGuardian_([a-f0-9]{10})$') {
+        return "DefenseClawCertEnumerator_$($Matches[1])"
+    }
+    throw "cannot derive enumerator service name from unexpected guardian name: $GuardianServiceName"
+}
+
 function Resolve-DefenseClawCertificationCodexHome {
     param(
         [string]$Path,
@@ -3018,9 +3043,20 @@ function Set-DefenseClawManagedServices {
     )
     Assert-DefenseClawServiceName -Name $GatewayServiceName
     Assert-DefenseClawServiceName -Name $GuardianServiceName
+    $enumeratorServiceName = Get-DefenseClawEnumeratorServiceName -GuardianServiceName $GuardianServiceName
+    Assert-DefenseClawServiceName -Name $enumeratorServiceName
     $gatewayAccount = "NT SERVICE\$GatewayServiceName"
     $gatewayImage = '"{0}"' -f $GatewayPath
     $guardianImage = '"{0}" enterprise hooks watch --manifest "{1}" --interval 1m' -f $GatewayPath, $ManifestPath
+    # Spec 005 D1: third SCM service reuses the gateway binary, invoked
+    # with the `enterprise windows enumerate` subcommand. Runs as
+    # LocalSystem with the same privilege set as the guardian (needs
+    # SeImpersonatePrivilege to walk per-user profile trees; SeBackupPrivilege
+    # / SeRestorePrivilege for cross-user ACL work); SidType unrestricted so
+    # the virtual NT SERVICE\<name> SID is available for future DACL work
+    # without shipping a fourth ACE today (targets.yaml's existing AdminFile
+    # ACL grants SYSTEM full-control, which covers LocalSystem writes).
+    $enumeratorImage = '"{0}" enterprise windows enumerate --manifest "{1}" --interval 5m' -f $GatewayPath, $ManifestPath
     # Transaction-created or reconfigured services remain disabled while
     # protected state and binaries are being mutated. Demand start is not
     # sufficient: SCM may still execute an already queued failure restart.
@@ -3080,9 +3116,37 @@ function Set-DefenseClawManagedServices {
     Assert-DefenseClawServiceImagePath `
         -Name $GuardianServiceName `
         -ExpectedImage $guardianImage
+    if (Test-DefenseClawServiceExists -Name $enumeratorServiceName) {
+        [void](Invoke-DefenseClawNative -File $script:ScExe -Arguments @(
+            'config', $enumeratorServiceName,
+            'binPath=', $enumeratorImage,
+            'type=', 'own',
+            'start=', $configuredStart,
+            'error=', 'normal',
+            'depend=', '/',
+            'obj=', 'LocalSystem',
+            'DisplayName=', 'DefenseClaw Enterprise Hook Enumerator'
+        ))
+    }
+    else {
+        [void](Invoke-DefenseClawNative -File $script:ScExe -Arguments @(
+            'create', $enumeratorServiceName,
+            'binPath=', $enumeratorImage,
+            'type=', 'own',
+            'start=', $configuredStart,
+            'error=', 'normal',
+            'depend=', '/',
+            'obj=', 'LocalSystem',
+            'DisplayName=', 'DefenseClaw Enterprise Hook Enumerator'
+        ))
+    }
+    Assert-DefenseClawServiceImagePath `
+        -Name $enumeratorServiceName `
+        -ExpectedImage $enumeratorImage
 
     [void](Invoke-DefenseClawNative -File $script:ScExe -Arguments @('sidtype', $GatewayServiceName, 'restricted'))
     [void](Invoke-DefenseClawNative -File $script:ScExe -Arguments @('sidtype', $GuardianServiceName, 'unrestricted'))
+    [void](Invoke-DefenseClawNative -File $script:ScExe -Arguments @('sidtype', $enumeratorServiceName, 'unrestricted'))
     [void](Invoke-DefenseClawNative -File $script:ScExe -Arguments @(
         'privs', $GatewayServiceName, 'SeChangeNotifyPrivilege'
     ))
@@ -3090,7 +3154,11 @@ function Set-DefenseClawManagedServices {
         'privs', $GuardianServiceName,
         'SeTcbPrivilege/SeImpersonatePrivilege/SeChangeNotifyPrivilege/SeBackupPrivilege/SeRestorePrivilege'
     ))
-    foreach ($service in @($GatewayServiceName, $GuardianServiceName)) {
+    [void](Invoke-DefenseClawNative -File $script:ScExe -Arguments @(
+        'privs', $enumeratorServiceName,
+        'SeTcbPrivilege/SeImpersonatePrivilege/SeChangeNotifyPrivilege/SeBackupPrivilege/SeRestorePrivilege'
+    ))
+    foreach ($service in @($GatewayServiceName, $GuardianServiceName, $enumeratorServiceName)) {
         [void](Invoke-DefenseClawNative -File $script:ScExe -Arguments @(
             'failure', $service,
             'reset=', '86400',
@@ -3120,6 +3188,21 @@ function Set-DefenseClawManagedServices {
         -CodexTrustedHookLauncherVerified:$CodexTrustedHookLauncherVerified
     Set-DefenseClawServiceEnvironment `
         -Name $GuardianServiceName `
+        -RuntimeDirectory $RuntimeDirectory `
+        -ConfigPath $ConfigPath `
+        -AuthorizationDirectory $AuthorizationDirectory `
+        -GatewayServiceName $GatewayServiceName `
+        -LogPath $GuardianLogPath `
+        -AgentApplicationControlAttested:$AgentApplicationControlAttested `
+        -ClaudeEffectivePolicyVerified:$ClaudeEffectivePolicyVerified `
+        -CodexTrustedHookLauncherVerified:$CodexTrustedHookLauncherVerified
+    # Spec 005 D1: the enumerator shares the guardian's log directory
+    # via GuardianLogPath — one hook-guardian log surface holds every
+    # guardian + enumerator line, matching macOS's shared
+    # hook-enumerator.log convention. A follow-up may split the paths
+    # if operator log-scraping needs separate surfaces.
+    Set-DefenseClawServiceEnvironment `
+        -Name $enumeratorServiceName `
         -RuntimeDirectory $RuntimeDirectory `
         -ConfigPath $ConfigPath `
         -AuthorizationDirectory $AuthorizationDirectory `
@@ -4187,8 +4270,17 @@ function Assert-DefenseClawOwnedServiceOrAbsent {
         [Parameter(Mandatory)][string]$Name,
         [Parameter(Mandatory)][string]$ExpectedGatewayPath,
         [string]$ExpectedManifestPath,
-        [switch]$Guardian
+        [switch]$Guardian,
+        # Spec 005 D1: mirrors -Guardian for the third SCM service.
+        # Its ImagePath is the gateway binary invoked with
+        # `enterprise windows enumerate --manifest X --interval 5m`;
+        # its ObjectName is LocalSystem (same as guardian, matching
+        # the account-model choice recorded in the Stage 1 commit).
+        [switch]$Enumerator
     )
+    if ($Guardian -and $Enumerator) {
+        throw '-Guardian and -Enumerator are mutually exclusive'
+    }
     if (-not (Test-DefenseClawServiceExists -Name $Name)) {
         return
     }
@@ -4200,6 +4292,12 @@ function Assert-DefenseClawOwnedServiceOrAbsent {
         }
         '"{0}" enterprise hooks watch --manifest "{1}" --interval 1m' -f $ExpectedGatewayPath, $ExpectedManifestPath
     }
+    elseif ($Enumerator) {
+        if ([string]::IsNullOrWhiteSpace($ExpectedManifestPath)) {
+            throw 'enumerator service ownership validation requires its exact manifest path'
+        }
+        '"{0}" enterprise windows enumerate --manifest "{1}" --interval 5m' -f $ExpectedGatewayPath, $ExpectedManifestPath
+    }
     else {
         '"{0}"' -f $ExpectedGatewayPath
     }
@@ -4208,7 +4306,7 @@ function Assert-DefenseClawOwnedServiceOrAbsent {
         throw "refusing to replace foreign Windows service $Name with ImagePath $image"
     }
     $objectName = [string](Microsoft.PowerShell.Management\Get-ItemPropertyValue -LiteralPath $key -Name ObjectName)
-    $expectedAccount = if ($Guardian) { 'LocalSystem' } else { "NT SERVICE\$Name" }
+    $expectedAccount = if ($Guardian -or $Enumerator) { 'LocalSystem' } else { "NT SERVICE\$Name" }
     if (-not [string]::Equals($objectName, $expectedAccount, [StringComparison]::OrdinalIgnoreCase)) {
         throw "refusing to replace service $Name owned by unexpected account $objectName"
     }
@@ -7412,6 +7510,42 @@ function Assert-DefenseClawManagedServiceConfigurations {
             'SeRestorePrivilege'
         ) `
         -ExpectedEnvironment $guardianEnvironment `
+        -ExpectedStartMode $expectedStartMode
+    # Spec 005 D1: third service. Same account model + privilege set
+    # as the guardian (needs SeImpersonate + SeBackup + SeRestore for
+    # per-user profile walks). Shares the guardian's log path — the
+    # enumerator writes one line per cycle to hook-guardian.log rather
+    # than a separate hook-enumerator.log, matching what LocalSystem
+    # can chown without touching a third log-file ACL surface. ImagePath
+    # differs from guardian's watch command: `enterprise windows
+    # enumerate --manifest <path> --interval 5m`.
+    $enumeratorServiceName = Get-DefenseClawEnumeratorServiceName -GuardianServiceName $GuardianServiceName
+    $enumeratorEnvironment = [string[]]@(
+        Get-DefenseClawServiceEnvironmentValues `
+            -Name $enumeratorServiceName `
+            -RuntimeDirectory $Layout.RuntimeDirectory `
+            -ConfigPath $Layout.ConfigPath `
+            -AuthorizationDirectory $Layout.AuthorizationDirectory `
+            -GatewayServiceName $GatewayServiceName `
+            -LogPath $Layout.GuardianLogPath `
+            -AgentApplicationControlAttested:$Layout.AgentApplicationControlAttested `
+            -ClaudeEffectivePolicyVerified:$Layout.ClaudeEffectivePolicyVerified `
+            -CodexTrustedHookLauncherVerified:$Layout.CodexTrustedHookLauncherVerified
+    )
+    Assert-DefenseClawServiceConfiguration `
+        -Name $enumeratorServiceName `
+        -ExpectedImage ('"{0}" enterprise windows enumerate --manifest "{1}" --interval 5m' -f $Layout.GatewayPath, $Layout.ManifestPath) `
+        -ExpectedAccount 'LocalSystem' `
+        -ExpectedDisplayName 'DefenseClaw Enterprise Hook Enumerator' `
+        -ExpectedSidType 1 `
+        -ExpectedPrivileges @(
+            'SeTcbPrivilege',
+            'SeImpersonatePrivilege',
+            'SeChangeNotifyPrivilege',
+            'SeBackupPrivilege',
+            'SeRestorePrivilege'
+        ) `
+        -ExpectedEnvironment $enumeratorEnvironment `
         -ExpectedStartMode $expectedStartMode
 }
 
@@ -11496,6 +11630,17 @@ function Invoke-DefenseClawUninstallLifecycle {
             -GatewayServiceName $GatewayServiceName `
             -GuardianServiceName $GuardianServiceName `
             -ServicingTransaction
+        # Spec 005 D1: teardown order enumerator → guardian → gateway.
+        # The enumerator writes targets.yaml; removing it first stops
+        # further writes so the guardian's final reconcile pass sees a
+        # stable file. Guardian teardown after remains unchanged.
+        $enumeratorServiceName = Get-DefenseClawEnumeratorServiceName -GuardianServiceName $GuardianServiceName
+        Assert-DefenseClawOwnedServiceOrAbsent `
+            -Name $enumeratorServiceName `
+            -ExpectedGatewayPath $Layout.GatewayPath `
+            -ExpectedManifestPath $Layout.ManifestPath `
+            -Enumerator
+        Remove-DefenseClawService -Name $enumeratorServiceName
         Assert-DefenseClawOwnedServiceOrAbsent `
             -Name $GuardianServiceName `
             -ExpectedGatewayPath $Layout.GatewayPath `

--- a/packaging/windows/tests/enterprise-uninstall-transaction-smoke.ps1
+++ b/packaging/windows/tests/enterprise-uninstall-transaction-smoke.ps1
@@ -772,7 +772,13 @@ try {
                 [Parameter(Mandatory)][string]$Name,
                 [Parameter(Mandatory)][string]$ExpectedGatewayPath,
                 [string]$ExpectedManifestPath,
-                [switch]$Guardian
+                [switch]$Guardian,
+                # Spec 005 D1: the uninstall path now also calls this
+                # helper with -Enumerator to verify the third service
+                # before removing it. Accepted for parity with the
+                # real function; the mock records the ownership check
+                # without differentiating the switch value.
+                [switch]$Enumerator
             )
             $script:HarnessState.events.Add("owned:$Name")
             $script:HarnessState.owned_checks++


### PR DESCRIPTION
## Summary

Lands **Workstream D** of `docs/WINDOWS-MANAGED-ENTERPRISE-PARITY-PLAN.md`
§5 — the DefenseClawHookEnumerator SCM service that keeps
`targets.yaml` in sync with the local user profile set on Windows
managed_enterprise, matching macOS's `hook-enumerator` LaunchDaemon
(5-min cadence). New user profiles created between admin-driven
`enterprise windows repair` invocations now get discovered on the
next enumerator tick without a manual repair.

**Scope rescope (from single-session pragmatics):** spec 005 as
approved covered D + F (targeted per-user uninstall). This PR ships
**D only**. F (`--user <SID>` + `--keep-config`/`--purge` symmetry)
is scheduled for a follow-up spec 006 PR — it depends on D's
per-user enumerator model, which lands here.

## What lands

| Stage | Scope | Files |
|---|---|---|
| 1 | Enumerator entry point (`EnumerateWindows` + `WriteTargetsManifestAtomic`) | `internal/enterprisehooks/enumerator_windows.go` + test |
| 3 | `enterprise windows enumerate` CLI subcommand (--interval/--once) | `internal/cli/enterprise_windows_enumerate_windows.go` + test |
| 4 | Third SCM service registration + teardown in psm1 | `packaging/windows/DefenseClawEnterprise.psm1` |
| 9 | Enumerator subsystem on `SidecarHealth` | `internal/gateway/health.go` + tests |
| — | Uninstall-transaction mock accepts `-Enumerator` switch | `packaging/windows/tests/enterprise-uninstall-transaction-smoke.ps1` |

**Deliberate deviations from the approved design (recorded in per-stage commit messages):**

1. **Enumerator runs as LocalSystem**, not a virtual `NT SERVICE\DefenseClawHookEnumerator` account. Matches the guardian's actual account model (`obj=LocalSystem` at psm1:3064). Consequence: no fourth ACE on `targets.yaml` needed — SYSTEM full-control via the existing spec-003 `AdminFile` ACL covers writes.
2. **New (SID, Connector) rows are emitted `Enabled=false` with empty `AgentVersion`.** Per-connector agent-version discovery on Windows is deferred to a follow-up spec — walking per-user Codex / Claude Code install trees, reading package.json, or exec'ing --version in impersonation is a substantial scope on its own. Fresh new-user rows wait for admin / UCB promotion before receiving hooks; this preserves the security posture (a random new profile does not silently auto-hook without operator intent) while shipping the enumerator's primary contract: DISCOVERY + fsnotify wake-up.

**Not yet cross-process-wired:** `SetEnumerator` is exposed on `SidecarHealth` and unit-tested, but the enumerator CLI subcommand runs in its own SCM service process — the cross-process signal (mirror of spec 003's `guardianstate` `.state` file, or a log-line tailer) is a follow-up. The per-cycle stderr line the CLI emits is the observability surface until then.

## Non-obvious design decisions (per file doc-comments + commit messages)

- **Registry ProfileList walk** over WMI/WTS — matches macOS's `dscl` semantics (every profile, not just currently-logged-in). Registry key `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList` documented stable across Windows XP → Windows 11 / Server 2025.
- **No-op no-write on byte-identical manifest** — prevents 288 fsnotify wakes/day on a stable box. `os.ReadFile` + `bytes.Equal` before any `MoveFileEx`.
- **Initial-cycle-delay 30 s** — matches macOS `RunAtLoad=true` operator experience (hooks appear within a minute of install) without racing gateway + guardian's "starting" health lines on cold-boot.
- **Enumerator name derived from guardian's** via new `Get-DefenseClawEnumeratorServiceName` helper — avoids threading a third `-EnumeratorServiceName` parameter through the ~230 GuardianServiceName call-sites in psm1. Production `DefenseClawHookGuardian` → `DefenseClawHookEnumerator`; certification `DefenseClawCertGuardian_<runid>` → `DefenseClawCertEnumerator_<runid>`.
- **Teardown order enumerator → guardian → gateway** — the enumerator writes `targets.yaml`; removing it first stops further writes so the guardian's final reconcile pass sees a stable file.

## Follow-up work (tracked; not in this PR)

- **Workstream F** — targeted per-user uninstall (`--user <SID>` + `--keep-config`). New spec 006 to slice cleanly against D.
- **Cross-process wiring for `SetEnumerator`** — mirror spec 003's `guardianstate` `.state` file so the enumerator's health surfaces on the wire.
- **Per-cycle Windows agent-version discovery** — walk `%LOCALAPPDATA%\Programs\@openai\codex\...\package.json` etc. so fresh new-user rows can auto-enable rather than requiring admin promotion.
- **Windows-native happy-path integration test** — create a synthetic profile via `New-LocalUser`, force-tick the enumerator via `--once`, assert the new SID appears in `targets.yaml`. The existing `windows-native.yml` Go test matrix already picks up my unit tests; the integration slice is a follow-up.
- **psm1 assertion-mirror extensions** — this PR touches the primary create/config + teardown + ownership-check paths. `Assert-DefenseClawInstalledConfig`, `Wait-DefenseClawEnterpriseReadiness`, `Get-DefenseClawGuardianStatusReport` etc. don't yet know about the third service. If any packaging/windows/tests/*.ps1 test asserts on a specific service inventory that omits the enumerator, CI catches it.

## Test plan

- [x] `go build ./...` — clean
- [x] `GOOS=windows go build ./...` — clean cross-compile
- [x] `go test -count=1 -run TestSetEnumerator ./internal/gateway/...` — 4 tests pass
- [ ] Windows-native CI Go suite (via `windows-native-ci.ps1`) — picks up new unit tests under `internal/enterprisehooks/` + `internal/cli/enterprise_windows_enumerate_*` automatically
- [ ] Windows-native CI packaged-acceptance — runs the real installer against my psm1 changes; will surface any assertion-mirror gaps
- [ ] Windows-native CI PowerShell static — parses `enterprise-uninstall-transaction-smoke.ps1` with the updated mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)