### PR TITLE
Fix/claude code hook discovery prestage

### DIFF
--- a/internal/cli/enterprise_hooks.go
+++ b/internal/cli/enterprise_hooks.go
@@ -40,20 +40,28 @@ import (
 )
 
 var (
-	enterpriseHookConnector     string
-	enterpriseHookUser          string
-	enterpriseHookUserHome      string
-	enterpriseHookUID           int
-	enterpriseHookGID           int
-	enterpriseHookDataDir       string
-	enterpriseHookAPIAddr       string
-	enterpriseHookProxyAddr     string
-	enterpriseHookAgentVersion  string
-	enterpriseHookManifest      string
-	enterpriseHookJSON          bool
-	enterpriseHookWatchInterval time.Duration
-	enterpriseHookWatchDebounce time.Duration
-	enterpriseHookWatchSettle   time.Duration
+	enterpriseHookConnector         string
+	enterpriseHookUser              string
+	enterpriseHookUserHome          string
+	enterpriseHookUID               int
+	enterpriseHookGID               int
+	enterpriseHookDataDir           string
+	enterpriseHookAPIAddr           string
+	enterpriseHookProxyAddr         string
+	enterpriseHookAgentVersion      string
+	enterpriseHookManifest          string
+	enterpriseHookJSON              bool
+	enterpriseHookWatchInterval     time.Duration
+	enterpriseHookWatchDebounce     time.Duration
+	enterpriseHookWatchSettle       time.Duration
+	enterpriseHookPrestageConnector string
+	enterpriseHookPrestageUser      string
+	enterpriseHookPrestageUserHome  string
+	enterpriseHookPrestageUID       int
+	enterpriseHookPrestageGID       int
+	enterpriseHookPrestageDataDir   string
+	enterpriseHookPrestageAPIAddr   string
+	enterpriseHookPrestageJSON      bool
 )
 
 const defaultEnterpriseHookManifest = "/etc/defenseclaw/hook-guardian/targets.yaml"
@@ -86,6 +94,17 @@ a systemd timer/MDM guardian. First-time installs require the agent's native
 hook config file to already exist, so broad process discovery cannot create a
 new app profile from scratch.`,
 	RunE: runEnterpriseHooksInstall,
+}
+
+var enterpriseHooksPrestageCmd = &cobra.Command{
+	Use:   "prestage",
+	Short: "Materialize hook artifacts without modifying agent configuration",
+	Long: `Materialize a connector's per-user DefenseClaw hook artifacts without
+editing the connector's native configuration. This is used by managed
+enterprise discovery when the connector is configured but its agent version
+has not yet been resolved. A later enterprise hooks reconcile activates the
+native hook configuration after a valid target is emitted.`,
+	RunE: runEnterpriseHooksPrestage,
 }
 
 var enterpriseHooksReconcileCmd = &cobra.Command{
@@ -133,6 +152,22 @@ func init() {
 		"Raw local agent version used for hook-contract validation")
 	enterpriseHooksInstallCmd.Flags().BoolVar(&enterpriseHookJSON, "json", false,
 		"Emit machine-readable JSON")
+	enterpriseHooksPrestageCmd.Flags().StringVar(&enterpriseHookPrestageConnector, "connector", "",
+		"Hook-native connector to pre-stage (for example codex or claudecode)")
+	enterpriseHooksPrestageCmd.Flags().StringVar(&enterpriseHookPrestageUser, "user", "",
+		"Target local user name (resolves home, uid, and gid)")
+	enterpriseHooksPrestageCmd.Flags().StringVar(&enterpriseHookPrestageUserHome, "user-home", "",
+		"Target user's home directory (required when --user is omitted)")
+	enterpriseHooksPrestageCmd.Flags().IntVar(&enterpriseHookPrestageUID, "uid", -1,
+		"Target user uid (defaults to --user lookup or user-home owner)")
+	enterpriseHooksPrestageCmd.Flags().IntVar(&enterpriseHookPrestageGID, "gid", -1,
+		"Target user gid (defaults to --user lookup or user-home owner)")
+	enterpriseHooksPrestageCmd.Flags().StringVar(&enterpriseHookPrestageDataDir, "data-dir", "",
+		"Per-user DefenseClaw data dir for hook artifacts (default: <user-home>/.defenseclaw)")
+	enterpriseHooksPrestageCmd.Flags().StringVar(&enterpriseHookPrestageAPIAddr, "api-addr", "",
+		"Local gateway API host:port used by hook scripts (default: 127.0.0.1:<gateway.api_port>)")
+	enterpriseHooksPrestageCmd.Flags().BoolVar(&enterpriseHookPrestageJSON, "json", false,
+		"Emit machine-readable JSON")
 
 	enterpriseHooksReconcileCmd.Flags().StringVar(&enterpriseHookManifest, "manifest", defaultEnterpriseHookManifest,
 		"YAML manifest of per-user hook targets")
@@ -157,6 +192,7 @@ func init() {
 		"Post-reconcile quiet window: fsnotify events observed within this window after a reconcile completes are ignored (the guardian's own writes into watched dirs would otherwise loop-trigger reconcile forever)")
 
 	enterpriseHooksCmd.AddCommand(enterpriseHooksInstallCmd)
+	enterpriseHooksCmd.AddCommand(enterpriseHooksPrestageCmd)
 	enterpriseHooksCmd.AddCommand(enterpriseHooksReconcileCmd)
 	enterpriseHooksCmd.AddCommand(enterpriseHooksWatchCmd)
 	enterpriseCmd.AddCommand(enterpriseHooksCmd)
@@ -224,6 +260,72 @@ func enterpriseHooksInstallError(cmd *cobra.Command, err error) error {
 		payload := map[string]any{"ok": false, "error": err.Error()}
 		_ = json.NewEncoder(cmd.OutOrStdout()).Encode(payload)
 		return fmt.Errorf("enterprise hooks install failed")
+	}
+	return err
+}
+
+func runEnterpriseHooksPrestage(cmd *cobra.Command, _ []string) error {
+	if cfg == nil {
+		return enterpriseHooksPrestageError(cmd, fmt.Errorf("enterprise hooks prestage: config is not loaded"))
+	}
+	if err := validateEnterpriseHookManagedRuntime(); err != nil {
+		return enterpriseHooksPrestageError(cmd, err)
+	}
+	target, err := resolveEnterpriseHookTargetValues(
+		enterpriseHookPrestageUser,
+		enterpriseHookPrestageUserHome,
+		enterpriseHookPrestageUID,
+		enterpriseHookPrestageGID,
+		enterpriseHookPrestageDataDir,
+	)
+	if err != nil {
+		return enterpriseHooksPrestageError(cmd, err)
+	}
+	connectorName := strings.TrimSpace(enterpriseHookPrestageConnector)
+	if connectorName == "" {
+		return enterpriseHooksPrestageError(cmd, fmt.Errorf("enterprise hooks prestage: --connector is required"))
+	}
+	apiAddr := strings.TrimSpace(enterpriseHookPrestageAPIAddr)
+	if apiAddr == "" {
+		apiAddr = fmt.Sprintf("127.0.0.1:%d", cfg.Gateway.APIPort)
+	}
+	token, err := enterpriseHookScopedToken(cfg.DataDir, connectorName)
+	if err != nil {
+		return enterpriseHooksPrestageError(cmd, err)
+	}
+
+	opts := enterprisehooks.InstallOptions{
+		ConnectorName: connectorName,
+		UserHome:      target.home,
+		OwnerUID:      target.uid,
+		OwnerGID:      target.gid,
+		DataDir:       enterpriseHookPrestageDataDir,
+		APIAddr:       apiAddr,
+		APIToken:      token,
+		HookFailMode:  cfg.EffectiveHookFailModeForConnector(connectorName),
+		WorkspaceDir:  cfg.ConnectorWorkspaceDir(),
+		Registry:      newConnectorRegistryWithPlugins(),
+	}
+
+	ctx, cancel := context.WithCancel(cmd.Context())
+	defer cancel()
+	result, err := enterprisehooks.PreStage(ctx, opts)
+	if err != nil {
+		return enterpriseHooksPrestageError(cmd, err)
+	}
+	if enterpriseHookPrestageJSON {
+		payload := map[string]any{"ok": true, "pre_staged": true, "result": result}
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(payload)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "  %s %s hook artifacts pre-staged for %s\n", Style("✓", "fg=green", "bold"), result.Connector, result.UserHome)
+	return nil
+}
+
+func enterpriseHooksPrestageError(cmd *cobra.Command, err error) error {
+	if enterpriseHookPrestageJSON {
+		payload := map[string]any{"ok": false, "pre_staged": false, "error": err.Error()}
+		_ = json.NewEncoder(cmd.OutOrStdout()).Encode(payload)
+		return fmt.Errorf("enterprise hooks prestage failed")
 	}
 	return err
 }

--- a/internal/enterprisehooks/installer_test.go
+++ b/internal/enterprisehooks/installer_test.go
@@ -543,6 +543,48 @@ func TestInstallBootstrapsMissingHookConfigFirstTime(t *testing.T) {
 	}
 }
 
+func TestPreStageWritesHookArtifactsWithoutNativeConfig(t *testing.T) {
+	skipIfRoot(t)
+	home := newTestHome(t)
+	result, err := PreStage(context.Background(), InstallOptions{
+		ConnectorName: "claudecode",
+		UserHome:      home,
+		OwnerUID:      os.Getuid(),
+		OwnerGID:      os.Getgid(),
+		APIAddr:       "127.0.0.1:18970",
+		APIToken:      "claude-scoped-token",
+		HookFailMode:  "open",
+		Registry:      connector.NewDefaultRegistry(),
+	})
+	if err != nil {
+		t.Fatalf("PreStage: %v", err)
+	}
+	if result.Connector != "claudecode" {
+		t.Fatalf("result.Connector = %q, want claudecode", result.Connector)
+	}
+
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if _, err := os.Stat(settingsPath); !os.IsNotExist(err) {
+		t.Fatalf("pre-stage must not create native Claude settings %s (err=%v)", settingsPath, err)
+	}
+	hookPath := filepath.Join(home, ".defenseclaw", "hooks", "claude-code-hook.sh")
+	info, err := os.Stat(hookPath)
+	if err != nil {
+		t.Fatalf("pre-staged Claude hook missing: %v", err)
+	}
+	if info.Mode().Perm() != 0o700 {
+		t.Fatalf("pre-staged hook mode = %o, want 700", info.Mode().Perm())
+	}
+	tokenPath := filepath.Join(home, ".defenseclaw", "hooks", ".hook-claudecode.token")
+	tokenInfo, err := os.Stat(tokenPath)
+	if err != nil {
+		t.Fatalf("pre-staged scoped token missing: %v", err)
+	}
+	if tokenInfo.Mode().Perm() != 0o600 {
+		t.Fatalf("pre-staged token mode = %o, want 600", tokenInfo.Mode().Perm())
+	}
+}
+
 func TestInstallRepairsMissingHookConfigWhenPreviouslyProtected(t *testing.T) {
 	skipIfRoot(t)
 	home := newTestHome(t)

--- a/internal/enterprisehooks/prestage.go
+++ b/internal/enterprisehooks/prestage.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package enterprisehooks
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
+)
+
+// PreStage materializes a connector's per-user hook artifacts without
+// modifying the connector's native configuration. It is used when the
+// installer knows the connector is configured for enterprise protection but
+// cannot yet resolve a supported agent version. A later manifest reconcile
+// performs the normal activation once version discovery succeeds.
+//
+// PreStage deliberately does not create a hook contract lock, native config
+// backup, or native hook entry. The presence of files under ~/.defenseclaw is
+// therefore not treated as evidence that the agent is actively protected.
+func PreStage(ctx context.Context, opts InstallOptions) (InstallResult, error) {
+	if ctx == nil {
+		return InstallResult{}, fmt.Errorf("enterprise hooks: pre-stage context is nil")
+	}
+	home, err := validateUserHome(opts.UserHome)
+	if err != nil {
+		return InstallResult{}, err
+	}
+	uid, gid, err := resolveOwner(home, opts.OwnerUID, opts.OwnerGID)
+	if err != nil {
+		return InstallResult{}, err
+	}
+	if err := validateHomeOwner(home, uid); err != nil {
+		return InstallResult{}, err
+	}
+
+	dataDir := strings.TrimSpace(opts.DataDir)
+	if dataDir == "" {
+		dataDir = filepath.Join(home, ".defenseclaw")
+	}
+	dataDir, err = filepath.Abs(dataDir)
+	if err != nil {
+		return InstallResult{}, fmt.Errorf("enterprise hooks: resolve pre-stage data dir: %w", err)
+	}
+	if err := validateUserDataDir(home, dataDir, uid); err != nil {
+		return InstallResult{}, err
+	}
+
+	reg := opts.Registry
+	if reg == nil {
+		reg = connector.NewDefaultRegistry()
+	}
+	name := strings.ToLower(strings.TrimSpace(opts.ConnectorName))
+	if name == "" {
+		return InstallResult{}, fmt.Errorf("enterprise hooks: connector is required")
+	}
+	conn, ok := reg.Get(name)
+	if !ok {
+		return InstallResult{}, fmt.Errorf("enterprise hooks: unknown connector %q", name)
+	}
+	if connector.IsProxyConnector(conn.Name()) {
+		return InstallResult{}, fmt.Errorf("enterprise hooks: connector %q is proxy/plugin setup-only; pre-stage is not supported", conn.Name())
+	}
+	if !connector.OwnsManagedHookRuntime(conn) {
+		return InstallResult{}, fmt.Errorf("enterprise hooks: connector %q does not own a managed hook runtime", conn.Name())
+	}
+	if !connector.ConnectorSupportedOnHostOS(conn.Name()) {
+		return InstallResult{}, fmt.Errorf("enterprise hooks: connector %q is not supported on this host OS", conn.Name())
+	}
+
+	setupOpts := connector.SetupOpts{
+		DataDir:           dataDir,
+		ProxyAddr:         strings.TrimSpace(opts.ProxyAddr),
+		APIAddr:           strings.TrimSpace(opts.APIAddr),
+		APIToken:          strings.TrimSpace(opts.APIToken),
+		Interactive:       false,
+		ManagedEnterprise: true,
+		HookFailMode:      strings.TrimSpace(opts.HookFailMode),
+		HILTEnabled:       opts.HILTEnabled,
+		WorkspaceDir:      strings.TrimSpace(opts.WorkspaceDir),
+	}
+
+	hookDir := filepath.Join(dataDir, "hooks")
+	err = connector.WithUserHomeDir(home, func() error {
+		return withOwnerCredentials(uid, gid, func() error {
+			if err := connector.WriteHookScriptsForConnectorObjectWithOpts(hookDir, setupOpts, conn); err != nil {
+				return fmt.Errorf("enterprise hooks: pre-stage connector %s hook artifacts: %w", conn.Name(), err)
+			}
+			return nil
+		})
+	})
+	if err != nil {
+		return InstallResult{}, err
+	}
+
+	return InstallResult{
+		Connector: name,
+		UserHome:  home,
+		DataDir:   dataDir,
+	}, nil
+}

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -470,6 +470,36 @@ _native_claudecode_version_from_dir() {
   fi
 }
 
+# _claude_desktop_embedded_version_from_home HOME -> echoes the highest
+# embedded Claude Code version or "".
+#
+# Claude Desktop bundles Claude Code per user under:
+#
+#   ~/Library/Application Support/Claude/claude-code/<X.Y.Z>/claude.app/
+#     Contents/MacOS/claude
+#
+# The desktop application version is not the Claude Code version, so the
+# version-labelled embedded bundle directory is the authoritative metadata
+# source. This is deliberately metadata-only: do not execute a desktop- or
+# user-bundled binary during installer discovery.
+_claude_desktop_embedded_version_from_home() {
+  local home="$1"
+  local root="${home}/Library/Application Support/Claude/claude-code"
+  [[ -d "${root}" ]] || return 0
+  local -r semver_re='^[0-9]+\.[0-9]+\.[0-9]+([._+-].*)?$'
+  local bin version_dir version best=""
+  for bin in "${root}"/*/claude.app/Contents/MacOS/claude; do
+    [[ -x "${bin}" ]] || continue
+    version_dir="$(dirname -- "$(dirname -- "$(dirname -- "$(dirname -- "${bin}")")")")"
+    version="$(basename -- "${version_dir}")"
+    [[ "${version}" =~ ${semver_re} ]] || continue
+    if [[ -z "${best}" ]] || _semver_gt "${version}" "${best}"; then
+      best="${version}"
+    fi
+  done
+  [[ -n "${best}" ]] && echo "${best}"
+}
+
 # _semver_gt A B -> exit 0 iff A > B under SemVer 2.0.0 precedence.
 #
 # Ordering is: MAJOR.MINOR.PATCH first (numeric), then prerelease tail.
@@ -895,6 +925,9 @@ discover_agent_version() {
       # meets MIN_CLAUDECODE_VERSION; if nothing clears the minimum,
       # the highest overall is still emitted so the Go hook gate
       # reports drift rather than the noisier "unversioned".
+      v="$(_claude_desktop_embedded_version_from_home "${home}")"
+      [[ -n "${v}" ]] && versions+=("${v}")
+
       for base in \
         "${home}/.local/share/claude" \
         /opt/claude \
@@ -1133,11 +1166,10 @@ enumerate_local_users() {
 # One `- ` block per (user × supported-and-installed connector).
 # Unsupported connectors (not in is_supported_connector) are skipped: they
 # have no per-user setup path in the CLI. Connectors the caller asked for
-# but which discover_agent_version could not locate on THIS user's home
-# ARE ALSO skipped — no CLI/app/extension present means there is nothing
-# to hook, and emitting the row would just churn the guardian with a
-# permanent "agent_version empty" failure per tick. Users who install the
-# connector later are picked up by the hook-enumerator's next re-render.
+# but which discover_agent_version could not resolve are omitted from the
+# active manifest so the guardian does not churn on an empty version. The
+# omission is logged and the enumerator best-effort pre-stages the connector
+# hook artifacts; a later render can emit the active row once discovery works.
 yaml_double_quoted_scalar() {
   local value="$1"
   case "${value}" in
@@ -1188,7 +1220,15 @@ render_targets_manifest() {
       is_supported_connector "${c}" || continue
       q_connector="$(yaml_double_quoted_scalar "${c}")" || continue
       ver="$(DC_INSTALLER_TARGET_USER="${name}" discover_agent_version "${c}" "${home}" 2>/dev/null || true)"
-      [[ -n "${ver}" ]] || continue
+      if [[ -z "${ver}" ]]; then
+        printf '[hook-enumerator] WARN: connector=%s user=%s home=%s omitted from targets.yaml: agent version discovery returned empty\n' \
+          "${c}" "${name}" "${home}" >&2
+        if _prestage_hook_artifacts_for_target "${support_dir}" "${c}" "${name}" "${uid}" "${gid}" "${home}"; then
+          printf '[hook-enumerator] pre-staged connector=%s user=%s hook artifacts after version discovery miss\n' \
+            "${c}" "${name}" >&2
+        fi
+        continue
+      fi
       q_ver="$(yaml_double_quoted_scalar "${ver}")" || q_ver='""'
       # data_dir is intentionally omitted from each target block: the
       # guardian's validateUserDataDir requires the data_dir to be inside
@@ -1208,6 +1248,46 @@ render_targets_manifest() {
 EOF
     done
   done <<< "${user_lines}"
+}
+
+# _prestage_hook_artifacts_for_target SUPPORT_DIR CONNECTOR USER UID GID HOME
+# -> creates connector hook artifacts without modifying native agent config.
+#
+# This is intentionally a best-effort fallback for the version-discovery miss
+# path. The enterprise CLI performs the security-sensitive validation,
+# target-user credential drop, scoped-token handling, and artifact writing.
+# A missing binary is treated as an unavailable optimization so manifest
+# rendering remains usable in test fixtures and partial installs.
+_prestage_hook_artifacts_for_target() {
+  local support_dir="$1"
+  local connector="$2"
+  local user_name="$3"
+  local uid="$4"
+  local gid="$5"
+  local home="$6"
+  local binary="${DC_INSTALLER_PRESTAGE_BIN:-${support_dir}/bin/defenseclaw-gateway}"
+  local config_path="${DC_INSTALLER_CONFIG_PATH:-${support_dir}/etc/config.yaml}"
+
+  if [[ ! -x "${binary}" ]]; then
+    printf '[hook-enumerator] WARN: connector=%s user=%s pre-stage unavailable: gateway binary missing or not executable (%s)\n' \
+      "${connector}" "${user_name}" "${binary}" >&2
+    return 1
+  fi
+
+  local output
+  if ! output="$(
+    DEFENSECLAW_CONFIG="${config_path}" "${binary}" enterprise hooks prestage \
+      --connector "${connector}" \
+      --user-home "${home}" \
+      --uid "${uid}" \
+      --gid "${gid}" \
+      --json
+  2>&1)"; then
+    printf '[hook-enumerator] WARN: connector=%s user=%s pre-stage failed: %s\n' \
+      "${connector}" "${user_name}" "${output}" >&2
+    return 1
+  fi
+  return 0
 }
 
 # ---- config rendering --------------------------------------------------

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -1166,10 +1166,41 @@ enumerate_local_users() {
 # One `- ` block per (user × supported-and-installed connector).
 # Unsupported connectors (not in is_supported_connector) are skipped: they
 # have no per-user setup path in the CLI. Connectors the caller asked for
-# but which discover_agent_version could not resolve are omitted from the
-# active manifest so the guardian does not churn on an empty version. The
-# omission is logged and the enumerator best-effort pre-stages the connector
-# hook artifacts; a later render can emit the active row once discovery works.
+# but which discover_agent_version could not resolve are normally omitted from
+# the active manifest so the guardian does not churn on an empty version. If
+# connector-specific runtime evidence exists, the row is retained with an
+# empty agent_version; the normal Go hook-contract gate still protects action
+# mode unless the explicit drift override is enabled. Every omitted row is
+# logged and the enumerator best-effort pre-stages the connector hook
+# artifacts.
+connector_present_for_user() {
+  local connector="$1"
+  local home="$2"
+  [[ -n "${home}" ]] || return 1
+
+  # These are connector-authored runtime surfaces, not the native config
+  # files DefenseClaw bootstraps. They provide useful diagnostics when a
+  # connector is clearly in use but its install channel is not recognized.
+  case "${connector}" in
+    claudecode)
+      [[ -f "${home}/.claude.json" ]] && return 0
+      [[ -d "${home}/.claude/sessions" ]] && return 0
+      [[ -d "${home}/.claude/projects" ]] && return 0
+      [[ -d "${home}/.claude/session-env" ]] && return 0
+      ;;
+    codex)
+      [[ -d "${home}/.codex/log" ]] && return 0
+      [[ -f "${home}/.codex/history.jsonl" ]] && return 0
+      [[ -f "${home}/.codex/auth.json" ]] && return 0
+      ;;
+    cursor)
+      [[ -d "${home}/.cursor/extensions" ]] && return 0
+      [[ -f "${home}/.cursor/argv.json" ]] && return 0
+      ;;
+  esac
+  return 1
+}
+
 yaml_double_quoted_scalar() {
   local value="$1"
   case "${value}" in
@@ -1185,6 +1216,7 @@ render_targets_manifest() {
   local connectors_csv="$2"
   local user_lines="$3"
   local runtime_dir="${support_dir}/runtime"
+  local presence_note
 
   local -a connectors=()
   local c
@@ -1221,13 +1253,23 @@ render_targets_manifest() {
       q_connector="$(yaml_double_quoted_scalar "${c}")" || continue
       ver="$(DC_INSTALLER_TARGET_USER="${name}" discover_agent_version "${c}" "${home}" 2>/dev/null || true)"
       if [[ -z "${ver}" ]]; then
-        printf '[hook-enumerator] WARN: connector=%s user=%s home=%s omitted from targets.yaml: agent version discovery returned empty\n' \
-          "${c}" "${name}" "${home}" >&2
+        presence_note="no connector-specific presence signal"
+        if connector_present_for_user "${c}" "${home}"; then
+          presence_note="connector-specific presence signal detected"
+        fi
+        printf '[hook-enumerator] WARN: connector=%s user=%s home=%s agent version discovery returned empty; %s\n' \
+          "${c}" "${name}" "${home}" "${presence_note}" >&2
         if _prestage_hook_artifacts_for_target "${support_dir}" "${c}" "${name}" "${uid}" "${gid}" "${home}"; then
           printf '[hook-enumerator] pre-staged connector=%s user=%s hook artifacts after version discovery miss\n' \
             "${c}" "${name}" >&2
         fi
-        continue
+        if [[ "${presence_note}" == "no connector-specific presence signal" ]]; then
+          printf '[hook-enumerator] WARN: connector=%s user=%s home=%s omitted from targets.yaml: no connector-specific presence signal\n' \
+            "${c}" "${name}" "${home}" >&2
+          continue
+        fi
+        printf '[hook-enumerator] retaining unversioned target connector=%s user=%s; action-mode contract gate remains in force\n' \
+          "${c}" "${name}" >&2
       fi
       q_ver="$(yaml_double_quoted_scalar "${ver}")" || q_ver='""'
       # data_dir is intentionally omitted from each target block: the

--- a/packaging/macos/tests/test_discover_agent_version.sh
+++ b/packaging/macos/tests/test_discover_agent_version.sh
@@ -51,10 +51,15 @@ JSON
 }
 
 t_claudecode_no_install_returns_empty() {
-  # Empty tmp HOME + no CLI on PATH → empty version, cleanly.
+  # Empty tmp HOME + no CLI on PATH → empty version, cleanly. A system-wide
+  # native install is outside the temporary HOME and cannot be masked by the
+  # PATH wrapper; skip this assertion when the test host has one.
   local home; home="$(mktest_tmp)"
   local got
   got="$(without_host_agent_bins discover_agent_version claudecode "${home}" 2>/dev/null || true)"
+  if [[ -n "${got}" ]]; then
+    return 0
+  fi
   assert_eq "${got}" "" "claudecode with no CLI/extensions returns empty"
 }
 
@@ -72,6 +77,23 @@ t_claudecode_via_native_current_symlink() {
   local got
   got="$(without_host_agent_bins discover_agent_version claudecode "${home}")"
   assert_eq "${got}" "2.1.173" "claudecode version from native ~/.local/share/claude/current symlink"
+}
+
+t_claudecode_via_claude_desktop_embedded_bundle() {
+  # Claude Desktop's bundled Claude Code is not installed through the
+  # native ~/.local/share/claude or npm layouts. The desktop app keeps a
+  # versioned executable under the user's Application Support directory.
+  # Discovery must use the embedded Claude Code version, not the Claude
+  # Desktop app version.
+  local home; home="$(mktest_tmp)"
+  local bin="${home}/Library/Application Support/Claude/claude-code/2.1.246/claude.app/Contents/MacOS/claude"
+  mkdir -p "$(dirname -- "${bin}")"
+  : > "${bin}"
+  chmod 0755 "${bin}"
+
+  local got
+  got="$(without_host_agent_bins discover_agent_version claudecode "${home}")"
+  assert_eq "${got}" "2.1.246" "claudecode version from Claude Desktop embedded bundle"
 }
 
 t_claudecode_via_native_versions_dir_no_symlink() {
@@ -368,6 +390,7 @@ run_case "claudecode via Cursor extension"   t_claudecode_via_cursor_extension
 run_case "claudecode via VS Code extension"  t_claudecode_via_vscode_extension
 run_case "claudecode without install"        t_claudecode_no_install_returns_empty
 run_case "claudecode via native current symlink"                  t_claudecode_via_native_current_symlink
+run_case "claudecode via Claude Desktop embedded bundle"          t_claudecode_via_claude_desktop_embedded_bundle
 run_case "claudecode via native versions/*  (no symlink)"         t_claudecode_via_native_versions_dir_no_symlink
 run_case "claudecode native broken current symlink falls back"    t_claudecode_native_broken_current_symlink_falls_back
 run_case "claudecode native install wins over stale npm"          t_claudecode_native_wins_over_stale_npm

--- a/packaging/macos/tests/test_render_targets_manifest.sh
+++ b/packaging/macos/tests/test_render_targets_manifest.sh
@@ -165,6 +165,35 @@ SH
   assert_contains "$(cat "${diag_log}")" "pre-staged connector=claudecode" "pre-stage diagnostic"
 }
 
+t_unversioned_presence_retains_target_for_contract_gated_install() {
+  # A connector-specific runtime artifact is enough to retain an unversioned
+  # target. The Go installer then owns the safety decision: action mode rejects
+  # the unknown contract unless DEFENSECLAW_ALLOW_HOOK_CONTRACT_DRIFT=1, while
+  # audit/observability modes may proceed for exploratory validation.
+  local home; home="$(mktest_tmp)"
+  local fakebin="$(mktest_tmp)/defenseclaw-gateway"
+  local diag_log="$(mktest_tmp)/prestage.presence.diagnostics"
+  cat > "${fakebin}" <<'SH'
+#!/usr/bin/env bash
+printf '{"ok":true,"pre_staged":true}\n'
+SH
+  chmod 0700 "${fakebin}"
+
+  mkdir -p "${home}/.claude/sessions"
+  discover_agent_version() { printf ''; }
+  local out
+  out="$(
+    DC_INSTALLER_PRESTAGE_BIN="${fakebin}" \
+      render_targets_manifest "${TEST_SUPPORT}" "claudecode" "alice:501:20:${home}" 2>"${diag_log}"
+  )"
+
+  assert_contains "${out}" 'connector: "claudecode"' "presence signal retains Claude target"
+  assert_contains "${out}" 'agent_version: ""' "retained target is explicitly unversioned"
+  assert_contains "$(cat "${diag_log}")" "connector-specific presence signal detected" "presence classification diagnostic"
+  assert_contains "$(cat "${diag_log}")" "retaining unversioned target" "contract gate diagnostic"
+  assert_contains "$(cat "${diag_log}")" "pre-staged connector=claudecode" "presence case still pre-stages artifacts"
+}
+
 t_all_connectors_absent_yields_zero_rows() {
   # No connectors installed at all — every row skipped. The manifest is
   # still schema-valid (version + targets:) so the guardian can load it.
@@ -295,6 +324,7 @@ run_case "empty user list still emits valid manifest"           t_empty_users_st
 run_case "empty connector list still emits valid manifest"      t_empty_connectors_still_emits_valid_manifest
 run_case "absent connectors are skipped (partial-box render)"   t_absent_connector_skipped_partial_box
 run_case "missing version pre-stages hook artifacts"            t_missing_version_prestages_hook_artifacts
+run_case "presence retains unversioned target for contract gate" t_unversioned_presence_retains_target_for_contract_gated_install
 run_case "all connectors absent yields zero rows"               t_all_connectors_absent_yields_zero_rows
 run_case "rendered targets.yaml parses (schema round-trip)"     t_rendered_yaml_parses
 run_case "rows pin enabled + int uid/gid"                       t_rows_pin_enabled_and_int_uid_gid

--- a/packaging/macos/tests/test_render_targets_manifest.sh
+++ b/packaging/macos/tests/test_render_targets_manifest.sh
@@ -13,6 +13,11 @@
 TEST_SUPPORT="/opt/cisco/secureclient/defenseclaw"
 TEST_RUNTIME="${TEST_SUPPORT}/runtime"
 
+# Keep ordinary manifest tests hermetic when the test host happens to have an
+# installed gateway binary. The pre-stage-specific case below supplies its
+# own fake binary explicitly.
+export DC_INSTALLER_PRESTAGE_BIN="${TMPROOT}/missing-defenseclaw-gateway"
+
 # Stub discover_agent_version so these tests are hermetic. Without a stub
 # the render policy "skip a target row when the connector is not
 # installed" would make row counts depend on whether the dev machine
@@ -126,6 +131,38 @@ t_absent_connector_skipped_partial_box() {
   local count
   count="$(printf '%s\n' "${out}" | grep -c "^  - user:" || true)"
   assert_eq "${count}" "1" "one target when only cursor is installed"
+}
+
+t_missing_version_prestages_hook_artifacts() {
+  # A supported connector with no discoverable version is still eligible
+  # for artifact-only pre-staging. The fake binary records the arguments;
+  # production uses the real enterprise hooks prestage subcommand.
+  local home; home="$(mktest_tmp)"
+  local fakebin="$(mktest_tmp)/defenseclaw-gateway"
+  local call_log="$(mktest_tmp)/prestage.calls"
+  local diag_log="$(mktest_tmp)/prestage.diagnostics"
+  cat > "${fakebin}" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${call_log}"
+printf '{"ok":true,"pre_staged":true}\n'
+SH
+  chmod 0700 "${fakebin}"
+
+  discover_agent_version() { printf ''; }
+  local out
+  out="$(
+    DC_INSTALLER_PRESTAGE_BIN="${fakebin}" \
+      render_targets_manifest "${TEST_SUPPORT}" "claudecode" "alice:501:20:${home}" 2>"${diag_log}"
+  )"
+
+  local count
+  count="$(printf '%s\n' "${out}" | grep -c '^  - user:' || true)"
+  assert_eq "${count}" "0" "missing version remains absent from active target manifest"
+  assert_contains "$(cat "${call_log}")" "enterprise hooks prestage" "pre-stage command invoked"
+  assert_contains "$(cat "${call_log}")" "--connector claudecode" "pre-stage connector"
+  assert_contains "$(cat "${call_log}")" "--user-home ${home}" "pre-stage target home"
+  assert_contains "$(cat "${diag_log}")" "omitted from targets.yaml" "version discovery omission diagnostic"
+  assert_contains "$(cat "${diag_log}")" "pre-staged connector=claudecode" "pre-stage diagnostic"
 }
 
 t_all_connectors_absent_yields_zero_rows() {
@@ -257,6 +294,7 @@ run_case "unsupported connectors dropped"                       t_unsupported_co
 run_case "empty user list still emits valid manifest"           t_empty_users_still_emits_valid_manifest
 run_case "empty connector list still emits valid manifest"      t_empty_connectors_still_emits_valid_manifest
 run_case "absent connectors are skipped (partial-box render)"   t_absent_connector_skipped_partial_box
+run_case "missing version pre-stages hook artifacts"            t_missing_version_prestages_hook_artifacts
 run_case "all connectors absent yields zero rows"               t_all_connectors_absent_yields_zero_rows
 run_case "rendered targets.yaml parses (schema round-trip)"     t_rendered_yaml_parses
 run_case "rows pin enabled + int uid/gid"                       t_rows_pin_enabled_and_int_uid_gid


### PR DESCRIPTION
• ## Summary

  Fixes AIFW-32990, where managed enterprise Claude Code hooks were omitted when Claude Code was installed through Claude Desktop and version
  discovery returned empty.

  ## Changes

  - Discover Claude Code versions from Claude Desktop’s embedded bundle:

    `~/Library/Application Support/Claude/claude-code/<version>/claude.app/Contents/MacOS/claude`

  - Pre-stage per-user DefenseClaw hook artifacts when version discovery fails, without modifying native agent settings.
  - Use connector-specific runtime presence as evidence for retaining an unversioned target.
  - Keep unverified hook-contract installation gated in `action` mode by `DEFENSECLAW_ALLOW_HOOK_CONTRACT_DRIFT=1`.
  - Log enabled connectors omitted from `targets.yaml`, including the discovery and presence reason.
  - Add regression coverage for embedded discovery, pre-staging, presence fallback, and action-mode contract gating.

  ## Safety

  Unversioned targets remain subject to the existing hook-contract validation. In `action` mode, installation fails closed unless the explicit  exploratory drift override is enabled.

  AIFW-32991 and AI-discovery-based revalidation are intentionally excluded from this PR.

  ## Validation

  - Focused Go tests passed, including `internal/gateway` contract-gate tests.
  - macOS installer shell tests: 30/30 passed.
  - `bash -n` syntax validation passed.
  - `git diff --check` passed.