### PR TITLE
fix(windows): scan real user profiles for AI discovery on managed_enterprise

### DIFF
--- a/internal/cli/enterprise_windows_enumerate_windows.go
+++ b/internal/cli/enterprise_windows_enumerate_windows.go
@@ -230,6 +230,16 @@ func runEnterpriseWindowsEnumerateSingleCycle(
 	if err != nil {
 		return fmt.Errorf("enterprise windows enumerate: write manifest: %w", err)
 	}
+	// Sibling pass: ensure the CertGateway service SID has Read+Execute on
+	// each enrolled user's inventory dotdirs (~/.claude, ~/.codex, …). The
+	// gateway runs under a virtual service account whose access to user
+	// profiles is not implicit; without this grant the AI discovery scanner
+	// walks the right paths but ReadDir returns access-denied and every
+	// skill/plugin/rule/mcp signal is suppressed. Idempotent; per-directory
+	// failures log-only so one bad DACL doesn't block the enumerator cycle.
+	if grantErr := enterprisehooks.GrantGatewayInventoryReadForManifest(manifest, "", logf); grantErr != nil {
+		fmt.Fprintf(stderr, "[hook-enumerator] inventory-DACL pass failed: %v\n", grantErr)
+	}
 	elapsed := time.Since(start)
 
 	fmt.Fprintf(stderr, "[hook-enumerator] cycle complete users=%d targets=%d changed=%t elapsed=%s\n",

--- a/internal/enterprisehooks/enumeration_logger.go
+++ b/internal/enterprisehooks/enumeration_logger.go
@@ -1,0 +1,13 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package enterprisehooks
+
+// EnumerationLogger receives one line per user profile the enumerator dropped
+// or annotated, so an operator can debug WHY a specific user isn't getting
+// hooked. Matches the macOS `_enumerate_users_warn` shape. Nil is safe (drops
+// are silent).
+//
+// Kept in a cross-platform file so non-Windows stubs (e.g. the inventory-DACL
+// pass) can reference the type without duplicating a build-tagged declaration.
+type EnumerationLogger func(subject, reason string)

--- a/internal/enterprisehooks/enumerator_windows.go
+++ b/internal/enterprisehooks/enumerator_windows.go
@@ -63,12 +63,6 @@ var windowsHookConnectors = map[string]struct{}{
 	"cursor":     {},
 }
 
-// EnumerationLogger receives one line per user profile the enumerator
-// dropped or annotated, so an operator can debug WHY a specific user
-// isn't getting hooked. Matches the macOS `_enumerate_users_warn`
-// shape. Nil is safe (drops are silent).
-type EnumerationLogger func(subject, reason string)
-
 // EnumerateOptions controls a single enumeration cycle. All fields
 // are optional.
 type EnumerateOptions struct {

--- a/internal/enterprisehooks/inventory_dacl_other.go
+++ b/internal/enterprisehooks/inventory_dacl_other.go
@@ -1,0 +1,14 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package enterprisehooks
+
+// GrantGatewayInventoryReadForManifest is a Windows-only no-op on other
+// platforms. macOS uses per-user launchd agents that inherit user permissions
+// naturally; Linux systemd-user runs likewise. Only the Windows service model
+// requires the gateway service SID to be added to the user profile DACLs.
+func GrantGatewayInventoryReadForManifest(_ Manifest, _ string, _ EnumerationLogger) error {
+	return nil
+}

--- a/internal/enterprisehooks/inventory_dacl_windows.go
+++ b/internal/enterprisehooks/inventory_dacl_windows.go
@@ -1,0 +1,271 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package enterprisehooks
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"unsafe"
+
+	"github.com/defenseclaw/defenseclaw/internal/winpath"
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+// inventoryDACLDotdirs enumerates the top-level user-profile subdirectories the
+// AI discovery scanner walks for skill, plugin, rule, and MCP-config signatures.
+// Kept in sync with the catalog under internal/inventory/ai_signatures.json —
+// this list covers the ancestor traversal that the scanner needs. Child ACEs
+// inherit from these parents via SUB_CONTAINERS_AND_OBJECTS_INHERIT so
+// per-file reads don't need a separate grant.
+var inventoryDACLDotdirs = []string{
+	".claude",
+	".codex",
+	".cursor",
+	".gemini",
+	".openhands",
+	".openclaw",
+	".hermes",
+	".windsurf",
+	".codeium",
+	".amp",
+	".opencode",
+	".agents",
+	".config",
+}
+
+// gatewayServiceNamePattern matches the certification-scoped gateway service
+// name. The scope suffix (10 lowercase hex chars) is generated at install time
+// and shared across CertGateway/CertGuardian/CertEnumerator/CertCMIDBroker.
+var gatewayServiceNamePattern = regexp.MustCompile(`^DefenseClawCertGateway_[a-f0-9]{10}$`)
+
+// productionGatewayServiceName is the un-scoped gateway service name used by
+// production installs (no cert suffix).
+const productionGatewayServiceName = "DefenseClawGateway"
+
+// GrantGatewayInventoryReadForManifest ensures the DefenseClaw CertGateway
+// service's virtual service account has Read+Execute+Traverse ACEs on the
+// inventory-relevant dotdirs under each enrolled user's profile. The gateway
+// runs under NT SERVICE\DefenseClawCertGateway_<scope>, a virtual service
+// account with no implicit access to user profiles; without this grant the AI
+// discovery scanner walks the right paths but ReadDir returns "access denied"
+// and every skill/plugin/rule/mcp_server signal is silently suppressed.
+//
+// Idempotent: SetEntriesInAcl merges by trustee, so repeated ticks with the
+// same ACE parameters land byte-identical DACLs. Dotdirs that don't exist yet
+// are skipped (the user may not have started that CLI yet); the next tick
+// re-tries. Per-directory errors are logged and do not abort the pass — one
+// user's misconfigured DACL should not block enrollment for the other users.
+//
+// If gatewayServiceName is empty, discovers it via SCM enumeration (matches
+// the cert-scoped or production naming). Returns an error only if the pass
+// cannot even begin (SCM unavailable, service SID resolution fails); per-path
+// failures are logged and swallowed.
+func GrantGatewayInventoryReadForManifest(manifest Manifest, gatewayServiceName string, logf EnumerationLogger) error {
+	name := strings.TrimSpace(gatewayServiceName)
+	if name == "" {
+		discovered, err := discoverGatewayServiceName()
+		if err != nil {
+			return fmt.Errorf("enterprise hooks: discover gateway service name: %w", err)
+		}
+		name = discovered
+	}
+	if !gatewayServiceNamePattern.MatchString(name) && name != productionGatewayServiceName {
+		return fmt.Errorf("enterprise hooks: refusing untrusted gateway service name %q", name)
+	}
+	account := `NT SERVICE\` + name
+	sid, _, _, err := windows.LookupSID("", account)
+	if err != nil {
+		return fmt.Errorf("enterprise hooks: resolve gateway service SID %q: %w", account, err)
+	}
+	if !sidIsNTServiceInventory(sid) {
+		return fmt.Errorf("enterprise hooks: gateway service account %q did not resolve to NT SERVICE authority", account)
+	}
+
+	granted, skipped, failed := 0, 0, 0
+	seenHome := map[string]struct{}{}
+	for _, target := range manifest.Targets {
+		home := filepath.Clean(strings.TrimSpace(target.UserHome))
+		if home == "" {
+			continue
+		}
+		key := strings.ToLower(home)
+		if _, dup := seenHome[key]; dup {
+			continue
+		}
+		seenHome[key] = struct{}{}
+		for _, dotdir := range inventoryDACLDotdirs {
+			path := filepath.Join(home, dotdir)
+			result, err := ensureInventoryReadACE(path, sid)
+			switch {
+			case err != nil:
+				failed++
+				logfSafely(logf, target.SID, fmt.Sprintf("inventory-DACL grant %s: %v", path, err))
+			case result == inventoryDACLGranted:
+				granted++
+			case result == inventoryDACLAlreadyPresent:
+				skipped++
+			}
+		}
+	}
+	logfSafely(logf, "", fmt.Sprintf("inventory-DACL pass gateway=%s granted=%d already_present=%d failed=%d", name, granted, skipped, failed))
+	return nil
+}
+
+type inventoryDACLResult int
+
+const (
+	inventoryDACLSkippedMissing inventoryDACLResult = iota
+	inventoryDACLGranted
+	inventoryDACLAlreadyPresent
+)
+
+// ensureInventoryReadACE adds an ACE granting Read+Execute+Traverse on `path`
+// to `sid`, inheriting to sub-containers and objects. If `path` doesn't exist
+// or isn't a directory, silently succeed — the user may not have started the
+// corresponding CLI yet; the next tick retries.
+func ensureInventoryReadACE(path string, sid *windows.SID) (inventoryDACLResult, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return inventoryDACLSkippedMissing, nil
+		}
+		return inventoryDACLSkippedMissing, fmt.Errorf("stat: %w", err)
+	}
+	if !fi.IsDir() {
+		return inventoryDACLSkippedMissing, nil
+	}
+	extended, err := winpath.Extended(path)
+	if err != nil {
+		return inventoryDACLSkippedMissing, fmt.Errorf("extend: %w", err)
+	}
+	sd, err := windows.GetNamedSecurityInfo(
+		extended,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		return inventoryDACLSkippedMissing, fmt.Errorf("get DACL: %w", err)
+	}
+	existing, _, err := sd.DACL()
+	if err != nil {
+		return inventoryDACLSkippedMissing, fmt.Errorf("inspect DACL: %w", err)
+	}
+	if existing != nil && daclContainsInventoryReadACE(existing, sid) {
+		return inventoryDACLAlreadyPresent, nil
+	}
+	entry := windows.EXPLICIT_ACCESS{
+		AccessPermissions: windows.GENERIC_READ | windows.GENERIC_EXECUTE,
+		AccessMode:        windows.GRANT_ACCESS,
+		Inheritance:       windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  windows.TRUSTEE_IS_USER,
+			TrusteeValue: windows.TrusteeValueFromSID(sid),
+		},
+	}
+	merged, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{entry}, existing)
+	if err != nil {
+		return inventoryDACLSkippedMissing, fmt.Errorf("merge ACE: %w", err)
+	}
+	if err := windows.SetNamedSecurityInfo(
+		extended,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+		nil, nil, merged, nil,
+	); err != nil {
+		return inventoryDACLSkippedMissing, fmt.Errorf("set DACL: %w", err)
+	}
+	return inventoryDACLGranted, nil
+}
+
+// daclContainsInventoryReadACE reports whether `acl` already contains an
+// allow-access ACE granting `sid` at least Read+Execute. Used as an idempotency
+// short-circuit so repeat ticks skip the (get, merge, set) round-trip when the
+// ACE is already present.
+func daclContainsInventoryReadACE(acl *windows.ACL, sid *windows.SID) bool {
+	if acl == nil || sid == nil {
+		return false
+	}
+	const wantMask = uint32(windows.GENERIC_READ | windows.GENERIC_EXECUTE)
+	for i := uint32(0); i < uint32(acl.AceCount); i++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(acl, i, &ace); err != nil || ace == nil {
+			continue
+		}
+		if ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE {
+			continue
+		}
+		aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+		if aceSID == nil || !windows.EqualSid(aceSID, sid) {
+			continue
+		}
+		if uint32(ace.Mask)&wantMask == wantMask {
+			return true
+		}
+	}
+	return false
+}
+
+// discoverGatewayServiceName looks up the DefenseClaw gateway service via the
+// Service Control Manager. Prefers a certification-scoped service if present;
+// falls back to the production name. Returns an error if neither is installed.
+func discoverGatewayServiceName() (string, error) {
+	manager, err := mgr.Connect()
+	if err != nil {
+		return "", fmt.Errorf("connect SCM: %w", err)
+	}
+	defer manager.Disconnect()
+	names, err := manager.ListServices()
+	if err != nil {
+		return "", fmt.Errorf("enumerate services: %w", err)
+	}
+	var certScoped string
+	for _, n := range names {
+		switch {
+		case gatewayServiceNamePattern.MatchString(n):
+			// Prefer the first certification-scoped match; the pattern
+			// contract enforces exactly one per install.
+			if certScoped == "" {
+				certScoped = n
+			}
+		case n == productionGatewayServiceName:
+			// Keep looking for a cert-scoped one; production is the fallback.
+		}
+	}
+	if certScoped != "" {
+		return certScoped, nil
+	}
+	for _, n := range names {
+		if n == productionGatewayServiceName {
+			return productionGatewayServiceName, nil
+		}
+	}
+	return "", errors.New("no DefenseClaw gateway service installed")
+}
+
+// sidIsNTServiceInventory validates that `sid` names an NT SERVICE virtual
+// account: SID authority is NT AUTHORITY (Value 5) with first sub-authority 80
+// (SECURITY_SERVICE_ID_BASE_RID). Deliberately duplicated from the equivalent
+// helper in internal/managed to avoid an enterprisehooks → managed import;
+// contract is byte-identical and covered by the shared trust-model comment.
+func sidIsNTServiceInventory(sid *windows.SID) bool {
+	if sid == nil || !sid.IsValid() {
+		return false
+	}
+	authority := sid.IdentifierAuthority()
+	if authority.Value != [6]byte{0, 0, 0, 0, 0, 5} {
+		return false
+	}
+	if sid.SubAuthorityCount() < 1 {
+		return false
+	}
+	return sid.SubAuthority(0) == 80
+}

--- a/internal/enterprisehooks/inventory_dacl_windows.go
+++ b/internal/enterprisehooks/inventory_dacl_windows.go
@@ -158,7 +158,19 @@ func ensureInventoryReadACE(path string, sid *windows.SID) (inventoryDACLResult,
 	if err != nil {
 		return inventoryDACLSkippedMissing, fmt.Errorf("inspect DACL: %w", err)
 	}
-	if existing != nil && daclContainsInventoryReadACE(existing, sid) {
+	// Refuse to touch a directory that has no explicit DACL. `existing == nil`
+	// after a successful `sd.DACL()` means the descriptor carries a null DACL
+	// (everyone-allowed semantics, not a missing-info error). Passing that
+	// through `ACLFromEntries(entries, nil)` would build an ACL containing
+	// only our gateway grant and `SetNamedSecurityInfo` would replace the
+	// null DACL with a DACL granting exclusively the gateway service SID —
+	// silently stripping access from every other principal. Skip and surface
+	// the anomaly via the failed counter so an operator can investigate the
+	// unusual permission state.
+	if existing == nil {
+		return inventoryDACLSkippedMissing, fmt.Errorf("null DACL on %s; refusing to replace with sole gateway-service ACE", path)
+	}
+	if daclContainsInventoryReadACE(existing, sid) {
 		return inventoryDACLAlreadyPresent, nil
 	}
 	entry := windows.EXPLICIT_ACCESS{
@@ -187,14 +199,27 @@ func ensureInventoryReadACE(path string, sid *windows.SID) (inventoryDACLResult,
 }
 
 // daclContainsInventoryReadACE reports whether `acl` already contains an
-// allow-access ACE granting `sid` at least Read+Execute. Used as an idempotency
-// short-circuit so repeat ticks skip the (get, merge, set) round-trip when the
-// ACE is already present.
+// allow-access ACE granting `sid` at least Read+Execute with the same
+// inheritance semantics we would install. Used as an idempotency short-circuit
+// so repeat ticks skip the (get, merge, set) round-trip when the ACE is
+// already present in the exact shape we need.
+//
+// Inheritance requirements match the `SUB_CONTAINERS_AND_OBJECTS_INHERIT` flag
+// set we pass to `ACLFromEntries`: both OBJECT_INHERIT_ACE (files) and
+// CONTAINER_INHERIT_ACE (subdirs) must be present, and neither
+// NO_PROPAGATE_INHERIT_ACE nor INHERIT_ONLY_ACE may be set — an ACE that
+// grants the parent but does not propagate to children is NOT equivalent for
+// our purposes (the scanner reads files INSIDE the dotdirs, not the dotdir
+// itself), and an INHERIT_ONLY_ACE that doesn't apply to the parent leaves
+// the traversal grant absent. Rebuilding the ACL is preferable to leaving a
+// half-configured ACE in place.
 func daclContainsInventoryReadACE(acl *windows.ACL, sid *windows.SID) bool {
 	if acl == nil || sid == nil {
 		return false
 	}
 	const wantMask = uint32(windows.GENERIC_READ | windows.GENERIC_EXECUTE)
+	const requiredInherit = uint8(windows.OBJECT_INHERIT_ACE | windows.CONTAINER_INHERIT_ACE)
+	const forbiddenInherit = uint8(windows.NO_PROPAGATE_INHERIT_ACE | windows.INHERIT_ONLY_ACE)
 	for i := uint32(0); i < uint32(acl.AceCount); i++ {
 		var ace *windows.ACCESS_ALLOWED_ACE
 		if err := windows.GetAce(acl, i, &ace); err != nil || ace == nil {
@@ -207,9 +232,17 @@ func daclContainsInventoryReadACE(acl *windows.ACL, sid *windows.SID) bool {
 		if aceSID == nil || !windows.EqualSid(aceSID, sid) {
 			continue
 		}
-		if uint32(ace.Mask)&wantMask == wantMask {
-			return true
+		if uint32(ace.Mask)&wantMask != wantMask {
+			continue
 		}
+		flags := ace.Header.AceFlags
+		if flags&requiredInherit != requiredInherit {
+			continue
+		}
+		if flags&forbiddenInherit != 0 {
+			continue
+		}
+		return true
 	}
 	return false
 }

--- a/internal/inventory/ai_discovery.go
+++ b/internal/inventory/ai_discovery.go
@@ -719,6 +719,23 @@ func normalizeAIDiscoveryOptions(opts AIDiscoveryOptions) AIDiscoveryOptions {
 	if opts.HomeDir == "" {
 		opts.HomeDir, _ = platformDiscoveryHomeDir()
 	}
+	// Windows service-context override. When no caller-supplied HomeDirs
+	// are set and the platform enumerator finds real interactive-user
+	// profiles (HKLM\...\ProfileList → S-1-5-21-... SIDs), prefer those
+	// over the current-user Known Folder — the sidecar runs as a service
+	// account whose ~ resolves to a virtual C:\Windows\ServiceProfiles
+	// path, so a bare-~ scan never sees any real .claude/.codex/.cursor
+	// directories. On non-Windows this returns nil (launchd/systemd-user
+	// already scope the process to the right $HOME). HomeDir is repointed
+	// at the first real profile so ScanRoots=["~"] still resolves to a
+	// meaningful root and downstream helpers that read opts.HomeDir keep
+	// working.
+	if len(opts.HomeDirs) == 0 {
+		if platformHomes := platformDiscoveryHomeDirs(); len(platformHomes) > 0 {
+			opts.HomeDirs = platformHomes
+			opts.HomeDir = platformHomes[0]
+		}
+	}
 	// Dedupe HomeDirs and ensure HomeDir participates so single-user
 	// installs (unmanaged / dev) keep working without a config change.
 	// Order-preserving so detectors return signals in a stable order

--- a/internal/inventory/ai_discovery.go
+++ b/internal/inventory/ai_discovery.go
@@ -730,7 +730,15 @@ func normalizeAIDiscoveryOptions(opts AIDiscoveryOptions) AIDiscoveryOptions {
 	// at the first real profile so ScanRoots=["~"] still resolves to a
 	// meaningful root and downstream helpers that read opts.HomeDir keep
 	// working.
-	if len(opts.HomeDirs) == 0 {
+	//
+	// Gated on ManagedEnterprise: only in managed installs (where the
+	// enterprise admin has consented to fleet-wide inventory of every
+	// enrolled user) do we cross the single-user → all-users boundary.
+	// Unmanaged / dev installs keep the historical single-user posture —
+	// the current process's own ~ is the only scan surface, so a
+	// developer running a local build does not silently start reading
+	// their coworkers' dotdirs on a shared workstation.
+	if opts.ManagedEnterprise && len(opts.HomeDirs) == 0 {
 		if platformHomes := platformDiscoveryHomeDirs(); len(platformHomes) > 0 {
 			opts.HomeDirs = platformHomes
 			opts.HomeDir = platformHomes[0]

--- a/internal/inventory/ai_discovery_platform_nonwindows.go
+++ b/internal/inventory/ai_discovery_platform_nonwindows.go
@@ -16,6 +16,16 @@ func platformDiscoveryHomeDir() (string, error) {
 	return os.UserHomeDir()
 }
 
+// platformDiscoveryHomeDirs enumerates additional user profile roots the scan
+// should walk. On macOS/Linux the process user's `$HOME` already resolves to
+// the right place (launchd agents run per-user; systemd/systemd-user likewise),
+// so this returns nil and the single HomeDir path drives the scan. The Windows
+// override enumerates HKLM\...\ProfileList so a service-context scan sees each
+// real interactive user's home rather than its own virtual ServiceProfiles dir.
+func platformDiscoveryHomeDirs() []string {
+	return nil
+}
+
 func platformDiscoveryVariable(name, _ string) (string, bool) {
 	return os.LookupEnv(name)
 }

--- a/internal/inventory/ai_discovery_platform_windows.go
+++ b/internal/inventory/ai_discovery_platform_windows.go
@@ -52,6 +52,90 @@ func platformDiscoveryHomeDir() (string, error) {
 	return filepath.Clean(path), nil
 }
 
+// profileListRegistryKey is HKLM's inventory of resolved user profile
+// directories, keyed by SID. It's the same authority the enterprise-hook
+// enumerator uses to discover interactive users; reusing it keeps discovery
+// scanning aligned with the hook-lifecycle enrollment surface without pulling
+// in the enterprisehooks package.
+const profileListRegistryKey = `SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList`
+
+// platformDiscoveryHomeDirs enumerates interactive-user profile roots by
+// walking HKLM\...\ProfileList. The gateway sidecar runs as a service (its
+// current-user Known Folder resolves to a per-service virtual profile under
+// C:\Windows\ServiceProfiles\), so a bare ~/... expansion never sees any real
+// user's .claude/.codex/.cursor directories. Feeding this list into
+// AIDiscoveryOptions.HomeDirs makes homesToScan() enumerate real profiles.
+//
+// Filter: only S-1-5-21-... SIDs (local-account or domain-account interactive
+// users, 5+ sub-authorities), matching the same coarse gate the hook
+// enumerator applies at internal/enterprisehooks/enumerator_windows.go. Stale
+// ProfileList entries whose ProfileImagePath no longer exists are skipped so
+// the scan does not waste ticks on ghost profiles.
+func platformDiscoveryHomeDirs() []string {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, profileListRegistryKey, registry.READ)
+	if err != nil {
+		return nil
+	}
+	defer key.Close()
+	names, err := key.ReadSubKeyNames(-1)
+	if err != nil {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(names))
+	out := make([]string, 0, len(names))
+	for _, sid := range names {
+		if !isInteractiveUserSID(sid) {
+			continue
+		}
+		subKey, err := registry.OpenKey(
+			registry.LOCAL_MACHINE,
+			profileListRegistryKey+`\`+sid,
+			registry.QUERY_VALUE,
+		)
+		if err != nil {
+			continue
+		}
+		raw, _, err := subKey.GetStringValue("ProfileImagePath")
+		_ = subKey.Close()
+		if err != nil {
+			continue
+		}
+		expanded, expandErr := registry.ExpandString(raw)
+		if expandErr != nil {
+			expanded = raw
+		}
+		expanded = filepath.Clean(strings.TrimSpace(expanded))
+		if expanded == "" {
+			continue
+		}
+		if fi, err := os.Stat(expanded); err != nil || !fi.IsDir() {
+			continue
+		}
+		lower := strings.ToLower(expanded)
+		if _, ok := seen[lower]; ok {
+			continue
+		}
+		seen[lower] = struct{}{}
+		out = append(out, expanded)
+	}
+	return out
+}
+
+// isInteractiveUserSID reports whether sid names a local or domain user
+// account whose profile hosts real per-user configuration. Matches the
+// coarse gate the enterprise-hook enumerator uses (S-1-5-21-... with 5+
+// sub-authorities); virtual service accounts (S-1-5-80-...), well-known
+// principals (S-1-5-18 LocalSystem, S-1-5-19/20), and machine SIDs never
+// carry AI-agent config directories worth scanning.
+func isInteractiveUserSID(sid string) bool {
+	if !strings.HasPrefix(sid, "S-1-5-21-") {
+		return false
+	}
+	// S-1-5-21-<domain-3-tuple>-<RID> → at least 5 sub-authorities after
+	// the S-1-5- prefix. Splitting on '-' produces >=8 pieces.
+	return len(strings.Split(sid, "-")) >= 8
+}
+
 func platformDiscoveryVariable(name, home string) (string, bool) {
 	var folderID *windows.KNOWNFOLDERID
 	switch strings.ToUpper(strings.TrimSpace(name)) {


### PR DESCRIPTION
## Summary

Fixes the AI discovery inventory scanner on Windows managed_enterprise so it walks real interactive user profiles instead of the gateway service's virtual profile, and grants the gateway service SID Read access to the inventory-relevant dotdirs so `ReadDir` doesn't fail closed.

Before this change, on a Windows managed_enterprise install:
- `~/.claude/skills`, `~/.codex/plugins`, `~/.cursor/rules`, etc. were expanded against `C:\Windows\ServiceProfiles\DefenseClawCertGateway_<scope>\` (the CertGateway service's per-service virtual profile) rather than any real user's home.
- Even if the paths had been correct, the CertGateway service runs under a virtual service SID (`NT SERVICE\DefenseClawCertGateway_<scope>`) that has no implicit access to `C:\Users\<user>\.*` — ReadDir returned ERROR_ACCESS_DENIED.

Result: AI Discovery emitted only `active_process` and `supported_connector` signals; `skill`, `plugin`, `rule`, `mcp_server` never fired on Windows. macOS parity broken.

## Root causes

**RC1** — `platformDiscoveryHomeDir` on Windows uses `winpath.CurrentUserKnownFolderPathWithFlags(FOLDERID_Profile)`, which for a service returns the virtual service profile, not any real user's home. macOS launchd agents scope `\$HOME` per user; Windows service-context code has no equivalent.

**RC2** — User dotdirs default-grant `NT AUTHORITY\SYSTEM` + `BUILTIN\Administrators` + the user themselves. The virtual service SID `NT SERVICE\DefenseClawCertGateway_*` is in none of those groups — no traversal or read access to `\.claude/`, `\.codex/`, `\.cursor/`, etc.

## Fix

Two commits' worth of changes in one PR since they're logically one thing: making AI discovery scan real users on Windows.

### Part 1 — `platformDiscoveryHomeDirs()` (`internal/inventory/ai_discovery_platform_windows.go`)

New Windows-only helper walks `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList`, filters to interactive-user SIDs (`S-1-5-21-…` with ≥5 sub-authorities — same coarse gate the enterprise-hook enumerator uses), resolves `ProfileImagePath` for each, and returns the paths of existing home directories.

`normalizeAIDiscoveryOptions` (`internal/inventory/ai_discovery.go`) now prefers these over the current-user Known Folder when no caller-supplied `HomeDirs` is set. Non-Windows returns nil — per-user launchd/systemd-user already handles that on macOS/Linux.

### Part 2 — `GrantGatewayInventoryReadForManifest()` (`internal/enterprisehooks/inventory_dacl_windows.go`)

Runs at the end of every enumerator single-cycle (already the natural per-user reconciliation point). For each `UserHome` in the manifest, adds a `GRANT_ACCESS` ACE (`GENERIC_READ | GENERIC_EXECUTE`, `SUB_CONTAINERS_AND_OBJECTS_INHERIT`) for the CertGateway virtual service SID on the inventory-relevant dotdirs (`~/.claude`, `~/.codex`, `~/.cursor`, `~/.gemini`, `~/.openhands`, `~/.openclaw`, `~/.hermes`, `~/.windsurf`, `~/.codeium`, `~/.amp`, `~/.opencode`, `~/.agents`, `~/.config`).

**Idempotent** — pre-checks the DACL via `GetAce` and skips the write when the ACE is already present. Steady-state ticks are byte-identical no-ops.

**Gateway service SID resolution** — discovered via SCM enumeration (matches `DefenseClawCertGateway_<10hex>` cert-scoped or `DefenseClawGateway` production name). Validates the resolved SID is under NT SERVICE authority before granting.

**Non-existent dirs** — silently skipped; retried on the next cycle. One user's misconfigured DACL doesn't block enrollment for other users.

### Part 3 — small refactor

`EnumerationLogger` type extracted from `enumerator_windows.go` into `internal/enterprisehooks/enumeration_logger.go` (cross-platform) so the non-Windows stub in the DACL pass can reference the type.

## Threat model note

Grants Read+Execute+Traverse only, on catalog-known dotdirs only, only for the gateway service's own virtual SID — not to Administrators, not to Everyone, and never a Write bit. Preserves the CertGateway virtual-service-account isolation posture (alternative Option C would have been to run the gateway as LocalSystem, which was rejected as a broader posture shift).

## What's NOT fixed here (deferred)

Catalog entries that use \`\$LOCALAPPDATA\` / \`\$APPDATA\` / \`\$USERPROFILE\` env-var expansion (Hermes, some Antigravity paths) still resolve to the service's virtual profile because `platformDiscoveryVariable` uses `winpath.CurrentUserKnownFolderPathWithFlags`. This affects a small number of connectors; Claude/Codex/Cursor coverage — which use `~` expansion — is fully restored. Follow-up will plumb the interactive-user HomeDir into `platformDiscoveryVariable` for env-var resolution too.

## Test plan

- [x] `GOOS=windows GOARCH=amd64 go build ./...` clean
- [x] `GOOS=windows GOARCH=amd64 go vet ./...` clean
- [x] `go build ./...` clean (darwin)
- [x] `go vet ./...` clean (darwin)
- [x] `go test ./internal/inventory/... ./internal/enterprisehooks/...` clean
- [x] End-to-end on Windows 11 managed_enterprise VM:
  - Scanner walks `C:\Users\dclawadmin` (real profile), not `C:\Windows\ServiceProfiles\DefenseClawCertGateway_*`
  - Enumerator's inventory-DACL pass grants Read+Execute on dotdirs, then short-circuits to no-op on subsequent cycles
  - AI discovery emits `skill`, `plugin`, `rule`, `mcp_server` categories: **12 skill, 6 rule, 6 mcp_server, 3 plugin** (was 0 for all)
  - Signals per tick: **12 → 31** (+158%)
  - Outbound POST to `us.api.inspect.aidefense.security.cisco.com/api/v1/defenseclaw/events/ingest` returns `status=200` with new content hashes marked `"inserted":true`
- [ ] CI green (waiting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)