### PR TITLE
fix(macos): correct gateway start command

### DIFF
--- a/macos/DefenseClawMac/DefenseClawMac/Features/OverviewView.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/OverviewView.swift
@@ -270,10 +270,10 @@ struct OverviewView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     HStack {
-                        Text("defenseclaw gateway start")
+                        Text("defenseclaw-gateway start")
                             .font(.system(.caption, design: .monospaced))
                         Button {
-                            copyToPasteboard("defenseclaw gateway start")
+                            copyToPasteboard("defenseclaw-gateway start")
                         } label: { Image(systemName: "doc.on.doc") }
                         .buttonStyle(.borderless)
                         .accessibilityLabel("Copy gateway start command")


### PR DESCRIPTION
<html><head></head><body><h2><span>Problem</span></h2><p><span>When the gateway is unreachable, the macOS Overview screen recommends </span><code><span>defenseclaw gateway start</span></code><span> with a small copy icon for pasting the command into a terminal. However, the </span><code><span>defenseclaw</span></code><span> CLI does not provide a </span><code><span>gateway</span></code><span> subcommand, so the command fails whether it is copied or entered manually.</span></p><h2><span>Current Situation</span></h2><p><span>DefenseClaw provides gateway lifecycle commands through the separate </span><code><span>defenseclaw-gateway</span></code><span> executable. The command registry, CLI reference, scripts, and other user-facing guidance consistently use </span><code><span>defenseclaw-gateway start</span></code><span>.</span></p><p><span>The macOS Services card is the exception: it displays and copies the invalid </span><code><span>defenseclaw gateway start</span></code><span> command.</span></p><h2><span>Solution</span></h2><p><span>Update the command displayed by the macOS Services card—and the value copied by its clipboard button—to:</span></p><p><code><span>defenseclaw-gateway start</span></code></p><p><span>Risk is low because this is a display-only correction and does not change gateway behavior, configuration, or APIs.</span></p><h2><span>Architecture Diagram</span></h2><p><span>N/A</span></p><h2><span>What Changed (Where &amp; How)</span></h2>
File | Summary
-- | --
macos/DefenseClawMac/DefenseClawMac/Features/OverviewView.swift | Corrected the displayed and copied gateway start command.

<h2><span>Breaking Changes</span></h2><p><span>None.</span></p><h2><span>Open Issues / Follow-ups</span></h2><p><span>None.</span></p><h2><span>Test Plan</span></h2><ul><li><p><code><span>make macos-app-license-check macos-app-test</span></code></p><ul><li><p><span>All macOS license and native test checks passed.</span></p></li><li><p><span>The Release configuration build completed successfully.</span></p></li></ul></li><li><p><code><span>git diff --check</span></code></p><ul><li><p><span>Passed.</span></p></li></ul></li><li><p><span>Confirmed the corrected command matches the macOS command registry and canonical CLI reference.</span></p></li></ul><p><span>No dedicated regression test was added because this change only corrects a static UI label and clipboard value. The existing macOS test suite and Release build pass.</span></p><p><span>This is my first submission ever.  Please go easy.  I prepared it with assistance from Codex; I reviewed all changes and submissions myself.  I hope this is okay.</span></p></body></html>