### PR TITLE
fix(windows): auto-authorize new users on the enumerator SCM service at parity with macOS

### DIFF
--- a/docs/WINDOWS-ENTERPRISE-THREAT-MODEL.md
+++ b/docs/WINDOWS-ENTERPRISE-THREAT-MODEL.md
@@ -393,17 +393,41 @@ not an administrator authority even though it is a machine service.
    probe). Managed-enterprise deployments are administrator-controlled at
    the *policy* layer — which connectors are pushed, and which SID scope
    the guardian authorization ledger accepts — not at the per-device
-   authorization layer. A local admin who can create an interactive user
-   (`S-1-5-21-…`) on the target machine can therefore cause that user to
-   be enrolled on the next enumerator tick; this is the accepted cost of
-   parity with macOS, whose `launchd`-driven `render-targets.sh` operates
-   under the same posture. The exact SID membership check (row W-28
-   above) still fail-closes on an unregistered SID between enumerator
-   ticks, and the guardian authorization ledger records every enrollment
-   for audit. `Install -NoStart` keeps the complete planned all-user
-   enrollment because it makes no immediate readiness claim. An explicit
-   manifest that enables a disconnected target remains authoritative and
-   fails readiness until the exact SID has an active token.
+   authorization layer. Three residual sub-risks follow from this posture:
+
+   a. **Local-admin user creation → auto-enrollment.** A local admin
+      who can create an interactive user (`S-1-5-21-…`) on the target
+      machine causes that user to be enrolled on the next enumerator
+      tick. macOS's `launchd`-driven `render-targets.sh` operates under
+      the same posture; this is the accepted cost of parity. The exact
+      SID membership check (row W-28 above) still fail-closes on an
+      unregistered SID between enumerator ticks, and the guardian
+      authorization ledger records every enrollment for audit.
+
+   b. **Unprivileged self-enrollment via user-writable `package.json`.**
+      The per-connector version probe reads a `version` field from
+      package metadata under paths inside the user's own profile
+      (`AppData\Roaming\npm\node_modules\@…\package.json`,
+      `AppData\Local\Programs\cursor\resources\app\package.json`).
+      Any interactive user can create these files with a plausible
+      `version` string and cause the enumerator to auto-authorize
+      their `(SID, Connector)` on the next tick, *without actually
+      installing a supported CLI*. This is deliberately accepted
+      because enrollment confers no privilege to the target — it
+      only means that user's own agent invocations become subject to
+      DefenseClaw inspection. A user who self-enrolls opts themselves
+      *into* monitoring, which is a security-neutral (or
+      defense-positive) outcome; there is no path from "user drops a
+      fake `package.json`" to "attacker gains inspection authority
+      over another user's traffic." Endpoint policy remains
+      authoritative for what shell / CLI activity is actually visible
+      to DefenseClaw once the row exists.
+
+   c. **`Install -NoStart` planned-enrollment.** `Install -NoStart`
+      keeps the complete planned all-user enrollment because it makes
+      no immediate readiness claim. An explicit manifest that enables
+      a disconnected target remains authoritative and fails readiness
+      until the exact SID has an active token.
 4. Application control and vendor MDM/GPO policy are optional defense-in-depth
    controls, not features DefenseClaw can synthesize. Their absence does not
    block managed-hook readiness, but leaves the user-owned hook race described

--- a/docs/WINDOWS-ENTERPRISE-THREAT-MODEL.md
+++ b/docs/WINDOWS-ENTERPRISE-THREAT-MODEL.md
@@ -383,13 +383,27 @@ not an administrator authority even though it is a machine service.
 3. A target without an active, safe WTS token cannot be repaired. The guardian
    records failure and retries rather than writing the profile as LocalSystem.
    The activating install-time `-Mode` / `-Connector` shorthand therefore
-   seeds enabled rows only for eligible `WTSActive` profile SIDs. The protected
-   enumerator retains other discovered profiles as disabled rows pending an
-   explicit administrator lifecycle action; it does not treat them as
-   authenticated deferred enrollment. `Install -NoStart` keeps the complete
-   planned all-user enrollment because it makes no immediate readiness claim.
-   An explicit manifest that enables a disconnected target remains
-   authoritative and fails readiness until the exact SID has an active token.
+   seeds enabled rows only for eligible `WTSActive` profile SIDs.
+
+   Post-install, the SCM hook-enumerator runs on a 5-minute interval and
+   auto-authorizes newly-discovered `(SID, Connector)` rows whose per-user
+   profile contains a supported CLI (parity with macOS
+   `render-targets.sh`; see
+   `internal/enterprisehooks/agent_version_windows.go` for the per-connector
+   probe). Managed-enterprise deployments are administrator-controlled at
+   the *policy* layer — which connectors are pushed, and which SID scope
+   the guardian authorization ledger accepts — not at the per-device
+   authorization layer. A local admin who can create an interactive user
+   (`S-1-5-21-…`) on the target machine can therefore cause that user to
+   be enrolled on the next enumerator tick; this is the accepted cost of
+   parity with macOS, whose `launchd`-driven `render-targets.sh` operates
+   under the same posture. The exact SID membership check (row W-28
+   above) still fail-closes on an unregistered SID between enumerator
+   ticks, and the guardian authorization ledger records every enrollment
+   for audit. `Install -NoStart` keeps the complete planned all-user
+   enrollment because it makes no immediate readiness claim. An explicit
+   manifest that enables a disconnected target remains authoritative and
+   fails readiness until the exact SID has an active token.
 4. Application control and vendor MDM/GPO policy are optional defense-in-depth
    controls, not features DefenseClaw can synthesize. Their absence does not
    block managed-hook readiness, but leaves the user-owned hook race described

--- a/internal/cli/enterprise_windows_enumerate_windows.go
+++ b/internal/cli/enterprise_windows_enumerate_windows.go
@@ -104,10 +104,12 @@ Two modes:
   * default: enter an interval loop suitable for an SCM ImagePath. On every
     tick the service publishes an updated targets.yaml, auto-authorizing
     newly-discovered (SID, Connector) rows whose per-user profile contains
-    a supported CLI. Profiles with no discoverable CLI are silently skipped
-    (macOS parity). The byte-identical short-circuit in
-    WriteTargetsManifestAtomic keeps steady-state ticks free of file
-    mutation.
+    a supported CLI. Profiles with no discoverable CLI are omitted from the
+    manifest without failing the cycle — the per-row reason is emitted to
+    stderr under the '[hook-enumerator] skipped ...' line so an operator
+    can see why a specific user was left out (macOS parity). The
+    byte-identical short-circuit in WriteTargetsManifestAtomic keeps
+    steady-state ticks free of file mutation.
 
   * --once: run a single cycle synchronously and exit. Used by the
     installer to publish targets.yaml before deployment commit.

--- a/internal/cli/enterprise_windows_enumerate_windows.go
+++ b/internal/cli/enterprise_windows_enumerate_windows.go
@@ -74,13 +74,19 @@ type enterpriseWindowsEnumerateOptions struct {
 //     exits. Used by the installer's fresh-install path (replaces
 //     the retired inline PowerShell walk at
 //     `DefenseClawEnterprise.psm1:3663-3736`).
-//   - default (no `--once`): enters the read-only interval-loop the
-//     SCM service invokes at boot. It audits the current profile set
-//     against the authenticated committed manifest but never changes
-//     authorization. New profiles require an administrator Repair or
-//     Upgrade.
+//   - default (no `--once`): enters the interval-loop the SCM
+//     service invokes at boot. On every tick it publishes an
+//     updated targets.yaml, auto-authorizing newly-discovered
+//     (SID, Connector) rows whose per-user profile contains a
+//     supported CLI (parity with macOS render-targets.sh). Rows
+//     with no discoverable CLI are silently skipped. The
+//     byte-identical short-circuit in WriteTargetsManifestAtomic
+//     keeps steady-state ticks free of file mutation.
 //
-// Spec 005 REQ-03, REQ-04, REQ-13, REQ-18, REQ-19.
+// Spec 005 REQ-03, REQ-04, REQ-13, REQ-18, REQ-19 (REQ-13's
+// audit-only sub-clause is superseded by the macOS-parity
+// auto-authorize posture; see
+// docs/WINDOWS-ENTERPRISE-THREAT-MODEL.md residual-risk section).
 func newEnterpriseWindowsEnumerateCommand() *cobra.Command {
 	opts := &enterpriseWindowsEnumerateOptions{
 		interval:     enterpriseWindowsEnumerateDefaultInterval,
@@ -88,30 +94,32 @@ func newEnterpriseWindowsEnumerateCommand() *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "enumerate",
-		Short: "Publish pre-commit targets or audit committed Windows enrollment",
+		Short: "Publish Windows managed-enterprise hook enrollment on every tick",
 		Long: `Walk HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList to
 discover local user profiles, filter to interactive users (S-1-5-21-…), and
-compare them with the hook-guardian's authenticated targets.yaml.
+publish an updated hook-guardian targets.yaml.
 
 Two modes:
 
-  * default: enter a read-only audit loop suitable for an SCM ImagePath.
-    The service never rewrites targets.yaml and never authorizes a profile
-    created after deployment commit. Newly discovered or changed profiles
-    are reported for an administrator-run Repair or Upgrade.
+  * default: enter an interval loop suitable for an SCM ImagePath. On every
+    tick the service publishes an updated targets.yaml, auto-authorizing
+    newly-discovered (SID, Connector) rows whose per-user profile contains
+    a supported CLI. Profiles with no discoverable CLI are silently skipped
+    (macOS parity). The byte-identical short-circuit in
+    WriteTargetsManifestAtomic keeps steady-state ticks free of file
+    mutation.
 
   * --once: run a single cycle synchronously and exit. Used by the
-    installer to publish targets.yaml before deployment commit. This is
-    the only mode that writes the manifest.
+    installer to publish targets.yaml before deployment commit.
 
 Both modes authenticate the manifest's ancestry, exact AdminFile descriptor,
-regular-file identity, link contract, and schema. --once stages an authorized
-update under the exact AdminFile contract and publishes it atomically. Service
-audits fail closed on trust drift and leave the committed manifest untouched.
+regular-file identity, link contract, and schema, and both stage an authorized
+update under the exact AdminFile contract before atomic replace. On trust
+drift, both modes fail closed and leave the committed manifest untouched.
 
 Managed-enterprise Windows only. macOS's LaunchDaemon-based
-'hook-enumerator' + render-targets.sh already covers the darwin
-side; nothing about this subcommand is invoked on non-Windows OSes.
+'hook-enumerator' + render-targets.sh covers the darwin side;
+nothing about this subcommand is invoked on non-Windows OSes.
 `,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -162,10 +170,20 @@ func runEnterpriseWindowsEnumerate(
 	return runEnterpriseWindowsEnumerateInterval(ctx, stderr, opts, manifestPath)
 }
 
-// runEnterpriseWindowsEnumerateSingleCycle runs one bounded cycle and returns.
-// publish=true is reserved for the installer's pre-commit --once path. The
-// long-running SCM service always passes publish=false so a profile discovered
-// after commit cannot become authorized without an administrator lifecycle.
+// runEnterpriseWindowsEnumerateSingleCycle runs one bounded cycle
+// and returns. Both call sites pass publish=true today:
+//
+//   - The `--once` installer path publishes the initial pre-commit
+//     targets.yaml.
+//   - The long-running SCM interval loop publishes an updated
+//     targets.yaml on every tick (auto-authorize parity with
+//     macOS render-targets.sh). Byte-identical short-circuit in
+//     WriteTargetsManifestAtomic keeps steady-state ticks
+//     mutation-free.
+//
+// publish=false is retained on the parameter for callers that
+// legitimately want a dry-run (test rigs, admin diagnostics) but
+// is no longer wired in from either shipping call site.
 func runEnterpriseWindowsEnumerateSingleCycle(
 	ctx context.Context,
 	stderr io.Writer,
@@ -337,7 +355,15 @@ func runEnterpriseWindowsEnumerateInterval(
 	// First cycle: log the outcome but do NOT bail on a transient
 	// "config missing" error — the whole point of REQ-04 is to
 	// tolerate deferred-config boots.
-	if err := runEnterpriseWindowsEnumerateSingleCycle(ctx, stderr, manifestPath, false); err != nil {
+	//
+	// publish=true (parity with macOS render-targets.sh): each tick
+	// auto-authorizes newly-discovered (SID, Connector) rows whose
+	// per-user profile contains a supported CLI (see
+	// internal/enterprisehooks/agent_version_windows.go). Rows
+	// without a discoverable CLI are silently skipped. The
+	// byte-identical short-circuit in WriteTargetsManifestAtomic
+	// keeps steady-state ticks free of fsnotify wakes.
+	if err := runEnterpriseWindowsEnumerateSingleCycle(ctx, stderr, manifestPath, true); err != nil {
 		if !isEnterpriseWindowsEnumerateConfigMissing(err) {
 			fmt.Fprintf(stderr, "[hook-enumerator] initial cycle failed: %v\n", err)
 		}
@@ -350,7 +376,7 @@ func runEnterpriseWindowsEnumerateInterval(
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			if err := runEnterpriseWindowsEnumerateSingleCycle(ctx, stderr, manifestPath, false); err != nil {
+			if err := runEnterpriseWindowsEnumerateSingleCycle(ctx, stderr, manifestPath, true); err != nil {
 				if !isEnterpriseWindowsEnumerateConfigMissing(err) {
 					fmt.Fprintf(stderr, "[hook-enumerator] cycle failed: %v\n", err)
 				}

--- a/internal/cli/enterprise_windows_enumerate_windows_test.go
+++ b/internal/cli/enterprise_windows_enumerate_windows_test.go
@@ -50,7 +50,7 @@ func TestNewEnterpriseWindowsEnumerateCommandRegistersFlags(t *testing.T) {
 	// this check.
 	if !strings.Contains(cmd.Long, "publishes an updated targets.yaml") ||
 		!strings.Contains(cmd.Long, "auto-authorizing") ||
-		!strings.Contains(cmd.Long, "silently skipped") ||
+		!strings.Contains(cmd.Long, "omitted from the manifest without failing the cycle") ||
 		!strings.Contains(cmd.Long, "macOS parity") {
 		t.Fatalf("command documentation does not describe the macOS-parity auto-authorize posture:\n%s", cmd.Long)
 	}

--- a/internal/cli/enterprise_windows_enumerate_windows_test.go
+++ b/internal/cli/enterprise_windows_enumerate_windows_test.go
@@ -42,9 +42,10 @@ func TestNewEnterpriseWindowsEnumerateCommandRegistersFlags(t *testing.T) {
 			t.Fatalf("flag %q not registered", name)
 		}
 	}
-	if !strings.Contains(cmd.Long, "service never rewrites targets.yaml") ||
-		!strings.Contains(cmd.Long, "administrator-run Repair or Upgrade") {
-		t.Fatalf("command documentation does not describe the finite-profile audit boundary:\n%s", cmd.Long)
+	if !strings.Contains(cmd.Long, "publishes an updated targets.yaml") ||
+		!strings.Contains(cmd.Long, "auto-authorizing newly-discovered") ||
+		!strings.Contains(cmd.Long, "macOS parity") {
+		t.Fatalf("command documentation does not describe the macOS-parity auto-authorize posture:\n%s", cmd.Long)
 	}
 }
 

--- a/internal/cli/enterprise_windows_enumerate_windows_test.go
+++ b/internal/cli/enterprise_windows_enumerate_windows_test.go
@@ -42,8 +42,15 @@ func TestNewEnterpriseWindowsEnumerateCommandRegistersFlags(t *testing.T) {
 			t.Fatalf("flag %q not registered", name)
 		}
 	}
+	// Each substring is deliberately short enough to stay within one
+	// line of the raw Long block — strings.Contains is byte-level,
+	// so phrases that span the Long block's line-wrap (e.g.
+	// "auto-authorizing newly-discovered" is rendered with a
+	// newline+indent between the two words) would spuriously fail
+	// this check.
 	if !strings.Contains(cmd.Long, "publishes an updated targets.yaml") ||
-		!strings.Contains(cmd.Long, "auto-authorizing newly-discovered") ||
+		!strings.Contains(cmd.Long, "auto-authorizing") ||
+		!strings.Contains(cmd.Long, "silently skipped") ||
 		!strings.Contains(cmd.Long, "macOS parity") {
 		t.Fatalf("command documentation does not describe the macOS-parity auto-authorize posture:\n%s", cmd.Long)
 	}

--- a/internal/cli/enterprise_windows_enumerate_windows_test.go
+++ b/internal/cli/enterprise_windows_enumerate_windows_test.go
@@ -42,16 +42,19 @@ func TestNewEnterpriseWindowsEnumerateCommandRegistersFlags(t *testing.T) {
 			t.Fatalf("flag %q not registered", name)
 		}
 	}
-	// Each substring is deliberately short enough to stay within one
-	// line of the raw Long block — strings.Contains is byte-level,
-	// so phrases that span the Long block's line-wrap (e.g.
-	// "auto-authorizing newly-discovered" is rendered with a
-	// newline+indent between the two words) would spuriously fail
-	// this check.
-	if !strings.Contains(cmd.Long, "publishes an updated targets.yaml") ||
-		!strings.Contains(cmd.Long, "auto-authorizing") ||
-		!strings.Contains(cmd.Long, "omitted from the manifest without failing the cycle") ||
-		!strings.Contains(cmd.Long, "macOS parity") {
+	// Normalize whitespace before matching. The raw `cmd.Long` block
+	// wraps at column ~80 with two-space indent, so any assertion
+	// phrase that spans a wrap point (e.g. "omitted from the
+	// manifest" reflows as "omitted from the\n    manifest") would
+	// spuriously fail a byte-level `strings.Contains`. Collapsing
+	// every run of whitespace to a single space lets the assertions
+	// focus on semantic content rather than the reflow shape, and
+	// stays robust when the surrounding paragraph is edited.
+	long := strings.Join(strings.Fields(cmd.Long), " ")
+	if !strings.Contains(long, "publishes an updated targets.yaml") ||
+		!strings.Contains(long, "auto-authorizing") ||
+		!strings.Contains(long, "omitted from the manifest without failing the cycle") ||
+		!strings.Contains(long, "macOS parity") {
 		t.Fatalf("command documentation does not describe the macOS-parity auto-authorize posture:\n%s", cmd.Long)
 	}
 }

--- a/internal/enterprisehooks/agent_version_other.go
+++ b/internal/enterprisehooks/agent_version_other.go
@@ -10,27 +10,16 @@
 
 //go:build !windows
 
+// The Windows per-connector agent-version probe
+// (`discoverWindowsAgentVersion`, `windowsAgentVersionExplain`) is
+// defined in `agent_version_windows.go` under a `//go:build windows`
+// tag and is only referenced by the equally-Windows-tagged
+// `enumerator_windows.go`. There is no non-Windows caller of those
+// symbols and therefore no stub is needed here — `golangci-lint`'s
+// `unused` analyzer flagged the prior stubs (returning empty
+// unconditionally) as dead code across the non-Windows build. This
+// file is intentionally empty apart from the package clause so the
+// file layout mirrors the Windows sibling without smuggling dead
+// symbols into the darwin / linux build.
+
 package enterprisehooks
-
-// discoverWindowsAgentVersion is a Windows-only feature — this stub
-// exists so the package compiles cross-platform. The macOS
-// enumerator (packaging/macos/lib/render-targets.sh) already covers
-// the darwin side via `discover_agent_version`; nothing about this
-// Go function is invoked on non-Windows OSes. The stub returns
-// empty so any accidental non-Windows caller would drop the row,
-// which is the safe default.
-func discoverWindowsAgentVersion(profileHome, connectorName string) string {
-	_ = profileHome
-	_ = connectorName
-	return ""
-}
-
-// windowsAgentVersionExplain matches its Windows counterpart's
-// signature so callers can share the same reason-reporting shape
-// across platforms. Non-Windows callers always get the "unsupported
-// platform" explanation.
-func windowsAgentVersionExplain(profileHome, connectorName string) (string, string) {
-	_ = profileHome
-	_ = connectorName
-	return "", "windows agent-version discovery is not compiled on this platform"
-}

--- a/internal/enterprisehooks/agent_version_other.go
+++ b/internal/enterprisehooks/agent_version_other.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package enterprisehooks
+
+// discoverWindowsAgentVersion is a Windows-only feature — this stub
+// exists so the package compiles cross-platform. The macOS
+// enumerator (packaging/macos/lib/render-targets.sh) already covers
+// the darwin side via `discover_agent_version`; nothing about this
+// Go function is invoked on non-Windows OSes. The stub returns
+// empty so any accidental non-Windows caller would drop the row,
+// which is the safe default.
+func discoverWindowsAgentVersion(profileHome, connectorName string) string {
+	_ = profileHome
+	_ = connectorName
+	return ""
+}
+
+// windowsAgentVersionExplain matches its Windows counterpart's
+// signature so callers can share the same reason-reporting shape
+// across platforms. Non-Windows callers always get the "unsupported
+// platform" explanation.
+func windowsAgentVersionExplain(profileHome, connectorName string) (string, string) {
+	_ = profileHome
+	_ = connectorName
+	return "", "windows agent-version discovery is not compiled on this platform"
+}

--- a/internal/enterprisehooks/agent_version_windows.go
+++ b/internal/enterprisehooks/agent_version_windows.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -132,6 +133,64 @@ func windowsAgentVersionCandidatePaths(profileHome, connectorName string) []stri
 	}
 }
 
+// readBoundedWindowsAgentPackageJSON opens `candidate`, applies the
+// trust checks (reparse-chain rejection, regular-file check), and
+// returns at most `windowsAgentVersionMaxBytes` bytes. Any of these
+// conditions returns a non-nil error and empty payload:
+//
+//   - `candidate` is empty or its ancestor chain crosses a Windows
+//     junction / symlink (per `winpath.RejectReparseChain`);
+//   - the target is a symlink / non-regular file;
+//   - `os.Open` fails;
+//   - `io.ReadAll` on an `io.LimitReader(f, max+1)` returns more
+//     than `windowsAgentVersionMaxBytes` bytes — i.e. the on-disk
+//     file grew past the ceiling between check and read.
+//
+// The +1-byte trick lets the caller distinguish "read exactly `max`
+// bytes and the file is at least that big" from "file is strictly
+// larger than `max`, we should reject" without ever allocating a
+// slice larger than `max + 1`. This closes the Lstat -> ReadFile
+// race a hostile profile owner could exploit to force the
+// LocalSystem enumerator to allocate an arbitrarily large buffer:
+// even if the file grew between checks, our read is capped.
+//
+// The old shape — `os.Lstat` (size check) then `os.ReadFile` (no
+// cap) — was flagged by CodeRabbit as a resource-exhaustion
+// vector. This helper is the fix.
+func readBoundedWindowsAgentPackageJSON(candidate string) ([]byte, error) {
+	if strings.TrimSpace(candidate) == "" {
+		return nil, errors.New("empty candidate path")
+	}
+	// Ancestor reparse-point rejection: refuses to open any path
+	// whose parent chain crosses a Windows junction or symbolic
+	// link. Mirrors the treatment applied to the enumerator's
+	// ProfileImagePath reads (see enumerator_windows.go).
+	if err := winpath.RejectReparseChain(candidate); err != nil {
+		return nil, err
+	}
+	// Lstat is retained as a fast-path for the leaf shape check
+	// (symlink / non-regular files bypass reading entirely). The
+	// authoritative size check runs on the opened handle below.
+	if info, err := os.Lstat(candidate); err != nil {
+		return nil, err
+	} else if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("candidate is not a regular file: mode=%s", info.Mode())
+	}
+	f, err := os.Open(candidate)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, windowsAgentVersionMaxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > windowsAgentVersionMaxBytes {
+		return nil, fmt.Errorf("candidate exceeds bounded size %d", windowsAgentVersionMaxBytes)
+	}
+	return data, nil
+}
+
 // readWindowsAgentVersionCandidate applies the trust checks and
 // bounded read to one candidate path. Returns the version string
 // and `true` iff the file exists, its ancestor chain contains no
@@ -145,34 +204,8 @@ func windowsAgentVersionCandidatePaths(profileHome, connectorName string) []stri
 // complete` summary line, which reports how many `(SID, Connector)`
 // rows were emitted vs skipped.
 func readWindowsAgentVersionCandidate(candidate string) (string, bool) {
-	if strings.TrimSpace(candidate) == "" {
-		return "", false
-	}
-	// Ancestor reparse-point rejection: refuses to open any path
-	// whose parent chain crosses a Windows junction or symbolic
-	// link. Mirrors the treatment applied to the enumerator's
-	// ProfileImagePath reads (see enumerator_windows.go).
-	if err := winpath.RejectReparseChain(candidate); err != nil {
-		return "", false
-	}
-	info, err := os.Lstat(candidate)
+	data, err := readBoundedWindowsAgentPackageJSON(candidate)
 	if err != nil {
-		return "", false
-	}
-	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-		return "", false
-	}
-	if info.Size() > windowsAgentVersionMaxBytes {
-		return "", false
-	}
-	data, err := os.ReadFile(candidate)
-	if err != nil {
-		return "", false
-	}
-	// Double-bounded — a race that appended between Lstat and
-	// ReadFile still hits the ceiling. Reject rather than parse
-	// arbitrary bytes.
-	if int64(len(data)) > windowsAgentVersionMaxBytes {
 		return "", false
 	}
 	var parsed windowsAgentPackageJSON
@@ -207,34 +240,28 @@ func windowsAgentVersionExplain(profileHome, connectorName string) (string, stri
 	}
 	var lastReason string
 	for _, candidate := range candidates {
-		if err := winpath.RejectReparseChain(candidate); err != nil {
-			lastReason = "ancestor reparse chain refused"
-			continue
-		}
-		info, err := os.Lstat(candidate)
+		data, err := readBoundedWindowsAgentPackageJSON(candidate)
 		if err != nil {
+			// Preserve the historical operator-facing reason
+			// strings where the caller distinguishes shapes; the
+			// bounded helper collapses reparse / regular-file /
+			// size errors into typed messages we can categorize
+			// here without leaking full paths.
 			if errors.Is(err, os.ErrNotExist) {
 				lastReason = fmt.Sprintf("no %s package.json under this profile", connectorName)
-			} else {
-				lastReason = fmt.Sprintf("candidate lstat failed: %v", err)
+				continue
 			}
-			continue
-		}
-		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-			lastReason = "candidate is not a regular file"
-			continue
-		}
-		if info.Size() > windowsAgentVersionMaxBytes {
-			lastReason = "candidate exceeds bounded size"
-			continue
-		}
-		data, err := os.ReadFile(candidate)
-		if err != nil {
-			lastReason = fmt.Sprintf("candidate read failed: %v", err)
-			continue
-		}
-		if int64(len(data)) > windowsAgentVersionMaxBytes {
-			lastReason = "candidate grew past bounded size mid-read"
+			msg := err.Error()
+			switch {
+			case strings.Contains(msg, "reparse"):
+				lastReason = "ancestor reparse chain refused"
+			case strings.Contains(msg, "regular file"):
+				lastReason = "candidate is not a regular file"
+			case strings.Contains(msg, "exceeds bounded size"):
+				lastReason = "candidate exceeds bounded size"
+			default:
+				lastReason = fmt.Sprintf("candidate read failed: %v", err)
+			}
 			continue
 		}
 		var parsed windowsAgentPackageJSON

--- a/internal/enterprisehooks/agent_version_windows.go
+++ b/internal/enterprisehooks/agent_version_windows.go
@@ -1,0 +1,256 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package enterprisehooks
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/defenseclaw/defenseclaw/internal/winpath"
+)
+
+// windowsAgentVersionMaxBytes caps how many bytes any single
+// version-probe read is allowed to consume. package.json files for
+// modern npm-installed CLIs sit around 1–4 KiB; the ceiling exists
+// so a hostile user profile cannot induce the enumerator (running as
+// LocalSystem) to slurp an arbitrarily large blob just by dropping a
+// giant file at the probed path. Kept well above realistic sizes so
+// a legitimate agent update never trips it.
+const windowsAgentVersionMaxBytes = 64 * 1024
+
+// windowsAgentPackageJSON is the shape we care about — just the
+// `version` field. json.Decoder.DisallowUnknownFields is NOT used
+// because npm CLIs ship dozens of other fields; we ignore them.
+type windowsAgentPackageJSON struct {
+	Version string `json:"version"`
+}
+
+// discoverWindowsAgentVersion returns a per-user agent version for
+// `connectorName` under the target's home directory `profileHome`,
+// or an empty string if:
+//   - the connector is not one this probe knows about,
+//   - the CLI is not installed under any known path in this
+//     profile,
+//   - the version metadata file exists but is unreadable, exceeds
+//     the bounded size, or fails JSON parse,
+//   - any ancestor of the probed path is a reparse point (Windows
+//     junction / mount point) — refused for the same reason
+//     `winpath.RejectReparseChain` is used elsewhere in the
+//     enumerator: a per-user reparse chain could redirect a read
+//     into a system directory and let a user profile influence
+//     what the LocalSystem enumerator ingests.
+//
+// The macOS analogue is `discover_agent_version` in
+// `packaging/macos/lib/installer_lib.sh`, which returns empty for
+// the same reasons. The enumerator caller drops any user × connector
+// with empty discovery — mirroring macOS's silently-skip behaviour.
+//
+// No process is ever spawned; all reads are static filesystem
+// inspection of well-known JSON manifests. This keeps the probe
+// safe to run as LocalSystem against a hostile user profile — we do
+// not execute the discovered binary or ask it to introspect itself.
+func discoverWindowsAgentVersion(profileHome, connectorName string) string {
+	profileHome = strings.TrimSpace(profileHome)
+	connectorName = strings.ToLower(strings.TrimSpace(connectorName))
+	if profileHome == "" || connectorName == "" {
+		return ""
+	}
+	if !filepath.IsAbs(profileHome) {
+		return ""
+	}
+	cleanHome := filepath.Clean(profileHome)
+
+	candidates := windowsAgentVersionCandidatePaths(cleanHome, connectorName)
+	for _, candidate := range candidates {
+		version, ok := readWindowsAgentVersionCandidate(candidate)
+		if ok {
+			return version
+		}
+	}
+	return ""
+}
+
+// windowsAgentVersionCandidatePaths returns the ordered set of
+// package.json paths to try for `connectorName` under
+// `profileHome`. The order matters: probes higher in the list are
+// preferred. Each connector's candidate set covers the install
+// flavours we've observed on real Windows QA hosts:
+//
+//   - `claudecode`: npm-global install under
+//     `%APPDATA%\npm\node_modules\@anthropic-ai\claude-code\`.
+//     `%APPDATA%` on Windows resolves to
+//     `%USERPROFILE%\AppData\Roaming` — the enumerator receives
+//     the profile's home directory so we build the Roaming path
+//     directly.
+//   - `codex`: npm-global install under
+//     `%APPDATA%\npm\node_modules\@openai\codex\`. The MSIX-store
+//     flavour (`C:\Program Files\WindowsApps\OpenAI.Codex_…\`)
+//     lives OUTSIDE the profile and is machine-scoped; probing it
+//     is a follow-up that requires a separate lookup path. For
+//     now we return empty for MSIX-only installs so the
+//     enumerator drops the row (parity with macOS's behaviour when
+//     the codex CLI is absent).
+//   - `cursor`: Cursor Desktop's per-user install at
+//     `%LOCALAPPDATA%\Programs\cursor\resources\app\package.json`.
+//     `%LOCALAPPDATA%` = `%USERPROFILE%\AppData\Local`.
+//
+// Every candidate is a fully-cleaned absolute path anchored inside
+// `profileHome`. Callers never see relative paths, symlinks, or
+// user-supplied path fragments.
+func windowsAgentVersionCandidatePaths(profileHome, connectorName string) []string {
+	appDataRoaming := filepath.Join(profileHome, "AppData", "Roaming")
+	appDataLocal := filepath.Join(profileHome, "AppData", "Local")
+	switch connectorName {
+	case "claudecode":
+		return []string{
+			filepath.Join(appDataRoaming, "npm", "node_modules", "@anthropic-ai", "claude-code", "package.json"),
+		}
+	case "codex":
+		return []string{
+			filepath.Join(appDataRoaming, "npm", "node_modules", "@openai", "codex", "package.json"),
+		}
+	case "cursor":
+		return []string{
+			filepath.Join(appDataLocal, "Programs", "cursor", "resources", "app", "package.json"),
+		}
+	default:
+		return nil
+	}
+}
+
+// readWindowsAgentVersionCandidate applies the trust checks and
+// bounded read to one candidate path. Returns the version string
+// and `true` iff the file exists, its ancestor chain contains no
+// reparse points, its size fits under `windowsAgentVersionMaxBytes`,
+// and its `version` field parses as a non-empty string.
+//
+// Every failure returns `"", false` without logging or wrapping —
+// the enumerator loops over candidates and treats a false return as
+// "try the next one." Silent-drop is the intended shape here; the
+// audit trail lives at the enumerator's `[hook-enumerator] audit
+// complete` summary line, which reports how many `(SID, Connector)`
+// rows were emitted vs skipped.
+func readWindowsAgentVersionCandidate(candidate string) (string, bool) {
+	if strings.TrimSpace(candidate) == "" {
+		return "", false
+	}
+	// Ancestor reparse-point rejection: refuses to open any path
+	// whose parent chain crosses a Windows junction or symbolic
+	// link. Mirrors the treatment applied to the enumerator's
+	// ProfileImagePath reads (see enumerator_windows.go).
+	if err := winpath.RejectReparseChain(candidate); err != nil {
+		return "", false
+	}
+	info, err := os.Lstat(candidate)
+	if err != nil {
+		return "", false
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return "", false
+	}
+	if info.Size() > windowsAgentVersionMaxBytes {
+		return "", false
+	}
+	data, err := os.ReadFile(candidate)
+	if err != nil {
+		return "", false
+	}
+	// Double-bounded — a race that appended between Lstat and
+	// ReadFile still hits the ceiling. Reject rather than parse
+	// arbitrary bytes.
+	if int64(len(data)) > windowsAgentVersionMaxBytes {
+		return "", false
+	}
+	var parsed windowsAgentPackageJSON
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return "", false
+	}
+	version := strings.TrimSpace(parsed.Version)
+	if version == "" {
+		return "", false
+	}
+	return version, true
+}
+
+// windowsAgentVersionExplain is a diagnostic wrapper used by the
+// enumerator when it wants an operator-facing reason for why a row
+// was skipped, without changing the primary silent-drop contract of
+// discoverWindowsAgentVersion. Returns a short human-readable
+// phrase plus the same "" / version signal. Never leaks path
+// contents into the reason string beyond the connector name.
+func windowsAgentVersionExplain(profileHome, connectorName string) (string, string) {
+	profileHome = strings.TrimSpace(profileHome)
+	connectorName = strings.ToLower(strings.TrimSpace(connectorName))
+	if profileHome == "" {
+		return "", "profile home is empty"
+	}
+	if !filepath.IsAbs(profileHome) {
+		return "", "profile home is not absolute"
+	}
+	candidates := windowsAgentVersionCandidatePaths(filepath.Clean(profileHome), connectorName)
+	if len(candidates) == 0 {
+		return "", fmt.Sprintf("no probe defined for connector %q", connectorName)
+	}
+	var lastReason string
+	for _, candidate := range candidates {
+		if err := winpath.RejectReparseChain(candidate); err != nil {
+			lastReason = "ancestor reparse chain refused"
+			continue
+		}
+		info, err := os.Lstat(candidate)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				lastReason = fmt.Sprintf("no %s package.json under this profile", connectorName)
+			} else {
+				lastReason = fmt.Sprintf("candidate lstat failed: %v", err)
+			}
+			continue
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			lastReason = "candidate is not a regular file"
+			continue
+		}
+		if info.Size() > windowsAgentVersionMaxBytes {
+			lastReason = "candidate exceeds bounded size"
+			continue
+		}
+		data, err := os.ReadFile(candidate)
+		if err != nil {
+			lastReason = fmt.Sprintf("candidate read failed: %v", err)
+			continue
+		}
+		if int64(len(data)) > windowsAgentVersionMaxBytes {
+			lastReason = "candidate grew past bounded size mid-read"
+			continue
+		}
+		var parsed windowsAgentPackageJSON
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			lastReason = "candidate is not valid JSON"
+			continue
+		}
+		version := strings.TrimSpace(parsed.Version)
+		if version == "" {
+			lastReason = "candidate has empty version field"
+			continue
+		}
+		return version, ""
+	}
+	if lastReason == "" {
+		lastReason = "no candidate matched"
+	}
+	return "", lastReason
+}

--- a/internal/enterprisehooks/agent_version_windows.go
+++ b/internal/enterprisehooks/agent_version_windows.go
@@ -260,7 +260,17 @@ func windowsAgentVersionExplain(profileHome, connectorName string) (string, stri
 			case strings.Contains(msg, "exceeds bounded size"):
 				lastReason = "candidate exceeds bounded size"
 			default:
-				lastReason = fmt.Sprintf("candidate read failed: %v", err)
+				// Path-free reason on purpose: os.PathError.Error()
+				// embeds the candidate absolute path, which the
+				// enumerator forwards to `logfSafely` unredacted.
+				// Formatting `err` with `%v` would leak that path
+				// to every operator tailing gateway.err.log
+				// (including any operator without filesystem
+				// visibility into that user profile). The
+				// categorized reasons above cover the common
+				// diagnostic shapes; anything else is just
+				// "candidate read failed."
+				lastReason = "candidate read failed"
 			}
 			continue
 		}

--- a/internal/enterprisehooks/agent_version_windows_test.go
+++ b/internal/enterprisehooks/agent_version_windows_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package enterprisehooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeWindowsAgentPackageJSON drops a minimal package.json under
+// `dir` with the given version. Parent directories are created
+// with default (test-scoped) permissions.
+func writeWindowsAgentPackageJSON(t *testing.T, dir, version string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	body, err := json.Marshal(map[string]any{
+		"name":    "test-agent",
+		"version": version,
+	})
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), body, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionReturnsEmptyForUnknownConnector(t *testing.T) {
+	home := t.TempDir()
+	if got := discoverWindowsAgentVersion(home, "openclaw"); got != "" {
+		t.Fatalf("unknown connector: got %q, want empty", got)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionReturnsEmptyForRelativeHome(t *testing.T) {
+	if got := discoverWindowsAgentVersion(`AppData\Local`, "cursor"); got != "" {
+		t.Fatalf("relative home: got %q, want empty", got)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionReturnsEmptyWhenNoCLIInstalled(t *testing.T) {
+	home := t.TempDir()
+	for _, conn := range []string{"claudecode", "codex", "cursor"} {
+		if got := discoverWindowsAgentVersion(home, conn); got != "" {
+			t.Fatalf("connector %q on empty home: got %q, want empty (macOS parity)", conn, got)
+		}
+	}
+}
+
+func TestDiscoverWindowsAgentVersionClaudeCode(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Roaming", "npm", "node_modules", "@anthropic-ai", "claude-code")
+	writeWindowsAgentPackageJSON(t, dir, "0.2.3")
+	got := discoverWindowsAgentVersion(home, "claudecode")
+	if got != "0.2.3" {
+		t.Fatalf("claudecode discovery: got %q, want 0.2.3", got)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionCodex(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Roaming", "npm", "node_modules", "@openai", "codex")
+	writeWindowsAgentPackageJSON(t, dir, "0.42.0")
+	got := discoverWindowsAgentVersion(home, "codex")
+	if got != "0.42.0" {
+		t.Fatalf("codex discovery: got %q, want 0.42.0", got)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionCursor(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Local", "Programs", "cursor", "resources", "app")
+	writeWindowsAgentPackageJSON(t, dir, "1.6.14")
+	got := discoverWindowsAgentVersion(home, "cursor")
+	if got != "1.6.14" {
+		t.Fatalf("cursor discovery: got %q, want 1.6.14", got)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionRejectsOversizedPackageJSON(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Roaming", "npm", "node_modules", "@openai", "codex")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// One byte over the ceiling — guarantees the size check fires
+	// even if the ceiling constant is later widened.
+	oversize := make([]byte, windowsAgentVersionMaxBytes+1)
+	for i := range oversize {
+		oversize[i] = 'x'
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), oversize, 0o644); err != nil {
+		t.Fatalf("write oversize fixture: %v", err)
+	}
+	if got := discoverWindowsAgentVersion(home, "codex"); got != "" {
+		t.Fatalf("oversize package.json: got %q, want empty (drop)", got)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionRejectsMalformedJSON(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Local", "Programs", "cursor", "resources", "app")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{not-json"), 0o644); err != nil {
+		t.Fatalf("write malformed fixture: %v", err)
+	}
+	if got := discoverWindowsAgentVersion(home, "cursor"); got != "" {
+		t.Fatalf("malformed json: got %q, want empty (drop)", got)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionRejectsEmptyVersionField(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Roaming", "npm", "node_modules", "@anthropic-ai", "claude-code")
+	writeWindowsAgentPackageJSON(t, dir, "  ") // whitespace-only version
+	if got := discoverWindowsAgentVersion(home, "claudecode"); got != "" {
+		t.Fatalf("whitespace-only version: got %q, want empty (drop)", got)
+	}
+}
+
+func TestWindowsAgentVersionExplainSurfacesReasons(t *testing.T) {
+	home := t.TempDir()
+	// Not installed → explain should report "no <connector>
+	// package.json under this profile".
+	version, reason := windowsAgentVersionExplain(home, "codex")
+	if version != "" {
+		t.Fatalf("explain unexpectedly returned version %q for empty home", version)
+	}
+	if !strings.Contains(reason, "codex") {
+		t.Fatalf("explain reason %q did not mention connector name", reason)
+	}
+
+	// Installed → explain returns the version and empty reason.
+	dir := filepath.Join(home, "AppData", "Roaming", "npm", "node_modules", "@openai", "codex")
+	writeWindowsAgentPackageJSON(t, dir, "0.42.0")
+	version, reason = windowsAgentVersionExplain(home, "codex")
+	if version != "0.42.0" {
+		t.Fatalf("explain version: got %q, want 0.42.0", version)
+	}
+	if reason != "" {
+		t.Fatalf("explain reason on success: got %q, want empty", reason)
+	}
+}

--- a/internal/enterprisehooks/enumerator_windows.go
+++ b/internal/enterprisehooks/enumerator_windows.go
@@ -211,7 +211,13 @@ func EnumerateWindows(ctx context.Context, cfg *config.Config, opts EnumerateOpt
 				Connector: conn,
 				DataDir:   dataDir,
 			}
-			applyPreviousRowState(&row, previous, opts.Logger)
+			if !applyPreviousRowState(&row, previous, opts.Logger) {
+				// New (SID, Connector) row with no discoverable per-user
+				// agent-version — dropped for macOS parity. The
+				// enumerator's audit-complete summary reflects the
+				// skip.
+				continue
+			}
 			targets = append(targets, row)
 		}
 	}
@@ -401,17 +407,42 @@ func loadPreviousManifestForEnumeration(path string, logf EnumerationLogger) map
 	return previous
 }
 
-// applyPreviousRowState copies AgentVersion + Enabled + Deferred from the
-// existing manifest into `row` if a match is found. If no match, it
-// leaves both fields at their zero values — Enabled stays nil (the
-// default-enabled behaviour), but since AgentVersion is empty the
-// row cannot be enabled (LoadManifest's requireAgentVersion check
-// runs on enabled rows). To keep new rows well-formed in that state
-// we explicitly disable them so LoadManifest's per-row validation
-// skips them, avoiding a load-time reject.
-func applyPreviousRowState(row *ManifestTarget, previous map[string]ManifestTarget, logf EnumerationLogger) {
+// applyPreviousRowState resolves `row`'s AgentVersion + Enabled +
+// Deferred + User/UID/GID for either a known-from-prior-manifest
+// (SID, Connector) pair or a newly-discovered one.
+//
+// Returns `true` when the row should be emitted, `false` when the
+// caller should drop it.
+//
+//   - Previously-known (SID, Connector): copy AgentVersion +
+//     Enabled + Deferred + User/UID/GID from the prior row and
+//     return true. Preserving the operator's prior Enabled
+//     decision means a disabled prior row stays disabled, and an
+//     enabled prior row stays enabled with its recorded
+//     AgentVersion.
+//   - Newly-discovered (SID, Connector): consult
+//     `discoverWindowsAgentVersion` to see whether this user's
+//     profile contains a supported per-user install of the
+//     connector's CLI.
+//   - If a version is discoverable: emit the row with
+//     `Enabled: true`, `Deferred: false`, `AgentVersion: <found>`.
+//     This is the auto-authorize path — parity with macOS
+//     render-targets.sh, which emits enabled rows for any
+//     (user × connector) whose CLI is present.
+//   - If no version is discoverable: return false. The caller
+//     drops the row entirely — parity with macOS, which never
+//     emits a row for a user whose CLI is not installed.
+//
+// The historical "emit disabled, wait for admin Repair" branch is
+// gone. Managed-enterprise deployments are admin-driven at the
+// policy layer (which connectors are pushed, which SID
+// membership), not the per-device authorization layer; the
+// enumerator's job is discovery. See
+// docs/WINDOWS-ENTERPRISE-THREAT-MODEL.md residual-risk section for
+// the new posture.
+func applyPreviousRowState(row *ManifestTarget, previous map[string]ManifestTarget, logf EnumerationLogger) bool {
 	if row == nil {
-		return
+		return false
 	}
 	key := previousManifestKey(row.SID, row.Connector)
 	if prev, ok := previous[key]; ok {
@@ -421,17 +452,35 @@ func applyPreviousRowState(row *ManifestTarget, previous map[string]ManifestTarg
 		row.User = prev.User
 		row.UID = prev.UID
 		row.GID = prev.GID
-		return
+		return true
 	}
-	// New (SID, Connector) row: keep AgentVersion empty and mark
-	// Enabled=false so LoadManifest's schema validation skips this
-	// target. An admin or UCB flow promotes it later by writing the
-	// AgentVersion + flipping Enabled=true. This preserves the
-	// security posture — a new user profile is DISCOVERED by the
-	// enumerator but does not auto-hook without operator intent.
-	disabled := false
-	row.Enabled = &disabled
-	logfSafely(logf, row.SID, fmt.Sprintf("newly-discovered (SID, %s) row emitted as disabled; admin must supply agent_version + enable", row.Connector))
+	version, reason := windowsAgentVersionExplain(row.UserHome, row.Connector)
+	if version == "" {
+		logfSafely(
+			logf,
+			row.SID,
+			fmt.Sprintf(
+				"newly-discovered (SID, %s) row skipped: %s",
+				row.Connector,
+				reason,
+			),
+		)
+		return false
+	}
+	enabled := true
+	row.AgentVersion = version
+	row.Enabled = &enabled
+	row.Deferred = false
+	logfSafely(
+		logf,
+		row.SID,
+		fmt.Sprintf(
+			"newly-discovered (SID, %s) row auto-authorized at version %s",
+			row.Connector,
+			version,
+		),
+	)
+	return true
 }
 
 func previousManifestKey(sid, connector string) string {

--- a/internal/enterprisehooks/enumerator_windows_test.go
+++ b/internal/enterprisehooks/enumerator_windows_test.go
@@ -512,11 +512,12 @@ func TestWriteTargetsManifestAtomicRejectsHardLinkedDestination(t *testing.T) {
 }
 
 // TestApplyPreviousRowStatePreservesAgentVersion asserts the
-// AgentVersion + Enabled + Deferred preservation invariant spec 005 REQ-08's
-// design says: a row that already exists in the file keeps its
-// agent_version + enabled state across enumeration cycles. A NEW
-// row starts with Enabled=false so LoadManifest's schema validation
-// skips it (avoiding a load-time reject on empty AgentVersion).
+// AgentVersion + Enabled + Deferred preservation invariant spec
+// 005 REQ-08's design says: a row that already exists in the file
+// keeps its agent_version + enabled state across enumeration
+// cycles. A NEW row is auto-authorized at the per-user CLI's
+// discovered version (macOS parity) — or dropped entirely if no
+// per-user CLI is present.
 func TestApplyPreviousRowStatePreservesAgentVersion(t *testing.T) {
 	enabled := true
 	previous := map[string]ManifestTarget{
@@ -534,7 +535,9 @@ func TestApplyPreviousRowStatePreservesAgentVersion(t *testing.T) {
 		SID:       "s-1-5-21-1000-2000-3000-1001", // deliberate case
 		Connector: "codex",
 	}
-	applyPreviousRowState(&matched, previous, nil)
+	if !applyPreviousRowState(&matched, previous, nil) {
+		t.Fatal("existing-row emission signal: want true, got false")
+	}
 	if matched.AgentVersion != "0.145.0" {
 		t.Fatalf("existing-row AgentVersion not preserved: got %q, want %q", matched.AgentVersion, "0.145.0")
 	}
@@ -544,18 +547,54 @@ func TestApplyPreviousRowStatePreservesAgentVersion(t *testing.T) {
 	if !matched.Deferred {
 		t.Fatal("existing-row Deferred=true not preserved")
 	}
+}
 
-	// No match: emit disabled with empty AgentVersion.
+// TestApplyPreviousRowStateAutoAuthorizesNewRowWithDiscoverableCLI
+// pins the macOS-parity auto-authorize path: a newly-discovered
+// (SID, Connector) whose per-user profile contains a supported CLI
+// (via the package.json probe added in the previous commit) is
+// emitted with Enabled=true, AgentVersion set to the discovered
+// value, and Deferred=false.
+func TestApplyPreviousRowStateAutoAuthorizesNewRowWithDiscoverableCLI(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Roaming", "npm", "node_modules", "@openai", "codex")
+	writeWindowsAgentPackageJSON(t, dir, "0.42.0")
+
 	fresh := ManifestTarget{
 		SID:       "S-1-5-21-9999-8888-7777-1001",
+		UserHome:  home,
+		Connector: "codex",
+	}
+	if !applyPreviousRowState(&fresh, nil, nil) {
+		t.Fatal("new row with discoverable CLI: emission signal want true, got false")
+	}
+	if fresh.AgentVersion != "0.42.0" {
+		t.Fatalf("new row AgentVersion: got %q, want 0.42.0", fresh.AgentVersion)
+	}
+	if fresh.Enabled == nil || !*fresh.Enabled {
+		t.Fatal("new row Enabled: want pointer-to-true")
+	}
+	if fresh.Deferred {
+		t.Fatal("new row Deferred: want false")
+	}
+}
+
+// TestApplyPreviousRowStateDropsNewRowWithoutDiscoverableCLI pins
+// the macOS-parity silent-skip: a newly-discovered (SID, Connector)
+// whose per-user profile has NO supported CLI is dropped entirely.
+// applyPreviousRowState returns false; the caller in EnumerateWindows
+// treats false as "skip this row" (no target emitted).
+func TestApplyPreviousRowStateDropsNewRowWithoutDiscoverableCLI(t *testing.T) {
+	home := t.TempDir()
+	// No package.json under home — every probe path is absent.
+
+	fresh := ManifestTarget{
+		SID:       "S-1-5-21-9999-8888-7777-1001",
+		UserHome:  home,
 		Connector: "claudecode",
 	}
-	applyPreviousRowState(&fresh, previous, nil)
-	if fresh.AgentVersion != "" {
-		t.Fatalf("fresh row: AgentVersion should be empty; got %q", fresh.AgentVersion)
-	}
-	if fresh.Enabled == nil || *fresh.Enabled {
-		t.Fatal("fresh row: Enabled should be pointer-to-false")
+	if applyPreviousRowState(&fresh, nil, nil) {
+		t.Fatal("new row without discoverable CLI: emission signal want false, got true (row would have been emitted)")
 	}
 }
 


### PR DESCRIPTION
## Summary

Bring the Windows `DefenseClawHookEnumerator` SCM service to parity with macOS `render-targets.sh`: on every 5-minute tick, publish an updated `targets.yaml` that auto-authorizes newly-discovered `(SID, Connector)` rows whose per-user profile contains a supported CLI. Historically the Windows enumerator was audit-only — it logged unauthorized discoveries but never rewrote the manifest, forcing an administrator `Repair`/`Upgrade` to enroll any user added post-install.

## Rationale

Managed enterprise deployments are admin-driven at the *policy* layer (which connectors are pushed, which SIDs are in scope), not the per-device authorization layer. The macOS side has always operated this way — `packaging/macos/lib/render-targets.sh` runs on a 300 s `launchd` interval as root and rewrites `targets.yaml` on every tick. Windows now follows.

## Three-commit ladder

1. **`76ff9007` — per-connector agent-version probe.**
   New `internal/enterprisehooks/agent_version_windows.go` +
   non-Windows stub + tests. Static-filesystem, no-process-spawn
   probe that reads `version` from a well-known package.json path
   per connector:
   - `claudecode`: `<profile>\AppData\Roaming\npm\node_modules\@anthropic-ai\claude-code\package.json`
   - `codex`: `<profile>\AppData\Roaming\npm\node_modules\@openai\codex\package.json`
   - `cursor`: `<profile>\AppData\Local\Programs\cursor\resources\app\package.json`

   Silent-drop contract on {unknown connector, relative home, ancestor reparse chain, oversized file, malformed JSON, empty version field} — mirroring macOS's `discover_agent_version` behaviour. 64 KiB double-bounded read to defeat mid-read growth races.

2. **`9b7e708b` — `applyPreviousRowState` emits enabled with discovered version, or drops.**
   New rows are either auto-authorized (`Enabled=true`, `AgentVersion=<discovered>`, `Deferred=false`) or silently dropped when no CLI is discoverable. Existing rows preserve `AgentVersion + Enabled + Deferred + User/UID/GID` verbatim from the prior manifest. `applyPreviousRowState` now returns a `bool` emission signal; the caller in `EnumerateWindows` skips rows that return `false`. No user-visible service behaviour change from this commit alone — the SCM interval still passes `publish=false`.

3. **`d3018a00` — flip the SCM interval to `publish=true`.**
   `runEnterpriseWindowsEnumerateInterval` now passes `publish=true` on both the initial cycle and every tick. `newEnterpriseWindowsEnumerateCommand`'s cobra `Long` block is rewritten to describe the new posture. `WINDOWS-ENTERPRISE-THREAT-MODEL.md` residual-risk section 3 is updated: replaces "disabled rows pending an explicit administrator lifecycle action" with "auto-authorizes newly-discovered rows whose per-user profile contains a supported CLI," and explicitly names the new residual risk (a local admin who can create interactive users can enroll them on the next tick).

## What DIDN'T change

- The `--once` installer path still passes `publish=true` (it always did).
- `WriteTargetsManifestAtomic`'s byte-identical short-circuit stays — a stable box hits `bytes.Equal` on every tick and never mutates the file.
- The guardian's `rowsHash` idempotency + `settleUntil` window are unchanged — safe to receive frequent publishes.
- `protected_targets.json` (guardian authorization ledger) remains guardian-only writes.
- The manifest DACL, LocalSystem authority, and SCM service registration are all unchanged.
- The `publish=false` audit-cycle code path is retained on the parameter for test rigs and admin diagnostics.

## Test plan

- [x] `GOOS=windows GOARCH=amd64 go build ./...` clean
- [x] `GOOS=windows GOARCH=amd64 go vet ./...` clean
- [x] Windows test binaries compile clean (`go test -c` for both `internal/enterprisehooks/` and `internal/cli/`)
- [x] Darwin tests clean on affected packages (pre-existing `/private/var` failures unrelated to this PR)
- [ ] CI: `Windows x64 Go suite` — must be green
- [ ] CI: `Windows PowerShell harness validation` — must be green
- [ ] CI: `Windows complete Python suite / shard 3` — must be green
- [ ] CI: `Windows native Setup install and lifecycle acceptance` — must be green
- [ ] Manual VM verification per plan:
  1. Fresh install with `--connector codex,claudecode,cursor`
  2. Add a new local user with a discoverable CLI
  3. Wait ≤ 5 min
  4. Expect `[hook-enumerator] audit complete authorized_users=2 authorized_targets=... publication=enabled ...` in `hook-guardian.log`
  5. Expect the new user's hooks fire when they invoke their CLI
  6. Repeat with a user whose profile has no discoverable CLI → row is NOT emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)