### PR TITLE
fix(hooks): presence-based fallback (macOS, cherry-pick #785) + broaden Windows probe

### DIFF
--- a/internal/enterprisehooks/agent_version_windows.go
+++ b/internal/enterprisehooks/agent_version_windows.go
@@ -107,29 +107,29 @@ var windowsMachineScopedCursorPackageJSON = `C:\Program Files\Cursor\resources\a
 // Per-connector candidates:
 //
 //   - `claudecode`:
-//       1. `%APPDATA%\npm\node_modules\@anthropic-ai\claude-code\package.json`
-//          — npm-global (the historical baseline).
-//       2. `%USERPROFILE%\.bun\install\global\node_modules\@anthropic-ai\claude-code\package.json`
-//          — Bun global install (`bun install -g @anthropic-ai/claude-code`).
-//       3. `%LOCALAPPDATA%\Yarn\Data\global\node_modules\@anthropic-ai\claude-code\package.json`
-//          — Yarn Classic global install (still common on legacy hosts).
+//     1. `%APPDATA%\npm\node_modules\@anthropic-ai\claude-code\package.json`
+//     — npm-global (the historical baseline).
+//     2. `%USERPROFILE%\.bun\install\global\node_modules\@anthropic-ai\claude-code\package.json`
+//     — Bun global install (`bun install -g @anthropic-ai/claude-code`).
+//     3. `%LOCALAPPDATA%\Yarn\Data\global\node_modules\@anthropic-ai\claude-code\package.json`
+//     — Yarn Classic global install (still common on legacy hosts).
 //
 //   - `codex`:
-//       1. `%APPDATA%\npm\node_modules\@openai\codex\package.json` — npm-global.
-//       2. `%USERPROFILE%\.bun\install\global\node_modules\@openai\codex\package.json`
-//          — Bun global.
-//       3. `%LOCALAPPDATA%\Yarn\Data\global\node_modules\@openai\codex\package.json`
-//          — Yarn Classic global.
+//     1. `%APPDATA%\npm\node_modules\@openai\codex\package.json` — npm-global.
+//     2. `%USERPROFILE%\.bun\install\global\node_modules\@openai\codex\package.json`
+//     — Bun global.
+//     3. `%LOCALAPPDATA%\Yarn\Data\global\node_modules\@openai\codex\package.json`
+//     — Yarn Classic global.
 //     MSIX-store install (`C:\Program Files\WindowsApps\OpenAI.Codex_…\`) still
 //     requires a glob-resolved lookup and stays out of scope here; a follow-up
 //     probe can add it once the glob-vs-reparse-chain interaction is worked out.
 //
 //   - `cursor`:
-//       1. `%LOCALAPPDATA%\Programs\cursor\resources\app\package.json`
-//          — Cursor Desktop per-user install.
-//       2. `windowsMachineScopedCursorPackageJSON` — Cursor MSI machine-scoped
-//          install. Path is a package variable so tests can override; the
-//          production default is `C:\Program Files\Cursor\resources\app\package.json`.
+//     1. `%LOCALAPPDATA%\Programs\cursor\resources\app\package.json`
+//     — Cursor Desktop per-user install.
+//     2. `windowsMachineScopedCursorPackageJSON` — Cursor MSI machine-scoped
+//     install. Path is a package variable so tests can override; the
+//     production default is `C:\Program Files\Cursor\resources\app\package.json`.
 //
 // All per-user candidates are fully-cleaned absolute paths anchored inside
 // `profileHome`; the one machine-scoped candidate is anchored at a fixed

--- a/internal/enterprisehooks/agent_version_windows.go
+++ b/internal/enterprisehooks/agent_version_windows.go
@@ -85,48 +85,78 @@ func discoverWindowsAgentVersion(profileHome, connectorName string) string {
 	return ""
 }
 
+// windowsMachineScopedCursorPackageJSON points at Cursor's per-machine
+// install (MSI installer, admin-installed). Unlike the per-user candidates
+// this path is NOT derived from the profile home — every user on the box
+// sees the same version. Kept as a package-level variable so tests can
+// stub it to a hermetic `t.TempDir()` fixture instead of trying to write
+// to the real Program Files tree.
+var windowsMachineScopedCursorPackageJSON = `C:\Program Files\Cursor\resources\app\package.json`
+
 // windowsAgentVersionCandidatePaths returns the ordered set of
 // package.json paths to try for `connectorName` under
 // `profileHome`. The order matters: probes higher in the list are
-// preferred. Each connector's candidate set covers the install
-// flavours we've observed on real Windows QA hosts:
+// preferred (first match wins). Each connector's candidate set covers the
+// install flavours we've observed on real Windows QA hosts plus the
+// major package managers users install these CLIs through in practice —
+// a probe list too narrow becomes a silent-drop when the user installed
+// via a channel we didn't cover (real customer symptom on macOS drove
+// the presence-fallback in packaging/macos/lib/installer_lib.sh; the
+// probe broadening here is the Windows-side coverage improvement).
 //
-//   - `claudecode`: npm-global install under
-//     `%APPDATA%\npm\node_modules\@anthropic-ai\claude-code\`.
-//     `%APPDATA%` on Windows resolves to
-//     `%USERPROFILE%\AppData\Roaming` — the enumerator receives
-//     the profile's home directory so we build the Roaming path
-//     directly.
-//   - `codex`: npm-global install under
-//     `%APPDATA%\npm\node_modules\@openai\codex\`. The MSIX-store
-//     flavour (`C:\Program Files\WindowsApps\OpenAI.Codex_…\`)
-//     lives OUTSIDE the profile and is machine-scoped; probing it
-//     is a follow-up that requires a separate lookup path. For
-//     now we return empty for MSIX-only installs so the
-//     enumerator drops the row (parity with macOS's behaviour when
-//     the codex CLI is absent).
-//   - `cursor`: Cursor Desktop's per-user install at
-//     `%LOCALAPPDATA%\Programs\cursor\resources\app\package.json`.
-//     `%LOCALAPPDATA%` = `%USERPROFILE%\AppData\Local`.
+// Per-connector candidates:
 //
-// Every candidate is a fully-cleaned absolute path anchored inside
-// `profileHome`. Callers never see relative paths, symlinks, or
-// user-supplied path fragments.
+//   - `claudecode`:
+//       1. `%APPDATA%\npm\node_modules\@anthropic-ai\claude-code\package.json`
+//          — npm-global (the historical baseline).
+//       2. `%USERPROFILE%\.bun\install\global\node_modules\@anthropic-ai\claude-code\package.json`
+//          — Bun global install (`bun install -g @anthropic-ai/claude-code`).
+//       3. `%LOCALAPPDATA%\Yarn\Data\global\node_modules\@anthropic-ai\claude-code\package.json`
+//          — Yarn Classic global install (still common on legacy hosts).
+//
+//   - `codex`:
+//       1. `%APPDATA%\npm\node_modules\@openai\codex\package.json` — npm-global.
+//       2. `%USERPROFILE%\.bun\install\global\node_modules\@openai\codex\package.json`
+//          — Bun global.
+//       3. `%LOCALAPPDATA%\Yarn\Data\global\node_modules\@openai\codex\package.json`
+//          — Yarn Classic global.
+//     MSIX-store install (`C:\Program Files\WindowsApps\OpenAI.Codex_…\`) still
+//     requires a glob-resolved lookup and stays out of scope here; a follow-up
+//     probe can add it once the glob-vs-reparse-chain interaction is worked out.
+//
+//   - `cursor`:
+//       1. `%LOCALAPPDATA%\Programs\cursor\resources\app\package.json`
+//          — Cursor Desktop per-user install.
+//       2. `windowsMachineScopedCursorPackageJSON` — Cursor MSI machine-scoped
+//          install. Path is a package variable so tests can override; the
+//          production default is `C:\Program Files\Cursor\resources\app\package.json`.
+//
+// All per-user candidates are fully-cleaned absolute paths anchored inside
+// `profileHome`; the one machine-scoped candidate is anchored at a fixed
+// system root and reads the same package.json for every user (correct: it
+// documents the version of the shared install on the box).
 func windowsAgentVersionCandidatePaths(profileHome, connectorName string) []string {
 	appDataRoaming := filepath.Join(profileHome, "AppData", "Roaming")
 	appDataLocal := filepath.Join(profileHome, "AppData", "Local")
+	bunGlobal := filepath.Join(profileHome, ".bun", "install", "global", "node_modules")
+	yarnGlobal := filepath.Join(appDataLocal, "Yarn", "Data", "global", "node_modules")
 	switch connectorName {
 	case "claudecode":
 		return []string{
 			filepath.Join(appDataRoaming, "npm", "node_modules", "@anthropic-ai", "claude-code", "package.json"),
+			filepath.Join(bunGlobal, "@anthropic-ai", "claude-code", "package.json"),
+			filepath.Join(yarnGlobal, "@anthropic-ai", "claude-code", "package.json"),
 		}
 	case "codex":
 		return []string{
 			filepath.Join(appDataRoaming, "npm", "node_modules", "@openai", "codex", "package.json"),
+			filepath.Join(bunGlobal, "@openai", "codex", "package.json"),
+			filepath.Join(yarnGlobal, "@openai", "codex", "package.json"),
 		}
 	case "cursor":
 		return []string{
 			filepath.Join(appDataLocal, "Programs", "cursor", "resources", "app", "package.json"),
+			windowsMachineScopedCursorPackageJSON,
 		}
 	default:
 		return nil

--- a/internal/enterprisehooks/agent_version_windows_test.go
+++ b/internal/enterprisehooks/agent_version_windows_test.go
@@ -92,6 +92,97 @@ func TestDiscoverWindowsAgentVersionCursor(t *testing.T) {
 	}
 }
 
+// TestDiscoverWindowsAgentVersionClaudeCodeBunGlobal covers the
+// `bun install -g @anthropic-ai/claude-code` install flavour — the
+// probe now walks `%USERPROFILE%\.bun\install\global\node_modules\...`
+// in addition to the npm-global path.
+func TestDiscoverWindowsAgentVersionClaudeCodeBunGlobal(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".bun", "install", "global", "node_modules", "@anthropic-ai", "claude-code")
+	writeWindowsAgentPackageJSON(t, dir, "0.5.9")
+	got := discoverWindowsAgentVersion(home, "claudecode")
+	if got != "0.5.9" {
+		t.Fatalf("bun-global claudecode: got %q, want 0.5.9", got)
+	}
+}
+
+// TestDiscoverWindowsAgentVersionClaudeCodeYarnGlobal covers the
+// Yarn Classic global install still common on legacy hosts.
+func TestDiscoverWindowsAgentVersionClaudeCodeYarnGlobal(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Local", "Yarn", "Data", "global", "node_modules", "@anthropic-ai", "claude-code")
+	writeWindowsAgentPackageJSON(t, dir, "0.5.10")
+	got := discoverWindowsAgentVersion(home, "claudecode")
+	if got != "0.5.10" {
+		t.Fatalf("yarn-global claudecode: got %q, want 0.5.10", got)
+	}
+}
+
+// TestDiscoverWindowsAgentVersionCodexBunGlobal + YarnGlobal cover
+// the same alternative install channels for codex.
+func TestDiscoverWindowsAgentVersionCodexBunGlobal(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".bun", "install", "global", "node_modules", "@openai", "codex")
+	writeWindowsAgentPackageJSON(t, dir, "0.42.5")
+	got := discoverWindowsAgentVersion(home, "codex")
+	if got != "0.42.5" {
+		t.Fatalf("bun-global codex: got %q, want 0.42.5", got)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionCodexYarnGlobal(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Local", "Yarn", "Data", "global", "node_modules", "@openai", "codex")
+	writeWindowsAgentPackageJSON(t, dir, "0.42.7")
+	got := discoverWindowsAgentVersion(home, "codex")
+	if got != "0.42.7" {
+		t.Fatalf("yarn-global codex: got %q, want 0.42.7", got)
+	}
+}
+
+// TestDiscoverWindowsAgentVersionCursorMachineScoped covers the
+// Cursor MSI (machine-scoped) install. The probe path is a
+// package-level variable stubbed here to a temp fixture; production
+// default is `C:\Program Files\Cursor\resources\app\package.json`.
+func TestDiscoverWindowsAgentVersionCursorMachineScoped(t *testing.T) {
+	prev := windowsMachineScopedCursorPackageJSON
+	t.Cleanup(func() { windowsMachineScopedCursorPackageJSON = prev })
+
+	machineRoot := t.TempDir()
+	dir := filepath.Join(machineRoot, "Cursor", "resources", "app")
+	writeWindowsAgentPackageJSON(t, dir, "1.7.0")
+	windowsMachineScopedCursorPackageJSON = filepath.Join(dir, "package.json")
+
+	// Per-user profile is empty — no Programs\cursor install — so the
+	// probe must fall through to the machine-scoped candidate.
+	got := discoverWindowsAgentVersion(t.TempDir(), "cursor")
+	if got != "1.7.0" {
+		t.Fatalf("machine-scoped cursor: got %q, want 1.7.0", got)
+	}
+}
+
+// TestDiscoverWindowsAgentVersionOrderPrefersPerUserOverMachineScoped
+// pins the "first match wins" ordering: when both a per-user and a
+// machine-scoped install exist, the per-user version is reported.
+func TestDiscoverWindowsAgentVersionOrderPrefersPerUserOverMachineScoped(t *testing.T) {
+	prev := windowsMachineScopedCursorPackageJSON
+	t.Cleanup(func() { windowsMachineScopedCursorPackageJSON = prev })
+
+	home := t.TempDir()
+	perUserDir := filepath.Join(home, "AppData", "Local", "Programs", "cursor", "resources", "app")
+	writeWindowsAgentPackageJSON(t, perUserDir, "1.6.14")
+
+	machineRoot := t.TempDir()
+	machineDir := filepath.Join(machineRoot, "Cursor", "resources", "app")
+	writeWindowsAgentPackageJSON(t, machineDir, "1.7.0")
+	windowsMachineScopedCursorPackageJSON = filepath.Join(machineDir, "package.json")
+
+	got := discoverWindowsAgentVersion(home, "cursor")
+	if got != "1.6.14" {
+		t.Fatalf("per-user precedence: got %q, want 1.6.14 (per-user wins over machine 1.7.0)", got)
+	}
+}
+
 func TestDiscoverWindowsAgentVersionRejectsOversizedPackageJSON(t *testing.T) {
 	home := t.TempDir()
 	dir := filepath.Join(home, "AppData", "Roaming", "npm", "node_modules", "@openai", "codex")

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -1064,40 +1064,66 @@ enumerate_local_users() {
 # observability / audit modes the target wires end-to-end. If the presence
 # signal is also absent, the row is still skipped as before.
 
-# connector_present_for_user CONNECTOR HOME -> exit 0 iff there is a cheap
-# per-user artifact on disk indicating the user has interacted with this
+# connector_present_for_user CONNECTOR HOME -> exit 0 iff there is a
+# per-user artifact on disk indicating the user has actually used this
 # connector's CLI, even when discover_agent_version could not resolve the
 # install path. Used as a fallback presence check in render_targets_manifest
 # so a CLI installed via a channel we don't probe still gets a manifest row.
 #
-# The signals are limited to files/directories the connector's CLI itself
-# creates on first launch — never anything an unrelated app could scatter.
-# Kept strict on purpose: false positives here churn the guardian with a
-# per-tick "agent_version empty" failure the operator has to reconcile.
+# CRITICAL: none of the signals below may match a directory or file that
+# prepare_userspace_for (this same library, above) creates as part of
+# installer bootstrap. Otherwise every DefenseClaw pkg install would
+# create the presence marker itself, the fallback would fire for every
+# eligible user × connector, and the guardian would churn on connectors
+# the user has never touched.
+#
+# Blocked signals (DefenseClaw-authored — must NOT be checked here):
+#   claudecode: ~/.claude, ~/.claude/settings.json
+#   codex:      ~/.codex, ~/.codex/config.toml
+#   cursor:     ~/.cursor, ~/.cursor/hooks.json
+#
+# Allowed signals below are artifacts the connector's CLI itself
+# creates on first launch — never anything prepare_userspace_for nor
+# an unrelated app could scatter.
 connector_present_for_user() {
   local connector="$1"
   local home="$2"
   [[ -n "${home}" ]] || return 1
   case "${connector}" in
     claudecode)
-      # Claude Code CLI writes ~/.claude/ (sessions, session-env, plugins,
-      # skills, telemetry) and ~/.claude.json (user settings). Claude
-      # Desktop stores under ~/Library/Application Support/Claude/ and
-      # does NOT populate ~/.claude, so this is a CLI-specific signal.
-      [[ -d "${home}/.claude" || -f "${home}/.claude.json" ]] && return 0
+      # ~/.claude.json is Claude Code CLI's project-trust file at the
+      # home root; DefenseClaw never touches it. The subdirs under
+      # ~/.claude below are CLI runtime state (sessions, per-project
+      # data, env snapshots per session) — the DART bundle from the
+      # customer that motivated this fix showed all three populated on
+      # a box where DefenseClaw's discover_agent_version came up empty.
+      # Claude Desktop uses ~/Library/Application Support/Claude/ and
+      # does NOT populate ~/.claude, so each of these is CLI-specific.
+      [[ -f "${home}/.claude.json" ]] && return 0
+      [[ -d "${home}/.claude/sessions" ]] && return 0
+      [[ -d "${home}/.claude/projects" ]] && return 0
+      [[ -d "${home}/.claude/session-env" ]] && return 0
       ;;
     codex)
-      # Codex CLI writes ~/.codex/config.toml and ~/.codex/log/. The
-      # ChatGPT.app-bundled codex 0.145+ still uses this dir.
-      [[ -d "${home}/.codex" ]] && return 0
+      # Codex CLI runtime artifacts. history.jsonl is written on every
+      # chat exchange; auth.json holds the OAuth cache after first
+      # login; log/ is created the first time codex boots. Any of them
+      # implies actual CLI use. DefenseClaw only writes config.toml.
+      [[ -d "${home}/.codex/log" ]] && return 0
+      [[ -f "${home}/.codex/history.jsonl" ]] && return 0
+      [[ -f "${home}/.codex/auth.json" ]] && return 0
       ;;
     cursor)
-      # Cursor's IDE creates ~/.cursor/ on first launch (extensions,
-      # hooks.json, argv.json). The version probe already covers Cursor
-      # via the extension package.json path, so this branch is a
-      # symmetry/robustness fallback for hosts whose extension dir is
-      # unreadable at enumeration time.
-      [[ -d "${home}/.cursor" ]] && return 0
+      # Cursor IDE runtime artifacts. extensions/ is populated the
+      # first time the IDE launches (even with zero third-party
+      # extensions, a manifest file is written); argv.json is the
+      # editor's saved-startup-args file. DefenseClaw only writes
+      # hooks.json. The version probe already covers Cursor via the
+      # extension package.json path — this branch is a symmetry /
+      # robustness fallback for hosts whose extension dir metadata is
+      # transiently unreadable at enumeration time.
+      [[ -d "${home}/.cursor/extensions" ]] && return 0
+      [[ -f "${home}/.cursor/argv.json" ]] && return 0
       ;;
   esac
   return 1

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -1042,12 +1042,67 @@ enumerate_local_users() {
 #
 # One `- ` block per (user × supported-and-installed connector).
 # Unsupported connectors (not in is_supported_connector) are skipped: they
-# have no per-user setup path in the CLI. Connectors the caller asked for
-# but which discover_agent_version could not locate on THIS user's home
-# ARE ALSO skipped — no CLI/app/extension present means there is nothing
-# to hook, and emitting the row would just churn the guardian with a
-# permanent "agent_version empty" failure per tick. Users who install the
-# connector later are picked up by the hook-enumerator's next re-render.
+# have no per-user setup path in the CLI.
+#
+# Connectors the caller asked for but which discover_agent_version could
+# not locate on THIS user's home used to be skipped unconditionally. That
+# rule made an unrecoverable "silent drop" whenever the CLI was installed
+# via a channel discover_agent_version does not probe (Bun, pnpm, custom
+# PATH shim, Homebrew tap, etc.) — the row never appeared in
+# targets.yaml, the guardian never installed hooks, and the operator got
+# no diagnostic pointing at the discovery gap.
+#
+# Now: when the version probe returns empty, fall back to a cheap per-user
+# PRESENCE signal (connector_present_for_user). If the connector's user
+# config surface exists on this user, emit the row with an empty
+# agent_version and let the Go guardian handle it — the sidecar's
+# ResolveHookContract has an Unversioned branch that returns the
+# connector's DefaultForUnversioned contract. In `action` mode the Go
+# guardian's validateHookContract still fail-shuts per-target (unless
+# DEFENSECLAW_ALLOW_HOOK_CONTRACT_DRIFT=1), which surfaces the failure in
+# protected_targets.json — infinitely better than a silent drop. In
+# observability / audit modes the target wires end-to-end. If the presence
+# signal is also absent, the row is still skipped as before.
+
+# connector_present_for_user CONNECTOR HOME -> exit 0 iff there is a cheap
+# per-user artifact on disk indicating the user has interacted with this
+# connector's CLI, even when discover_agent_version could not resolve the
+# install path. Used as a fallback presence check in render_targets_manifest
+# so a CLI installed via a channel we don't probe still gets a manifest row.
+#
+# The signals are limited to files/directories the connector's CLI itself
+# creates on first launch — never anything an unrelated app could scatter.
+# Kept strict on purpose: false positives here churn the guardian with a
+# per-tick "agent_version empty" failure the operator has to reconcile.
+connector_present_for_user() {
+  local connector="$1"
+  local home="$2"
+  [[ -n "${home}" ]] || return 1
+  case "${connector}" in
+    claudecode)
+      # Claude Code CLI writes ~/.claude/ (sessions, session-env, plugins,
+      # skills, telemetry) and ~/.claude.json (user settings). Claude
+      # Desktop stores under ~/Library/Application Support/Claude/ and
+      # does NOT populate ~/.claude, so this is a CLI-specific signal.
+      [[ -d "${home}/.claude" || -f "${home}/.claude.json" ]] && return 0
+      ;;
+    codex)
+      # Codex CLI writes ~/.codex/config.toml and ~/.codex/log/. The
+      # ChatGPT.app-bundled codex 0.145+ still uses this dir.
+      [[ -d "${home}/.codex" ]] && return 0
+      ;;
+    cursor)
+      # Cursor's IDE creates ~/.cursor/ on first launch (extensions,
+      # hooks.json, argv.json). The version probe already covers Cursor
+      # via the extension package.json path, so this branch is a
+      # symmetry/robustness fallback for hosts whose extension dir is
+      # unreadable at enumeration time.
+      [[ -d "${home}/.cursor" ]] && return 0
+      ;;
+  esac
+  return 1
+}
+
 yaml_double_quoted_scalar() {
   local value="$1"
   case "${value}" in
@@ -1098,7 +1153,15 @@ render_targets_manifest() {
       is_supported_connector "${c}" || continue
       q_connector="$(yaml_double_quoted_scalar "${c}")" || continue
       ver="$(DC_INSTALLER_TARGET_USER="${name}" discover_agent_version "${c}" "${home}" 2>/dev/null || true)"
-      [[ -n "${ver}" ]] || continue
+      if [[ -z "${ver}" ]]; then
+        # Version probe came up empty. Only emit a row when a cheap
+        # user-scoped presence signal proves the connector CLI has been
+        # used on this account — otherwise the guardian churns forever
+        # trying to install hooks for a CLI that doesn't exist here. See
+        # connector_present_for_user above and render_targets_manifest's
+        # header comment for the full rationale.
+        connector_present_for_user "${c}" "${home}" || continue
+      fi
       q_ver="$(yaml_double_quoted_scalar "${ver}")" || q_ver='""'
       # data_dir is intentionally omitted from each target block: the
       # guardian's validateUserDataDir requires the data_dir to be inside

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -619,6 +619,50 @@ _read_json_version() {
   _read_json_field "${path}" "version"
 }
 
+# _claude_desktop_embedded_version_from_home HOME -> echoes the highest
+# Claude Code version bundled inside Claude Desktop, or "".
+#
+# Claude Desktop bundles Claude Code per user under:
+#
+#   ~/Library/Application Support/Claude/claude-code/<X.Y.Z>/claude.app/
+#     Contents/MacOS/claude
+#
+# and drops a convenience shim at ~/.local/bin/claude pointing into that
+# tree. The shim-basename walk in the npm/PATH probe below stops at
+# "claude" / "MacOS" (neither is semver-shaped) so the version has to be
+# extracted from the parent-dir chain of the concrete binary — 4 hops
+# above the terminal binary. The Claude Desktop application version is
+# not the Claude Code version, so the version-labelled embedded bundle
+# directory is the authoritative metadata source.
+#
+# Metadata-only: readdir + basename, no exec of a desktop- or user-
+# bundled binary during installer discovery.
+#
+# Ported from PR #785 (release-26.7.3 backport of PR #798 / AIFW-32990,
+# author @rucpande) — the customer bundle 0827_0914 (jlunde) had
+# 2.1.219 embedded here and got silently dropped by the npm-only probe.
+# The consolidated Go implementation in
+# docs/PLAN-consolidate-hook-enumerator.md will supersede this bash
+# probe alongside the rest of `discover_agent_version` (Appendix B row 6).
+_claude_desktop_embedded_version_from_home() {
+  local home="$1"
+  local root="${home}/Library/Application Support/Claude/claude-code"
+  [[ -d "${root}" ]] || return 0
+  local -r semver_re='^[0-9]+\.[0-9]+\.[0-9]+([._+-].*)?$'
+  local bin version_dir version best=""
+  for bin in "${root}"/*/claude.app/Contents/MacOS/claude; do
+    [[ -x "${bin}" ]] || continue
+    version_dir="$(dirname -- "$(dirname -- "$(dirname -- "$(dirname -- "${bin}")")")")"
+    version="$(basename -- "${version_dir}")"
+    [[ "${version}" =~ ${semver_re} ]] || continue
+    if [[ -z "${best}" ]] || \
+       [[ "$(printf '%s\n%s\n' "${best}" "${version}" | sort -V | tail -1)" == "${version}" ]]; then
+      best="${version}"
+    fi
+  done
+  [[ -n "${best}" ]] && echo "${best}"
+}
+
 discover_agent_version() {
   local connector="$1"
   local home="$2"
@@ -728,7 +772,23 @@ discover_agent_version() {
       ;;
     claudecode)
       # Claude Code ships both as a standalone npm CLI (has a
-      # package.json we can read) and as a Cursor / VS Code extension.
+      # package.json we can read) and as a Cursor / VS Code extension,
+      # AND as a per-user Claude Desktop-bundled binary.
+      #
+      # Probe order:
+      #   1. Claude Desktop-bundled — ~/Library/Application Support/Claude/
+      #      claude-code/<X.Y.Z>/claude.app/... — the shim at
+      #      ~/.local/bin/claude points here on newer Claude Desktop
+      #      builds and the shim-basename walk yields "claude"/"MacOS"
+      #      which fails the semver regex. Consulting the version-labelled
+      #      parent directory is the only way to recover the version.
+      #      Regression on customer bundle 0827_0914 (jlunde, AIFW-32990).
+      #   2. npm-global / Cursor / VS Code extension package.json
+      #      (historical baseline).
+      local v
+      v="$(_claude_desktop_embedded_version_from_home "${home}")"
+      if [[ -n "${v}" ]]; then echo "${v}"; return; fi
+
       local pkg
       for pkg in \
         "${home}"/.npm-global/lib/node_modules/@anthropic-ai/claude-code/package.json \
@@ -737,7 +797,7 @@ discover_agent_version() {
         "${home}"/.cursor/extensions/anthropic.claude-code-*/package.json \
         "${home}"/.vscode/extensions/anthropic.claude-code-*/package.json; do
         [[ -f "${pkg}" ]] || continue
-        local v; v="$(_probe_json_version "${pkg}" claudecode)"
+        v="$(_probe_json_version "${pkg}" claudecode)"
         if [[ -n "${v}" ]]; then echo "${v}"; return; fi
       done
       ;;

--- a/packaging/macos/tests/test_discover_agent_version.sh
+++ b/packaging/macos/tests/test_discover_agent_version.sh
@@ -86,6 +86,52 @@ JSON
   assert_eq "${got}" "2.0.99" "claudecode version from VS Code extension"
 }
 
+t_claudecode_via_claude_desktop_embedded_bundle() {
+  # Regression for customer bundle 0827_0914 (jlunde). Claude Desktop
+  # bundles Claude Code under ~/Library/Application Support/Claude/
+  # claude-code/<X.Y.Z>/claude.app/... and drops a shim at
+  # ~/.local/bin/claude pointing to the deep binary. The shim-basename
+  # walk yields "claude" / "MacOS" (both non-semver) so the version
+  # has to come from the version-labelled bundle directory 4 hops
+  # above the terminal binary. jlunde's box had 2.1.219 embedded here;
+  # use that as a concrete regression pin.
+  #
+  # Ported from PR #785 (release-26.7.3 backport of PR #798, author
+  # @rucpande, AIFW-32990) as a surgical port. The full 26.7.3-shape
+  # discovery (versions/*/ walker, SemVer comparator, node-manager
+  # glob walker, etc.) is out of scope for this release-branch fix —
+  # see docs/PLAN-consolidate-hook-enumerator.md for the consolidated
+  # Go replacement that supersedes this bash probe.
+  local home; home="$(mktest_tmp)"
+  local bin="${home}/Library/Application Support/Claude/claude-code/2.1.219/claude.app/Contents/MacOS/claude"
+  mkdir -p "$(dirname -- "${bin}")"
+  : > "${bin}"
+  chmod 0755 "${bin}"
+
+  local got
+  got="$(without_host_agent_bins discover_agent_version claudecode "${home}")"
+  assert_eq "${got}" "2.1.219" "claudecode version from Claude Desktop embedded bundle"
+}
+
+t_claudecode_desktop_embedded_picks_highest_version() {
+  # Multiple Claude Desktop-bundled versions coexist during upgrade
+  # windows. Discovery must pick the highest semver-shaped directory
+  # so a stale bundle doesn't shadow the active install.
+  local home; home="$(mktest_tmp)"
+  local root="${home}/Library/Application Support/Claude/claude-code"
+  local ver
+  for ver in 2.1.144 2.1.219 2.1.171; do
+    local bin="${root}/${ver}/claude.app/Contents/MacOS/claude"
+    mkdir -p "$(dirname -- "${bin}")"
+    : > "${bin}"
+    chmod 0755 "${bin}"
+  done
+
+  local got
+  got="$(without_host_agent_bins discover_agent_version claudecode "${home}")"
+  assert_eq "${got}" "2.1.219" "claudecode picks highest Claude Desktop embedded version"
+}
+
 t_claudecode_no_install_returns_empty() {
   # Empty tmp HOME + no CLI on PATH → empty version, cleanly.
   local home; home="$(mktest_tmp)"
@@ -529,6 +575,8 @@ run_case "amp package metadata identity"      t_amp_metadata_requires_package_id
 run_case "amp without metadata is unversioned" t_amp_missing_metadata_may_be_unversioned
 run_case "claudecode via Cursor extension"   t_claudecode_via_cursor_extension
 run_case "claudecode via VS Code extension"  t_claudecode_via_vscode_extension
+run_case "claudecode via Claude Desktop embedded bundle" t_claudecode_via_claude_desktop_embedded_bundle
+run_case "claudecode Claude Desktop picks highest bundled" t_claudecode_desktop_embedded_picks_highest_version
 run_case "claudecode without install"        t_claudecode_no_install_returns_empty
 run_case "codex without home metadata"       t_codex_no_home_metadata_uses_system_or_empty
 run_case "codex from user npm metadata"      t_codex_from_user_npm_metadata

--- a/packaging/macos/tests/test_render_targets_manifest.sh
+++ b/packaging/macos/tests/test_render_targets_manifest.sh
@@ -387,7 +387,17 @@ t_all_connectors_absent_yields_zero_rows() {
   # will wire hooks the moment a supported connector CLI appears.
   discover_agent_version() { printf ''; }
 
-  local users="shawnxu:501:20:/Users/shawnxu"
+  # Use a mktemp'd home so the presence-fallback in
+  # render_targets_manifest can't find any CLI-authored artifact for the
+  # stub user — the assertion is "zero rows when nothing is installed",
+  # which is only provable against a home that provably has nothing in
+  # it. A hardcoded path like /Users/shawnxu can carry over dev-box
+  # dotfiles (e.g. ~/.claude/sessions from a real Claude Code session)
+  # and flip the presence signal to true, emitting a row and failing the
+  # test. Matches the mktemp pattern used in t_absent_connector_skipped_partial_box.
+  local test_home
+  test_home="$(mktemp -d "${TMPROOT}/home.absent.XXXXXX")"
+  local users="shawnxu:501:20:${test_home}"
   local out
   out="$(render_targets_manifest "${TEST_SUPPORT}" "codex,claudecode,cursor" "${users}")"
 

--- a/packaging/macos/tests/test_render_targets_manifest.sh
+++ b/packaging/macos/tests/test_render_targets_manifest.sh
@@ -148,18 +148,19 @@ t_unversioned_but_present_emits_row_with_empty_version() {
   # sidecar spammed HIGH-severity hook_guardian:unverified every 60s with
   # no diagnostic pointing at the discovery gap.
   #
-  # Now: when the version probe returns empty AND the connector's
-  # user-scoped config surface exists on this user, emit the row with
-  # an empty agent_version and let the Go guardian's ResolveHookContract
-  # fall back to DefaultForUnversioned. In `action` mode the Go
-  # validateHookContract still fail-shuts per-target (surfacing the
-  # failure in protected_targets.json instead of a silent drop).
+  # Now: when the version probe returns empty AND a CLI-only artifact
+  # exists on this user, emit the row with an empty agent_version and let
+  # the Go guardian's ResolveHookContract fall back to DefaultForUnversioned.
+  # In `action` mode the Go validateHookContract still fail-shuts
+  # per-target (surfacing the failure in protected_targets.json instead
+  # of a silent drop).
   discover_agent_version() { printf ''; }
 
   local test_home
   test_home="$(mktemp -d "${TMPROOT}/home.jlunde.XXXXXX")"
-  # jlunde's DART bundle showed ~/.claude/ (11 subdirs, active CLI use)
-  # but discover_agent_version returned empty. Reproduce that shape.
+  # jlunde's DART bundle showed ~/.claude/sessions/ populated with active
+  # CLI session data. That subdir is created only by the Claude Code CLI
+  # itself — never by prepare_claudecode_userspace. Reproduce that shape.
   mkdir -p "${test_home}/.claude/sessions"
   local users="jlunde:501:20:${test_home}"
   local out
@@ -167,33 +168,118 @@ t_unversioned_but_present_emits_row_with_empty_version() {
 
   assert_contains     "${out}" 'connector: "claudecode"' "claudecode row emitted via presence fallback"
   assert_contains     "${out}" 'agent_version: ""'       "empty agent_version passed through so Go picks DefaultForUnversioned"
-  assert_not_contains "${out}" 'connector: "codex"'      "codex still skipped (no ~/.codex presence signal)"
+  assert_not_contains "${out}" 'connector: "codex"'      "codex still skipped (no CLI-only signal in ~/.codex)"
   local count
   count="$(printf '%s\n' "${out}" | grep -c "^  - user:" || true)"
   assert_eq "${count}" "1" "exactly one target row emitted via presence fallback"
 }
 
-t_presence_fallback_covers_codex_dir() {
-  # Codex CLI's user-scoped surface is ~/.codex/config.toml. Ensure the
-  # fallback recognises it even when discover_agent_version can't reach
-  # the install (e.g. ChatGPT.app not readable at enumerator run time).
+t_presence_fallback_covers_codex_history() {
+  # Codex CLI writes ~/.codex/history.jsonl on every chat exchange. That
+  # file is CLI-only (prepare_codex_userspace never creates it), so a
+  # user with real codex history but a version-discovery gap should get
+  # a target row emitted.
   discover_agent_version() { printf ''; }
 
   local test_home
   test_home="$(mktemp -d "${TMPROOT}/home.codexuser.XXXXXX")"
   mkdir -p "${test_home}/.codex"
-  : > "${test_home}/.codex/config.toml"
+  # history.jsonl is CLI-only — DefenseClaw never writes this file.
+  : > "${test_home}/.codex/history.jsonl"
   local users="codexuser:501:20:${test_home}"
   local out
   out="$(render_targets_manifest "${TEST_SUPPORT}" "codex" "${users}")"
 
-  assert_contains "${out}" 'connector: "codex"'   "codex row emitted via ~/.codex presence signal"
+  assert_contains "${out}" 'connector: "codex"'   "codex row emitted via ~/.codex/history.jsonl (CLI-only)"
   assert_contains "${out}" 'agent_version: ""'    "empty agent_version passed through"
+}
+
+t_defenseclaw_prepared_state_does_not_trigger_fallback() {
+  # Regression per CodeRabbit review on PR #785: prepare_userspace_for
+  # (installer_lib.sh, above) creates ~/.claude, ~/.claude/settings.json,
+  # ~/.codex, ~/.codex/config.toml, ~/.cursor, and ~/.cursor/hooks.json
+  # for every eligible user × supported connector at pkg-install time.
+  # Those directories then persist after upgrades and even after the user
+  # uninstalls the connector CLI. If the presence check keyed on the
+  # bare directory, the guardian would churn forever emitting per-tick
+  # "agent_version empty" failures for a connector the user never used.
+  #
+  # This test reproduces EXACTLY what prepare_userspace_for leaves on
+  # disk, with discover_agent_version stubbed empty, and asserts that
+  # NO fallback row is emitted for any of the three connectors.
+  discover_agent_version() { printf ''; }
+
+  local test_home
+  test_home="$(mktemp -d "${TMPROOT}/home.dc_only.XXXXXX")"
+
+  # Mirror prepare_claudecode_userspace exactly.
+  mkdir -p "${test_home}/.claude"
+  printf '{}\n' > "${test_home}/.claude/settings.json"
+  # Mirror prepare_codex_userspace exactly.
+  mkdir -p "${test_home}/.codex"
+  cat > "${test_home}/.codex/config.toml" <<'TOML'
+# Created by DefenseClaw installer so the enterprise hook guardian can
+# repair this file. Edit freely; DefenseClaw only owns [hooks], [otel],
+# and the top-level notify entries.
+TOML
+  # Mirror prepare_cursor_userspace exactly.
+  mkdir -p "${test_home}/.cursor"
+  printf '{"version":1,"hooks":{}}\n' > "${test_home}/.cursor/hooks.json"
+
+  local users="fresh:501:20:${test_home}"
+  local out
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "codex,claudecode,cursor" "${users}")"
+
+  assert_not_contains "${out}" 'connector: "claudecode"' "prepare_claudecode_userspace state alone must not trigger fallback"
+  assert_not_contains "${out}" 'connector: "codex"'      "prepare_codex_userspace state alone must not trigger fallback"
+  assert_not_contains "${out}" 'connector: "cursor"'     "prepare_cursor_userspace state alone must not trigger fallback"
+  local count
+  count="$(printf '%s\n' "${out}" | grep -c "^  - user:" || true)"
+  assert_eq "${count}" "0" "no target rows emitted from DefenseClaw-only bootstrap state"
+
+  # Sanity: connector_present_for_user itself must reject each
+  # DefenseClaw-authored surface directly, not just via the render loop.
+  connector_present_for_user claudecode "${test_home}"
+  assert_status "$?" "1" "helper rejects claudecode when only ~/.claude + settings.json present"
+  connector_present_for_user codex "${test_home}"
+  assert_status "$?" "1" "helper rejects codex when only ~/.codex + config.toml present"
+  connector_present_for_user cursor "${test_home}"
+  assert_status "$?" "1" "helper rejects cursor when only ~/.cursor + hooks.json present"
+}
+
+t_legacy_prepared_dir_then_cli_use_triggers_fallback() {
+  # Follow-on to t_defenseclaw_prepared_state_does_not_trigger_fallback:
+  # once the user actually launches the CLI on top of the legacy prepared
+  # state, the CLI-only artifacts appear and the fallback SHOULD fire.
+  # This proves the tightened signals still catch the customer's real
+  # scenario (jlunde had a pre-existing prepared ~/.claude/settings.json
+  # AND live CLI sessions/session-env/projects state).
+  discover_agent_version() { printf ''; }
+
+  local test_home
+  test_home="$(mktemp -d "${TMPROOT}/home.legacy.XXXXXX")"
+
+  # Legacy DefenseClaw-prepared state.
+  mkdir -p "${test_home}/.claude"
+  printf '{}\n' > "${test_home}/.claude/settings.json"
+  # Then the user actually launches Claude Code. This is a CLI-only
+  # subdir prepare_claudecode_userspace never creates.
+  mkdir -p "${test_home}/.claude/sessions"
+
+  local users="mixed:501:20:${test_home}"
+  local out
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "claudecode" "${users}")"
+
+  assert_contains "${out}" 'connector: "claudecode"' "fallback fires once CLI-only ~/.claude/sessions appears"
+  assert_contains "${out}" 'agent_version: ""'       "row emitted with empty agent_version"
 }
 
 t_connector_present_for_user_signals() {
   # Unit-level coverage for the helper itself so the presence rules
   # can't drift silently when discover_agent_version is stubbed.
+  # Every asserted-present signal below MUST NOT be a directory or
+  # file that prepare_userspace_for creates — see the header comment
+  # on connector_present_for_user.
   local test_home
   test_home="$(mktemp -d "${TMPROOT}/home.present.XXXXXX")"
 
@@ -205,27 +291,80 @@ t_connector_present_for_user_signals() {
   connector_present_for_user cursor "${test_home}"
   assert_status "$?" "1" "cursor absent on empty home"
 
-  # ~/.claude.json alone is enough for claudecode.
+  # DefenseClaw-authored surfaces must NOT flip the helper to present.
+  # These mirror prepare_*_userspace one-to-one and are what makes the
+  # collision hazard real; the helper has to reject them.
+  mkdir -p "${test_home}/.claude"
+  printf '{}\n' > "${test_home}/.claude/settings.json"
+  mkdir -p "${test_home}/.codex"
+  : > "${test_home}/.codex/config.toml"
+  mkdir -p "${test_home}/.cursor"
+  : > "${test_home}/.cursor/hooks.json"
+  connector_present_for_user claudecode "${test_home}"
+  assert_status "$?" "1" "claudecode still absent under DefenseClaw-only bootstrap"
+  connector_present_for_user codex "${test_home}"
+  assert_status "$?" "1" "codex still absent under DefenseClaw-only bootstrap"
+  connector_present_for_user cursor "${test_home}"
+  assert_status "$?" "1" "cursor still absent under DefenseClaw-only bootstrap"
+
+  # ~/.claude.json (project trust file at home root, CLI-only) → present.
   : > "${test_home}/.claude.json"
   connector_present_for_user claudecode "${test_home}"
   assert_status "$?" "0" "claudecode detected via ~/.claude.json"
 
-  # ~/.claude/ dir is also enough (either signal wins).
-  local other_home
-  other_home="$(mktemp -d "${TMPROOT}/home.present2.XXXXXX")"
-  mkdir -p "${other_home}/.claude"
-  connector_present_for_user claudecode "${other_home}"
-  assert_status "$?" "0" "claudecode detected via ~/.claude dir"
+  # Each CLI-only claudecode subdir independently flips to present.
+  local sessions_home
+  sessions_home="$(mktemp -d "${TMPROOT}/home.sessions.XXXXXX")"
+  mkdir -p "${sessions_home}/.claude/sessions"
+  connector_present_for_user claudecode "${sessions_home}"
+  assert_status "$?" "0" "claudecode detected via ~/.claude/sessions"
 
-  # ~/.codex/ dir → codex present.
-  mkdir -p "${other_home}/.codex"
-  connector_present_for_user codex "${other_home}"
-  assert_status "$?" "0" "codex detected via ~/.codex dir"
+  local projects_home
+  projects_home="$(mktemp -d "${TMPROOT}/home.projects.XXXXXX")"
+  mkdir -p "${projects_home}/.claude/projects"
+  connector_present_for_user claudecode "${projects_home}"
+  assert_status "$?" "0" "claudecode detected via ~/.claude/projects"
 
-  # ~/.cursor/ dir → cursor present.
-  mkdir -p "${other_home}/.cursor"
-  connector_present_for_user cursor "${other_home}"
-  assert_status "$?" "0" "cursor detected via ~/.cursor dir"
+  local senv_home
+  senv_home="$(mktemp -d "${TMPROOT}/home.senv.XXXXXX")"
+  mkdir -p "${senv_home}/.claude/session-env"
+  connector_present_for_user claudecode "${senv_home}"
+  assert_status "$?" "0" "claudecode detected via ~/.claude/session-env"
+
+  # Codex CLI runtime artifacts.
+  local codex_log_home
+  codex_log_home="$(mktemp -d "${TMPROOT}/home.codexlog.XXXXXX")"
+  mkdir -p "${codex_log_home}/.codex/log"
+  connector_present_for_user codex "${codex_log_home}"
+  assert_status "$?" "0" "codex detected via ~/.codex/log"
+
+  local codex_hist_home
+  codex_hist_home="$(mktemp -d "${TMPROOT}/home.codexhist.XXXXXX")"
+  mkdir -p "${codex_hist_home}/.codex"
+  : > "${codex_hist_home}/.codex/history.jsonl"
+  connector_present_for_user codex "${codex_hist_home}"
+  assert_status "$?" "0" "codex detected via ~/.codex/history.jsonl"
+
+  local codex_auth_home
+  codex_auth_home="$(mktemp -d "${TMPROOT}/home.codexauth.XXXXXX")"
+  mkdir -p "${codex_auth_home}/.codex"
+  : > "${codex_auth_home}/.codex/auth.json"
+  connector_present_for_user codex "${codex_auth_home}"
+  assert_status "$?" "0" "codex detected via ~/.codex/auth.json"
+
+  # Cursor IDE runtime artifacts.
+  local cursor_ext_home
+  cursor_ext_home="$(mktemp -d "${TMPROOT}/home.cursorext.XXXXXX")"
+  mkdir -p "${cursor_ext_home}/.cursor/extensions"
+  connector_present_for_user cursor "${cursor_ext_home}"
+  assert_status "$?" "0" "cursor detected via ~/.cursor/extensions"
+
+  local cursor_argv_home
+  cursor_argv_home="$(mktemp -d "${TMPROOT}/home.cursorargv.XXXXXX")"
+  mkdir -p "${cursor_argv_home}/.cursor"
+  : > "${cursor_argv_home}/.cursor/argv.json"
+  connector_present_for_user cursor "${cursor_argv_home}"
+  assert_status "$?" "0" "cursor detected via ~/.cursor/argv.json"
 
   # Empty home arg is a hard "not present" — must not scan the invoking
   # user's real dotfiles.
@@ -233,7 +372,9 @@ t_connector_present_for_user_signals() {
   assert_status "$?" "1" "empty home never returns present"
 
   # Unknown connector never returns present.
-  connector_present_for_user made_up_connector "${other_home}"
+  local unknown_home
+  unknown_home="$(mktemp -d "${TMPROOT}/home.unknown.XXXXXX")"
+  connector_present_for_user made_up_connector "${unknown_home}"
   assert_status "$?" "1" "unknown connector name never returns present"
 }
 
@@ -368,7 +509,9 @@ run_case "empty connector list still emits valid manifest"      t_empty_connecto
 run_case "absent connectors are skipped (partial-box render)"   t_absent_connector_skipped_partial_box
 run_case "all connectors absent yields zero rows"               t_all_connectors_absent_yields_zero_rows
 run_case "unversioned but present emits row with empty version" t_unversioned_but_present_emits_row_with_empty_version
-run_case "presence fallback covers ~/.codex"                    t_presence_fallback_covers_codex_dir
+run_case "presence fallback covers ~/.codex/history.jsonl"      t_presence_fallback_covers_codex_history
+run_case "DefenseClaw-prepared state alone doesn't trigger fallback" t_defenseclaw_prepared_state_does_not_trigger_fallback
+run_case "legacy prepared dir + CLI use → fallback fires"       t_legacy_prepared_dir_then_cli_use_triggers_fallback
 run_case "connector_present_for_user helper signals"            t_connector_present_for_user_signals
 run_case "rendered targets.yaml parses (schema round-trip)"     t_rendered_yaml_parses
 run_case "rows pin enabled + int uid/gid"                       t_rows_pin_enabled_and_int_uid_gid

--- a/packaging/macos/tests/test_render_targets_manifest.sh
+++ b/packaging/macos/tests/test_render_targets_manifest.sh
@@ -110,10 +110,12 @@ t_empty_connectors_still_emits_valid_manifest() {
 }
 
 t_absent_connector_skipped_partial_box() {
-  # Regression: a box with only cursor installed must NOT get target rows
-  # for codex or claudecode. Otherwise the guardian churns forever trying
-  # to install hooks for a CLI that doesn't exist on the host. See
-  # discover_agent_version + render_targets_manifest empty-version skip.
+  # Regression: a box with only cursor installed AND no user-scoped
+  # config surfaces for the other connectors must NOT get target rows
+  # for codex or claudecode. Otherwise the guardian churns forever
+  # trying to install hooks for a CLI that doesn't exist on the host.
+  # See discover_agent_version + render_targets_manifest empty-version
+  # skip and the connector_present_for_user fallback.
   discover_agent_version() {
     case "$1" in
       cursor) printf '3.14.27' ;;
@@ -121,16 +123,118 @@ t_absent_connector_skipped_partial_box() {
     esac
   }
 
-  local users="shawnxu:501:20:/Users/shawnxu"
+  # Use a mktemp'd HOME that provably has none of the presence signals
+  # (~/.claude, ~/.claude.json, ~/.codex, ~/.cursor). This isolates the
+  # test from any stray files on the developer's real filesystem.
+  local test_home
+  test_home="$(mktemp -d "${TMPROOT}/home.shawnxu.XXXXXX")"
+  local users="shawnxu:501:20:${test_home}"
   local out
   out="$(render_targets_manifest "${TEST_SUPPORT}" "codex,claudecode,cursor" "${users}")"
 
   assert_contains     "${out}" 'connector: "cursor"'     "cursor row emitted"
-  assert_not_contains "${out}" 'connector: "codex"'      "codex row skipped (not installed)"
-  assert_not_contains "${out}" 'connector: "claudecode"' "claudecode row skipped (not installed)"
+  assert_not_contains "${out}" 'connector: "codex"'      "codex row skipped (not installed, no presence signal)"
+  assert_not_contains "${out}" 'connector: "claudecode"' "claudecode row skipped (not installed, no presence signal)"
   local count
   count="$(printf '%s\n' "${out}" | grep -c "^  - user:" || true)"
   assert_eq "${count}" "1" "one target when only cursor is installed"
+}
+
+t_unversioned_but_present_emits_row_with_empty_version() {
+  # Regression for the customer bundle where Claude Code CLI was installed
+  # via a channel discover_agent_version does not probe (e.g. Bun, pnpm,
+  # Homebrew tap, custom PATH shim). Before this fix the row was silently
+  # dropped from targets.yaml, the guardian never wired hooks, and the
+  # sidecar spammed HIGH-severity hook_guardian:unverified every 60s with
+  # no diagnostic pointing at the discovery gap.
+  #
+  # Now: when the version probe returns empty AND the connector's
+  # user-scoped config surface exists on this user, emit the row with
+  # an empty agent_version and let the Go guardian's ResolveHookContract
+  # fall back to DefaultForUnversioned. In `action` mode the Go
+  # validateHookContract still fail-shuts per-target (surfacing the
+  # failure in protected_targets.json instead of a silent drop).
+  discover_agent_version() { printf ''; }
+
+  local test_home
+  test_home="$(mktemp -d "${TMPROOT}/home.jlunde.XXXXXX")"
+  # jlunde's DART bundle showed ~/.claude/ (11 subdirs, active CLI use)
+  # but discover_agent_version returned empty. Reproduce that shape.
+  mkdir -p "${test_home}/.claude/sessions"
+  local users="jlunde:501:20:${test_home}"
+  local out
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "claudecode,codex" "${users}")"
+
+  assert_contains     "${out}" 'connector: "claudecode"' "claudecode row emitted via presence fallback"
+  assert_contains     "${out}" 'agent_version: ""'       "empty agent_version passed through so Go picks DefaultForUnversioned"
+  assert_not_contains "${out}" 'connector: "codex"'      "codex still skipped (no ~/.codex presence signal)"
+  local count
+  count="$(printf '%s\n' "${out}" | grep -c "^  - user:" || true)"
+  assert_eq "${count}" "1" "exactly one target row emitted via presence fallback"
+}
+
+t_presence_fallback_covers_codex_dir() {
+  # Codex CLI's user-scoped surface is ~/.codex/config.toml. Ensure the
+  # fallback recognises it even when discover_agent_version can't reach
+  # the install (e.g. ChatGPT.app not readable at enumerator run time).
+  discover_agent_version() { printf ''; }
+
+  local test_home
+  test_home="$(mktemp -d "${TMPROOT}/home.codexuser.XXXXXX")"
+  mkdir -p "${test_home}/.codex"
+  : > "${test_home}/.codex/config.toml"
+  local users="codexuser:501:20:${test_home}"
+  local out
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "codex" "${users}")"
+
+  assert_contains "${out}" 'connector: "codex"'   "codex row emitted via ~/.codex presence signal"
+  assert_contains "${out}" 'agent_version: ""'    "empty agent_version passed through"
+}
+
+t_connector_present_for_user_signals() {
+  # Unit-level coverage for the helper itself so the presence rules
+  # can't drift silently when discover_agent_version is stubbed.
+  local test_home
+  test_home="$(mktemp -d "${TMPROOT}/home.present.XXXXXX")"
+
+  # No surfaces yet: every connector must return false.
+  connector_present_for_user claudecode "${test_home}"
+  assert_status "$?" "1" "claudecode absent on empty home"
+  connector_present_for_user codex "${test_home}"
+  assert_status "$?" "1" "codex absent on empty home"
+  connector_present_for_user cursor "${test_home}"
+  assert_status "$?" "1" "cursor absent on empty home"
+
+  # ~/.claude.json alone is enough for claudecode.
+  : > "${test_home}/.claude.json"
+  connector_present_for_user claudecode "${test_home}"
+  assert_status "$?" "0" "claudecode detected via ~/.claude.json"
+
+  # ~/.claude/ dir is also enough (either signal wins).
+  local other_home
+  other_home="$(mktemp -d "${TMPROOT}/home.present2.XXXXXX")"
+  mkdir -p "${other_home}/.claude"
+  connector_present_for_user claudecode "${other_home}"
+  assert_status "$?" "0" "claudecode detected via ~/.claude dir"
+
+  # ~/.codex/ dir → codex present.
+  mkdir -p "${other_home}/.codex"
+  connector_present_for_user codex "${other_home}"
+  assert_status "$?" "0" "codex detected via ~/.codex dir"
+
+  # ~/.cursor/ dir → cursor present.
+  mkdir -p "${other_home}/.cursor"
+  connector_present_for_user cursor "${other_home}"
+  assert_status "$?" "0" "cursor detected via ~/.cursor dir"
+
+  # Empty home arg is a hard "not present" — must not scan the invoking
+  # user's real dotfiles.
+  connector_present_for_user claudecode ""
+  assert_status "$?" "1" "empty home never returns present"
+
+  # Unknown connector never returns present.
+  connector_present_for_user made_up_connector "${other_home}"
+  assert_status "$?" "1" "unknown connector name never returns present"
 }
 
 t_all_connectors_absent_yields_zero_rows() {
@@ -263,6 +367,9 @@ run_case "empty user list still emits valid manifest"           t_empty_users_st
 run_case "empty connector list still emits valid manifest"      t_empty_connectors_still_emits_valid_manifest
 run_case "absent connectors are skipped (partial-box render)"   t_absent_connector_skipped_partial_box
 run_case "all connectors absent yields zero rows"               t_all_connectors_absent_yields_zero_rows
+run_case "unversioned but present emits row with empty version" t_unversioned_but_present_emits_row_with_empty_version
+run_case "presence fallback covers ~/.codex"                    t_presence_fallback_covers_codex_dir
+run_case "connector_present_for_user helper signals"            t_connector_present_for_user_signals
 run_case "rendered targets.yaml parses (schema round-trip)"     t_rendered_yaml_parses
 run_case "rows pin enabled + int uid/gid"                       t_rows_pin_enabled_and_int_uid_gid
 run_case "rows omit data_dir (per-user Install default is used)" t_rows_omit_data_dir


### PR DESCRIPTION
## Summary

Cherry-picks the two commits from [PR #785](https://github.com/cisco-ai-defense/defenseclaw/pull/785) (targeting `release-26.7.3`) onto `release-defenseclaw-enterprise-26.8.4`, then adds a Windows-side complement so the same silent-drop failure mode is fixed on both platforms.

**Original customer signal (macOS 26.5.2, DART bundle `0827_0914`):** `render_targets_manifest` skipped the `claudecode` target row because `discover_agent_version` came up empty, even though `~/.claude/` on the user's home had 11 subdirs and 59 session-env entries — clear active Claude Code CLI use. Guardian then spammed HIGH-severity `[error:hook_guardian] code=unverified` every 60s and never wired claudecode hooks; operator had zero diagnostic pointing at the discovery gap.

## macOS (cherry-picked from #785)

- **`4effd63fd`** `fix(hooks): presence-based fallback for hook-enumerator (macOS)` — when `discover_agent_version` returns empty AND `connector_present_for_user` is true, emit the row with `agent_version: ""` and let Go's `ResolveHookContract` route to the `Unversioned` branch (`DefaultForUnversioned`).
- **`ea6f0bb76`** `fix(hooks): CodeRabbit — narrow presence signals to CLI-only artifacts` — CodeRabbit review round: presence signals restricted to CLI-authored surfaces (`~/.claude/sessions`, `~/.codex/log`, etc.) so `prepare_userspace_for`-created bootstrap directories don't trigger false positives.

Both commits applied cleanly to 26.8.4. Both files (`packaging/macos/lib/installer_lib.sh`, `packaging/macos/tests/test_render_targets_manifest.sh`) exist unchanged on the 26.8.4 base.

## Windows (new — `add6c7c00`)

Windows has the same silent-drop pattern:
- `discoverWindowsAgentVersion` only probes `%APPDATA%\npm\node_modules\@anthropic-ai\claude-code\package.json` (npm-global) — anything installed via Bun, Yarn Classic, machine-scoped MSI, etc. silently drops the row in `applyPreviousRowState`.

Windows can't reuse the presence-fallback pattern directly: `validateManifestPlatformTarget` in `manifest_windows.go` rejects `Enabled=true` rows with empty `AgentVersion` at LoadManifest time, so \"emit-with-empty-version\" would fail schema validation before the Go guardian could route to `Unversioned`. Full parity would require relaxing that check plus updates to `requireWindowsEnterpriseManagedAgentVersion` — deferred as a separate change.

Instead: **broaden the probe path list** to cover the alternative install channels users actually pick.

New candidates (order = first match wins; per-user before machine-scoped):

| Connector | New probe path | Install channel |
|---|---|---|
| claudecode | `%USERPROFILE%\.bun\install\global\node_modules\@anthropic-ai\claude-code\package.json` | `bun install -g` |
| claudecode | `%LOCALAPPDATA%\Yarn\Data\global\node_modules\@anthropic-ai\claude-code\package.json` | Yarn Classic global |
| codex | `%USERPROFILE%\.bun\install\global\node_modules\@openai\codex\package.json` | `bun install -g` |
| codex | `%LOCALAPPDATA%\Yarn\Data\global\node_modules\@openai\codex\package.json` | Yarn Classic global |
| cursor | `windowsMachineScopedCursorPackageJSON` (default `C:\Program Files\Cursor\resources\app\package.json`) | Cursor MSI, machine-scoped |

Machine-scoped Cursor path is a package-level variable so tests can stub to `t.TempDir()` rather than write to the real Program Files tree.

**Still out of scope (follow-ups):**
- MSIX-store codex install at `C:\Program Files\WindowsApps\OpenAI.Codex_*\` — needs a glob-resolved lookup with careful reparse-chain handling.
- pnpm global — pnpm store version is a variable subdir; also needs glob.

## Test plan

- [x] `bash packaging/macos/tests/run_tests.sh packaging/macos/tests/test_render_targets_manifest.sh` → 15/15 passed
- [x] `GOOS=windows GOARCH=amd64 go build ./...` clean
- [x] `GOOS=windows GOARCH=amd64 go vet ./...` clean
- [x] `go build ./...` clean (darwin)
- [x] `go vet ./...` clean (darwin)
- [x] `go test -count=1 ./internal/enterprisehooks/...` — pass; Windows-tagged tests skipped on darwin, exercise on Windows CI.
- [x] New Windows tests:
  - `TestDiscoverWindowsAgentVersionClaudeCodeBunGlobal`
  - `TestDiscoverWindowsAgentVersionClaudeCodeYarnGlobal`
  - `TestDiscoverWindowsAgentVersionCodexBunGlobal`
  - `TestDiscoverWindowsAgentVersionCodexYarnGlobal`
  - `TestDiscoverWindowsAgentVersionCursorMachineScoped`
  - `TestDiscoverWindowsAgentVersionOrderPrefersPerUserOverMachineScoped`
- [ ] CI green (pending)

## Rollback

Revert all three commits. No config / schema / env-var / plist changes. `targets.yaml` gains rows in the specific cases where a user has a connector's CLI installed via a non-standard channel — the intended coverage improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)