### PR TITLE
fix(windows): move UI-IPC socket root from ProgramData to Program Files

### DIFF
--- a/internal/ipc/paths.go
+++ b/internal/ipc/paths.go
@@ -56,10 +56,10 @@ const (
 //  3. managed_enterprise → resolveManagedIPCSocketPath(cfg):
 //     - linux/darwin: filepath.Join(filepath.Dir(cfg.DataDir),
 //     "ipc", SocketFileName)
-//     - windows:      filepath.Join(<TrustedProgramData>, "Cisco",
+//     - windows:      filepath.Join(<TrustedProgramFiles>, "Cisco",
 //     "Cisco Secure Client", "DefenseClaw", "ipc",
 //     SocketFileName). See spec 004 REQ-02. Returns "" when
-//     TrustedProgramData resolution fails; the caller's
+//     TrustedProgramFiles resolution fails; the caller's
 //     ResolveSocketPath empty-check turns that into a
 //     distinguishable "ipc: resolve socket path: empty"
 //     server-start error rather than a fall-through to a
@@ -73,14 +73,14 @@ const (
 // — that value is honored verbatim by the resolver above (there is no
 // linux/darwin-side validator; ownership + mode checks at server
 // start-up are the trust boundary). On Windows the socket path is
-// fixed to <TrustedProgramData>/Cisco/Cisco Secure Client/DefenseClaw/
+// fixed to <TrustedProgramFiles>/Cisco/Cisco Secure Client/DefenseClaw/
 // ipc/SocketFileName: validateWindowsSocketPathOverride (in
 // internal/ipc/server_windows.go) refuses any override whose parent
 // does not equal the trusted root, so cfg.Managed.SocketPath is
 // effectively non-configurable there.
 //
 // Never returns an error: rule 4 always produces a value (rule 3 may
-// return "" on Windows when the TrustedProgramData registry lookup
+// return "" on Windows when the TrustedProgramFiles registry lookup
 // fails — the server refuses to start in that case).
 func ResolveSocketPath(cfg *config.Config) string {
 	if cfg == nil {

--- a/internal/ipc/paths_windows.go
+++ b/internal/ipc/paths_windows.go
@@ -20,13 +20,20 @@ import (
 )
 
 // windowsManagedIPCRelativeDir is the subpath under
-// TrustedProgramData that holds the DefenseClaw UDS socket. The
+// TrustedProgramFiles that holds the DefenseClaw UDS socket. The
 // literal is fixed by the AVC integration contract: Cisco Secure
 // Client's Windows GUI dials this exact path. Changing it requires
 // a coordinated change with the AVC packaging team.
 //
 // The final socket path is
-// `<TrustedProgramData>\Cisco\Cisco Secure Client\DefenseClaw\ipc\defenseclaw_ipc.sock`.
+// `<TrustedProgramFiles>\Cisco\Cisco Secure Client\DefenseClaw\ipc\defenseclaw_ipc.sock`.
+//
+// Historical note: earlier builds placed this under TrustedProgramData
+// (ProgramData is the Windows convention for mutable machine state).
+// The AVC release-26.8.4 integration moved it under TrustedProgramFiles
+// so both peers dial the same known-root prefix. The virtual service
+// SID granted DACL rights on this directory during install can bind /
+// unlink the socket under Program Files just as under ProgramData.
 //
 // See spec 004 REQ-02 and parity plan §4.2 C1.
 var windowsManagedIPCRelativeDir = filepath.Join(
@@ -34,12 +41,12 @@ var windowsManagedIPCRelativeDir = filepath.Join(
 )
 
 // resolveManagedIPCSocketPath returns the managed-enterprise UDS
-// socket path on Windows. Resolves `TrustedProgramData` through the
+// socket path on Windows. Resolves `TrustedProgramFiles` through the
 // same fail-closed registry path env_config_windows.go uses so the
-// user-supplied `%ProgramData%` env cannot redirect the socket
+// user-supplied `%ProgramFiles%` env cannot redirect the socket
 // off-disk or into a per-user profile.
 //
-// Returns "" when TrustedProgramData resolution fails; the caller
+// Returns "" when TrustedProgramFiles resolution fails; the caller
 // (ResolveSocketPath in paths.go) turns that into a distinguishable
 // "ipc: resolve socket path: empty" server-start error rather than
 // falling back to a per-user path.
@@ -47,9 +54,9 @@ var windowsManagedIPCRelativeDir = filepath.Join(
 // Spec 004 REQ-02.
 func resolveManagedIPCSocketPath(cfg *config.Config) string {
 	_ = cfg // reserved: a future spec may consult cfg.Managed for override plumbing
-	programData, err := winpath.TrustedProgramData()
-	if err != nil || programData == "" {
+	programFiles, err := winpath.TrustedProgramFiles()
+	if err != nil || programFiles == "" {
 		return ""
 	}
-	return filepath.Join(programData, windowsManagedIPCRelativeDir, SocketFileName)
+	return filepath.Join(programFiles, windowsManagedIPCRelativeDir, SocketFileName)
 }

--- a/internal/ipc/paths_windows_test.go
+++ b/internal/ipc/paths_windows_test.go
@@ -34,25 +34,25 @@ func TestResolveManagedIPCSocketPathWindowsHonoursExplicitOverride(t *testing.T)
 	}
 }
 
-// TestResolveManagedIPCSocketPathWindowsProducesProgramDataPath
+// TestResolveManagedIPCSocketPathWindowsProducesProgramFilesPath
 // asserts the default resolver produces a path under
-// TrustedProgramData. On CI (`CI=true`) a failed TrustedProgramData
+// TrustedProgramFiles. On CI (`CI=true`) a failed TrustedProgramFiles
 // resolution is a hard failure — a regression in winpath would
-// otherwise produce a green build while leaving the ProgramData
+// otherwise produce a green build while leaving the Program Files
 // path unverified. On a developer laptop the test skips
 // gracefully because the registry key may legitimately be
 // unreadable outside of a real Windows managed_enterprise
 // install. See CR spec-004:PRRT_kwDORuAK-s6ankzr.
-func TestResolveManagedIPCSocketPathWindowsProducesProgramDataPath(t *testing.T) {
+func TestResolveManagedIPCSocketPathWindowsProducesProgramFilesPath(t *testing.T) {
 	cfg := &config.Config{DeploymentMode: string(config.DeploymentModeManagedEnterprise)}
 	got := ResolveSocketPath(cfg)
 	if got == "" {
 		if os.Getenv("CI") != "" {
-			t.Fatalf("TrustedProgramData resolution returned empty on a CI runner — winpath registry access must succeed for the managed IPC surface")
+			t.Fatalf("TrustedProgramFiles resolution returned empty on a CI runner — winpath registry access must succeed for the managed IPC surface")
 		}
-		t.Skip("TrustedProgramData resolution failed on this host; running outside CI so skipping")
+		t.Skip("TrustedProgramFiles resolution failed on this host; running outside CI so skipping")
 	}
-	// Expected shape: <programData>\Cisco\Cisco Secure Client\DefenseClaw\ipc\defenseclaw_ipc.sock
+	// Expected shape: <programFiles>\Cisco\Cisco Secure Client\DefenseClaw\ipc\defenseclaw_ipc.sock
 	if !strings.HasSuffix(got, filepath.Join(windowsManagedIPCRelativeDir, SocketFileName)) {
 		t.Fatalf("socket path missing expected suffix: got %q, want ending %q",
 			got, filepath.Join(windowsManagedIPCRelativeDir, SocketFileName))

--- a/internal/ipc/server_windows.go
+++ b/internal/ipc/server_windows.go
@@ -157,7 +157,7 @@ func validateWindowsSocketPathOverride(socketPath string) error {
 	// Shape anchor: the socket must live under an "ipc" directory. In
 	// production this is fully subsumed by the trusted-root check below,
 	// which requires an exact case-insensitive match against
-	// TrustedProgramData/…/ipc — check 3 can only fire for inputs check 4
+	// TrustedProgramFiles/…/ipc — check 3 can only fire for inputs check 4
 	// would also reject. It IS load-bearing under the test hook
 	// (allowUnsafeSocketOverrideForTest) which short-circuits check 4:
 	// leaving this shape check ensures the tests still exercise a
@@ -175,14 +175,14 @@ func validateWindowsSocketPathOverride(socketPath string) error {
 	if allowUnsafeSocketOverrideForTest {
 		return nil
 	}
-	programData, err := winpath.TrustedProgramData()
+	programFiles, err := winpath.TrustedProgramFiles()
 	if err != nil {
-		return fmt.Errorf("ipc: resolve trusted program data root: %w", err)
+		return fmt.Errorf("ipc: resolve trusted program files root: %w", err)
 	}
-	if programData == "" {
-		return fmt.Errorf("ipc: trusted program data root is empty; refusing to bind IPC surface")
+	if programFiles == "" {
+		return fmt.Errorf("ipc: trusted program files root is empty; refusing to bind IPC surface")
 	}
-	trustedParent := filepath.Clean(filepath.Join(programData, windowsManagedIPCRelativeDir))
+	trustedParent := filepath.Clean(filepath.Join(programFiles, windowsManagedIPCRelativeDir))
 	if !strings.EqualFold(parent, trustedParent) {
 		return fmt.Errorf(
 			"ipc: socket path override must live under the trusted managed root %q (got parent %q)",

--- a/packaging/windows/DefenseClawEnterprise.psm1
+++ b/packaging/windows/DefenseClawEnterprise.psm1
@@ -5039,8 +5039,11 @@ function Initialize-DefenseClawManagedIPCDirectory {
         [Parameter(Mandatory)][string]$GatewayServiceName
     )
     $gatewaySID = Get-DefenseClawServiceSID -ServiceName $GatewayServiceName
+    # AVC release-26.8.4 integration: the UI-IPC UDS socket lives under
+    # Program Files, not ProgramData. Path parity with the Go resolver
+    # in internal/ipc/paths_windows.go is mandatory. Spec 004 REQ-02.
     $expectedIPCDirectory = [IO.Path]::Combine(
-        $script:ProgramData,
+        $script:ProgramFiles,
         'Cisco',
         'Cisco Secure Client',
         'DefenseClaw',
@@ -5064,12 +5067,12 @@ function Initialize-DefenseClawManagedIPCDirectory {
         Initialize-DefenseClawManagedRoot `
             -Path $parent `
             -Label 'managed IPC parent' `
-            -RequiredBase $script:ProgramData
+            -RequiredBase $script:ProgramFiles
     }
     else {
         Assert-DefenseClawTrustedAncestors `
             -Path $parent `
-            -RequiredBase $script:ProgramData
+            -RequiredBase $script:ProgramFiles
     }
 
     if (Microsoft.PowerShell.Management\Test-Path -LiteralPath $ipcDirectory) {
@@ -5293,8 +5296,11 @@ function Revoke-DefenseClawManagedIPCServiceAccess {
             -GatewayServiceSID $GatewayServiceSID
     }
 
+    # AVC release-26.8.4 integration: the UI-IPC UDS socket lives under
+    # Program Files, not ProgramData. Path parity with the Go resolver
+    # in internal/ipc/paths_windows.go is mandatory. Spec 004 REQ-02.
     $expectedIPCDirectory = [IO.Path]::Combine(
-        $script:ProgramData,
+        $script:ProgramFiles,
         'Cisco',
         'Cisco Secure Client',
         'DefenseClaw',
@@ -5315,7 +5321,7 @@ function Revoke-DefenseClawManagedIPCServiceAccess {
     Assert-DefenseClawNoReparsePath -Path $ipcDirectory -AllowMissingLeaf
     Assert-DefenseClawTrustedAncestors `
         -Path ([IO.Path]::GetDirectoryName($ipcDirectory)) `
-        -RequiredBase $script:ProgramData
+        -RequiredBase $script:ProgramFiles
 
     $nativeSecurity = Initialize-DefenseClawNativeSecurity
     # This final-component OPEN_REPARSE_POINT call is the sole absence proof.
@@ -6324,8 +6330,13 @@ function Get-DefenseClawLayout {
     $gatewayLogDirectory = Microsoft.PowerShell.Management\Join-Path $logDirectory 'gateway'
     $brokerLogDirectory = Microsoft.PowerShell.Management\Join-Path $logDirectory 'cmid-broker'
     $guardianLogDirectory = Microsoft.PowerShell.Management\Join-Path $logDirectory 'guardian'
+    # The DefenseClaw managed-IPC UDS socket lives under Program Files
+    # (not ProgramData) as of the AVC release-26.8.4 integration —
+    # Cisco Secure Client's Windows GUI dials the socket under Program
+    # Files so DefenseClaw follows. Path parity with
+    # internal/ipc/paths_windows.go is mandatory. Spec 004 REQ-02.
     $managedIPCDirectory = [IO.Path]::Combine(
-        $script:ProgramData,
+        $script:ProgramFiles,
         'Cisco',
         'Cisco Secure Client',
         'DefenseClaw',

--- a/packaging/windows/tests/enterprise-module-smoke.ps1
+++ b/packaging/windows/tests/enterprise-module-smoke.ps1
@@ -514,7 +514,7 @@ namespace DefenseClaw.Windows.Tests
         -StateRoot (Join-Path $script:ProgramData 'Cisco\Cisco Secure Client\DefenseClaw')
     $expectedCodexParent = Join-Path $script:ProgramData 'OpenAI\Codex'
     $expectedManagedIPCDirectory = Join-Path `
-        $script:ProgramData `
+        $script:ProgramFiles `
         'Cisco\Cisco Secure Client\DefenseClaw\ipc'
     if (-not [string]::Equals(
         [string]$layout.ManagedIPCDirectory,


### PR DESCRIPTION
## Summary

- Swap the DefenseClaw UI-IPC UDS socket root from
  `TrustedProgramData` → `TrustedProgramFiles` so the socket lives at
  `C:\Program Files\Cisco\Cisco Secure Client\DefenseClaw\ipc\defenseclaw_ipc.sock`
  instead of its historical `C:\ProgramData\...\DefenseClaw\ipc\...` location.
- Subpath under the root (`Cisco\Cisco Secure Client\DefenseClaw\ipc\`) is unchanged; only the root moves.
- All producers and consumers updated together in lockstep: Go resolver + trust-anchor validator, PS install layout constructor + init helper + transactional cleanup, and the module-boundary smoke test that pins the expected layout.

## Rationale

Per the AVC release-26.8.4 integration alignment, Cisco Secure Client's Windows GUI dials the socket under Program Files. DefenseClaw follows so both peers dial the same known-root prefix.

**Convention note.** Windows convention is Program Files = immutable, ProgramData = mutable per-machine state, and a UDS socket is mutable. The move works — the virtual gateway service SID granted DACL rights on this directory during install can bind / unlink the socket under Program Files just as under ProgramData, and the ACL logic (`$managedIPCDirectoryRights` + `Assert-DefenseClawPathAcl`) is anchor-agnostic — but the reviewer will notice. This PR body is the acknowledgement.

**AVC-side coordination.** Assumed to land in lockstep. This PR does not maintain a compat window listening on both paths.

## Files touched

- `internal/ipc/paths_windows.go` — `resolveManagedIPCSocketPath` swaps `winpath.TrustedProgramData` → `winpath.TrustedProgramFiles`; doc comment on `windowsManagedIPCRelativeDir` names the new root and includes a one-line historical note.
- `internal/ipc/server_windows.go` — `validateWindowsSocketPathOverride`'s trust-anchor check swaps to the new resolver so an operator override with the old parent is rejected.
- `internal/ipc/paths.go` — `ResolveSocketPath` doc block names the new resolver.
- `internal/ipc/paths_windows_test.go` — default-resolver test renamed to `…ProducesProgramFilesPath` and asserts the Program Files shape; skip-outside-CI comment updated.
- `packaging/windows/DefenseClawEnterprise.psm1` — layout constructor's `$managedIPCDirectory` joins `$script:ProgramFiles`; `Initialize-DefenseClawManagedIPCDirectory` and the transactional cleanup both assert the new root and require `$script:ProgramFiles` as the trusted-ancestor base.
- `packaging/windows/tests/enterprise-module-smoke.ps1` — module-boundary layout assertion expects `$script:ProgramFiles`.

## Test plan

- [x] `GOOS=windows GOARCH=amd64 go build ./...` clean
- [x] `GOOS=windows GOARCH=amd64 go vet ./...` clean
- [x] `go test ./internal/ipc/...` clean on darwin (Windows-specific test skips gracefully)
- [ ] CI: `Windows x64 Go suite` — runs `paths_windows_test.go` under the new resolver
- [ ] CI: `Windows PowerShell harness validation` — runs the updated `enterprise-module-smoke.ps1`
- [ ] CI: `Windows complete Python suite / shard 3` — invokes the module smoke via pwsh + powershell
- [ ] CI: `Windows native Setup install and lifecycle acceptance` — real install/uninstall on a Windows runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)