### PR TITLE
cherry-pick: forward-port release-26.8.4 fixes (#781, #782, #784, #786, #802) to main

### DIFF
--- a/docs/WINDOWS-ENTERPRISE-THREAT-MODEL.md
+++ b/docs/WINDOWS-ENTERPRISE-THREAT-MODEL.md
@@ -383,13 +383,51 @@ not an administrator authority even though it is a machine service.
 3. A target without an active, safe WTS token cannot be repaired. The guardian
    records failure and retries rather than writing the profile as LocalSystem.
    The activating install-time `-Mode` / `-Connector` shorthand therefore
-   seeds enabled rows only for eligible `WTSActive` profile SIDs. The protected
-   enumerator retains other discovered profiles as disabled rows pending an
-   explicit administrator lifecycle action; it does not treat them as
-   authenticated deferred enrollment. `Install -NoStart` keeps the complete
-   planned all-user enrollment because it makes no immediate readiness claim.
-   An explicit manifest that enables a disconnected target remains
-   authoritative and fails readiness until the exact SID has an active token.
+   seeds enabled rows only for eligible `WTSActive` profile SIDs.
+
+   Post-install, the SCM hook-enumerator runs on a 5-minute interval and
+   auto-authorizes newly-discovered `(SID, Connector)` rows whose per-user
+   profile contains a supported CLI (parity with macOS
+   `render-targets.sh`; see
+   `internal/enterprisehooks/agent_version_windows.go` for the per-connector
+   probe). Managed-enterprise deployments are administrator-controlled at
+   the *policy* layer — which connectors are pushed, and which SID scope
+   the guardian authorization ledger accepts — not at the per-device
+   authorization layer. Three residual sub-risks follow from this posture:
+
+   a. **Local-admin user creation → auto-enrollment.** A local admin
+      who can create an interactive user (`S-1-5-21-…`) on the target
+      machine causes that user to be enrolled on the next enumerator
+      tick. macOS's `launchd`-driven `render-targets.sh` operates under
+      the same posture; this is the accepted cost of parity. The exact
+      SID membership check (row W-28 above) still fail-closes on an
+      unregistered SID between enumerator ticks, and the guardian
+      authorization ledger records every enrollment for audit.
+
+   b. **Unprivileged self-enrollment via user-writable `package.json`.**
+      The per-connector version probe reads a `version` field from
+      package metadata under paths inside the user's own profile
+      (`AppData\Roaming\npm\node_modules\@…\package.json`,
+      `AppData\Local\Programs\cursor\resources\app\package.json`).
+      Any interactive user can create these files with a plausible
+      `version` string and cause the enumerator to auto-authorize
+      their `(SID, Connector)` on the next tick, *without actually
+      installing a supported CLI*. This is deliberately accepted
+      because enrollment confers no privilege to the target — it
+      only means that user's own agent invocations become subject to
+      DefenseClaw inspection. A user who self-enrolls opts themselves
+      *into* monitoring, which is a security-neutral (or
+      defense-positive) outcome; there is no path from "user drops a
+      fake `package.json`" to "attacker gains inspection authority
+      over another user's traffic." Endpoint policy remains
+      authoritative for what shell / CLI activity is actually visible
+      to DefenseClaw once the row exists.
+
+   c. **`Install -NoStart` planned-enrollment.** `Install -NoStart`
+      keeps the complete planned all-user enrollment because it makes
+      no immediate readiness claim. An explicit manifest that enables
+      a disconnected target remains authoritative and fails readiness
+      until the exact SID has an active token.
 4. Application control and vendor MDM/GPO policy are optional defense-in-depth
    controls, not features DefenseClaw can synthesize. Their absence does not
    block managed-hook readiness, but leaves the user-owned hook race described

--- a/docs/WINDOWS-ENTERPRISE-THREAT-MODEL.md
+++ b/docs/WINDOWS-ENTERPRISE-THREAT-MODEL.md
@@ -387,7 +387,8 @@ not an administrator authority even though it is a machine service.
 
    Post-install, the SCM hook-enumerator runs on a 5-minute interval and
    auto-authorizes newly-discovered `(SID, Connector)` rows whose per-user
-   profile contains a supported CLI (parity with macOS
+   profile contains a supported CLI OR whose connector has a supported
+   machine-scoped install shared across all users (parity with macOS
    `render-targets.sh`; see
    `internal/enterprisehooks/agent_version_windows.go` for the per-connector
    probe). Managed-enterprise deployments are administrator-controlled at
@@ -404,17 +405,25 @@ not an administrator authority even though it is a machine service.
       unregistered SID between enumerator ticks, and the guardian
       authorization ledger records every enrollment for audit.
 
-   b. **Unprivileged self-enrollment via user-writable `package.json`.**
+   b. **Unprivileged self-enrollment via user-writable `package.json`,
+      or admin-driven all-user enrollment via a machine-scoped install.**
       The per-connector version probe reads a `version` field from
       package metadata under paths inside the user's own profile
       (`AppData\Roaming\npm\node_modules\@…\package.json`,
-      `AppData\Local\Programs\cursor\resources\app\package.json`).
-      Any interactive user can create these files with a plausible
-      `version` string and cause the enumerator to auto-authorize
-      their `(SID, Connector)` on the next tick, *without actually
-      installing a supported CLI*. This is deliberately accepted
-      because enrollment confers no privilege to the target — it
-      only means that user's own agent invocations become subject to
+      `AppData\Local\Programs\cursor\resources\app\package.json`) OR
+      — for connectors that ship a machine-scoped installer — from a
+      fixed shared path such as
+      `C:\Program Files\Cursor\resources\app\package.json` (Cursor's
+      MSI installer). Any interactive user can create the per-user
+      files with a plausible `version` string and cause the enumerator
+      to auto-authorize their `(SID, Connector)` on the next tick,
+      *without actually installing a supported CLI*. A machine-scoped
+      install of a supported connector (admin-only to write) causes
+      that `(SID, Connector)` row to auto-authorize for *every*
+      enumerated profile on the box, because the shared version is
+      by construction the same for every user. This is deliberately
+      accepted because enrollment confers no privilege to the target —
+      it only means that user's own agent invocations become subject to
       DefenseClaw inspection. A user who self-enrolls opts themselves
       *into* monitoring, which is a security-neutral (or
       defense-positive) outcome; there is no path from "user drops a

--- a/internal/cli/enterprise_windows_enumerate_windows.go
+++ b/internal/cli/enterprise_windows_enumerate_windows.go
@@ -230,6 +230,16 @@ func runEnterpriseWindowsEnumerateSingleCycle(
 	if err != nil {
 		return fmt.Errorf("enterprise windows enumerate: write manifest: %w", err)
 	}
+	// Sibling pass: ensure the CertGateway service SID has Read+Execute on
+	// each enrolled user's inventory dotdirs (~/.claude, ~/.codex, …). The
+	// gateway runs under a virtual service account whose access to user
+	// profiles is not implicit; without this grant the AI discovery scanner
+	// walks the right paths but ReadDir returns access-denied and every
+	// skill/plugin/rule/mcp signal is suppressed. Idempotent; per-directory
+	// failures log-only so one bad DACL doesn't block the enumerator cycle.
+	if grantErr := enterprisehooks.GrantGatewayInventoryReadForManifest(manifest, "", logf); grantErr != nil {
+		fmt.Fprintf(stderr, "[hook-enumerator] inventory-DACL pass failed: %v\n", grantErr)
+	}
 	elapsed := time.Since(start)
 
 	fmt.Fprintf(stderr, "[hook-enumerator] cycle complete users=%d targets=%d changed=%t elapsed=%s\n",

--- a/internal/cli/enterprise_windows_enumerate_windows.go
+++ b/internal/cli/enterprise_windows_enumerate_windows.go
@@ -74,13 +74,19 @@ type enterpriseWindowsEnumerateOptions struct {
 //     exits. Used by the installer's fresh-install path (replaces
 //     the retired inline PowerShell walk at
 //     `DefenseClawEnterprise.psm1:3663-3736`).
-//   - default (no `--once`): enters the read-only interval-loop the
-//     SCM service invokes at boot. It audits the current profile set
-//     against the authenticated committed manifest but never changes
-//     authorization. New profiles require an administrator Repair or
-//     Upgrade.
+//   - default (no `--once`): enters the interval-loop the SCM
+//     service invokes at boot. On every tick it publishes an
+//     updated targets.yaml, auto-authorizing newly-discovered
+//     (SID, Connector) rows whose per-user profile contains a
+//     supported CLI (parity with macOS render-targets.sh). Rows
+//     with no discoverable CLI are silently skipped. The
+//     byte-identical short-circuit in WriteTargetsManifestAtomic
+//     keeps steady-state ticks free of file mutation.
 //
-// Spec 005 REQ-03, REQ-04, REQ-13, REQ-18, REQ-19.
+// Spec 005 REQ-03, REQ-04, REQ-13, REQ-18, REQ-19 (REQ-13's
+// audit-only sub-clause is superseded by the macOS-parity
+// auto-authorize posture; see
+// docs/WINDOWS-ENTERPRISE-THREAT-MODEL.md residual-risk section).
 func newEnterpriseWindowsEnumerateCommand() *cobra.Command {
 	opts := &enterpriseWindowsEnumerateOptions{
 		interval:     enterpriseWindowsEnumerateDefaultInterval,
@@ -88,30 +94,34 @@ func newEnterpriseWindowsEnumerateCommand() *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "enumerate",
-		Short: "Publish pre-commit targets or audit committed Windows enrollment",
+		Short: "Publish Windows managed-enterprise hook enrollment on every tick",
 		Long: `Walk HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList to
 discover local user profiles, filter to interactive users (S-1-5-21-…), and
-compare them with the hook-guardian's authenticated targets.yaml.
+publish an updated hook-guardian targets.yaml.
 
 Two modes:
 
-  * default: enter a read-only audit loop suitable for an SCM ImagePath.
-    The service never rewrites targets.yaml and never authorizes a profile
-    created after deployment commit. Newly discovered or changed profiles
-    are reported for an administrator-run Repair or Upgrade.
+  * default: enter an interval loop suitable for an SCM ImagePath. On every
+    tick the service publishes an updated targets.yaml, auto-authorizing
+    newly-discovered (SID, Connector) rows whose per-user profile contains
+    a supported CLI. Profiles with no discoverable CLI are omitted from the
+    manifest without failing the cycle — the per-row reason is emitted to
+    stderr under the '[hook-enumerator] skipped ...' line so an operator
+    can see why a specific user was left out (macOS parity). The
+    byte-identical short-circuit in WriteTargetsManifestAtomic keeps
+    steady-state ticks free of file mutation.
 
   * --once: run a single cycle synchronously and exit. Used by the
-    installer to publish targets.yaml before deployment commit. This is
-    the only mode that writes the manifest.
+    installer to publish targets.yaml before deployment commit.
 
 Both modes authenticate the manifest's ancestry, exact AdminFile descriptor,
-regular-file identity, link contract, and schema. --once stages an authorized
-update under the exact AdminFile contract and publishes it atomically. Service
-audits fail closed on trust drift and leave the committed manifest untouched.
+regular-file identity, link contract, and schema, and both stage an authorized
+update under the exact AdminFile contract before atomic replace. On trust
+drift, both modes fail closed and leave the committed manifest untouched.
 
 Managed-enterprise Windows only. macOS's LaunchDaemon-based
-'hook-enumerator' + render-targets.sh already covers the darwin
-side; nothing about this subcommand is invoked on non-Windows OSes.
+'hook-enumerator' + render-targets.sh covers the darwin side;
+nothing about this subcommand is invoked on non-Windows OSes.
 `,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -162,10 +172,20 @@ func runEnterpriseWindowsEnumerate(
 	return runEnterpriseWindowsEnumerateInterval(ctx, stderr, opts, manifestPath)
 }
 
-// runEnterpriseWindowsEnumerateSingleCycle runs one bounded cycle and returns.
-// publish=true is reserved for the installer's pre-commit --once path. The
-// long-running SCM service always passes publish=false so a profile discovered
-// after commit cannot become authorized without an administrator lifecycle.
+// runEnterpriseWindowsEnumerateSingleCycle runs one bounded cycle
+// and returns. Both call sites pass publish=true today:
+//
+//   - The `--once` installer path publishes the initial pre-commit
+//     targets.yaml.
+//   - The long-running SCM interval loop publishes an updated
+//     targets.yaml on every tick (auto-authorize parity with
+//     macOS render-targets.sh). Byte-identical short-circuit in
+//     WriteTargetsManifestAtomic keeps steady-state ticks
+//     mutation-free.
+//
+// publish=false is retained on the parameter for callers that
+// legitimately want a dry-run (test rigs, admin diagnostics) but
+// is no longer wired in from either shipping call site.
 func runEnterpriseWindowsEnumerateSingleCycle(
 	ctx context.Context,
 	stderr io.Writer,
@@ -337,7 +357,15 @@ func runEnterpriseWindowsEnumerateInterval(
 	// First cycle: log the outcome but do NOT bail on a transient
 	// "config missing" error — the whole point of REQ-04 is to
 	// tolerate deferred-config boots.
-	if err := runEnterpriseWindowsEnumerateSingleCycle(ctx, stderr, manifestPath, false); err != nil {
+	//
+	// publish=true (parity with macOS render-targets.sh): each tick
+	// auto-authorizes newly-discovered (SID, Connector) rows whose
+	// per-user profile contains a supported CLI (see
+	// internal/enterprisehooks/agent_version_windows.go). Rows
+	// without a discoverable CLI are silently skipped. The
+	// byte-identical short-circuit in WriteTargetsManifestAtomic
+	// keeps steady-state ticks free of fsnotify wakes.
+	if err := runEnterpriseWindowsEnumerateSingleCycle(ctx, stderr, manifestPath, true); err != nil {
 		if !isEnterpriseWindowsEnumerateConfigMissing(err) {
 			fmt.Fprintf(stderr, "[hook-enumerator] initial cycle failed: %v\n", err)
 		}
@@ -350,7 +378,7 @@ func runEnterpriseWindowsEnumerateInterval(
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			if err := runEnterpriseWindowsEnumerateSingleCycle(ctx, stderr, manifestPath, false); err != nil {
+			if err := runEnterpriseWindowsEnumerateSingleCycle(ctx, stderr, manifestPath, true); err != nil {
 				if !isEnterpriseWindowsEnumerateConfigMissing(err) {
 					fmt.Fprintf(stderr, "[hook-enumerator] cycle failed: %v\n", err)
 				}

--- a/internal/cli/enterprise_windows_enumerate_windows_test.go
+++ b/internal/cli/enterprise_windows_enumerate_windows_test.go
@@ -42,9 +42,20 @@ func TestNewEnterpriseWindowsEnumerateCommandRegistersFlags(t *testing.T) {
 			t.Fatalf("flag %q not registered", name)
 		}
 	}
-	if !strings.Contains(cmd.Long, "service never rewrites targets.yaml") ||
-		!strings.Contains(cmd.Long, "administrator-run Repair or Upgrade") {
-		t.Fatalf("command documentation does not describe the finite-profile audit boundary:\n%s", cmd.Long)
+	// Normalize whitespace before matching. The raw `cmd.Long` block
+	// wraps at column ~80 with two-space indent, so any assertion
+	// phrase that spans a wrap point (e.g. "omitted from the
+	// manifest" reflows as "omitted from the\n    manifest") would
+	// spuriously fail a byte-level `strings.Contains`. Collapsing
+	// every run of whitespace to a single space lets the assertions
+	// focus on semantic content rather than the reflow shape, and
+	// stays robust when the surrounding paragraph is edited.
+	long := strings.Join(strings.Fields(cmd.Long), " ")
+	if !strings.Contains(long, "publishes an updated targets.yaml") ||
+		!strings.Contains(long, "auto-authorizing") ||
+		!strings.Contains(long, "omitted from the manifest without failing the cycle") ||
+		!strings.Contains(long, "macOS parity") {
+		t.Fatalf("command documentation does not describe the macOS-parity auto-authorize posture:\n%s", cmd.Long)
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -199,6 +199,19 @@ func rootPersistentPreRunNoAuditE(cmd *cobra.Command, _ []string) error {
 	if versionJSON {
 		return nil
 	}
+	// Skip the daemon bootstrap (PID registration + config load) for
+	// lifecycle utilities that operate on operator-supplied paths and
+	// do not touch DefenseClaw state. These subcommands must run on
+	// hosts where the daemon has NOT been installed yet — most
+	// importantly `enterprise hooks scrub` invoked from macOS
+	// uninstall.sh's --purge path against a host with no v8
+	// config.yaml. Mirrors the same exemption in
+	// rootPersistentPreRunE above; the two initializers must agree on
+	// the annotation contract or scrub regresses whenever it's routed
+	// through the no-audit variant.
+	if cmd != nil && cmd.Annotations["defenseclaw.skip-daemon-bootstrap"] == "true" {
+		return nil
+	}
 	if err := daemon.RegisterCurrentProcess(); err != nil {
 		return err
 	}

--- a/internal/enterprisehooks/agent_version_other.go
+++ b/internal/enterprisehooks/agent_version_other.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+// The Windows per-connector agent-version probe
+// (`discoverWindowsAgentVersion`, `windowsAgentVersionExplain`) is
+// defined in `agent_version_windows.go` under a `//go:build windows`
+// tag and is only referenced by the equally-Windows-tagged
+// `enumerator_windows.go`. There is no non-Windows caller of those
+// symbols and therefore no stub is needed here — `golangci-lint`'s
+// `unused` analyzer flagged the prior stubs (returning empty
+// unconditionally) as dead code across the non-Windows build. This
+// file is intentionally empty apart from the package clause so the
+// file layout mirrors the Windows sibling without smuggling dead
+// symbols into the darwin / linux build.
+
+package enterprisehooks

--- a/internal/enterprisehooks/agent_version_windows.go
+++ b/internal/enterprisehooks/agent_version_windows.go
@@ -1,0 +1,293 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package enterprisehooks
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/defenseclaw/defenseclaw/internal/winpath"
+)
+
+// windowsAgentVersionMaxBytes caps how many bytes any single
+// version-probe read is allowed to consume. package.json files for
+// modern npm-installed CLIs sit around 1–4 KiB; the ceiling exists
+// so a hostile user profile cannot induce the enumerator (running as
+// LocalSystem) to slurp an arbitrarily large blob just by dropping a
+// giant file at the probed path. Kept well above realistic sizes so
+// a legitimate agent update never trips it.
+const windowsAgentVersionMaxBytes = 64 * 1024
+
+// windowsAgentPackageJSON is the shape we care about — just the
+// `version` field. json.Decoder.DisallowUnknownFields is NOT used
+// because npm CLIs ship dozens of other fields; we ignore them.
+type windowsAgentPackageJSON struct {
+	Version string `json:"version"`
+}
+
+// discoverWindowsAgentVersion returns a per-user agent version for
+// `connectorName` under the target's home directory `profileHome`,
+// or an empty string if:
+//   - the connector is not one this probe knows about,
+//   - the CLI is not installed under any known path in this
+//     profile,
+//   - the version metadata file exists but is unreadable, exceeds
+//     the bounded size, or fails JSON parse,
+//   - any ancestor of the probed path is a reparse point (Windows
+//     junction / mount point) — refused for the same reason
+//     `winpath.RejectReparseChain` is used elsewhere in the
+//     enumerator: a per-user reparse chain could redirect a read
+//     into a system directory and let a user profile influence
+//     what the LocalSystem enumerator ingests.
+//
+// The macOS analogue is `discover_agent_version` in
+// `packaging/macos/lib/installer_lib.sh`, which returns empty for
+// the same reasons. The enumerator caller drops any user × connector
+// with empty discovery — mirroring macOS's silently-skip behaviour.
+//
+// No process is ever spawned; all reads are static filesystem
+// inspection of well-known JSON manifests. This keeps the probe
+// safe to run as LocalSystem against a hostile user profile — we do
+// not execute the discovered binary or ask it to introspect itself.
+func discoverWindowsAgentVersion(profileHome, connectorName string) string {
+	profileHome = strings.TrimSpace(profileHome)
+	connectorName = strings.ToLower(strings.TrimSpace(connectorName))
+	if profileHome == "" || connectorName == "" {
+		return ""
+	}
+	if !filepath.IsAbs(profileHome) {
+		return ""
+	}
+	cleanHome := filepath.Clean(profileHome)
+
+	candidates := windowsAgentVersionCandidatePaths(cleanHome, connectorName)
+	for _, candidate := range candidates {
+		version, ok := readWindowsAgentVersionCandidate(candidate)
+		if ok {
+			return version
+		}
+	}
+	return ""
+}
+
+// windowsAgentVersionCandidatePaths returns the ordered set of
+// package.json paths to try for `connectorName` under
+// `profileHome`. The order matters: probes higher in the list are
+// preferred. Each connector's candidate set covers the install
+// flavours we've observed on real Windows QA hosts:
+//
+//   - `claudecode`: npm-global install under
+//     `%APPDATA%\npm\node_modules\@anthropic-ai\claude-code\`.
+//     `%APPDATA%` on Windows resolves to
+//     `%USERPROFILE%\AppData\Roaming` — the enumerator receives
+//     the profile's home directory so we build the Roaming path
+//     directly.
+//   - `codex`: npm-global install under
+//     `%APPDATA%\npm\node_modules\@openai\codex\`. The MSIX-store
+//     flavour (`C:\Program Files\WindowsApps\OpenAI.Codex_…\`)
+//     lives OUTSIDE the profile and is machine-scoped; probing it
+//     is a follow-up that requires a separate lookup path. For
+//     now we return empty for MSIX-only installs so the
+//     enumerator drops the row (parity with macOS's behaviour when
+//     the codex CLI is absent).
+//   - `cursor`: Cursor Desktop's per-user install at
+//     `%LOCALAPPDATA%\Programs\cursor\resources\app\package.json`.
+//     `%LOCALAPPDATA%` = `%USERPROFILE%\AppData\Local`.
+//
+// Every candidate is a fully-cleaned absolute path anchored inside
+// `profileHome`. Callers never see relative paths, symlinks, or
+// user-supplied path fragments.
+func windowsAgentVersionCandidatePaths(profileHome, connectorName string) []string {
+	appDataRoaming := filepath.Join(profileHome, "AppData", "Roaming")
+	appDataLocal := filepath.Join(profileHome, "AppData", "Local")
+	switch connectorName {
+	case "claudecode":
+		return []string{
+			filepath.Join(appDataRoaming, "npm", "node_modules", "@anthropic-ai", "claude-code", "package.json"),
+		}
+	case "codex":
+		return []string{
+			filepath.Join(appDataRoaming, "npm", "node_modules", "@openai", "codex", "package.json"),
+		}
+	case "cursor":
+		return []string{
+			filepath.Join(appDataLocal, "Programs", "cursor", "resources", "app", "package.json"),
+		}
+	default:
+		return nil
+	}
+}
+
+// readBoundedWindowsAgentPackageJSON opens `candidate`, applies the
+// trust checks (reparse-chain rejection, regular-file check), and
+// returns at most `windowsAgentVersionMaxBytes` bytes. Any of these
+// conditions returns a non-nil error and empty payload:
+//
+//   - `candidate` is empty or its ancestor chain crosses a Windows
+//     junction / symlink (per `winpath.RejectReparseChain`);
+//   - the target is a symlink / non-regular file;
+//   - `os.Open` fails;
+//   - `io.ReadAll` on an `io.LimitReader(f, max+1)` returns more
+//     than `windowsAgentVersionMaxBytes` bytes — i.e. the on-disk
+//     file grew past the ceiling between check and read.
+//
+// The +1-byte trick lets the caller distinguish "read exactly `max`
+// bytes and the file is at least that big" from "file is strictly
+// larger than `max`, we should reject" without ever allocating a
+// slice larger than `max + 1`. This closes the Lstat -> ReadFile
+// race a hostile profile owner could exploit to force the
+// LocalSystem enumerator to allocate an arbitrarily large buffer:
+// even if the file grew between checks, our read is capped.
+//
+// The old shape — `os.Lstat` (size check) then `os.ReadFile` (no
+// cap) — was flagged by CodeRabbit as a resource-exhaustion
+// vector. This helper is the fix.
+func readBoundedWindowsAgentPackageJSON(candidate string) ([]byte, error) {
+	if strings.TrimSpace(candidate) == "" {
+		return nil, errors.New("empty candidate path")
+	}
+	// Ancestor reparse-point rejection: refuses to open any path
+	// whose parent chain crosses a Windows junction or symbolic
+	// link. Mirrors the treatment applied to the enumerator's
+	// ProfileImagePath reads (see enumerator_windows.go).
+	if err := winpath.RejectReparseChain(candidate); err != nil {
+		return nil, err
+	}
+	// Lstat is retained as a fast-path for the leaf shape check
+	// (symlink / non-regular files bypass reading entirely). The
+	// authoritative size check runs on the opened handle below.
+	if info, err := os.Lstat(candidate); err != nil {
+		return nil, err
+	} else if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("candidate is not a regular file: mode=%s", info.Mode())
+	}
+	f, err := os.Open(candidate)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, windowsAgentVersionMaxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > windowsAgentVersionMaxBytes {
+		return nil, fmt.Errorf("candidate exceeds bounded size %d", windowsAgentVersionMaxBytes)
+	}
+	return data, nil
+}
+
+// readWindowsAgentVersionCandidate applies the trust checks and
+// bounded read to one candidate path. Returns the version string
+// and `true` iff the file exists, its ancestor chain contains no
+// reparse points, its size fits under `windowsAgentVersionMaxBytes`,
+// and its `version` field parses as a non-empty string.
+//
+// Every failure returns `"", false` without logging or wrapping —
+// the enumerator loops over candidates and treats a false return as
+// "try the next one." Silent-drop is the intended shape here; the
+// audit trail lives at the enumerator's `[hook-enumerator] audit
+// complete` summary line, which reports how many `(SID, Connector)`
+// rows were emitted vs skipped.
+func readWindowsAgentVersionCandidate(candidate string) (string, bool) {
+	data, err := readBoundedWindowsAgentPackageJSON(candidate)
+	if err != nil {
+		return "", false
+	}
+	var parsed windowsAgentPackageJSON
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return "", false
+	}
+	version := strings.TrimSpace(parsed.Version)
+	if version == "" {
+		return "", false
+	}
+	return version, true
+}
+
+// windowsAgentVersionExplain is a diagnostic wrapper used by the
+// enumerator when it wants an operator-facing reason for why a row
+// was skipped, without changing the primary silent-drop contract of
+// discoverWindowsAgentVersion. Returns a short human-readable
+// phrase plus the same "" / version signal. Never leaks path
+// contents into the reason string beyond the connector name.
+func windowsAgentVersionExplain(profileHome, connectorName string) (string, string) {
+	profileHome = strings.TrimSpace(profileHome)
+	connectorName = strings.ToLower(strings.TrimSpace(connectorName))
+	if profileHome == "" {
+		return "", "profile home is empty"
+	}
+	if !filepath.IsAbs(profileHome) {
+		return "", "profile home is not absolute"
+	}
+	candidates := windowsAgentVersionCandidatePaths(filepath.Clean(profileHome), connectorName)
+	if len(candidates) == 0 {
+		return "", fmt.Sprintf("no probe defined for connector %q", connectorName)
+	}
+	var lastReason string
+	for _, candidate := range candidates {
+		data, err := readBoundedWindowsAgentPackageJSON(candidate)
+		if err != nil {
+			// Preserve the historical operator-facing reason
+			// strings where the caller distinguishes shapes; the
+			// bounded helper collapses reparse / regular-file /
+			// size errors into typed messages we can categorize
+			// here without leaking full paths.
+			if errors.Is(err, os.ErrNotExist) {
+				lastReason = fmt.Sprintf("no %s package.json under this profile", connectorName)
+				continue
+			}
+			msg := err.Error()
+			switch {
+			case strings.Contains(msg, "reparse"):
+				lastReason = "ancestor reparse chain refused"
+			case strings.Contains(msg, "regular file"):
+				lastReason = "candidate is not a regular file"
+			case strings.Contains(msg, "exceeds bounded size"):
+				lastReason = "candidate exceeds bounded size"
+			default:
+				// Path-free reason on purpose: os.PathError.Error()
+				// embeds the candidate absolute path, which the
+				// enumerator forwards to `logfSafely` unredacted.
+				// Formatting `err` with `%v` would leak that path
+				// to every operator tailing gateway.err.log
+				// (including any operator without filesystem
+				// visibility into that user profile). The
+				// categorized reasons above cover the common
+				// diagnostic shapes; anything else is just
+				// "candidate read failed."
+				lastReason = "candidate read failed"
+			}
+			continue
+		}
+		var parsed windowsAgentPackageJSON
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			lastReason = "candidate is not valid JSON"
+			continue
+		}
+		version := strings.TrimSpace(parsed.Version)
+		if version == "" {
+			lastReason = "candidate has empty version field"
+			continue
+		}
+		return version, ""
+	}
+	if lastReason == "" {
+		lastReason = "no candidate matched"
+	}
+	return "", lastReason
+}

--- a/internal/enterprisehooks/agent_version_windows.go
+++ b/internal/enterprisehooks/agent_version_windows.go
@@ -261,9 +261,9 @@ func readWindowsAgentVersionCandidate(candidate string) (string, bool) {
 // enumerator's auto-authorization audit line, so a hostile user
 // profile that plants `version: "1.2.3\nFAKE audit line"` in an
 // otherwise plausible package.json could otherwise forge a
-// multi-line diagnostic. Reject any control character (including
-// embedded newlines) and enforce a small length ceiling; real
-// semvers with build metadata sit well under the cap.
+// multi-line diagnostic. Reject any control character (C0 0x00-0x1F,
+// DEL 0x7F, and C1 0x80-0x9F) and enforce a small length ceiling;
+// real semvers with build metadata sit well under the cap.
 func isValidWindowsAgentVersion(version string) bool {
 	if version == "" {
 		return false
@@ -272,13 +272,11 @@ func isValidWindowsAgentVersion(version string) bool {
 		return false
 	}
 	for _, r := range version {
-		if r == '\r' || r == '\n' || r == '\t' {
-			return false
-		}
-		// Broader control-character sweep: category Cc covers ASCII
-		// 0x00-0x1F / 0x7F and the C1 range, none of which appear in
-		// legitimate semver / build-metadata strings.
-		if r < 0x20 || r == 0x7f {
+		// C0 controls (0x00-0x1F), DEL (0x7F), and C1 controls
+		// (0x80-0x9F). None appear in legitimate semver strings and
+		// any of them can forge multi-line entries or terminal escape
+		// sequences in the auto-authorization audit line.
+		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
 			return false
 		}
 	}
@@ -346,8 +344,19 @@ func windowsAgentVersionExplain(profileHome, connectorName string) (string, stri
 			continue
 		}
 		version := strings.TrimSpace(parsed.Version)
-		if version == "" {
-			lastReason = "candidate has empty version field"
+		if !isValidWindowsAgentVersion(version) {
+			// Same guard as readWindowsAgentVersionCandidate: a
+			// user-controlled package.json can plant control
+			// characters or an oversized value in the version
+			// field; both must fail the probe so nothing hostile
+			// reaches the auto-authorization audit line in
+			// enumerator_windows.go. Report the shape without
+			// echoing the candidate value.
+			if version == "" {
+				lastReason = "candidate has empty version field"
+			} else {
+				lastReason = "candidate version failed validation"
+			}
 			continue
 		}
 		return version, ""

--- a/internal/enterprisehooks/agent_version_windows.go
+++ b/internal/enterprisehooks/agent_version_windows.go
@@ -85,48 +85,78 @@ func discoverWindowsAgentVersion(profileHome, connectorName string) string {
 	return ""
 }
 
+// windowsMachineScopedCursorPackageJSON points at Cursor's per-machine
+// install (MSI installer, admin-installed). Unlike the per-user candidates
+// this path is NOT derived from the profile home — every user on the box
+// sees the same version. Kept as a package-level variable so tests can
+// stub it to a hermetic `t.TempDir()` fixture instead of trying to write
+// to the real Program Files tree.
+var windowsMachineScopedCursorPackageJSON = `C:\Program Files\Cursor\resources\app\package.json`
+
 // windowsAgentVersionCandidatePaths returns the ordered set of
 // package.json paths to try for `connectorName` under
 // `profileHome`. The order matters: probes higher in the list are
-// preferred. Each connector's candidate set covers the install
-// flavours we've observed on real Windows QA hosts:
+// preferred (first match wins). Each connector's candidate set covers the
+// install flavours we've observed on real Windows QA hosts plus the
+// major package managers users install these CLIs through in practice —
+// a probe list too narrow becomes a silent-drop when the user installed
+// via a channel we didn't cover (real customer symptom on macOS drove
+// the presence-fallback in packaging/macos/lib/installer_lib.sh; the
+// probe broadening here is the Windows-side coverage improvement).
 //
-//   - `claudecode`: npm-global install under
-//     `%APPDATA%\npm\node_modules\@anthropic-ai\claude-code\`.
-//     `%APPDATA%` on Windows resolves to
-//     `%USERPROFILE%\AppData\Roaming` — the enumerator receives
-//     the profile's home directory so we build the Roaming path
-//     directly.
-//   - `codex`: npm-global install under
-//     `%APPDATA%\npm\node_modules\@openai\codex\`. The MSIX-store
-//     flavour (`C:\Program Files\WindowsApps\OpenAI.Codex_…\`)
-//     lives OUTSIDE the profile and is machine-scoped; probing it
-//     is a follow-up that requires a separate lookup path. For
-//     now we return empty for MSIX-only installs so the
-//     enumerator drops the row (parity with macOS's behaviour when
-//     the codex CLI is absent).
-//   - `cursor`: Cursor Desktop's per-user install at
-//     `%LOCALAPPDATA%\Programs\cursor\resources\app\package.json`.
-//     `%LOCALAPPDATA%` = `%USERPROFILE%\AppData\Local`.
+// Per-connector candidates:
 //
-// Every candidate is a fully-cleaned absolute path anchored inside
-// `profileHome`. Callers never see relative paths, symlinks, or
-// user-supplied path fragments.
+//   - `claudecode`:
+//     1. `%APPDATA%\npm\node_modules\@anthropic-ai\claude-code\package.json`
+//     — npm-global (the historical baseline).
+//     2. `%USERPROFILE%\.bun\install\global\node_modules\@anthropic-ai\claude-code\package.json`
+//     — Bun global install (`bun install -g @anthropic-ai/claude-code`).
+//     3. `%LOCALAPPDATA%\Yarn\Data\global\node_modules\@anthropic-ai\claude-code\package.json`
+//     — Yarn Classic global install (still common on legacy hosts).
+//
+//   - `codex`:
+//     1. `%APPDATA%\npm\node_modules\@openai\codex\package.json` — npm-global.
+//     2. `%USERPROFILE%\.bun\install\global\node_modules\@openai\codex\package.json`
+//     — Bun global.
+//     3. `%LOCALAPPDATA%\Yarn\Data\global\node_modules\@openai\codex\package.json`
+//     — Yarn Classic global.
+//     MSIX-store install (`C:\Program Files\WindowsApps\OpenAI.Codex_…\`) still
+//     requires a glob-resolved lookup and stays out of scope here; a follow-up
+//     probe can add it once the glob-vs-reparse-chain interaction is worked out.
+//
+//   - `cursor`:
+//     1. `%LOCALAPPDATA%\Programs\cursor\resources\app\package.json`
+//     — Cursor Desktop per-user install.
+//     2. `windowsMachineScopedCursorPackageJSON` — Cursor MSI machine-scoped
+//     install. Path is a package variable so tests can override; the
+//     production default is `C:\Program Files\Cursor\resources\app\package.json`.
+//
+// All per-user candidates are fully-cleaned absolute paths anchored inside
+// `profileHome`; the one machine-scoped candidate is anchored at a fixed
+// system root and reads the same package.json for every user (correct: it
+// documents the version of the shared install on the box).
 func windowsAgentVersionCandidatePaths(profileHome, connectorName string) []string {
 	appDataRoaming := filepath.Join(profileHome, "AppData", "Roaming")
 	appDataLocal := filepath.Join(profileHome, "AppData", "Local")
+	bunGlobal := filepath.Join(profileHome, ".bun", "install", "global", "node_modules")
+	yarnGlobal := filepath.Join(appDataLocal, "Yarn", "Data", "global", "node_modules")
 	switch connectorName {
 	case "claudecode":
 		return []string{
 			filepath.Join(appDataRoaming, "npm", "node_modules", "@anthropic-ai", "claude-code", "package.json"),
+			filepath.Join(bunGlobal, "@anthropic-ai", "claude-code", "package.json"),
+			filepath.Join(yarnGlobal, "@anthropic-ai", "claude-code", "package.json"),
 		}
 	case "codex":
 		return []string{
 			filepath.Join(appDataRoaming, "npm", "node_modules", "@openai", "codex", "package.json"),
+			filepath.Join(bunGlobal, "@openai", "codex", "package.json"),
+			filepath.Join(yarnGlobal, "@openai", "codex", "package.json"),
 		}
 	case "cursor":
 		return []string{
 			filepath.Join(appDataLocal, "Programs", "cursor", "resources", "app", "package.json"),
+			windowsMachineScopedCursorPackageJSON,
 		}
 	default:
 		return nil

--- a/internal/enterprisehooks/agent_version_windows.go
+++ b/internal/enterprisehooks/agent_version_windows.go
@@ -33,6 +33,13 @@ import (
 // a legitimate agent update never trips it.
 const windowsAgentVersionMaxBytes = 64 * 1024
 
+// windowsAgentVersionMaxRunes caps the length of the accepted
+// `version` string. Real semvers even with build metadata sit well
+// under 64 chars; the ceiling exists so a user-controlled
+// package.json cannot feed a multi-KB blob into the audit log the
+// enumerator emits when it auto-authorizes a `(SID, Connector)` row.
+const windowsAgentVersionMaxRunes = 128
+
 // windowsAgentPackageJSON is the shape we care about — just the
 // `version` field. json.Decoder.DisallowUnknownFields is NOT used
 // because npm CLIs ship dozens of other fields; we ignore them.
@@ -243,10 +250,39 @@ func readWindowsAgentVersionCandidate(candidate string) (string, bool) {
 		return "", false
 	}
 	version := strings.TrimSpace(parsed.Version)
-	if version == "" {
+	if !isValidWindowsAgentVersion(version) {
 		return "", false
 	}
 	return version, true
+}
+
+// isValidWindowsAgentVersion reports whether `version` is safe to
+// return from a `package.json` probe. The value flows into the
+// enumerator's auto-authorization audit line, so a hostile user
+// profile that plants `version: "1.2.3\nFAKE audit line"` in an
+// otherwise plausible package.json could otherwise forge a
+// multi-line diagnostic. Reject any control character (including
+// embedded newlines) and enforce a small length ceiling; real
+// semvers with build metadata sit well under the cap.
+func isValidWindowsAgentVersion(version string) bool {
+	if version == "" {
+		return false
+	}
+	if len(version) > windowsAgentVersionMaxRunes {
+		return false
+	}
+	for _, r := range version {
+		if r == '\r' || r == '\n' || r == '\t' {
+			return false
+		}
+		// Broader control-character sweep: category Cc covers ASCII
+		// 0x00-0x1F / 0x7F and the C1 range, none of which appear in
+		// legitimate semver / build-metadata strings.
+		if r < 0x20 || r == 0x7f {
+			return false
+		}
+	}
+	return true
 }
 
 // windowsAgentVersionExplain is a diagnostic wrapper used by the

--- a/internal/enterprisehooks/agent_version_windows_test.go
+++ b/internal/enterprisehooks/agent_version_windows_test.go
@@ -92,6 +92,97 @@ func TestDiscoverWindowsAgentVersionCursor(t *testing.T) {
 	}
 }
 
+// TestDiscoverWindowsAgentVersionClaudeCodeBunGlobal covers the
+// `bun install -g @anthropic-ai/claude-code` install flavour — the
+// probe now walks `%USERPROFILE%\.bun\install\global\node_modules\...`
+// in addition to the npm-global path.
+func TestDiscoverWindowsAgentVersionClaudeCodeBunGlobal(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".bun", "install", "global", "node_modules", "@anthropic-ai", "claude-code")
+	writeWindowsAgentPackageJSON(t, dir, "0.5.9")
+	got := discoverWindowsAgentVersion(home, "claudecode")
+	if got != "0.5.9" {
+		t.Fatalf("bun-global claudecode: got %q, want 0.5.9", got)
+	}
+}
+
+// TestDiscoverWindowsAgentVersionClaudeCodeYarnGlobal covers the
+// Yarn Classic global install still common on legacy hosts.
+func TestDiscoverWindowsAgentVersionClaudeCodeYarnGlobal(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Local", "Yarn", "Data", "global", "node_modules", "@anthropic-ai", "claude-code")
+	writeWindowsAgentPackageJSON(t, dir, "0.5.10")
+	got := discoverWindowsAgentVersion(home, "claudecode")
+	if got != "0.5.10" {
+		t.Fatalf("yarn-global claudecode: got %q, want 0.5.10", got)
+	}
+}
+
+// TestDiscoverWindowsAgentVersionCodexBunGlobal + YarnGlobal cover
+// the same alternative install channels for codex.
+func TestDiscoverWindowsAgentVersionCodexBunGlobal(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".bun", "install", "global", "node_modules", "@openai", "codex")
+	writeWindowsAgentPackageJSON(t, dir, "0.42.5")
+	got := discoverWindowsAgentVersion(home, "codex")
+	if got != "0.42.5" {
+		t.Fatalf("bun-global codex: got %q, want 0.42.5", got)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionCodexYarnGlobal(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Local", "Yarn", "Data", "global", "node_modules", "@openai", "codex")
+	writeWindowsAgentPackageJSON(t, dir, "0.42.7")
+	got := discoverWindowsAgentVersion(home, "codex")
+	if got != "0.42.7" {
+		t.Fatalf("yarn-global codex: got %q, want 0.42.7", got)
+	}
+}
+
+// TestDiscoverWindowsAgentVersionCursorMachineScoped covers the
+// Cursor MSI (machine-scoped) install. The probe path is a
+// package-level variable stubbed here to a temp fixture; production
+// default is `C:\Program Files\Cursor\resources\app\package.json`.
+func TestDiscoverWindowsAgentVersionCursorMachineScoped(t *testing.T) {
+	prev := windowsMachineScopedCursorPackageJSON
+	t.Cleanup(func() { windowsMachineScopedCursorPackageJSON = prev })
+
+	machineRoot := t.TempDir()
+	dir := filepath.Join(machineRoot, "Cursor", "resources", "app")
+	writeWindowsAgentPackageJSON(t, dir, "1.7.0")
+	windowsMachineScopedCursorPackageJSON = filepath.Join(dir, "package.json")
+
+	// Per-user profile is empty — no Programs\cursor install — so the
+	// probe must fall through to the machine-scoped candidate.
+	got := discoverWindowsAgentVersion(t.TempDir(), "cursor")
+	if got != "1.7.0" {
+		t.Fatalf("machine-scoped cursor: got %q, want 1.7.0", got)
+	}
+}
+
+// TestDiscoverWindowsAgentVersionOrderPrefersPerUserOverMachineScoped
+// pins the "first match wins" ordering: when both a per-user and a
+// machine-scoped install exist, the per-user version is reported.
+func TestDiscoverWindowsAgentVersionOrderPrefersPerUserOverMachineScoped(t *testing.T) {
+	prev := windowsMachineScopedCursorPackageJSON
+	t.Cleanup(func() { windowsMachineScopedCursorPackageJSON = prev })
+
+	home := t.TempDir()
+	perUserDir := filepath.Join(home, "AppData", "Local", "Programs", "cursor", "resources", "app")
+	writeWindowsAgentPackageJSON(t, perUserDir, "1.6.14")
+
+	machineRoot := t.TempDir()
+	machineDir := filepath.Join(machineRoot, "Cursor", "resources", "app")
+	writeWindowsAgentPackageJSON(t, machineDir, "1.7.0")
+	windowsMachineScopedCursorPackageJSON = filepath.Join(machineDir, "package.json")
+
+	got := discoverWindowsAgentVersion(home, "cursor")
+	if got != "1.6.14" {
+		t.Fatalf("per-user precedence: got %q, want 1.6.14 (per-user wins over machine 1.7.0)", got)
+	}
+}
+
 func TestDiscoverWindowsAgentVersionRejectsOversizedPackageJSON(t *testing.T) {
 	home := t.TempDir()
 	dir := filepath.Join(home, "AppData", "Roaming", "npm", "node_modules", "@openai", "codex")

--- a/internal/enterprisehooks/agent_version_windows_test.go
+++ b/internal/enterprisehooks/agent_version_windows_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package enterprisehooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeWindowsAgentPackageJSON drops a minimal package.json under
+// `dir` with the given version. Parent directories are created
+// with default (test-scoped) permissions.
+func writeWindowsAgentPackageJSON(t *testing.T, dir, version string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	body, err := json.Marshal(map[string]any{
+		"name":    "test-agent",
+		"version": version,
+	})
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), body, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionReturnsEmptyForUnknownConnector(t *testing.T) {
+	home := t.TempDir()
+	if got := discoverWindowsAgentVersion(home, "openclaw"); got != "" {
+		t.Fatalf("unknown connector: got %q, want empty", got)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionReturnsEmptyForRelativeHome(t *testing.T) {
+	if got := discoverWindowsAgentVersion(`AppData\Local`, "cursor"); got != "" {
+		t.Fatalf("relative home: got %q, want empty", got)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionReturnsEmptyWhenNoCLIInstalled(t *testing.T) {
+	home := t.TempDir()
+	for _, conn := range []string{"claudecode", "codex", "cursor"} {
+		if got := discoverWindowsAgentVersion(home, conn); got != "" {
+			t.Fatalf("connector %q on empty home: got %q, want empty (macOS parity)", conn, got)
+		}
+	}
+}
+
+func TestDiscoverWindowsAgentVersionClaudeCode(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Roaming", "npm", "node_modules", "@anthropic-ai", "claude-code")
+	writeWindowsAgentPackageJSON(t, dir, "0.2.3")
+	got := discoverWindowsAgentVersion(home, "claudecode")
+	if got != "0.2.3" {
+		t.Fatalf("claudecode discovery: got %q, want 0.2.3", got)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionCodex(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Roaming", "npm", "node_modules", "@openai", "codex")
+	writeWindowsAgentPackageJSON(t, dir, "0.42.0")
+	got := discoverWindowsAgentVersion(home, "codex")
+	if got != "0.42.0" {
+		t.Fatalf("codex discovery: got %q, want 0.42.0", got)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionCursor(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Local", "Programs", "cursor", "resources", "app")
+	writeWindowsAgentPackageJSON(t, dir, "1.6.14")
+	got := discoverWindowsAgentVersion(home, "cursor")
+	if got != "1.6.14" {
+		t.Fatalf("cursor discovery: got %q, want 1.6.14", got)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionRejectsOversizedPackageJSON(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Roaming", "npm", "node_modules", "@openai", "codex")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// One byte over the ceiling — guarantees the size check fires
+	// even if the ceiling constant is later widened.
+	oversize := make([]byte, windowsAgentVersionMaxBytes+1)
+	for i := range oversize {
+		oversize[i] = 'x'
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), oversize, 0o644); err != nil {
+		t.Fatalf("write oversize fixture: %v", err)
+	}
+	if got := discoverWindowsAgentVersion(home, "codex"); got != "" {
+		t.Fatalf("oversize package.json: got %q, want empty (drop)", got)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionRejectsMalformedJSON(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Local", "Programs", "cursor", "resources", "app")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{not-json"), 0o644); err != nil {
+		t.Fatalf("write malformed fixture: %v", err)
+	}
+	if got := discoverWindowsAgentVersion(home, "cursor"); got != "" {
+		t.Fatalf("malformed json: got %q, want empty (drop)", got)
+	}
+}
+
+func TestDiscoverWindowsAgentVersionRejectsEmptyVersionField(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Roaming", "npm", "node_modules", "@anthropic-ai", "claude-code")
+	writeWindowsAgentPackageJSON(t, dir, "  ") // whitespace-only version
+	if got := discoverWindowsAgentVersion(home, "claudecode"); got != "" {
+		t.Fatalf("whitespace-only version: got %q, want empty (drop)", got)
+	}
+}
+
+func TestWindowsAgentVersionExplainSurfacesReasons(t *testing.T) {
+	home := t.TempDir()
+	// Not installed → explain should report "no <connector>
+	// package.json under this profile".
+	version, reason := windowsAgentVersionExplain(home, "codex")
+	if version != "" {
+		t.Fatalf("explain unexpectedly returned version %q for empty home", version)
+	}
+	if !strings.Contains(reason, "codex") {
+		t.Fatalf("explain reason %q did not mention connector name", reason)
+	}
+
+	// Installed → explain returns the version and empty reason.
+	dir := filepath.Join(home, "AppData", "Roaming", "npm", "node_modules", "@openai", "codex")
+	writeWindowsAgentPackageJSON(t, dir, "0.42.0")
+	version, reason = windowsAgentVersionExplain(home, "codex")
+	if version != "0.42.0" {
+		t.Fatalf("explain version: got %q, want 0.42.0", version)
+	}
+	if reason != "" {
+		t.Fatalf("explain reason on success: got %q, want empty", reason)
+	}
+}

--- a/internal/enterprisehooks/agent_version_windows_test.go
+++ b/internal/enterprisehooks/agent_version_windows_test.go
@@ -226,6 +226,35 @@ func TestDiscoverWindowsAgentVersionRejectsEmptyVersionField(t *testing.T) {
 	}
 }
 
+// TestDiscoverWindowsAgentVersionRejectsControlCharsInVersion guards
+// the auto-authorization audit line against a user-controlled
+// package.json planting a multi-line "version" string that could
+// forge additional log entries. Embedded LF / CR / other control
+// characters must trip the version validator and cause a silent
+// drop.
+func TestDiscoverWindowsAgentVersionRejectsControlCharsInVersion(t *testing.T) {
+	cases := map[string]string{
+		"newline":       "1.2.3\nFAKE audit line",
+		"carriage":      "1.2.3\rFAKE",
+		"tab":           "1.2.3\tFAKE",
+		"null":          "1.2.3\x00FAKE",
+		"escape":        "1.2.3\x1b[31mFAKE",
+		"del":           "1.2.3\x7fFAKE",
+		"too-long":      strings.Repeat("9", windowsAgentVersionMaxRunes+1),
+		"empty-trimmed": "",
+	}
+	for name, version := range cases {
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			dir := filepath.Join(home, "AppData", "Roaming", "npm", "node_modules", "@anthropic-ai", "claude-code")
+			writeWindowsAgentPackageJSON(t, dir, version)
+			if got := discoverWindowsAgentVersion(home, "claudecode"); got != "" {
+				t.Fatalf("hostile version %q: got %q, want empty (drop)", version, got)
+			}
+		})
+	}
+}
+
 func TestWindowsAgentVersionExplainSurfacesReasons(t *testing.T) {
 	home := t.TempDir()
 	// Not installed → explain should report "no <connector>

--- a/internal/enterprisehooks/agent_version_windows_test.go
+++ b/internal/enterprisehooks/agent_version_windows_test.go
@@ -240,6 +240,8 @@ func TestDiscoverWindowsAgentVersionRejectsControlCharsInVersion(t *testing.T) {
 		"null":          "1.2.3\x00FAKE",
 		"escape":        "1.2.3\x1b[31mFAKE",
 		"del":           "1.2.3\x7fFAKE",
+		"c1-nel":        "1.2.3\u0085FAKE", // C1 NEL (Next Line) — Unicode-aware terminals treat this as a line break
+		"c1-csi":        "1.2.3\u009bFAKE", // C1 CSI — 8-bit terminal control sequence introducer
 		"too-long":      strings.Repeat("9", windowsAgentVersionMaxRunes+1),
 		"empty-trimmed": "",
 	}
@@ -276,5 +278,32 @@ func TestWindowsAgentVersionExplainSurfacesReasons(t *testing.T) {
 	}
 	if reason != "" {
 		t.Fatalf("explain reason on success: got %q, want empty", reason)
+	}
+}
+
+// TestWindowsAgentVersionExplainRejectsControlCharsInVersion locks in
+// that the operator-facing diagnostic path applies the same version
+// validator as the primary silent-drop probe. Without this, a
+// user-controlled package.json could inject a multi-line "version"
+// string into the reason field, which the enumerator eventually
+// forwards to the auto-authorization audit line.
+func TestWindowsAgentVersionExplainRejectsControlCharsInVersion(t *testing.T) {
+	cases := []string{
+		"1.2.3\nFAKE audit line",
+		"1.2.3\u0085FAKE", // C1 NEL
+		"1.2.3\u009bFAKE", // C1 CSI
+		"1.2.3\x7fFAKE",   // DEL
+	}
+	for _, hostile := range cases {
+		home := t.TempDir()
+		dir := filepath.Join(home, "AppData", "Roaming", "npm", "node_modules", "@openai", "codex")
+		writeWindowsAgentPackageJSON(t, dir, hostile)
+		version, reason := windowsAgentVersionExplain(home, "codex")
+		if version != "" {
+			t.Fatalf("explain hostile version %q: got %q, want empty", hostile, version)
+		}
+		if !strings.Contains(reason, "failed validation") && !strings.Contains(reason, "empty version") {
+			t.Fatalf("explain hostile version %q: reason %q did not surface a validation-failure diagnostic", hostile, reason)
+		}
 	}
 }

--- a/internal/enterprisehooks/enumeration_logger.go
+++ b/internal/enterprisehooks/enumeration_logger.go
@@ -1,0 +1,13 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package enterprisehooks
+
+// EnumerationLogger receives one line per user profile the enumerator dropped
+// or annotated, so an operator can debug WHY a specific user isn't getting
+// hooked. Matches the macOS `_enumerate_users_warn` shape. Nil is safe (drops
+// are silent).
+//
+// Kept in a cross-platform file so non-Windows stubs (e.g. the inventory-DACL
+// pass) can reference the type without duplicating a build-tagged declaration.
+type EnumerationLogger func(subject, reason string)

--- a/internal/enterprisehooks/enumerator_windows.go
+++ b/internal/enterprisehooks/enumerator_windows.go
@@ -63,12 +63,6 @@ var windowsHookConnectors = map[string]struct{}{
 	"cursor":     {},
 }
 
-// EnumerationLogger receives one line per user profile the enumerator
-// dropped or annotated, so an operator can debug WHY a specific user
-// isn't getting hooked. Matches the macOS `_enumerate_users_warn`
-// shape. Nil is safe (drops are silent).
-type EnumerationLogger func(subject, reason string)
-
 // EnumerateOptions controls a single enumeration cycle. All fields
 // are optional.
 type EnumerateOptions struct {

--- a/internal/enterprisehooks/enumerator_windows.go
+++ b/internal/enterprisehooks/enumerator_windows.go
@@ -211,7 +211,13 @@ func EnumerateWindows(ctx context.Context, cfg *config.Config, opts EnumerateOpt
 				Connector: conn,
 				DataDir:   dataDir,
 			}
-			applyPreviousRowState(&row, previous, opts.Logger)
+			if !applyPreviousRowState(&row, previous, opts.Logger) {
+				// New (SID, Connector) row with no discoverable per-user
+				// agent-version — dropped for macOS parity. The
+				// enumerator's audit-complete summary reflects the
+				// skip.
+				continue
+			}
 			targets = append(targets, row)
 		}
 	}
@@ -401,17 +407,42 @@ func loadPreviousManifestForEnumeration(path string, logf EnumerationLogger) map
 	return previous
 }
 
-// applyPreviousRowState copies AgentVersion + Enabled + Deferred from the
-// existing manifest into `row` if a match is found. If no match, it
-// leaves both fields at their zero values — Enabled stays nil (the
-// default-enabled behaviour), but since AgentVersion is empty the
-// row cannot be enabled (LoadManifest's requireAgentVersion check
-// runs on enabled rows). To keep new rows well-formed in that state
-// we explicitly disable them so LoadManifest's per-row validation
-// skips them, avoiding a load-time reject.
-func applyPreviousRowState(row *ManifestTarget, previous map[string]ManifestTarget, logf EnumerationLogger) {
+// applyPreviousRowState resolves `row`'s AgentVersion + Enabled +
+// Deferred + User/UID/GID for either a known-from-prior-manifest
+// (SID, Connector) pair or a newly-discovered one.
+//
+// Returns `true` when the row should be emitted, `false` when the
+// caller should drop it.
+//
+//   - Previously-known (SID, Connector): copy AgentVersion +
+//     Enabled + Deferred + User/UID/GID from the prior row and
+//     return true. Preserving the operator's prior Enabled
+//     decision means a disabled prior row stays disabled, and an
+//     enabled prior row stays enabled with its recorded
+//     AgentVersion.
+//   - Newly-discovered (SID, Connector): consult
+//     `discoverWindowsAgentVersion` to see whether this user's
+//     profile contains a supported per-user install of the
+//     connector's CLI.
+//   - If a version is discoverable: emit the row with
+//     `Enabled: true`, `Deferred: false`, `AgentVersion: <found>`.
+//     This is the auto-authorize path — parity with macOS
+//     render-targets.sh, which emits enabled rows for any
+//     (user × connector) whose CLI is present.
+//   - If no version is discoverable: return false. The caller
+//     drops the row entirely — parity with macOS, which never
+//     emits a row for a user whose CLI is not installed.
+//
+// The historical "emit disabled, wait for admin Repair" branch is
+// gone. Managed-enterprise deployments are admin-driven at the
+// policy layer (which connectors are pushed, which SID
+// membership), not the per-device authorization layer; the
+// enumerator's job is discovery. See
+// docs/WINDOWS-ENTERPRISE-THREAT-MODEL.md residual-risk section for
+// the new posture.
+func applyPreviousRowState(row *ManifestTarget, previous map[string]ManifestTarget, logf EnumerationLogger) bool {
 	if row == nil {
-		return
+		return false
 	}
 	key := previousManifestKey(row.SID, row.Connector)
 	if prev, ok := previous[key]; ok {
@@ -421,17 +452,35 @@ func applyPreviousRowState(row *ManifestTarget, previous map[string]ManifestTarg
 		row.User = prev.User
 		row.UID = prev.UID
 		row.GID = prev.GID
-		return
+		return true
 	}
-	// New (SID, Connector) row: keep AgentVersion empty and mark
-	// Enabled=false so LoadManifest's schema validation skips this
-	// target. An admin or UCB flow promotes it later by writing the
-	// AgentVersion + flipping Enabled=true. This preserves the
-	// security posture — a new user profile is DISCOVERED by the
-	// enumerator but does not auto-hook without operator intent.
-	disabled := false
-	row.Enabled = &disabled
-	logfSafely(logf, row.SID, fmt.Sprintf("newly-discovered (SID, %s) row emitted as disabled; admin must supply agent_version + enable", row.Connector))
+	version, reason := windowsAgentVersionExplain(row.UserHome, row.Connector)
+	if version == "" {
+		logfSafely(
+			logf,
+			row.SID,
+			fmt.Sprintf(
+				"newly-discovered (SID, %s) row skipped: %s",
+				row.Connector,
+				reason,
+			),
+		)
+		return false
+	}
+	enabled := true
+	row.AgentVersion = version
+	row.Enabled = &enabled
+	row.Deferred = false
+	logfSafely(
+		logf,
+		row.SID,
+		fmt.Sprintf(
+			"newly-discovered (SID, %s) row auto-authorized at version %s",
+			row.Connector,
+			version,
+		),
+	)
+	return true
 }
 
 func previousManifestKey(sid, connector string) string {

--- a/internal/enterprisehooks/enumerator_windows_test.go
+++ b/internal/enterprisehooks/enumerator_windows_test.go
@@ -512,11 +512,12 @@ func TestWriteTargetsManifestAtomicRejectsHardLinkedDestination(t *testing.T) {
 }
 
 // TestApplyPreviousRowStatePreservesAgentVersion asserts the
-// AgentVersion + Enabled + Deferred preservation invariant spec 005 REQ-08's
-// design says: a row that already exists in the file keeps its
-// agent_version + enabled state across enumeration cycles. A NEW
-// row starts with Enabled=false so LoadManifest's schema validation
-// skips it (avoiding a load-time reject on empty AgentVersion).
+// AgentVersion + Enabled + Deferred preservation invariant spec
+// 005 REQ-08's design says: a row that already exists in the file
+// keeps its agent_version + enabled state across enumeration
+// cycles. A NEW row is auto-authorized at the per-user CLI's
+// discovered version (macOS parity) — or dropped entirely if no
+// per-user CLI is present.
 func TestApplyPreviousRowStatePreservesAgentVersion(t *testing.T) {
 	enabled := true
 	previous := map[string]ManifestTarget{
@@ -534,7 +535,9 @@ func TestApplyPreviousRowStatePreservesAgentVersion(t *testing.T) {
 		SID:       "s-1-5-21-1000-2000-3000-1001", // deliberate case
 		Connector: "codex",
 	}
-	applyPreviousRowState(&matched, previous, nil)
+	if !applyPreviousRowState(&matched, previous, nil) {
+		t.Fatal("existing-row emission signal: want true, got false")
+	}
 	if matched.AgentVersion != "0.145.0" {
 		t.Fatalf("existing-row AgentVersion not preserved: got %q, want %q", matched.AgentVersion, "0.145.0")
 	}
@@ -544,18 +547,54 @@ func TestApplyPreviousRowStatePreservesAgentVersion(t *testing.T) {
 	if !matched.Deferred {
 		t.Fatal("existing-row Deferred=true not preserved")
 	}
+}
 
-	// No match: emit disabled with empty AgentVersion.
+// TestApplyPreviousRowStateAutoAuthorizesNewRowWithDiscoverableCLI
+// pins the macOS-parity auto-authorize path: a newly-discovered
+// (SID, Connector) whose per-user profile contains a supported CLI
+// (via the package.json probe added in the previous commit) is
+// emitted with Enabled=true, AgentVersion set to the discovered
+// value, and Deferred=false.
+func TestApplyPreviousRowStateAutoAuthorizesNewRowWithDiscoverableCLI(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "AppData", "Roaming", "npm", "node_modules", "@openai", "codex")
+	writeWindowsAgentPackageJSON(t, dir, "0.42.0")
+
 	fresh := ManifestTarget{
 		SID:       "S-1-5-21-9999-8888-7777-1001",
+		UserHome:  home,
+		Connector: "codex",
+	}
+	if !applyPreviousRowState(&fresh, nil, nil) {
+		t.Fatal("new row with discoverable CLI: emission signal want true, got false")
+	}
+	if fresh.AgentVersion != "0.42.0" {
+		t.Fatalf("new row AgentVersion: got %q, want 0.42.0", fresh.AgentVersion)
+	}
+	if fresh.Enabled == nil || !*fresh.Enabled {
+		t.Fatal("new row Enabled: want pointer-to-true")
+	}
+	if fresh.Deferred {
+		t.Fatal("new row Deferred: want false")
+	}
+}
+
+// TestApplyPreviousRowStateDropsNewRowWithoutDiscoverableCLI pins
+// the macOS-parity silent-skip: a newly-discovered (SID, Connector)
+// whose per-user profile has NO supported CLI is dropped entirely.
+// applyPreviousRowState returns false; the caller in EnumerateWindows
+// treats false as "skip this row" (no target emitted).
+func TestApplyPreviousRowStateDropsNewRowWithoutDiscoverableCLI(t *testing.T) {
+	home := t.TempDir()
+	// No package.json under home — every probe path is absent.
+
+	fresh := ManifestTarget{
+		SID:       "S-1-5-21-9999-8888-7777-1001",
+		UserHome:  home,
 		Connector: "claudecode",
 	}
-	applyPreviousRowState(&fresh, previous, nil)
-	if fresh.AgentVersion != "" {
-		t.Fatalf("fresh row: AgentVersion should be empty; got %q", fresh.AgentVersion)
-	}
-	if fresh.Enabled == nil || *fresh.Enabled {
-		t.Fatal("fresh row: Enabled should be pointer-to-false")
+	if applyPreviousRowState(&fresh, nil, nil) {
+		t.Fatal("new row without discoverable CLI: emission signal want false, got true (row would have been emitted)")
 	}
 }
 

--- a/internal/enterprisehooks/inventory_dacl_other.go
+++ b/internal/enterprisehooks/inventory_dacl_other.go
@@ -1,0 +1,14 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package enterprisehooks
+
+// GrantGatewayInventoryReadForManifest is a Windows-only no-op on other
+// platforms. macOS uses per-user launchd agents that inherit user permissions
+// naturally; Linux systemd-user runs likewise. Only the Windows service model
+// requires the gateway service SID to be added to the user profile DACLs.
+func GrantGatewayInventoryReadForManifest(_ Manifest, _ string, _ EnumerationLogger) error {
+	return nil
+}

--- a/internal/enterprisehooks/inventory_dacl_windows.go
+++ b/internal/enterprisehooks/inventory_dacl_windows.go
@@ -1,0 +1,304 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package enterprisehooks
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"unsafe"
+
+	"github.com/defenseclaw/defenseclaw/internal/winpath"
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+// inventoryDACLDotdirs enumerates the top-level user-profile subdirectories the
+// AI discovery scanner walks for skill, plugin, rule, and MCP-config signatures.
+// Kept in sync with the catalog under internal/inventory/ai_signatures.json —
+// this list covers the ancestor traversal that the scanner needs. Child ACEs
+// inherit from these parents via SUB_CONTAINERS_AND_OBJECTS_INHERIT so
+// per-file reads don't need a separate grant.
+var inventoryDACLDotdirs = []string{
+	".claude",
+	".codex",
+	".cursor",
+	".gemini",
+	".openhands",
+	".openclaw",
+	".hermes",
+	".windsurf",
+	".codeium",
+	".amp",
+	".opencode",
+	".agents",
+	".config",
+}
+
+// gatewayServiceNamePattern matches the certification-scoped gateway service
+// name. The scope suffix (10 lowercase hex chars) is generated at install time
+// and shared across CertGateway/CertGuardian/CertEnumerator/CertCMIDBroker.
+var gatewayServiceNamePattern = regexp.MustCompile(`^DefenseClawCertGateway_[a-f0-9]{10}$`)
+
+// productionGatewayServiceName is the un-scoped gateway service name used by
+// production installs (no cert suffix).
+const productionGatewayServiceName = "DefenseClawGateway"
+
+// GrantGatewayInventoryReadForManifest ensures the DefenseClaw CertGateway
+// service's virtual service account has Read+Execute+Traverse ACEs on the
+// inventory-relevant dotdirs under each enrolled user's profile. The gateway
+// runs under NT SERVICE\DefenseClawCertGateway_<scope>, a virtual service
+// account with no implicit access to user profiles; without this grant the AI
+// discovery scanner walks the right paths but ReadDir returns "access denied"
+// and every skill/plugin/rule/mcp_server signal is silently suppressed.
+//
+// Idempotent: SetEntriesInAcl merges by trustee, so repeated ticks with the
+// same ACE parameters land byte-identical DACLs. Dotdirs that don't exist yet
+// are skipped (the user may not have started that CLI yet); the next tick
+// re-tries. Per-directory errors are logged and do not abort the pass — one
+// user's misconfigured DACL should not block enrollment for the other users.
+//
+// If gatewayServiceName is empty, discovers it via SCM enumeration (matches
+// the cert-scoped or production naming). Returns an error only if the pass
+// cannot even begin (SCM unavailable, service SID resolution fails); per-path
+// failures are logged and swallowed.
+func GrantGatewayInventoryReadForManifest(manifest Manifest, gatewayServiceName string, logf EnumerationLogger) error {
+	name := strings.TrimSpace(gatewayServiceName)
+	if name == "" {
+		discovered, err := discoverGatewayServiceName()
+		if err != nil {
+			return fmt.Errorf("enterprise hooks: discover gateway service name: %w", err)
+		}
+		name = discovered
+	}
+	if !gatewayServiceNamePattern.MatchString(name) && name != productionGatewayServiceName {
+		return fmt.Errorf("enterprise hooks: refusing untrusted gateway service name %q", name)
+	}
+	account := `NT SERVICE\` + name
+	sid, _, _, err := windows.LookupSID("", account)
+	if err != nil {
+		return fmt.Errorf("enterprise hooks: resolve gateway service SID %q: %w", account, err)
+	}
+	if !sidIsNTServiceInventory(sid) {
+		return fmt.Errorf("enterprise hooks: gateway service account %q did not resolve to NT SERVICE authority", account)
+	}
+
+	granted, skipped, failed := 0, 0, 0
+	seenHome := map[string]struct{}{}
+	for _, target := range manifest.Targets {
+		home := filepath.Clean(strings.TrimSpace(target.UserHome))
+		if home == "" {
+			continue
+		}
+		key := strings.ToLower(home)
+		if _, dup := seenHome[key]; dup {
+			continue
+		}
+		seenHome[key] = struct{}{}
+		for _, dotdir := range inventoryDACLDotdirs {
+			path := filepath.Join(home, dotdir)
+			result, err := ensureInventoryReadACE(path, sid)
+			switch {
+			case err != nil:
+				failed++
+				logfSafely(logf, target.SID, fmt.Sprintf("inventory-DACL grant %s: %v", path, err))
+			case result == inventoryDACLGranted:
+				granted++
+			case result == inventoryDACLAlreadyPresent:
+				skipped++
+			}
+		}
+	}
+	logfSafely(logf, "", fmt.Sprintf("inventory-DACL pass gateway=%s granted=%d already_present=%d failed=%d", name, granted, skipped, failed))
+	return nil
+}
+
+type inventoryDACLResult int
+
+const (
+	inventoryDACLSkippedMissing inventoryDACLResult = iota
+	inventoryDACLGranted
+	inventoryDACLAlreadyPresent
+)
+
+// ensureInventoryReadACE adds an ACE granting Read+Execute+Traverse on `path`
+// to `sid`, inheriting to sub-containers and objects. If `path` doesn't exist
+// or isn't a directory, silently succeed — the user may not have started the
+// corresponding CLI yet; the next tick retries.
+func ensureInventoryReadACE(path string, sid *windows.SID) (inventoryDACLResult, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return inventoryDACLSkippedMissing, nil
+		}
+		return inventoryDACLSkippedMissing, fmt.Errorf("stat: %w", err)
+	}
+	if !fi.IsDir() {
+		return inventoryDACLSkippedMissing, nil
+	}
+	extended, err := winpath.Extended(path)
+	if err != nil {
+		return inventoryDACLSkippedMissing, fmt.Errorf("extend: %w", err)
+	}
+	sd, err := windows.GetNamedSecurityInfo(
+		extended,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		return inventoryDACLSkippedMissing, fmt.Errorf("get DACL: %w", err)
+	}
+	existing, _, err := sd.DACL()
+	if err != nil {
+		return inventoryDACLSkippedMissing, fmt.Errorf("inspect DACL: %w", err)
+	}
+	// Refuse to touch a directory that has no explicit DACL. `existing == nil`
+	// after a successful `sd.DACL()` means the descriptor carries a null DACL
+	// (everyone-allowed semantics, not a missing-info error). Passing that
+	// through `ACLFromEntries(entries, nil)` would build an ACL containing
+	// only our gateway grant and `SetNamedSecurityInfo` would replace the
+	// null DACL with a DACL granting exclusively the gateway service SID —
+	// silently stripping access from every other principal. Skip and surface
+	// the anomaly via the failed counter so an operator can investigate the
+	// unusual permission state.
+	if existing == nil {
+		return inventoryDACLSkippedMissing, fmt.Errorf("null DACL on %s; refusing to replace with sole gateway-service ACE", path)
+	}
+	if daclContainsInventoryReadACE(existing, sid) {
+		return inventoryDACLAlreadyPresent, nil
+	}
+	entry := windows.EXPLICIT_ACCESS{
+		AccessPermissions: windows.GENERIC_READ | windows.GENERIC_EXECUTE,
+		AccessMode:        windows.GRANT_ACCESS,
+		Inheritance:       windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  windows.TRUSTEE_IS_USER,
+			TrusteeValue: windows.TrusteeValueFromSID(sid),
+		},
+	}
+	merged, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{entry}, existing)
+	if err != nil {
+		return inventoryDACLSkippedMissing, fmt.Errorf("merge ACE: %w", err)
+	}
+	if err := windows.SetNamedSecurityInfo(
+		extended,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+		nil, nil, merged, nil,
+	); err != nil {
+		return inventoryDACLSkippedMissing, fmt.Errorf("set DACL: %w", err)
+	}
+	return inventoryDACLGranted, nil
+}
+
+// daclContainsInventoryReadACE reports whether `acl` already contains an
+// allow-access ACE granting `sid` at least Read+Execute with the same
+// inheritance semantics we would install. Used as an idempotency short-circuit
+// so repeat ticks skip the (get, merge, set) round-trip when the ACE is
+// already present in the exact shape we need.
+//
+// Inheritance requirements match the `SUB_CONTAINERS_AND_OBJECTS_INHERIT` flag
+// set we pass to `ACLFromEntries`: both OBJECT_INHERIT_ACE (files) and
+// CONTAINER_INHERIT_ACE (subdirs) must be present, and neither
+// NO_PROPAGATE_INHERIT_ACE nor INHERIT_ONLY_ACE may be set — an ACE that
+// grants the parent but does not propagate to children is NOT equivalent for
+// our purposes (the scanner reads files INSIDE the dotdirs, not the dotdir
+// itself), and an INHERIT_ONLY_ACE that doesn't apply to the parent leaves
+// the traversal grant absent. Rebuilding the ACL is preferable to leaving a
+// half-configured ACE in place.
+func daclContainsInventoryReadACE(acl *windows.ACL, sid *windows.SID) bool {
+	if acl == nil || sid == nil {
+		return false
+	}
+	const wantMask = uint32(windows.GENERIC_READ | windows.GENERIC_EXECUTE)
+	const requiredInherit = uint8(windows.OBJECT_INHERIT_ACE | windows.CONTAINER_INHERIT_ACE)
+	const forbiddenInherit = uint8(windows.NO_PROPAGATE_INHERIT_ACE | windows.INHERIT_ONLY_ACE)
+	for i := uint32(0); i < uint32(acl.AceCount); i++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(acl, i, &ace); err != nil || ace == nil {
+			continue
+		}
+		if ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE {
+			continue
+		}
+		aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+		if aceSID == nil || !windows.EqualSid(aceSID, sid) {
+			continue
+		}
+		if uint32(ace.Mask)&wantMask != wantMask {
+			continue
+		}
+		flags := ace.Header.AceFlags
+		if flags&requiredInherit != requiredInherit {
+			continue
+		}
+		if flags&forbiddenInherit != 0 {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// discoverGatewayServiceName looks up the DefenseClaw gateway service via the
+// Service Control Manager. Prefers a certification-scoped service if present;
+// falls back to the production name. Returns an error if neither is installed.
+func discoverGatewayServiceName() (string, error) {
+	manager, err := mgr.Connect()
+	if err != nil {
+		return "", fmt.Errorf("connect SCM: %w", err)
+	}
+	defer manager.Disconnect()
+	names, err := manager.ListServices()
+	if err != nil {
+		return "", fmt.Errorf("enumerate services: %w", err)
+	}
+	var certScoped string
+	for _, n := range names {
+		switch {
+		case gatewayServiceNamePattern.MatchString(n):
+			// Prefer the first certification-scoped match; the pattern
+			// contract enforces exactly one per install.
+			if certScoped == "" {
+				certScoped = n
+			}
+		case n == productionGatewayServiceName:
+			// Keep looking for a cert-scoped one; production is the fallback.
+		}
+	}
+	if certScoped != "" {
+		return certScoped, nil
+	}
+	for _, n := range names {
+		if n == productionGatewayServiceName {
+			return productionGatewayServiceName, nil
+		}
+	}
+	return "", errors.New("no DefenseClaw gateway service installed")
+}
+
+// sidIsNTServiceInventory validates that `sid` names an NT SERVICE virtual
+// account: SID authority is NT AUTHORITY (Value 5) with first sub-authority 80
+// (SECURITY_SERVICE_ID_BASE_RID). Deliberately duplicated from the equivalent
+// helper in internal/managed to avoid an enterprisehooks → managed import;
+// contract is byte-identical and covered by the shared trust-model comment.
+func sidIsNTServiceInventory(sid *windows.SID) bool {
+	if sid == nil || !sid.IsValid() {
+		return false
+	}
+	authority := sid.IdentifierAuthority()
+	if authority.Value != [6]byte{0, 0, 0, 0, 0, 5} {
+		return false
+	}
+	if sid.SubAuthorityCount() < 1 {
+		return false
+	}
+	return sid.SubAuthority(0) == 80
+}

--- a/internal/enterprisehooks/inventory_dacl_windows.go
+++ b/internal/enterprisehooks/inventory_dacl_windows.go
@@ -107,7 +107,12 @@ func GrantGatewayInventoryReadForManifest(manifest Manifest, gatewayServiceName 
 			switch {
 			case err != nil:
 				failed++
-				logfSafely(logf, target.SID, fmt.Sprintf("inventory-DACL grant %s: %v", path, err))
+				// Log only the dotdir identifier and a sanitized error
+				// category, never the absolute path (`C:\Users\<name>\.claude`)
+				// or the wrapped Windows error text — the CLI enumeration
+				// logger writes this verbatim to stderr and the target's SID
+				// is already captured as the log-line prefix.
+				logfSafely(logf, target.SID, fmt.Sprintf("inventory-DACL grant dotdir=%s: %s", dotdir, sanitizeInventoryDACLError(err)))
 			case result == inventoryDACLGranted:
 				granted++
 			case result == inventoryDACLAlreadyPresent:
@@ -245,6 +250,34 @@ func daclContainsInventoryReadACE(acl *windows.ACL, sid *windows.SID) bool {
 		return true
 	}
 	return false
+}
+
+// sanitizeInventoryDACLError maps `err` to a short category label
+// safe to write into the enumeration log line. The Windows syscall
+// errors wrapped inside `ensureInventoryReadACE` failures often
+// stringify with the offending path (e.g. `stat` -> `os.PathError`,
+// whose Error() includes the absolute `C:\Users\<name>\.claude` path
+// verbatim). Emitting a category instead of the wrapped message
+// preserves the diagnostic signal — "permission-denied" vs
+// "not-found" vs other — without leaking the user's profile
+// location to the stderr audit stream.
+func sanitizeInventoryDACLError(err error) string {
+	if err == nil {
+		return ""
+	}
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return "not-found"
+	case errors.Is(err, os.ErrPermission):
+		return "permission-denied"
+	case errors.Is(err, windows.ERROR_ACCESS_DENIED):
+		return "permission-denied"
+	case errors.Is(err, windows.ERROR_FILE_NOT_FOUND),
+		errors.Is(err, windows.ERROR_PATH_NOT_FOUND):
+		return "not-found"
+	default:
+		return "other"
+	}
 }
 
 // discoverGatewayServiceName looks up the DefenseClaw gateway service via the

--- a/internal/gateway/ai_discovery_observability_v8.go
+++ b/internal/gateway/ai_discovery_observability_v8.go
@@ -5,7 +5,9 @@ package gateway
 
 import (
 	"context"
+	"fmt"
 	"math"
+	"os"
 	"strings"
 	"time"
 
@@ -319,7 +321,75 @@ func (adapter *aiDiscoveryV8Adapter) emitSignalLog(
 			return observability.Record{}, &sidecarObservabilityError{code: sidecarObservabilityBuildFailed}
 		}
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	// Human-readable info line for operators tailing gateway.err.log (macOS) /
+	// gateway.log (Windows). Format matches the historical macOS convention:
+	//   [ai_discovery:<category>] <state> <name> confidence=<0.NN>
+	// One line per successfully-emitted signal (delta on all modes; also
+	// `seen` on managed_enterprise where the caller ships snapshots every
+	// cadence). Runs AFTER Emit so a runtime failure never claims an
+	// emission that didn't reach the observability pipeline.
+	//
+	// displayName runs through aiDiscoverySanitizeLogValue at the log
+	// boundary: signal.Product / .Name / .SignalID can be operator-authored
+	// or catalog-driven; embedded CR/LF would inject synthetic log records,
+	// and an unbounded length could produce multi-KB lines. Trim +
+	// strip-controls + length cap defuse both.
+	displayName := aiDiscoverySanitizeLogValue(signal.Product)
+	if displayName == "" {
+		displayName = aiDiscoverySanitizeLogValue(signal.Name)
+	}
+	if displayName == "" {
+		displayName = aiDiscoverySanitizeLogValue(signal.SignalID)
+	}
+	if displayName == "" {
+		displayName = "(unnamed)"
+	}
+	category := aiDiscoverySanitizeLogValue(signal.Category)
+	state := aiDiscoverySanitizeLogValue(string(signal.State))
+	fmt.Fprintf(
+		os.Stderr,
+		"[ai_discovery:%s] %s %s confidence=%.2f\n",
+		category,
+		state,
+		displayName,
+		aiDiscoveryV8Clamp(signal.Confidence),
+	)
+	return nil
+}
+
+// aiDiscoverySanitizeLogValue prepares a signal field for single-line stderr
+// output: it trims surrounding whitespace, drops embedded control characters
+// (defends against log-record injection via CR/LF/NUL in an operator-authored
+// Product or Name), and caps the length so a hostile or misconfigured signal
+// cannot inflate the info-log line to multi-KB. Returns "" for values that are
+// empty after normalization so the caller can fall through its priority chain
+// (Product -> Name -> SignalID -> "(unnamed)").
+func aiDiscoverySanitizeLogValue(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(trimmed))
+	for _, r := range trimmed {
+		if r < 0x20 || r == 0x7f {
+			// Collapse any C0 control (incl. CR/LF/TAB/NUL) plus DEL to a
+			// single ASCII space so the token stays readable but cannot
+			// terminate the log line early.
+			b.WriteByte(' ')
+			continue
+		}
+		b.WriteRune(r)
+	}
+	out := strings.TrimSpace(b.String())
+	const aiDiscoveryLogValueMaxLen = 128
+	if len(out) > aiDiscoveryLogValueMaxLen {
+		out = out[:aiDiscoveryLogValueMaxLen] + "…"
+	}
+	return out
 }
 
 func (adapter *aiDiscoveryV8Adapter) emitComponentConfidenceLog(

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -2317,6 +2317,18 @@ func (s *Sidecar) newManagedInspector(ctx context.Context, siteLabel string) Ins
 // operators see the new signal without waiting out the cooldown).
 const cmidBuildLogCooldown = 30 * time.Second
 
+// cmidProviderTokenCacheTTL is the in-memory cache window applied to
+// the singleton cloudreg.Provider returned from ensureCMIDProvider.
+// The underlying provider makes a fresh IPC round-trip on every
+// Token() call (Windows named-pipe RPC, macOS private CMID daemon);
+// bearer tokens themselves live minutes to hours. Caching for 60s
+// cuts the IPC rate an order of magnitude on hot hook-decision paths
+// without holding a token past any realistic expiry. On a 401 the
+// consumer calls Invalidate(), which drops the cache immediately —
+// the TTL is a "reduce redundant refetches" bound, not a "risk
+// expiring tokens" bound.
+const cmidProviderTokenCacheTTL = 60 * time.Second
+
 // logCMIDBuildError emits a rate-limited operator-visible stderr line
 // describing why a CMID provider build or Refresh failed. Called from
 // every error branch in buildCMIDProvider and from the cached-Refresh-
@@ -2361,38 +2373,44 @@ func (s *Sidecar) logCMIDBuildLane(lane string) {
 // ensureCMIDProvider lazily constructs the managed cloud auth provider
 // on first use and caches it for the sidecar's lifetime.
 // Managed_enterprise only. Returns an error when the underlying
-// provider cannot Refresh (unsupported OS, no provider registered,
-// agent unavailable after the retry ladder). The error is surfaced so
-// the caller can take the fail-closed path.
+// provider cannot be constructed (unsupported OS, no provider
+// registered, agent unavailable after the retry ladder). The error is
+// surfaced so the caller can take the fail-closed path.
 //
-// T5.2 note (construction-time signal): every call to this helper —
-// cached or fresh — updates setInspectionAvailability with the latest
-// Refresh outcome. But this helper is ONLY reached from inspector
-// construction (newManagedInspector) and the boot guardrail; it does
-// NOT run on every inspection. Per-inspection availability is fed by
-// the CiscoDefenseClawInspectClient's availability observer (wired at
-// construction in newManagedInspector via bindAvailabilityObserver),
-// which fires on every Token() outcome. Together the two paths mean
-// /health reflects reality within one inspection latency of a lane
-// state change — construction-time signal picks up config reloads,
-// per-request signal picks up in-flight auth drops on a live cached
-// provider.
+// Callers today are (a) newManagedInspector at inspector construction
+// and (b) the managedaid ProviderResolver bound in
+// sidecar_observability_v8_bootstrap.go, which invokes this helper on
+// every managedaid.Adapter.Deliver batch. Because (b) is per-batch —
+// and, indirectly through the inspect lane's own re-entries, close to
+// per-hook-decision — this helper must be cheap on the cached path.
+// Historically it called Refresh() on every cached invocation to
+// probe availability; that turned into a fresh CMID-broker IPC
+// round-trip per Deliver on both macOS and Windows, defeating the
+// whole point of the process-wide bearer-token cache.
+//
+// New behavior: the cached path is a plain pointer return. Availability
+// is signaled through two orthogonal, already-wired channels:
+//   - the CiscoDefenseClawInspectClient availability observer fires on
+//     every Token() outcome (wired in newManagedInspector via
+//     bindAvailabilityObserver), so a broker outage flips the health
+//     signal within one hook decision;
+//   - managedaid delivery outcomes bubble transport / auth failures
+//     back through the dispatcher's classifyStatus / classifyTransport
+//     path, which the destination health surface already inspects.
+//
+// Config reload / boot still Refresh via buildCMIDProvider on the
+// first-construction branch below, so the boot-time availability
+// signal is unchanged.
+//
+// The returned provider is wrapped with cloudreg.WithTokenCache so
+// consumers that call Token() at a high cadence (inspect lane per
+// hook, managedaid per batch) reuse the last-issued bearer token
+// until either the TTL expires or a 401 → Invalidate() clears it.
 func (s *Sidecar) ensureCMIDProvider(ctx context.Context) (cloudreg.Provider, error) {
 	s.cmidProviderMu.Lock()
 	defer s.cmidProviderMu.Unlock()
 	if s.cmidProviderInst != nil {
-		// Refresh to check current availability. Keep the cached
-		// provider even on error — the provider's own Token()/
-		// Refresh() cycle handles per-call dlopen retries, so
-		// discarding the cache would just force a fresh cloudreg.New
-		// on the next hook without changing the outcome. Callers
-		// gate on the returned error, not the provider value.
-		err := s.cmidProviderInst.Refresh(ctx)
-		s.setInspectionAvailability(err)
-		if err != nil {
-			s.logCMIDBuildError("refresh-cached", err)
-		}
-		return s.cmidProviderInst, err
+		return s.cmidProviderInst, nil
 	}
 	prov, buildErr := s.buildCMIDProvider(ctx)
 	s.setInspectionAvailability(buildErr)
@@ -2405,8 +2423,15 @@ func (s *Sidecar) ensureCMIDProvider(ctx context.Context) (cloudreg.Provider, er
 	if prov == nil {
 		return nil, buildErr
 	}
-	s.cmidProviderInst = prov
-	return prov, buildErr
+	// Wrap once with the token cache before storing on the sidecar so
+	// every consumer that reaches for this provider observes the same
+	// cached bearer-token state. See cloudreg.WithTokenCache for the
+	// caching contract — notably that Invalidate() (called from the
+	// 401-retry path in doInspectHTTP and from managedaid.remint)
+	// drops the cache immediately, so a stale-token retry loop cannot
+	// form.
+	s.cmidProviderInst = cloudreg.WithTokenCache(prov, cmidProviderTokenCacheTTL)
+	return s.cmidProviderInst, buildErr
 }
 
 func (s *Sidecar) buildCMIDProvider(ctx context.Context) (cloudreg.Provider, error) {

--- a/internal/inventory/ai_discovery.go
+++ b/internal/inventory/ai_discovery.go
@@ -719,6 +719,31 @@ func normalizeAIDiscoveryOptions(opts AIDiscoveryOptions) AIDiscoveryOptions {
 	if opts.HomeDir == "" {
 		opts.HomeDir, _ = platformDiscoveryHomeDir()
 	}
+	// Windows service-context override. When no caller-supplied HomeDirs
+	// are set and the platform enumerator finds real interactive-user
+	// profiles (HKLM\...\ProfileList → S-1-5-21-... SIDs), prefer those
+	// over the current-user Known Folder — the sidecar runs as a service
+	// account whose ~ resolves to a virtual C:\Windows\ServiceProfiles
+	// path, so a bare-~ scan never sees any real .claude/.codex/.cursor
+	// directories. On non-Windows this returns nil (launchd/systemd-user
+	// already scope the process to the right $HOME). HomeDir is repointed
+	// at the first real profile so ScanRoots=["~"] still resolves to a
+	// meaningful root and downstream helpers that read opts.HomeDir keep
+	// working.
+	//
+	// Gated on ManagedEnterprise: only in managed installs (where the
+	// enterprise admin has consented to fleet-wide inventory of every
+	// enrolled user) do we cross the single-user → all-users boundary.
+	// Unmanaged / dev installs keep the historical single-user posture —
+	// the current process's own ~ is the only scan surface, so a
+	// developer running a local build does not silently start reading
+	// their coworkers' dotdirs on a shared workstation.
+	if opts.ManagedEnterprise && len(opts.HomeDirs) == 0 {
+		if platformHomes := platformDiscoveryHomeDirs(); len(platformHomes) > 0 {
+			opts.HomeDirs = platformHomes
+			opts.HomeDir = platformHomes[0]
+		}
+	}
 	// Dedupe HomeDirs and ensure HomeDir participates so single-user
 	// installs (unmanaged / dev) keep working without a config change.
 	// Order-preserving so detectors return signals in a stable order

--- a/internal/inventory/ai_discovery.go
+++ b/internal/inventory/ai_discovery.go
@@ -155,9 +155,15 @@ type AIDiscoveryOptions struct {
 	// HomeDir is kept for backward compatibility and continues to
 	// anchor "~" expansion in candidate paths.
 	HomeDirs []string
-	// ManagedEnterprise mirrors deployment_mode == managed_enterprise. It
-	// controls only the managed endpoint-inventory callback; canonical v8
-	// telemetry remains owned by the bound observability runtime.
+	// ManagedEnterprise mirrors deployment_mode == managed_enterprise at
+	// construction time. It is a static hint, not the live cadence gate:
+	// the sidecar can install/clear the managed endpoint-inventory callback
+	// on a running service across config reloads, so the fanoutReport gate
+	// keys on the live callback presence (see the SetManagedInventoryEmitHook
+	// contract) — the intra-cycle process tick is treated as a local refresh
+	// only whenever a managed callback is currently installed. Canonical v8
+	// scan-trace telemetry (StartScan / detector traces / End) remains owned
+	// by the bound observability runtime and fires on every tick.
 	ManagedEnterprise bool
 }
 
@@ -1086,7 +1092,7 @@ func (s *ContinuousDiscoveryService) runScanOnce(ctx context.Context, full bool,
 	s.lastErr = nil
 	s.mu.Unlock()
 
-	s.fanoutReport(ctx, report)
+	s.fanoutReport(ctx, report, full)
 	s.notifyReportObservers(ctx, report)
 	scanObservation.end(report)
 	return report, nil
@@ -1123,8 +1129,34 @@ func (s *ContinuousDiscoveryService) notifyReportObservers(ctx context.Context, 
 // path called ComputeComponentConfidence with its own
 // time.Now()). The snapshot is built lazily so default-config
 // installs (no OTel, redaction enabled) don't pay for a rollup
-// they'd discard.
-func (s *ContinuousDiscoveryService) fanoutReport(ctx context.Context, report AIDiscoveryReport) {
+// they'd discard. `full` mirrors the runScan tick kind so
+// managed_enterprise ships to AI Defense on the full-scan cadence
+// only, not on every process tick.
+func (s *ContinuousDiscoveryService) fanoutReport(ctx context.Context, report AIDiscoveryReport, full bool) {
+	// Read the live managed-mode signal once and reuse it for both
+	// the cadence gate and the hook fire below. Deployment mode can
+	// change without rebuilding this service (see the pre-existing
+	// contract at SetManagedInventoryEmitHook), so gating on
+	// construction-time s.opts.ManagedEnterprise would let the gate
+	// drift from the live mode after a config reload that swapped
+	// the hook without an aiRestart. Hook-presence is the same
+	// live-mode indicator the hook-fire path below uses.
+	s.managedInventoryEmitMu.RLock()
+	emit := s.managedInventoryEmit
+	s.managedInventoryEmitMu.RUnlock()
+	// managed_enterprise (live: hook installed) ships the endpoint
+	// inventory to AI Defense on the FULL-scan cadence
+	// (ScanIntervalMin) only. The intra-cycle process-only tick
+	// (ProcessIntervalSec) is a local refresh — the non-process
+	// detectors do not re-run on it, so replaying the
+	// carried-forward inventory + firing the connector/MCP hook
+	// every process tick would flood the AID event-ingest endpoint
+	// without adding new information. Non-managed mode (live: no
+	// hook installed) is unaffected; the observer emission is
+	// per-report by design for local telemetry sinks.
+	if !full && emit != nil {
+		return
+	}
 	observer := s.observabilityV8Snapshot()
 	v8On := observer != nil
 	// The generated v8 observer is the sole telemetry owner. Skip the rollup
@@ -1150,12 +1182,10 @@ func (s *ContinuousDiscoveryService) fanoutReport(ctx context.Context, report AI
 		}
 		_ = observer.EmitReport(ctx, reportForObservabilityV8(report), components)
 	}
-	// Hook installation is the live managed-mode gate. Deployment mode can
-	// change without rebuilding this service, so construction-time options
-	// must not suppress a callback installed by a later config generation.
-	s.managedInventoryEmitMu.RLock()
-	emit := s.managedInventoryEmit
-	s.managedInventoryEmitMu.RUnlock()
+	// emit is the same live managed-mode indicator snapshot read at
+	// the top of this function; reuse it so a concurrent
+	// SetManagedInventoryEmitHook can't cause the gate decision and
+	// the hook fire to disagree within one fanout.
 	if emit != nil {
 		emit(ctx)
 	}
@@ -3658,7 +3688,10 @@ func (s *ContinuousDiscoveryService) IngestExternalReport(ctx context.Context, r
 			enrichLocalModelProvenance(report.Signals[i].Model, modelProvenanceHints{})
 		}
 	}
-	s.fanoutReport(ctx, *report)
+	// External reports carry a complete inventory snapshot by contract
+	// (validated above), so treat the fanout as a full-scan cycle —
+	// managed_enterprise ships to AI Defense on this path as well.
+	s.fanoutReport(ctx, *report, true)
 	return nil
 }
 

--- a/internal/inventory/ai_discovery_managed_inventory_test.go
+++ b/internal/inventory/ai_discovery_managed_inventory_test.go
@@ -40,21 +40,152 @@ func TestManagedInventoryEmitHookTracksLiveModeTransitions(t *testing.T) {
 	var calls int
 	service := &ContinuousDiscoveryService{opts: AIDiscoveryOptions{ManagedEnterprise: false}}
 
-	service.fanoutReport(t.Context(), managedInventoryReport())
+	service.fanoutReport(t.Context(), managedInventoryReport(), true)
 	if calls != 0 {
 		t.Fatalf("unmanaged cadence calls=%d want=0", calls)
 	}
 
 	service.SetManagedInventoryEmitHook(func(context.Context) { calls++ })
-	service.fanoutReport(t.Context(), managedInventoryReport())
-	service.fanoutReport(t.Context(), managedInventoryReport())
+	service.fanoutReport(t.Context(), managedInventoryReport(), true)
+	service.fanoutReport(t.Context(), managedInventoryReport(), true)
 	if calls != 2 {
 		t.Fatalf("managed cadences after live install=%d want=2", calls)
 	}
 
 	service.SetManagedInventoryEmitHook(nil)
-	service.fanoutReport(t.Context(), managedInventoryReport())
+	service.fanoutReport(t.Context(), managedInventoryReport(), true)
 	if calls != 2 {
 		t.Fatalf("unmanaged cadence after live clear=%d want=2", calls)
 	}
+}
+
+// TestFanoutReport_ManagedSkipsNonFullTick pins the AI-Defense publish
+// cadence: in managed_enterprise the fanout — both the canonical v8
+// EmitReport (which carries the endpoint inventory to AI Defense) and
+// the connector/MCP inventory hook — runs on the FULL-scan cadence
+// only (ScanIntervalMin). The intra-cycle process-only tick
+// (ProcessIntervalSec) is a local refresh and must not re-publish.
+// Prior to this contract every process tick re-shipped the full
+// endpoint inventory, flooding the AID event-ingest endpoint at
+// ProcessIntervalSec cadence instead of ScanIntervalMin cadence.
+func TestFanoutReport_ManagedSkipsNonFullTick(t *testing.T) {
+	var hookCalls int
+	capture := &captureAIDiscoveryV8{}
+	service := &ContinuousDiscoveryService{opts: AIDiscoveryOptions{ManagedEnterprise: true}}
+	service.BindObservabilityV8(capture)
+	service.SetManagedInventoryEmitHook(func(context.Context) { hookCalls++ })
+
+	service.fanoutReport(t.Context(), managedInventoryReport(), false)
+
+	if hookCalls != 0 {
+		t.Fatalf("non-full tick in managed_enterprise must not fire the connector/MCP inventory hook, got %d calls", hookCalls)
+	}
+	if len(capture.reports) != 0 {
+		t.Fatalf("non-full tick in managed_enterprise must not publish an AI Defense report, got %d", len(capture.reports))
+	}
+
+	service.fanoutReport(t.Context(), managedInventoryReport(), true)
+	if hookCalls != 1 {
+		t.Fatalf("full tick in managed_enterprise must fire the hook exactly once, got %d", hookCalls)
+	}
+	if len(capture.reports) != 1 {
+		t.Fatalf("full tick in managed_enterprise must publish one report, got %d", len(capture.reports))
+	}
+}
+
+// TestFanoutReport_NonManagedIgnoresFullFlag pins that non-managed
+// mode (live: no managedInventoryEmit hook installed) publishes on
+// every tick regardless of full. The cadence gate must key on the
+// live hook presence — not on any construction-time hint — so a
+// service without a managed callback keeps feeding local v8 sinks on
+// the intra-cycle process tick.
+func TestFanoutReport_NonManagedIgnoresFullFlag(t *testing.T) {
+	for _, full := range []bool{true, false} {
+		full := full
+		t.Run(map[bool]string{true: "full", false: "process"}[full], func(t *testing.T) {
+			capture := &captureAIDiscoveryV8{}
+			service := &ContinuousDiscoveryService{opts: AIDiscoveryOptions{ManagedEnterprise: false}}
+			service.BindObservabilityV8(capture)
+			// No managed hook installed => live unmanaged. Both tick kinds
+			// must emit the v8 report to local sinks.
+			service.fanoutReport(t.Context(), managedInventoryReport(), full)
+			if len(capture.reports) != 1 {
+				t.Fatalf("non-managed (no hook) must emit v8 report for full=%v, got %d", full, len(capture.reports))
+			}
+		})
+	}
+}
+
+// TestFanoutReport_LiveTransitionsGateNonFullTick pins that the
+// fanoutReport cadence gate follows the live managed-mode signal
+// (hook presence), not the construction-time opts.ManagedEnterprise
+// hint. On unmanaged->managed the process tick begins to skip
+// immediately after SetManagedInventoryEmitHook is called; on
+// managed->unmanaged the process tick resumes emitting as soon as
+// the hook is cleared. Guards against drift when a config reload
+// swaps the hook without rebuilding the discovery service.
+func TestFanoutReport_LiveTransitionsGateNonFullTick(t *testing.T) {
+	t.Run("unmanaged_to_managed_live_install_skips_non_full_tick", func(t *testing.T) {
+		capture := &captureAIDiscoveryV8{}
+		var hookCalls int
+		// Construction-time opts flag is intentionally the OPPOSITE of
+		// the live-managed target below, to prove the gate does not key
+		// on it.
+		service := &ContinuousDiscoveryService{opts: AIDiscoveryOptions{ManagedEnterprise: false}}
+		service.BindObservabilityV8(capture)
+
+		// Baseline: no hook (live unmanaged). Process tick emits.
+		service.fanoutReport(t.Context(), managedInventoryReport(), false)
+		if len(capture.reports) != 1 {
+			t.Fatalf("baseline live-unmanaged process tick must emit v8 report, got %d", len(capture.reports))
+		}
+
+		// Live install: managed callback wired without a service
+		// rebuild. Subsequent process ticks must skip both v8 emission
+		// and the callback fire.
+		service.SetManagedInventoryEmitHook(func(context.Context) { hookCalls++ })
+		service.fanoutReport(t.Context(), managedInventoryReport(), false)
+		if len(capture.reports) != 1 {
+			t.Fatalf("after live managed install, process tick must skip v8 emission (still %d reports); got %d", 1, len(capture.reports))
+		}
+		if hookCalls != 0 {
+			t.Fatalf("after live managed install, process tick must skip hook fire, got %d calls", hookCalls)
+		}
+
+		// Full-scan tick after live install must both emit and fire.
+		service.fanoutReport(t.Context(), managedInventoryReport(), true)
+		if len(capture.reports) != 2 {
+			t.Fatalf("full tick after live managed install must emit v8 report, got %d", len(capture.reports))
+		}
+		if hookCalls != 1 {
+			t.Fatalf("full tick after live managed install must fire hook once, got %d", hookCalls)
+		}
+	})
+
+	t.Run("managed_to_unmanaged_live_clear_resumes_non_full_tick", func(t *testing.T) {
+		capture := &captureAIDiscoveryV8{}
+		var hookCalls int
+		// Construction-time opts flag is intentionally the OPPOSITE of
+		// the live-unmanaged target below.
+		service := &ContinuousDiscoveryService{opts: AIDiscoveryOptions{ManagedEnterprise: true}}
+		service.BindObservabilityV8(capture)
+		service.SetManagedInventoryEmitHook(func(context.Context) { hookCalls++ })
+
+		// Baseline: hook installed (live managed). Process tick skips.
+		service.fanoutReport(t.Context(), managedInventoryReport(), false)
+		if len(capture.reports) != 0 || hookCalls != 0 {
+			t.Fatalf("baseline live-managed process tick must skip: reports=%d hookCalls=%d", len(capture.reports), hookCalls)
+		}
+
+		// Live clear: hook removed without a service rebuild. Process
+		// ticks must resume emitting the v8 report; no hook to fire.
+		service.SetManagedInventoryEmitHook(nil)
+		service.fanoutReport(t.Context(), managedInventoryReport(), false)
+		if len(capture.reports) != 1 {
+			t.Fatalf("after live managed clear, process tick must resume v8 emission, got %d", len(capture.reports))
+		}
+		if hookCalls != 0 {
+			t.Fatalf("after live managed clear, hook must not fire, got %d calls", hookCalls)
+		}
+	})
 }

--- a/internal/inventory/ai_discovery_observability_v8_test.go
+++ b/internal/inventory/ai_discovery_observability_v8_test.go
@@ -152,7 +152,7 @@ func TestAIDiscoveryV8FanoutUsesOneRollupAndDoesNotResurrectLegacyAfterDetach(t 
 			"signal-1", "pypi", "openai", "1.0.0", "workspace-1", AIStateNew, "OpenAI SDK",
 		)},
 	}
-	service.fanoutReport(t.Context(), report)
+	service.fanoutReport(t.Context(), report, true)
 	if len(capture.reports) != 1 || len(capture.components) != 1 || len(capture.components[0]) != 1 {
 		t.Fatalf("reports=%d components=%v", len(capture.reports), capture.components)
 	}
@@ -163,7 +163,7 @@ func TestAIDiscoveryV8FanoutUsesOneRollupAndDoesNotResurrectLegacyAfterDetach(t 
 	}
 
 	service.BindObservabilityV8(nil)
-	service.fanoutReport(t.Context(), report)
+	service.fanoutReport(t.Context(), report, true)
 	if len(capture.reports) != 1 {
 		t.Fatalf("detached v8 fanout resurrected an emitter: reports=%d", len(capture.reports))
 	}
@@ -199,8 +199,8 @@ func TestAIDiscoveryV8ModelLifecycleUsesInstallationKeyedPseudonym(t *testing.T)
 	service.BindObservabilityV8(capture)
 
 	SetPathHashKey([]byte("installation-a"))
-	service.fanoutReport(t.Context(), report)
-	service.fanoutReport(t.Context(), report)
+	service.fanoutReport(t.Context(), report, true)
+	service.fanoutReport(t.Context(), report, true)
 	if len(capture.reports) != 2 || len(capture.reports[0].Signals) != 1 {
 		t.Fatalf("reports=%d first=%+v", len(capture.reports), capture.reports)
 	}
@@ -216,13 +216,13 @@ func TestAIDiscoveryV8ModelLifecycleUsesInstallationKeyedPseudonym(t *testing.T)
 	}
 
 	SetPathHashKey([]byte("installation-b"))
-	service.fanoutReport(t.Context(), report)
+	service.fanoutReport(t.Context(), report, true)
 	thirdID := capture.reports[2].Signals[0].SignalID
 	if thirdID == firstID {
 		t.Fatalf("different installation keys produced the same lifecycle id %q", thirdID)
 	}
 	SetPathHashKey(nil)
-	service.fanoutReport(t.Context(), report)
+	service.fanoutReport(t.Context(), report, true)
 	if unkeyedID := capture.reports[3].Signals[0].SignalID; unkeyedID != "" {
 		t.Fatalf("unkeyed model lifecycle correlation was not omitted: %q", unkeyedID)
 	}
@@ -266,7 +266,7 @@ func TestAIDiscoveryV8DroppedTraceAndReportStayOnCanonicalAdapter(t *testing.T) 
 	report := AIDiscoveryReport{Summary: AIDiscoverySummary{
 		ScanID: "scan-drop", Source: "scheduled", PrivacyMode: "enhanced", Result: "ok",
 	}}
-	service.fanoutReport(ctx, report)
+	service.fanoutReport(ctx, report, true)
 	observation.end(report)
 	observation.abort()
 

--- a/internal/inventory/ai_discovery_platform_nonwindows.go
+++ b/internal/inventory/ai_discovery_platform_nonwindows.go
@@ -16,6 +16,16 @@ func platformDiscoveryHomeDir() (string, error) {
 	return os.UserHomeDir()
 }
 
+// platformDiscoveryHomeDirs enumerates additional user profile roots the scan
+// should walk. On macOS/Linux the process user's `$HOME` already resolves to
+// the right place (launchd agents run per-user; systemd/systemd-user likewise),
+// so this returns nil and the single HomeDir path drives the scan. The Windows
+// override enumerates HKLM\...\ProfileList so a service-context scan sees each
+// real interactive user's home rather than its own virtual ServiceProfiles dir.
+func platformDiscoveryHomeDirs() []string {
+	return nil
+}
+
 func platformDiscoveryVariable(name, _ string) (string, bool) {
 	return os.LookupEnv(name)
 }

--- a/internal/inventory/ai_discovery_platform_windows.go
+++ b/internal/inventory/ai_discovery_platform_windows.go
@@ -52,6 +52,90 @@ func platformDiscoveryHomeDir() (string, error) {
 	return filepath.Clean(path), nil
 }
 
+// profileListRegistryKey is HKLM's inventory of resolved user profile
+// directories, keyed by SID. It's the same authority the enterprise-hook
+// enumerator uses to discover interactive users; reusing it keeps discovery
+// scanning aligned with the hook-lifecycle enrollment surface without pulling
+// in the enterprisehooks package.
+const profileListRegistryKey = `SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList`
+
+// platformDiscoveryHomeDirs enumerates interactive-user profile roots by
+// walking HKLM\...\ProfileList. The gateway sidecar runs as a service (its
+// current-user Known Folder resolves to a per-service virtual profile under
+// C:\Windows\ServiceProfiles\), so a bare ~/... expansion never sees any real
+// user's .claude/.codex/.cursor directories. Feeding this list into
+// AIDiscoveryOptions.HomeDirs makes homesToScan() enumerate real profiles.
+//
+// Filter: only S-1-5-21-... SIDs (local-account or domain-account interactive
+// users, 5+ sub-authorities), matching the same coarse gate the hook
+// enumerator applies at internal/enterprisehooks/enumerator_windows.go. Stale
+// ProfileList entries whose ProfileImagePath no longer exists are skipped so
+// the scan does not waste ticks on ghost profiles.
+func platformDiscoveryHomeDirs() []string {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, profileListRegistryKey, registry.READ)
+	if err != nil {
+		return nil
+	}
+	defer key.Close()
+	names, err := key.ReadSubKeyNames(-1)
+	if err != nil {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(names))
+	out := make([]string, 0, len(names))
+	for _, sid := range names {
+		if !isInteractiveUserSID(sid) {
+			continue
+		}
+		subKey, err := registry.OpenKey(
+			registry.LOCAL_MACHINE,
+			profileListRegistryKey+`\`+sid,
+			registry.QUERY_VALUE,
+		)
+		if err != nil {
+			continue
+		}
+		raw, _, err := subKey.GetStringValue("ProfileImagePath")
+		_ = subKey.Close()
+		if err != nil {
+			continue
+		}
+		expanded, expandErr := registry.ExpandString(raw)
+		if expandErr != nil {
+			expanded = raw
+		}
+		expanded = filepath.Clean(strings.TrimSpace(expanded))
+		if expanded == "" {
+			continue
+		}
+		if fi, err := os.Stat(expanded); err != nil || !fi.IsDir() {
+			continue
+		}
+		lower := strings.ToLower(expanded)
+		if _, ok := seen[lower]; ok {
+			continue
+		}
+		seen[lower] = struct{}{}
+		out = append(out, expanded)
+	}
+	return out
+}
+
+// isInteractiveUserSID reports whether sid names a local or domain user
+// account whose profile hosts real per-user configuration. Matches the
+// coarse gate the enterprise-hook enumerator uses (S-1-5-21-... with 5+
+// sub-authorities); virtual service accounts (S-1-5-80-...), well-known
+// principals (S-1-5-18 LocalSystem, S-1-5-19/20), and machine SIDs never
+// carry AI-agent config directories worth scanning.
+func isInteractiveUserSID(sid string) bool {
+	if !strings.HasPrefix(sid, "S-1-5-21-") {
+		return false
+	}
+	// S-1-5-21-<domain-3-tuple>-<RID> → at least 5 sub-authorities after
+	// the S-1-5- prefix. Splitting on '-' produces >=8 pieces.
+	return len(strings.Split(sid, "-")) >= 8
+}
+
 func platformDiscoveryVariable(name, home string) (string, bool) {
 	var folderID *windows.KNOWNFOLDERID
 	switch strings.ToUpper(strings.TrimSpace(name)) {

--- a/internal/inventory/ai_discovery_platform_windows.go
+++ b/internal/inventory/ai_discovery_platform_windows.go
@@ -104,8 +104,8 @@ func platformDiscoveryHomeDirs() []string {
 		if expandErr != nil {
 			expanded = raw
 		}
-		expanded = filepath.Clean(strings.TrimSpace(expanded))
-		if expanded == "" {
+		expanded, ok := normalizeProfileImagePath(expanded)
+		if !ok {
 			continue
 		}
 		if fi, err := os.Stat(expanded); err != nil || !fi.IsDir() {
@@ -119,6 +119,26 @@ func platformDiscoveryHomeDirs() []string {
 		out = append(out, expanded)
 	}
 	return out
+}
+
+// normalizeProfileImagePath trims and cleans a raw ProfileImagePath
+// registry value and reports whether it is safe to use as a discovery
+// home root. `filepath.Clean("")` returns "." — a whitespace-only or
+// otherwise blank registry value must NOT collapse into the process
+// working directory, which under managed-enterprise mode would become
+// a discovery HomeDir and misdirect the AI discovery scanner at the
+// service CWD. Reject the trimmed empty value BEFORE calling Clean,
+// and defensively reject a post-Clean "." for the same reason.
+func normalizeProfileImagePath(raw string) (string, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", false
+	}
+	cleaned := filepath.Clean(trimmed)
+	if cleaned == "" || cleaned == "." {
+		return "", false
+	}
+	return cleaned, true
 }
 
 // isInteractiveUserSID reports whether sid names a local or domain user

--- a/internal/inventory/ai_discovery_platform_windows.go
+++ b/internal/inventory/ai_discovery_platform_windows.go
@@ -128,14 +128,17 @@ func platformDiscoveryHomeDirs() []string {
 // working directory, which under managed-enterprise mode would become
 // a discovery HomeDir and misdirect the AI discovery scanner at the
 // service CWD. Reject the trimmed empty value BEFORE calling Clean,
-// and defensively reject a post-Clean "." for the same reason.
+// reject a post-Clean "." for the same reason, and reject any value
+// that is not an absolute path — a relative `ProfileImagePath` like
+// `Profiles\alice` or `..\..\etc` would similarly resolve against the
+// service CWD once passed to `os.Stat` and downstream discovery.
 func normalizeProfileImagePath(raw string) (string, bool) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
 		return "", false
 	}
 	cleaned := filepath.Clean(trimmed)
-	if cleaned == "" || cleaned == "." {
+	if cleaned == "" || cleaned == "." || !filepath.IsAbs(cleaned) {
 		return "", false
 	}
 	return cleaned, true

--- a/internal/inventory/ai_discovery_platform_windows_test.go
+++ b/internal/inventory/ai_discovery_platform_windows_test.go
@@ -261,6 +261,16 @@ func TestNormalizeProfileImagePathRejectsBlankValues(t *testing.T) {
 		"tabs":             "\t\t",
 		"newlines":         "\n",
 		"mixed-whitespace": "  \t\r\n ",
+		// Relative-path shapes must never resolve against the enumerator
+		// process working directory. On managed-enterprise mode, a
+		// ProfileImagePath registry value crafted to escape or land
+		// inside the service CWD would otherwise become a HomeDir for
+		// AI discovery.
+		"relative-simple":      `Profiles\alice`,
+		"relative-dotdot":      `..\..\etc`,
+		"relative-current-dir": `.`,
+		"relative-current-dot": `.\Users\bob`,
+		"drive-relative":       `\Users\alice`,
 	}
 	for name, raw := range rejected {
 		t.Run(name, func(t *testing.T) {

--- a/internal/inventory/ai_discovery_platform_windows_test.go
+++ b/internal/inventory/ai_discovery_platform_windows_test.go
@@ -247,3 +247,48 @@ func countString(values []string, want string) int {
 	}
 	return count
 }
+
+// TestNormalizeProfileImagePathRejectsBlankValues guards the
+// platformDiscoveryHomeDirs path: a whitespace-only ProfileImagePath
+// registry value must never turn into a discovery root, because
+// `filepath.Clean("")` returns "." and that would inject the
+// enumerator process working directory into HomeDirs under
+// managed-enterprise mode.
+func TestNormalizeProfileImagePathRejectsBlankValues(t *testing.T) {
+	rejected := map[string]string{
+		"empty":            "",
+		"whitespace":       "   ",
+		"tabs":             "\t\t",
+		"newlines":         "\n",
+		"mixed-whitespace": "  \t\r\n ",
+	}
+	for name, raw := range rejected {
+		t.Run(name, func(t *testing.T) {
+			if got, ok := normalizeProfileImagePath(raw); ok {
+				t.Fatalf("blank ProfileImagePath %q: got %q, want reject", raw, got)
+			}
+		})
+	}
+
+	accepted := map[string]struct {
+		raw  string
+		want string
+	}{
+		"absolute":         {raw: `C:\Users\alice`, want: `C:\Users\alice`},
+		"trimmed":          {raw: `  C:\Users\bob  `, want: `C:\Users\bob`},
+		"trailing-slash":   {raw: `C:\Users\carol\`, want: `C:\Users\carol`},
+		"forward-slashes":  {raw: `C:/Users/dave`, want: `C:\Users\dave`},
+		"trimmed-mixed-ws": {raw: "\tC:\\Users\\ellen\n", want: `C:\Users\ellen`},
+	}
+	for name, tc := range accepted {
+		t.Run(name, func(t *testing.T) {
+			got, ok := normalizeProfileImagePath(tc.raw)
+			if !ok {
+				t.Fatalf("valid ProfileImagePath %q rejected", tc.raw)
+			}
+			if got != tc.want {
+				t.Fatalf("normalize %q = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ipc/paths.go
+++ b/internal/ipc/paths.go
@@ -56,10 +56,10 @@ const (
 //  3. managed_enterprise → resolveManagedIPCSocketPath(cfg):
 //     - linux/darwin: filepath.Join(filepath.Dir(cfg.DataDir),
 //     "ipc", SocketFileName)
-//     - windows:      filepath.Join(<TrustedProgramData>, "Cisco",
+//     - windows:      filepath.Join(<TrustedProgramFiles>, "Cisco",
 //     "Cisco Secure Client", "DefenseClaw", "ipc",
 //     SocketFileName). See spec 004 REQ-02. Returns "" when
-//     TrustedProgramData resolution fails; the caller's
+//     TrustedProgramFiles resolution fails; the caller's
 //     ResolveSocketPath empty-check turns that into a
 //     distinguishable "ipc: resolve socket path: empty"
 //     server-start error rather than a fall-through to a
@@ -73,14 +73,14 @@ const (
 // — that value is honored verbatim by the resolver above (there is no
 // linux/darwin-side validator; ownership + mode checks at server
 // start-up are the trust boundary). On Windows the socket path is
-// fixed to <TrustedProgramData>/Cisco/Cisco Secure Client/DefenseClaw/
+// fixed to <TrustedProgramFiles>/Cisco/Cisco Secure Client/DefenseClaw/
 // ipc/SocketFileName: validateWindowsSocketPathOverride (in
 // internal/ipc/server_windows.go) refuses any override whose parent
 // does not equal the trusted root, so cfg.Managed.SocketPath is
 // effectively non-configurable there.
 //
 // Never returns an error: rule 4 always produces a value (rule 3 may
-// return "" on Windows when the TrustedProgramData registry lookup
+// return "" on Windows when the TrustedProgramFiles registry lookup
 // fails — the server refuses to start in that case).
 func ResolveSocketPath(cfg *config.Config) string {
 	if cfg == nil {

--- a/internal/ipc/paths_windows.go
+++ b/internal/ipc/paths_windows.go
@@ -20,13 +20,20 @@ import (
 )
 
 // windowsManagedIPCRelativeDir is the subpath under
-// TrustedProgramData that holds the DefenseClaw UDS socket. The
+// TrustedProgramFiles that holds the DefenseClaw UDS socket. The
 // literal is fixed by the AVC integration contract: Cisco Secure
 // Client's Windows GUI dials this exact path. Changing it requires
 // a coordinated change with the AVC packaging team.
 //
 // The final socket path is
-// `<TrustedProgramData>\Cisco\Cisco Secure Client\DefenseClaw\ipc\defenseclaw_ipc.sock`.
+// `<TrustedProgramFiles>\Cisco\Cisco Secure Client\DefenseClaw\ipc\defenseclaw_ipc.sock`.
+//
+// Historical note: earlier builds placed this under TrustedProgramData
+// (ProgramData is the Windows convention for mutable machine state).
+// The AVC release-26.8.4 integration moved it under TrustedProgramFiles
+// so both peers dial the same known-root prefix. The virtual service
+// SID granted DACL rights on this directory during install can bind /
+// unlink the socket under Program Files just as under ProgramData.
 //
 // See spec 004 REQ-02 and parity plan §4.2 C1.
 var windowsManagedIPCRelativeDir = filepath.Join(
@@ -34,12 +41,12 @@ var windowsManagedIPCRelativeDir = filepath.Join(
 )
 
 // resolveManagedIPCSocketPath returns the managed-enterprise UDS
-// socket path on Windows. Resolves `TrustedProgramData` through the
+// socket path on Windows. Resolves `TrustedProgramFiles` through the
 // same fail-closed registry path env_config_windows.go uses so the
-// user-supplied `%ProgramData%` env cannot redirect the socket
+// user-supplied `%ProgramFiles%` env cannot redirect the socket
 // off-disk or into a per-user profile.
 //
-// Returns "" when TrustedProgramData resolution fails; the caller
+// Returns "" when TrustedProgramFiles resolution fails; the caller
 // (ResolveSocketPath in paths.go) turns that into a distinguishable
 // "ipc: resolve socket path: empty" server-start error rather than
 // falling back to a per-user path.
@@ -47,9 +54,9 @@ var windowsManagedIPCRelativeDir = filepath.Join(
 // Spec 004 REQ-02.
 func resolveManagedIPCSocketPath(cfg *config.Config) string {
 	_ = cfg // reserved: a future spec may consult cfg.Managed for override plumbing
-	programData, err := winpath.TrustedProgramData()
-	if err != nil || programData == "" {
+	programFiles, err := winpath.TrustedProgramFiles()
+	if err != nil || programFiles == "" {
 		return ""
 	}
-	return filepath.Join(programData, windowsManagedIPCRelativeDir, SocketFileName)
+	return filepath.Join(programFiles, windowsManagedIPCRelativeDir, SocketFileName)
 }

--- a/internal/ipc/paths_windows_test.go
+++ b/internal/ipc/paths_windows_test.go
@@ -34,25 +34,25 @@ func TestResolveManagedIPCSocketPathWindowsHonoursExplicitOverride(t *testing.T)
 	}
 }
 
-// TestResolveManagedIPCSocketPathWindowsProducesProgramDataPath
+// TestResolveManagedIPCSocketPathWindowsProducesProgramFilesPath
 // asserts the default resolver produces a path under
-// TrustedProgramData. On CI (`CI=true`) a failed TrustedProgramData
+// TrustedProgramFiles. On CI (`CI=true`) a failed TrustedProgramFiles
 // resolution is a hard failure — a regression in winpath would
-// otherwise produce a green build while leaving the ProgramData
+// otherwise produce a green build while leaving the Program Files
 // path unverified. On a developer laptop the test skips
 // gracefully because the registry key may legitimately be
 // unreadable outside of a real Windows managed_enterprise
 // install. See CR spec-004:PRRT_kwDORuAK-s6ankzr.
-func TestResolveManagedIPCSocketPathWindowsProducesProgramDataPath(t *testing.T) {
+func TestResolveManagedIPCSocketPathWindowsProducesProgramFilesPath(t *testing.T) {
 	cfg := &config.Config{DeploymentMode: string(config.DeploymentModeManagedEnterprise)}
 	got := ResolveSocketPath(cfg)
 	if got == "" {
 		if os.Getenv("CI") != "" {
-			t.Fatalf("TrustedProgramData resolution returned empty on a CI runner — winpath registry access must succeed for the managed IPC surface")
+			t.Fatalf("TrustedProgramFiles resolution returned empty on a CI runner — winpath registry access must succeed for the managed IPC surface")
 		}
-		t.Skip("TrustedProgramData resolution failed on this host; running outside CI so skipping")
+		t.Skip("TrustedProgramFiles resolution failed on this host; running outside CI so skipping")
 	}
-	// Expected shape: <programData>\Cisco\Cisco Secure Client\DefenseClaw\ipc\defenseclaw_ipc.sock
+	// Expected shape: <programFiles>\Cisco\Cisco Secure Client\DefenseClaw\ipc\defenseclaw_ipc.sock
 	if !strings.HasSuffix(got, filepath.Join(windowsManagedIPCRelativeDir, SocketFileName)) {
 		t.Fatalf("socket path missing expected suffix: got %q, want ending %q",
 			got, filepath.Join(windowsManagedIPCRelativeDir, SocketFileName))

--- a/internal/ipc/server_windows.go
+++ b/internal/ipc/server_windows.go
@@ -157,7 +157,7 @@ func validateWindowsSocketPathOverride(socketPath string) error {
 	// Shape anchor: the socket must live under an "ipc" directory. In
 	// production this is fully subsumed by the trusted-root check below,
 	// which requires an exact case-insensitive match against
-	// TrustedProgramData/…/ipc — check 3 can only fire for inputs check 4
+	// TrustedProgramFiles/…/ipc — check 3 can only fire for inputs check 4
 	// would also reject. It IS load-bearing under the test hook
 	// (allowUnsafeSocketOverrideForTest) which short-circuits check 4:
 	// leaving this shape check ensures the tests still exercise a
@@ -175,14 +175,14 @@ func validateWindowsSocketPathOverride(socketPath string) error {
 	if allowUnsafeSocketOverrideForTest {
 		return nil
 	}
-	programData, err := winpath.TrustedProgramData()
+	programFiles, err := winpath.TrustedProgramFiles()
 	if err != nil {
-		return fmt.Errorf("ipc: resolve trusted program data root: %w", err)
+		return fmt.Errorf("ipc: resolve trusted program files root: %w", err)
 	}
-	if programData == "" {
-		return fmt.Errorf("ipc: trusted program data root is empty; refusing to bind IPC surface")
+	if programFiles == "" {
+		return fmt.Errorf("ipc: trusted program files root is empty; refusing to bind IPC surface")
 	}
-	trustedParent := filepath.Clean(filepath.Join(programData, windowsManagedIPCRelativeDir))
+	trustedParent := filepath.Clean(filepath.Join(programFiles, windowsManagedIPCRelativeDir))
 	if !strings.EqualFold(parent, trustedParent) {
 		return fmt.Errorf(
 			"ipc: socket path override must live under the trusted managed root %q (got parent %q)",

--- a/internal/managed/cloudreg/cache.go
+++ b/internal/managed/cloudreg/cache.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudreg
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// WithTokenCache decorates `inner` with an in-memory bearer-token cache so
+// consumers that call Token() at a high cadence do not pay a fresh IPC
+// round-trip to the underlying credential broker per call.
+//
+// Both currently-shipped Provider implementations (the Windows named-pipe
+// ClientProvider in internal/managed/cmidbroker and the private macOS CMID
+// daemon client registered from ai-common) make an IPC exchange on every
+// Token() call — visible on macOS in the
+// /Library/Logs/Cisco/SecureClient/CloudManagement/*_cmidapi.log dance per
+// call — even though the tokens themselves live minutes to hours. Wrapping at
+// the Provider level keeps a single caching layer for every consumer:
+//
+//   - the synchronous AI Defense inspect lane in
+//     internal/gateway/cisco_inspect_defense_claw.go, called per hook
+//     decision (hot path);
+//   - the asynchronous managedaid POST in
+//     internal/observability/destinations/managedaid, called per publish
+//     batch;
+//   - any future consumer of Sidecar.ensureCMIDProvider().
+//
+// TTL is the caller's choice. Set well inside the shortest expected token
+// lifetime; typical bearer tokens live 5-15 minutes and 60s caching cuts the
+// IPC dance rate 6-8x on a typical hook-decision hot path. A ttl <= 0
+// disables caching and returns `inner` unchanged, which is useful for tests
+// that need to observe every Token() invocation.
+//
+// Invalidation semantics:
+//
+//   - Invalidate() clears the cached value AND calls inner.Invalidate, so a
+//     401-driven invalidation from a consumer (e.g.
+//     doInspectHTTP.onUnauthorized in cisco_inspect_defense_claw.go, or the
+//     managedaid remint path) forces the next Token() to re-fetch through
+//     the broker.
+//
+//   - Refresh() calls inner.Refresh but does NOT clear the local cache.
+//     Rationale: existing DefenseClaw code uses Refresh() as a cheap
+//     availability probe against the broker's own state, not as a signal
+//     that the caller has decided our current token is stale. Clearing the
+//     cache on every Refresh would forcibly re-fetch on every availability
+//     probe, defeating the point of caching. If a probe reveals the broker
+//     has genuinely rotated the token underneath us, the next consumer call
+//     will hit a 401 and drop the cache via Invalidate() — the authoritative
+//     staleness signal.
+//
+// The wrapper is safe for concurrent Token() callers: readers hold a short
+// lock only to inspect / update the cache. A concurrent cache-miss can
+// result in overlapping inner.Token() calls — that is deliberately allowed
+// because provider.Token is documented as thread-safe by every current
+// implementation, and serializing under the wrapper's mutex would double
+// the latency of the first miss on a cold start.
+func WithTokenCache(inner Provider, ttl time.Duration) Provider {
+	if inner == nil {
+		return nil
+	}
+	if ttl <= 0 {
+		return inner
+	}
+	return &cachingProvider{inner: inner, ttl: ttl}
+}
+
+type cachingProvider struct {
+	inner Provider
+	ttl   time.Duration
+
+	mu sync.Mutex
+	// generation is bumped on every Invalidate() call. A Token() miss
+	// captures the current generation before releasing the lock to
+	// fetch through inner.Token; the resulting token is stored back
+	// into the cache only if the generation is unchanged at store
+	// time. This closes the "restore invalidated token" race: an
+	// in-flight fetch that started under generation N cannot repopulate
+	// the cache after a concurrent Invalidate() bumped it to N+1.
+	// Reported by CodeRabbit on PR #802.
+	generation uint64
+	token      string
+	at         time.Time
+}
+
+func (c *cachingProvider) Token(ctx context.Context) (string, error) {
+	c.mu.Lock()
+	if c.token != "" && time.Since(c.at) < c.ttl {
+		cached := c.token
+		c.mu.Unlock()
+		return cached, nil
+	}
+	// Capture the generation so a concurrent Invalidate can invalidate
+	// the value we're about to fetch — see cachingProvider.generation.
+	generation := c.generation
+	c.mu.Unlock()
+	token, err := c.inner.Token(ctx)
+	if err != nil || token == "" {
+		return token, err
+	}
+	c.mu.Lock()
+	if generation == c.generation {
+		c.token = token
+		c.at = time.Now()
+	}
+	// If generation drifted, the token we fetched is already
+	// considered stale by the caller who invalidated. Return it to
+	// this caller (they may still succeed with it — some brokers keep
+	// old tokens live briefly) but do not pollute the cache. The 401
+	// path will invalidate again if the token is truly rejected.
+	c.mu.Unlock()
+	return token, nil
+}
+
+func (c *cachingProvider) Refresh(ctx context.Context) error {
+	// Deliberately does NOT touch the local cache. Refresh() is used by
+	// Sidecar.ensureCMIDProvider as an availability probe; if we cleared
+	// our cache here, every probe would force the next Token() to
+	// re-fetch through the broker, which defeats the entire purpose of
+	// wrapping the provider. If the broker rotated the token underneath
+	// us during a probe, the next consumer request will observe a 401
+	// and drop our cache via Invalidate() — the authoritative staleness
+	// signal.
+	return c.inner.Refresh(ctx)
+}
+
+func (c *cachingProvider) Invalidate() {
+	// Hold the cache lock through inner.Invalidate so a concurrent
+	// Token() miss cannot start fetching a stale token during the
+	// broker-side invalidation window. Combined with the generation
+	// counter above, this makes cache pollution impossible: any
+	// in-flight fetch will observe the bumped generation on its
+	// return-and-store path and skip the store; any new fetch is
+	// blocked from starting until the invalidation completes.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.generation++
+	c.token = ""
+	c.at = time.Time{}
+	c.inner.Invalidate()
+}

--- a/internal/observability/destinations/managedaid/adapter.go
+++ b/internal/observability/destinations/managedaid/adapter.go
@@ -16,11 +16,13 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -347,21 +349,64 @@ func (adapter *Adapter) post(ctx context.Context, body []byte, token string) (in
 	request = request.WithContext(httptrace.WithClientTrace(request.Context(), &httptrace.ClientTrace{
 		WroteRequest: func(httptrace.WroteRequestInfo) { wrote.Store(true) },
 	}))
+	postStart := time.Now()
 	response, err := adapter.client.Do(request)
 	if err != nil {
 		if response != nil && response.Body != nil {
 			_ = response.Body.Close()
 		}
+		// Transport-level failure info line so an operator tailing
+		// gateway.err.log / gateway.log can see when the AI Defense POST
+		// couldn't complete at all (DNS, TCP, TLS, cancel, deadline).
+		// One line per attempt; low-frequency at the 5 min publish cadence.
+		// The endpoint URL is deliberately redacted to "AI DEFENSE" — the
+		// configured host is release-owned and static across a deployment
+		// so operators don't need it in every log line, and omitting it
+		// keeps regionalized endpoint labels out of log-forwarder pipelines
+		// that may not be scoped to the DefenseClaw tenant.
+		//
+		// `err` is unwrapped via sanitizeTransportError before formatting:
+		// net/http.Client.Do returns transport failures as *url.Error, and
+		// (*url.Error).Error() prints the full request URL, which would
+		// leak the endpoint we just redacted from the same log line.
+		// Unwrapping to url.Error.Err preserves the diagnostic (e.g.
+		// "dial tcp: connection refused", "context deadline exceeded")
+		// without exposing the URL.
+		fmt.Fprintf(os.Stderr, "[managedaid] POST AI DEFENSE bytes=%d elapsed=%s err=%v\n",
+			len(body), time.Since(postStart), sanitizeTransportError(err))
 		return 0, classifyTransportError(err, wrote.Load())
 	}
 	if response == nil {
+		fmt.Fprintf(os.Stderr, "[managedaid] POST AI DEFENSE bytes=%d elapsed=%s status=nil\n",
+			len(body), time.Since(postStart))
 		return 0, delivery.OutcomeAmbiguous
 	}
 	defer response.Body.Close()
 	responseBody, readErr := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
-	if readErr != nil || len(responseBody) > maxResponseBytes {
+	if readErr != nil {
+		// Genuine read/network failure while draining the response body.
+		// Same *url.Error-unwrap treatment as the transport branch above:
+		// io.ReadAll on response.Body can surface transport errors that
+		// still carry the request URL when wrapped by net/http internals.
+		fmt.Fprintf(os.Stderr, "[managedaid] POST AI DEFENSE bytes=%d elapsed=%s status=%d body-read-err=%v\n",
+			len(body), time.Since(postStart), response.StatusCode, sanitizeTransportError(readErr))
 		return 0, delivery.OutcomeAmbiguous
 	}
+	if len(responseBody) > maxResponseBytes {
+		// io.LimitReader was set to maxResponseBytes+1 exactly to detect
+		// this — a response body larger than the cap. Distinct from a
+		// read error so operators can tell "AI Defense returned a huge
+		// payload" from "the connection was cut mid-body".
+		fmt.Fprintf(os.Stderr, "[managedaid] POST AI DEFENSE bytes=%d elapsed=%s status=%d body-too-large=%d\n",
+			len(body), time.Since(postStart), response.StatusCode, len(responseBody))
+		return 0, delivery.OutcomeAmbiguous
+	}
+	// Success (or well-formed error response) info line — status + latency
+	// only. Full response body is deliberately NOT logged here; operators
+	// can enable the delivery-diagnostics destination or inspect
+	// gateway.jsonl for per-event `inserted`/`rejectCode` details.
+	fmt.Fprintf(os.Stderr, "[managedaid] POST AI DEFENSE bytes=%d elapsed=%s status=%d resp_bytes=%d\n",
+		len(body), time.Since(postStart), response.StatusCode, len(responseBody))
 	return response.StatusCode, ""
 }
 
@@ -412,6 +457,28 @@ func classifyStatus(status int) delivery.DeliveryOutcome {
 	default:
 		return delivery.OutcomePermanentPayload
 	}
+}
+
+// sanitizeTransportError returns an error safe to include in stderr
+// log lines that deliberately redact the AI Defense endpoint URL.
+// net/http.Client.Do wraps transport failures in *url.Error whose
+// Error() method prints the request URL verbatim (documented in
+// net/url; format is `<Op> "<URL>": <inner>`). Formatting that raw
+// error with %v defeats the URL redaction on the `[managedaid] POST
+// AI DEFENSE ...` info lines. Unwrap the URL layer once and return
+// the inner cause, preserving the diagnostic text (e.g. "dial tcp:
+// connection refused", "context deadline exceeded") without leaking
+// the endpoint. A nil error or an error not wrapping *url.Error
+// passes through unchanged.
+func sanitizeTransportError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) && urlErr.Err != nil {
+		return urlErr.Err
+	}
+	return err
 }
 
 func classifyTransportError(err error, wrote bool) delivery.DeliveryOutcome {

--- a/internal/observability/destinations/managedaid/adapter.go
+++ b/internal/observability/destinations/managedaid/adapter.go
@@ -460,25 +460,67 @@ func classifyStatus(status int) delivery.DeliveryOutcome {
 }
 
 // sanitizeTransportError returns an error safe to include in stderr
-// log lines that deliberately redact the AI Defense endpoint URL.
-// net/http.Client.Do wraps transport failures in *url.Error whose
-// Error() method prints the request URL verbatim (documented in
-// net/url; format is `<Op> "<URL>": <inner>`). Formatting that raw
-// error with %v defeats the URL redaction on the `[managedaid] POST
-// AI DEFENSE ...` info lines. Unwrap the URL layer once and return
-// the inner cause, preserving the diagnostic text (e.g. "dial tcp:
-// connection refused", "context deadline exceeded") without leaking
-// the endpoint. A nil error or an error not wrapping *url.Error
-// passes through unchanged.
+// log lines that deliberately redact the AI Defense endpoint URL and
+// resolved socket address. net/http.Client.Do wraps transport
+// failures in *url.Error whose Error() method prints the request URL
+// verbatim (documented in net/url; format is
+// `<Op> "<URL>": <inner>`). Formatting that raw error with %v
+// defeats the URL redaction on the `[managedaid] POST AI DEFENSE
+// ...` info lines. But the wrapped inner cause is often itself a
+// *net.OpError whose Error() includes the resolved remote Addr
+// (source [-> ]addr) — logging that verbatim would leak the same
+// endpoint we deliberately redacted at the URL layer. Map the error
+// to a short, address-free category label so the operator still
+// gets diagnostic signal (dial vs. read vs. TLS vs. context) without
+// disclosing endpoint or address details. A nil error passes
+// through unchanged.
 func sanitizeTransportError(err error) error {
 	if err == nil {
 		return nil
 	}
+	inner := err
 	var urlErr *url.Error
 	if errors.As(err, &urlErr) && urlErr.Err != nil {
-		return urlErr.Err
+		inner = urlErr.Err
 	}
-	return err
+	return errors.New(transportErrorCategory(inner))
+}
+
+// transportErrorCategory maps a transport error to a short label
+// safe to log. The label is chosen from a fixed set — none of them
+// contain the endpoint URL, resolved address, or SNI hostname.
+func transportErrorCategory(err error) string {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "context canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "context deadline exceeded"
+	case errors.Is(err, io.EOF), errors.Is(err, io.ErrUnexpectedEOF):
+		return "connection closed"
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		// opErr.Op describes the operation (dial/read/write/tls) and is
+		// a fixed set of Go-emitted strings; it never contains the
+		// remote address. Combine it with the closest safe classifier
+		// we can extract without falling back to opErr.Error() (which
+		// would re-inject the address).
+		op := opErr.Op
+		switch {
+		case opErr.Timeout():
+			return op + " timeout"
+		case op != "":
+			return op + " error"
+		}
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		if netErr.Timeout() {
+			return "network timeout"
+		}
+		return "network error"
+	}
+	return "transport error"
 }
 
 func classifyTransportError(err error, wrote bool) delivery.DeliveryOutcome {

--- a/internal/observability/destinations/managedaid/adapter_test.go
+++ b/internal/observability/destinations/managedaid/adapter_test.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -969,5 +970,48 @@ func TestAdapterRejectsOversizedAcknowledgement(t *testing.T) {
 	}
 	if err := dispatcher.Close(ctx); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestSanitizeTransportErrorDoesNotLeakEndpoint locks in that the
+// sanitized error string used on `[managedaid] POST AI DEFENSE`
+// stderr lines never carries the redacted URL nor the resolved
+// remote address, even when the underlying transport failure is a
+// *net.OpError wrapped inside a *url.Error (the shape
+// net/http.Client.Do produces for dial/read failures).
+func TestSanitizeTransportErrorDoesNotLeakEndpoint(t *testing.T) {
+	endpoint := "https://redacted.example.internal:8443/v1/logs"
+	remoteAddr := &net.TCPAddr{IP: net.ParseIP("10.99.88.77"), Port: 4433}
+	opErr := &net.OpError{
+		Op:     "dial",
+		Net:    "tcp",
+		Addr:   remoteAddr,
+		Source: nil,
+		Err:    errors.New("connection refused"),
+	}
+	urlErr := &url.Error{Op: "Post", URL: endpoint, Err: opErr}
+
+	sanitized := sanitizeTransportError(urlErr)
+	if sanitized == nil {
+		t.Fatalf("sanitizeTransportError returned nil for a non-nil error")
+	}
+	text := sanitized.Error()
+	for _, forbidden := range []string{
+		endpoint,
+		"redacted.example.internal",
+		remoteAddr.String(),
+		remoteAddr.IP.String(),
+		"connection refused",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("sanitized error %q leaks %q", text, forbidden)
+		}
+	}
+	if text == "" {
+		t.Fatalf("sanitized error is empty; expected a category label")
+	}
+
+	if sanitizeTransportError(nil) != nil {
+		t.Fatalf("sanitizeTransportError(nil) must return nil")
 	}
 }

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -655,12 +655,52 @@ _claude_desktop_embedded_version_from_home() {
     version_dir="$(dirname -- "$(dirname -- "$(dirname -- "$(dirname -- "${bin}")")")")"
     version="$(basename -- "${version_dir}")"
     [[ "${version}" =~ ${semver_re} ]] || continue
-    if [[ -z "${best}" ]] || \
-       [[ "$(printf '%s\n%s\n' "${best}" "${version}" | sort -V | tail -1)" == "${version}" ]]; then
+    if [[ -z "${best}" ]] || _semver_greater "${version}" "${best}"; then
       best="${version}"
     fi
   done
   [[ -n "${best}" ]] && echo "${best}"
+}
+
+# _semver_greater A B — exit 0 iff A > B when compared as
+# MAJOR.MINOR.PATCH numeric tuples. Only the numeric core is compared;
+# any pre-release / build suffix after PATCH is ignored. Callers must
+# have already validated shape against the semver-ish regex
+# `^[0-9]+\.[0-9]+\.[0-9]+([._+-].*)?$` before invoking this helper.
+# Implemented without `sort -V` so it does not depend on GNU
+# coreutils; older BSD `sort` (pre-Sequoia) may reject `-V` and
+# silently fall through to lexicographic ordering, which mis-ranks
+# e.g. `2.1.219` below `2.1.9` — the exact customer symptom PR #785
+# fixed. Bash regex + arithmetic on the fields is portable to BSD
+# userland and short enough to keep inline here rather than growing a
+# new dependency.
+_semver_greater() {
+  local -r core_re='^([0-9]+)\.([0-9]+)\.([0-9]+)'
+  local a_major=0 a_minor=0 a_patch=0
+  local b_major=0 b_minor=0 b_patch=0
+  if [[ "$1" =~ ${core_re} ]]; then
+    a_major="${BASH_REMATCH[1]}"
+    a_minor="${BASH_REMATCH[2]}"
+    a_patch="${BASH_REMATCH[3]}"
+  else
+    return 1
+  fi
+  if [[ "$2" =~ ${core_re} ]]; then
+    b_major="${BASH_REMATCH[1]}"
+    b_minor="${BASH_REMATCH[2]}"
+    b_patch="${BASH_REMATCH[3]}"
+  else
+    return 0
+  fi
+  if (( 10#${a_major} != 10#${b_major} )); then
+    (( 10#${a_major} > 10#${b_major} ))
+    return
+  fi
+  if (( 10#${a_minor} != 10#${b_minor} )); then
+    (( 10#${a_minor} > 10#${b_minor} ))
+    return
+  fi
+  (( 10#${a_patch} > 10#${b_patch} ))
 }
 
 discover_agent_version() {

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -619,6 +619,50 @@ _read_json_version() {
   _read_json_field "${path}" "version"
 }
 
+# _claude_desktop_embedded_version_from_home HOME -> echoes the highest
+# Claude Code version bundled inside Claude Desktop, or "".
+#
+# Claude Desktop bundles Claude Code per user under:
+#
+#   ~/Library/Application Support/Claude/claude-code/<X.Y.Z>/claude.app/
+#     Contents/MacOS/claude
+#
+# and drops a convenience shim at ~/.local/bin/claude pointing into that
+# tree. The shim-basename walk in the npm/PATH probe below stops at
+# "claude" / "MacOS" (neither is semver-shaped) so the version has to be
+# extracted from the parent-dir chain of the concrete binary — 4 hops
+# above the terminal binary. The Claude Desktop application version is
+# not the Claude Code version, so the version-labelled embedded bundle
+# directory is the authoritative metadata source.
+#
+# Metadata-only: readdir + basename, no exec of a desktop- or user-
+# bundled binary during installer discovery.
+#
+# Ported from PR #785 (release-26.7.3 backport of PR #798 / AIFW-32990,
+# author @rucpande) — the customer bundle 0827_0914 (jlunde) had
+# 2.1.219 embedded here and got silently dropped by the npm-only probe.
+# The consolidated Go implementation in
+# docs/PLAN-consolidate-hook-enumerator.md will supersede this bash
+# probe alongside the rest of `discover_agent_version` (Appendix B row 6).
+_claude_desktop_embedded_version_from_home() {
+  local home="$1"
+  local root="${home}/Library/Application Support/Claude/claude-code"
+  [[ -d "${root}" ]] || return 0
+  local -r semver_re='^[0-9]+\.[0-9]+\.[0-9]+([._+-].*)?$'
+  local bin version_dir version best=""
+  for bin in "${root}"/*/claude.app/Contents/MacOS/claude; do
+    [[ -x "${bin}" ]] || continue
+    version_dir="$(dirname -- "$(dirname -- "$(dirname -- "$(dirname -- "${bin}")")")")"
+    version="$(basename -- "${version_dir}")"
+    [[ "${version}" =~ ${semver_re} ]] || continue
+    if [[ -z "${best}" ]] || \
+       [[ "$(printf '%s\n%s\n' "${best}" "${version}" | sort -V | tail -1)" == "${version}" ]]; then
+      best="${version}"
+    fi
+  done
+  [[ -n "${best}" ]] && echo "${best}"
+}
+
 discover_agent_version() {
   local connector="$1"
   local home="$2"
@@ -728,7 +772,23 @@ discover_agent_version() {
       ;;
     claudecode)
       # Claude Code ships both as a standalone npm CLI (has a
-      # package.json we can read) and as a Cursor / VS Code extension.
+      # package.json we can read) and as a Cursor / VS Code extension,
+      # AND as a per-user Claude Desktop-bundled binary.
+      #
+      # Probe order:
+      #   1. Claude Desktop-bundled — ~/Library/Application Support/Claude/
+      #      claude-code/<X.Y.Z>/claude.app/... — the shim at
+      #      ~/.local/bin/claude points here on newer Claude Desktop
+      #      builds and the shim-basename walk yields "claude"/"MacOS"
+      #      which fails the semver regex. Consulting the version-labelled
+      #      parent directory is the only way to recover the version.
+      #      Regression on customer bundle 0827_0914 (jlunde, AIFW-32990).
+      #   2. npm-global / Cursor / VS Code extension package.json
+      #      (historical baseline).
+      local v
+      v="$(_claude_desktop_embedded_version_from_home "${home}")"
+      if [[ -n "${v}" ]]; then echo "${v}"; return; fi
+
       local pkg
       for pkg in \
         "${home}"/.npm-global/lib/node_modules/@anthropic-ai/claude-code/package.json \
@@ -737,7 +797,7 @@ discover_agent_version() {
         "${home}"/.cursor/extensions/anthropic.claude-code-*/package.json \
         "${home}"/.vscode/extensions/anthropic.claude-code-*/package.json; do
         [[ -f "${pkg}" ]] || continue
-        local v; v="$(_probe_json_version "${pkg}" claudecode)"
+        v="$(_probe_json_version "${pkg}" claudecode)"
         if [[ -n "${v}" ]]; then echo "${v}"; return; fi
       done
       ;;
@@ -1042,12 +1102,93 @@ enumerate_local_users() {
 #
 # One `- ` block per (user × supported-and-installed connector).
 # Unsupported connectors (not in is_supported_connector) are skipped: they
-# have no per-user setup path in the CLI. Connectors the caller asked for
-# but which discover_agent_version could not locate on THIS user's home
-# ARE ALSO skipped — no CLI/app/extension present means there is nothing
-# to hook, and emitting the row would just churn the guardian with a
-# permanent "agent_version empty" failure per tick. Users who install the
-# connector later are picked up by the hook-enumerator's next re-render.
+# have no per-user setup path in the CLI.
+#
+# Connectors the caller asked for but which discover_agent_version could
+# not locate on THIS user's home used to be skipped unconditionally. That
+# rule made an unrecoverable "silent drop" whenever the CLI was installed
+# via a channel discover_agent_version does not probe (Bun, pnpm, custom
+# PATH shim, Homebrew tap, etc.) — the row never appeared in
+# targets.yaml, the guardian never installed hooks, and the operator got
+# no diagnostic pointing at the discovery gap.
+#
+# Now: when the version probe returns empty, fall back to a cheap per-user
+# PRESENCE signal (connector_present_for_user). If the connector's user
+# config surface exists on this user, emit the row with an empty
+# agent_version and let the Go guardian handle it — the sidecar's
+# ResolveHookContract has an Unversioned branch that returns the
+# connector's DefaultForUnversioned contract. In `action` mode the Go
+# guardian's validateHookContract still fail-shuts per-target (unless
+# DEFENSECLAW_ALLOW_HOOK_CONTRACT_DRIFT=1), which surfaces the failure in
+# protected_targets.json — infinitely better than a silent drop. In
+# observability / audit modes the target wires end-to-end. If the presence
+# signal is also absent, the row is still skipped as before.
+
+# connector_present_for_user CONNECTOR HOME -> exit 0 iff there is a
+# per-user artifact on disk indicating the user has actually used this
+# connector's CLI, even when discover_agent_version could not resolve the
+# install path. Used as a fallback presence check in render_targets_manifest
+# so a CLI installed via a channel we don't probe still gets a manifest row.
+#
+# CRITICAL: none of the signals below may match a directory or file that
+# prepare_userspace_for (this same library, above) creates as part of
+# installer bootstrap. Otherwise every DefenseClaw pkg install would
+# create the presence marker itself, the fallback would fire for every
+# eligible user × connector, and the guardian would churn on connectors
+# the user has never touched.
+#
+# Blocked signals (DefenseClaw-authored — must NOT be checked here):
+#   claudecode: ~/.claude, ~/.claude/settings.json
+#   codex:      ~/.codex, ~/.codex/config.toml
+#   cursor:     ~/.cursor, ~/.cursor/hooks.json
+#
+# Allowed signals below are artifacts the connector's CLI itself
+# creates on first launch — never anything prepare_userspace_for nor
+# an unrelated app could scatter.
+connector_present_for_user() {
+  local connector="$1"
+  local home="$2"
+  [[ -n "${home}" ]] || return 1
+  case "${connector}" in
+    claudecode)
+      # ~/.claude.json is Claude Code CLI's project-trust file at the
+      # home root; DefenseClaw never touches it. The subdirs under
+      # ~/.claude below are CLI runtime state (sessions, per-project
+      # data, env snapshots per session) — the DART bundle from the
+      # customer that motivated this fix showed all three populated on
+      # a box where DefenseClaw's discover_agent_version came up empty.
+      # Claude Desktop uses ~/Library/Application Support/Claude/ and
+      # does NOT populate ~/.claude, so each of these is CLI-specific.
+      [[ -f "${home}/.claude.json" ]] && return 0
+      [[ -d "${home}/.claude/sessions" ]] && return 0
+      [[ -d "${home}/.claude/projects" ]] && return 0
+      [[ -d "${home}/.claude/session-env" ]] && return 0
+      ;;
+    codex)
+      # Codex CLI runtime artifacts. history.jsonl is written on every
+      # chat exchange; auth.json holds the OAuth cache after first
+      # login; log/ is created the first time codex boots. Any of them
+      # implies actual CLI use. DefenseClaw only writes config.toml.
+      [[ -d "${home}/.codex/log" ]] && return 0
+      [[ -f "${home}/.codex/history.jsonl" ]] && return 0
+      [[ -f "${home}/.codex/auth.json" ]] && return 0
+      ;;
+    cursor)
+      # Cursor IDE runtime artifacts. extensions/ is populated the
+      # first time the IDE launches (even with zero third-party
+      # extensions, a manifest file is written); argv.json is the
+      # editor's saved-startup-args file. DefenseClaw only writes
+      # hooks.json. The version probe already covers Cursor via the
+      # extension package.json path — this branch is a symmetry /
+      # robustness fallback for hosts whose extension dir metadata is
+      # transiently unreadable at enumeration time.
+      [[ -d "${home}/.cursor/extensions" ]] && return 0
+      [[ -f "${home}/.cursor/argv.json" ]] && return 0
+      ;;
+  esac
+  return 1
+}
+
 yaml_double_quoted_scalar() {
   local value="$1"
   case "${value}" in
@@ -1098,7 +1239,15 @@ render_targets_manifest() {
       is_supported_connector "${c}" || continue
       q_connector="$(yaml_double_quoted_scalar "${c}")" || continue
       ver="$(DC_INSTALLER_TARGET_USER="${name}" discover_agent_version "${c}" "${home}" 2>/dev/null || true)"
-      [[ -n "${ver}" ]] || continue
+      if [[ -z "${ver}" ]]; then
+        # Version probe came up empty. Only emit a row when a cheap
+        # user-scoped presence signal proves the connector CLI has been
+        # used on this account — otherwise the guardian churns forever
+        # trying to install hooks for a CLI that doesn't exist here. See
+        # connector_present_for_user above and render_targets_manifest's
+        # header comment for the full rationale.
+        connector_present_for_user "${c}" "${home}" || continue
+      fi
       q_ver="$(yaml_double_quoted_scalar "${ver}")" || q_ver='""'
       # data_dir is intentionally omitted from each target block: the
       # guardian's validateUserDataDir requires the data_dir to be inside

--- a/packaging/macos/tests/test_discover_agent_version.sh
+++ b/packaging/macos/tests/test_discover_agent_version.sh
@@ -86,6 +86,52 @@ JSON
   assert_eq "${got}" "2.0.99" "claudecode version from VS Code extension"
 }
 
+t_claudecode_via_claude_desktop_embedded_bundle() {
+  # Regression for customer bundle 0827_0914 (jlunde). Claude Desktop
+  # bundles Claude Code under ~/Library/Application Support/Claude/
+  # claude-code/<X.Y.Z>/claude.app/... and drops a shim at
+  # ~/.local/bin/claude pointing to the deep binary. The shim-basename
+  # walk yields "claude" / "MacOS" (both non-semver) so the version
+  # has to come from the version-labelled bundle directory 4 hops
+  # above the terminal binary. jlunde's box had 2.1.219 embedded here;
+  # use that as a concrete regression pin.
+  #
+  # Ported from PR #785 (release-26.7.3 backport of PR #798, author
+  # @rucpande, AIFW-32990) as a surgical port. The full 26.7.3-shape
+  # discovery (versions/*/ walker, SemVer comparator, node-manager
+  # glob walker, etc.) is out of scope for this release-branch fix —
+  # see docs/PLAN-consolidate-hook-enumerator.md for the consolidated
+  # Go replacement that supersedes this bash probe.
+  local home; home="$(mktest_tmp)"
+  local bin="${home}/Library/Application Support/Claude/claude-code/2.1.219/claude.app/Contents/MacOS/claude"
+  mkdir -p "$(dirname -- "${bin}")"
+  : > "${bin}"
+  chmod 0755 "${bin}"
+
+  local got
+  got="$(without_host_agent_bins discover_agent_version claudecode "${home}")"
+  assert_eq "${got}" "2.1.219" "claudecode version from Claude Desktop embedded bundle"
+}
+
+t_claudecode_desktop_embedded_picks_highest_version() {
+  # Multiple Claude Desktop-bundled versions coexist during upgrade
+  # windows. Discovery must pick the highest semver-shaped directory
+  # so a stale bundle doesn't shadow the active install.
+  local home; home="$(mktest_tmp)"
+  local root="${home}/Library/Application Support/Claude/claude-code"
+  local ver
+  for ver in 2.1.144 2.1.219 2.1.171; do
+    local bin="${root}/${ver}/claude.app/Contents/MacOS/claude"
+    mkdir -p "$(dirname -- "${bin}")"
+    : > "${bin}"
+    chmod 0755 "${bin}"
+  done
+
+  local got
+  got="$(without_host_agent_bins discover_agent_version claudecode "${home}")"
+  assert_eq "${got}" "2.1.219" "claudecode picks highest Claude Desktop embedded version"
+}
+
 t_claudecode_no_install_returns_empty() {
   # Empty tmp HOME + no CLI on PATH → empty version, cleanly.
   local home; home="$(mktest_tmp)"
@@ -529,6 +575,8 @@ run_case "amp package metadata identity"      t_amp_metadata_requires_package_id
 run_case "amp without metadata is unversioned" t_amp_missing_metadata_may_be_unversioned
 run_case "claudecode via Cursor extension"   t_claudecode_via_cursor_extension
 run_case "claudecode via VS Code extension"  t_claudecode_via_vscode_extension
+run_case "claudecode via Claude Desktop embedded bundle" t_claudecode_via_claude_desktop_embedded_bundle
+run_case "claudecode Claude Desktop picks highest bundled" t_claudecode_desktop_embedded_picks_highest_version
 run_case "claudecode without install"        t_claudecode_no_install_returns_empty
 run_case "codex without home metadata"       t_codex_no_home_metadata_uses_system_or_empty
 run_case "codex from user npm metadata"      t_codex_from_user_npm_metadata

--- a/packaging/macos/tests/test_discover_agent_version.sh
+++ b/packaging/macos/tests/test_discover_agent_version.sh
@@ -132,6 +132,26 @@ t_claudecode_desktop_embedded_picks_highest_version() {
   assert_eq "${got}" "2.1.219" "claudecode picks highest Claude Desktop embedded version"
 }
 
+t_claudecode_desktop_embedded_numeric_patch_ordering() {
+  # Guards against a lexicographic patch-field comparison (older BSD
+  # `sort` without `-V` would return "2.1.9" for {2.1.9, 2.1.219} —
+  # the exact symptom PR #785 fixed). The internal _semver_greater
+  # helper must order these numerically, not lexicographically.
+  local home; home="$(mktest_tmp)"
+  local root="${home}/Library/Application Support/Claude/claude-code"
+  local ver
+  for ver in 2.1.9 2.1.219; do
+    local bin="${root}/${ver}/claude.app/Contents/MacOS/claude"
+    mkdir -p "$(dirname -- "${bin}")"
+    : > "${bin}"
+    chmod 0755 "${bin}"
+  done
+
+  local got
+  got="$(without_host_agent_bins discover_agent_version claudecode "${home}")"
+  assert_eq "${got}" "2.1.219" "claudecode numeric patch ordering (2.1.219 > 2.1.9)"
+}
+
 t_claudecode_no_install_returns_empty() {
   # Empty tmp HOME + no CLI on PATH → empty version, cleanly.
   local home; home="$(mktest_tmp)"
@@ -577,6 +597,7 @@ run_case "claudecode via Cursor extension"   t_claudecode_via_cursor_extension
 run_case "claudecode via VS Code extension"  t_claudecode_via_vscode_extension
 run_case "claudecode via Claude Desktop embedded bundle" t_claudecode_via_claude_desktop_embedded_bundle
 run_case "claudecode Claude Desktop picks highest bundled" t_claudecode_desktop_embedded_picks_highest_version
+run_case "claudecode Claude Desktop numeric patch ordering" t_claudecode_desktop_embedded_numeric_patch_ordering
 run_case "claudecode without install"        t_claudecode_no_install_returns_empty
 run_case "codex without home metadata"       t_codex_no_home_metadata_uses_system_or_empty
 run_case "codex from user npm metadata"      t_codex_from_user_npm_metadata

--- a/packaging/macos/tests/test_render_targets_manifest.sh
+++ b/packaging/macos/tests/test_render_targets_manifest.sh
@@ -110,10 +110,12 @@ t_empty_connectors_still_emits_valid_manifest() {
 }
 
 t_absent_connector_skipped_partial_box() {
-  # Regression: a box with only cursor installed must NOT get target rows
-  # for codex or claudecode. Otherwise the guardian churns forever trying
-  # to install hooks for a CLI that doesn't exist on the host. See
-  # discover_agent_version + render_targets_manifest empty-version skip.
+  # Regression: a box with only cursor installed AND no user-scoped
+  # config surfaces for the other connectors must NOT get target rows
+  # for codex or claudecode. Otherwise the guardian churns forever
+  # trying to install hooks for a CLI that doesn't exist on the host.
+  # See discover_agent_version + render_targets_manifest empty-version
+  # skip and the connector_present_for_user fallback.
   discover_agent_version() {
     case "$1" in
       cursor) printf '3.14.27' ;;
@@ -121,16 +123,259 @@ t_absent_connector_skipped_partial_box() {
     esac
   }
 
-  local users="shawnxu:501:20:/Users/shawnxu"
+  # Use a mktemp'd HOME that provably has none of the presence signals
+  # (~/.claude, ~/.claude.json, ~/.codex, ~/.cursor). This isolates the
+  # test from any stray files on the developer's real filesystem.
+  local test_home
+  test_home="$(mktemp -d "${TMPROOT}/home.shawnxu.XXXXXX")"
+  local users="shawnxu:501:20:${test_home}"
   local out
   out="$(render_targets_manifest "${TEST_SUPPORT}" "codex,claudecode,cursor" "${users}")"
 
   assert_contains     "${out}" 'connector: "cursor"'     "cursor row emitted"
-  assert_not_contains "${out}" 'connector: "codex"'      "codex row skipped (not installed)"
-  assert_not_contains "${out}" 'connector: "claudecode"' "claudecode row skipped (not installed)"
+  assert_not_contains "${out}" 'connector: "codex"'      "codex row skipped (not installed, no presence signal)"
+  assert_not_contains "${out}" 'connector: "claudecode"' "claudecode row skipped (not installed, no presence signal)"
   local count
   count="$(printf '%s\n' "${out}" | grep -c "^  - user:" || true)"
   assert_eq "${count}" "1" "one target when only cursor is installed"
+}
+
+t_unversioned_but_present_emits_row_with_empty_version() {
+  # Regression for the customer bundle where Claude Code CLI was installed
+  # via a channel discover_agent_version does not probe (e.g. Bun, pnpm,
+  # Homebrew tap, custom PATH shim). Before this fix the row was silently
+  # dropped from targets.yaml, the guardian never wired hooks, and the
+  # sidecar spammed HIGH-severity hook_guardian:unverified every 60s with
+  # no diagnostic pointing at the discovery gap.
+  #
+  # Now: when the version probe returns empty AND a CLI-only artifact
+  # exists on this user, emit the row with an empty agent_version and let
+  # the Go guardian's ResolveHookContract fall back to DefaultForUnversioned.
+  # In `action` mode the Go validateHookContract still fail-shuts
+  # per-target (surfacing the failure in protected_targets.json instead
+  # of a silent drop).
+  discover_agent_version() { printf ''; }
+
+  local test_home
+  test_home="$(mktemp -d "${TMPROOT}/home.jlunde.XXXXXX")"
+  # jlunde's DART bundle showed ~/.claude/sessions/ populated with active
+  # CLI session data. That subdir is created only by the Claude Code CLI
+  # itself — never by prepare_claudecode_userspace. Reproduce that shape.
+  mkdir -p "${test_home}/.claude/sessions"
+  local users="jlunde:501:20:${test_home}"
+  local out
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "claudecode,codex" "${users}")"
+
+  assert_contains     "${out}" 'connector: "claudecode"' "claudecode row emitted via presence fallback"
+  assert_contains     "${out}" 'agent_version: ""'       "empty agent_version passed through so Go picks DefaultForUnversioned"
+  assert_not_contains "${out}" 'connector: "codex"'      "codex still skipped (no CLI-only signal in ~/.codex)"
+  local count
+  count="$(printf '%s\n' "${out}" | grep -c "^  - user:" || true)"
+  assert_eq "${count}" "1" "exactly one target row emitted via presence fallback"
+}
+
+t_presence_fallback_covers_codex_history() {
+  # Codex CLI writes ~/.codex/history.jsonl on every chat exchange. That
+  # file is CLI-only (prepare_codex_userspace never creates it), so a
+  # user with real codex history but a version-discovery gap should get
+  # a target row emitted.
+  discover_agent_version() { printf ''; }
+
+  local test_home
+  test_home="$(mktemp -d "${TMPROOT}/home.codexuser.XXXXXX")"
+  mkdir -p "${test_home}/.codex"
+  # history.jsonl is CLI-only — DefenseClaw never writes this file.
+  : > "${test_home}/.codex/history.jsonl"
+  local users="codexuser:501:20:${test_home}"
+  local out
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "codex" "${users}")"
+
+  assert_contains "${out}" 'connector: "codex"'   "codex row emitted via ~/.codex/history.jsonl (CLI-only)"
+  assert_contains "${out}" 'agent_version: ""'    "empty agent_version passed through"
+}
+
+t_defenseclaw_prepared_state_does_not_trigger_fallback() {
+  # Regression per CodeRabbit review on PR #785: prepare_userspace_for
+  # (installer_lib.sh, above) creates ~/.claude, ~/.claude/settings.json,
+  # ~/.codex, ~/.codex/config.toml, ~/.cursor, and ~/.cursor/hooks.json
+  # for every eligible user × supported connector at pkg-install time.
+  # Those directories then persist after upgrades and even after the user
+  # uninstalls the connector CLI. If the presence check keyed on the
+  # bare directory, the guardian would churn forever emitting per-tick
+  # "agent_version empty" failures for a connector the user never used.
+  #
+  # This test reproduces EXACTLY what prepare_userspace_for leaves on
+  # disk, with discover_agent_version stubbed empty, and asserts that
+  # NO fallback row is emitted for any of the three connectors.
+  discover_agent_version() { printf ''; }
+
+  local test_home
+  test_home="$(mktemp -d "${TMPROOT}/home.dc_only.XXXXXX")"
+
+  # Mirror prepare_claudecode_userspace exactly.
+  mkdir -p "${test_home}/.claude"
+  printf '{}\n' > "${test_home}/.claude/settings.json"
+  # Mirror prepare_codex_userspace exactly.
+  mkdir -p "${test_home}/.codex"
+  cat > "${test_home}/.codex/config.toml" <<'TOML'
+# Created by DefenseClaw installer so the enterprise hook guardian can
+# repair this file. Edit freely; DefenseClaw only owns [hooks], [otel],
+# and the top-level notify entries.
+TOML
+  # Mirror prepare_cursor_userspace exactly.
+  mkdir -p "${test_home}/.cursor"
+  printf '{"version":1,"hooks":{}}\n' > "${test_home}/.cursor/hooks.json"
+
+  local users="fresh:501:20:${test_home}"
+  local out
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "codex,claudecode,cursor" "${users}")"
+
+  assert_not_contains "${out}" 'connector: "claudecode"' "prepare_claudecode_userspace state alone must not trigger fallback"
+  assert_not_contains "${out}" 'connector: "codex"'      "prepare_codex_userspace state alone must not trigger fallback"
+  assert_not_contains "${out}" 'connector: "cursor"'     "prepare_cursor_userspace state alone must not trigger fallback"
+  local count
+  count="$(printf '%s\n' "${out}" | grep -c "^  - user:" || true)"
+  assert_eq "${count}" "0" "no target rows emitted from DefenseClaw-only bootstrap state"
+
+  # Sanity: connector_present_for_user itself must reject each
+  # DefenseClaw-authored surface directly, not just via the render loop.
+  connector_present_for_user claudecode "${test_home}"
+  assert_status "$?" "1" "helper rejects claudecode when only ~/.claude + settings.json present"
+  connector_present_for_user codex "${test_home}"
+  assert_status "$?" "1" "helper rejects codex when only ~/.codex + config.toml present"
+  connector_present_for_user cursor "${test_home}"
+  assert_status "$?" "1" "helper rejects cursor when only ~/.cursor + hooks.json present"
+}
+
+t_legacy_prepared_dir_then_cli_use_triggers_fallback() {
+  # Follow-on to t_defenseclaw_prepared_state_does_not_trigger_fallback:
+  # once the user actually launches the CLI on top of the legacy prepared
+  # state, the CLI-only artifacts appear and the fallback SHOULD fire.
+  # This proves the tightened signals still catch the customer's real
+  # scenario (jlunde had a pre-existing prepared ~/.claude/settings.json
+  # AND live CLI sessions/session-env/projects state).
+  discover_agent_version() { printf ''; }
+
+  local test_home
+  test_home="$(mktemp -d "${TMPROOT}/home.legacy.XXXXXX")"
+
+  # Legacy DefenseClaw-prepared state.
+  mkdir -p "${test_home}/.claude"
+  printf '{}\n' > "${test_home}/.claude/settings.json"
+  # Then the user actually launches Claude Code. This is a CLI-only
+  # subdir prepare_claudecode_userspace never creates.
+  mkdir -p "${test_home}/.claude/sessions"
+
+  local users="mixed:501:20:${test_home}"
+  local out
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "claudecode" "${users}")"
+
+  assert_contains "${out}" 'connector: "claudecode"' "fallback fires once CLI-only ~/.claude/sessions appears"
+  assert_contains "${out}" 'agent_version: ""'       "row emitted with empty agent_version"
+}
+
+t_connector_present_for_user_signals() {
+  # Unit-level coverage for the helper itself so the presence rules
+  # can't drift silently when discover_agent_version is stubbed.
+  # Every asserted-present signal below MUST NOT be a directory or
+  # file that prepare_userspace_for creates — see the header comment
+  # on connector_present_for_user.
+  local test_home
+  test_home="$(mktemp -d "${TMPROOT}/home.present.XXXXXX")"
+
+  # No surfaces yet: every connector must return false.
+  connector_present_for_user claudecode "${test_home}"
+  assert_status "$?" "1" "claudecode absent on empty home"
+  connector_present_for_user codex "${test_home}"
+  assert_status "$?" "1" "codex absent on empty home"
+  connector_present_for_user cursor "${test_home}"
+  assert_status "$?" "1" "cursor absent on empty home"
+
+  # DefenseClaw-authored surfaces must NOT flip the helper to present.
+  # These mirror prepare_*_userspace one-to-one and are what makes the
+  # collision hazard real; the helper has to reject them.
+  mkdir -p "${test_home}/.claude"
+  printf '{}\n' > "${test_home}/.claude/settings.json"
+  mkdir -p "${test_home}/.codex"
+  : > "${test_home}/.codex/config.toml"
+  mkdir -p "${test_home}/.cursor"
+  : > "${test_home}/.cursor/hooks.json"
+  connector_present_for_user claudecode "${test_home}"
+  assert_status "$?" "1" "claudecode still absent under DefenseClaw-only bootstrap"
+  connector_present_for_user codex "${test_home}"
+  assert_status "$?" "1" "codex still absent under DefenseClaw-only bootstrap"
+  connector_present_for_user cursor "${test_home}"
+  assert_status "$?" "1" "cursor still absent under DefenseClaw-only bootstrap"
+
+  # ~/.claude.json (project trust file at home root, CLI-only) → present.
+  : > "${test_home}/.claude.json"
+  connector_present_for_user claudecode "${test_home}"
+  assert_status "$?" "0" "claudecode detected via ~/.claude.json"
+
+  # Each CLI-only claudecode subdir independently flips to present.
+  local sessions_home
+  sessions_home="$(mktemp -d "${TMPROOT}/home.sessions.XXXXXX")"
+  mkdir -p "${sessions_home}/.claude/sessions"
+  connector_present_for_user claudecode "${sessions_home}"
+  assert_status "$?" "0" "claudecode detected via ~/.claude/sessions"
+
+  local projects_home
+  projects_home="$(mktemp -d "${TMPROOT}/home.projects.XXXXXX")"
+  mkdir -p "${projects_home}/.claude/projects"
+  connector_present_for_user claudecode "${projects_home}"
+  assert_status "$?" "0" "claudecode detected via ~/.claude/projects"
+
+  local senv_home
+  senv_home="$(mktemp -d "${TMPROOT}/home.senv.XXXXXX")"
+  mkdir -p "${senv_home}/.claude/session-env"
+  connector_present_for_user claudecode "${senv_home}"
+  assert_status "$?" "0" "claudecode detected via ~/.claude/session-env"
+
+  # Codex CLI runtime artifacts.
+  local codex_log_home
+  codex_log_home="$(mktemp -d "${TMPROOT}/home.codexlog.XXXXXX")"
+  mkdir -p "${codex_log_home}/.codex/log"
+  connector_present_for_user codex "${codex_log_home}"
+  assert_status "$?" "0" "codex detected via ~/.codex/log"
+
+  local codex_hist_home
+  codex_hist_home="$(mktemp -d "${TMPROOT}/home.codexhist.XXXXXX")"
+  mkdir -p "${codex_hist_home}/.codex"
+  : > "${codex_hist_home}/.codex/history.jsonl"
+  connector_present_for_user codex "${codex_hist_home}"
+  assert_status "$?" "0" "codex detected via ~/.codex/history.jsonl"
+
+  local codex_auth_home
+  codex_auth_home="$(mktemp -d "${TMPROOT}/home.codexauth.XXXXXX")"
+  mkdir -p "${codex_auth_home}/.codex"
+  : > "${codex_auth_home}/.codex/auth.json"
+  connector_present_for_user codex "${codex_auth_home}"
+  assert_status "$?" "0" "codex detected via ~/.codex/auth.json"
+
+  # Cursor IDE runtime artifacts.
+  local cursor_ext_home
+  cursor_ext_home="$(mktemp -d "${TMPROOT}/home.cursorext.XXXXXX")"
+  mkdir -p "${cursor_ext_home}/.cursor/extensions"
+  connector_present_for_user cursor "${cursor_ext_home}"
+  assert_status "$?" "0" "cursor detected via ~/.cursor/extensions"
+
+  local cursor_argv_home
+  cursor_argv_home="$(mktemp -d "${TMPROOT}/home.cursorargv.XXXXXX")"
+  mkdir -p "${cursor_argv_home}/.cursor"
+  : > "${cursor_argv_home}/.cursor/argv.json"
+  connector_present_for_user cursor "${cursor_argv_home}"
+  assert_status "$?" "0" "cursor detected via ~/.cursor/argv.json"
+
+  # Empty home arg is a hard "not present" — must not scan the invoking
+  # user's real dotfiles.
+  connector_present_for_user claudecode ""
+  assert_status "$?" "1" "empty home never returns present"
+
+  # Unknown connector never returns present.
+  local unknown_home
+  unknown_home="$(mktemp -d "${TMPROOT}/home.unknown.XXXXXX")"
+  connector_present_for_user made_up_connector "${unknown_home}"
+  assert_status "$?" "1" "unknown connector name never returns present"
 }
 
 t_all_connectors_absent_yields_zero_rows() {
@@ -142,7 +387,17 @@ t_all_connectors_absent_yields_zero_rows() {
   # will wire hooks the moment a supported connector CLI appears.
   discover_agent_version() { printf ''; }
 
-  local users="shawnxu:501:20:/Users/shawnxu"
+  # Use a mktemp'd home so the presence-fallback in
+  # render_targets_manifest can't find any CLI-authored artifact for the
+  # stub user — the assertion is "zero rows when nothing is installed",
+  # which is only provable against a home that provably has nothing in
+  # it. A hardcoded path like /Users/shawnxu can carry over dev-box
+  # dotfiles (e.g. ~/.claude/sessions from a real Claude Code session)
+  # and flip the presence signal to true, emitting a row and failing the
+  # test. Matches the mktemp pattern used in t_absent_connector_skipped_partial_box.
+  local test_home
+  test_home="$(mktemp -d "${TMPROOT}/home.absent.XXXXXX")"
+  local users="shawnxu:501:20:${test_home}"
   local out
   out="$(render_targets_manifest "${TEST_SUPPORT}" "codex,claudecode,cursor" "${users}")"
 
@@ -263,6 +518,11 @@ run_case "empty user list still emits valid manifest"           t_empty_users_st
 run_case "empty connector list still emits valid manifest"      t_empty_connectors_still_emits_valid_manifest
 run_case "absent connectors are skipped (partial-box render)"   t_absent_connector_skipped_partial_box
 run_case "all connectors absent yields zero rows"               t_all_connectors_absent_yields_zero_rows
+run_case "unversioned but present emits row with empty version" t_unversioned_but_present_emits_row_with_empty_version
+run_case "presence fallback covers ~/.codex/history.jsonl"      t_presence_fallback_covers_codex_history
+run_case "DefenseClaw-prepared state alone doesn't trigger fallback" t_defenseclaw_prepared_state_does_not_trigger_fallback
+run_case "legacy prepared dir + CLI use → fallback fires"       t_legacy_prepared_dir_then_cli_use_triggers_fallback
+run_case "connector_present_for_user helper signals"            t_connector_present_for_user_signals
 run_case "rendered targets.yaml parses (schema round-trip)"     t_rendered_yaml_parses
 run_case "rows pin enabled + int uid/gid"                       t_rows_pin_enabled_and_int_uid_gid
 run_case "rows omit data_dir (per-user Install default is used)" t_rows_omit_data_dir

--- a/packaging/windows/DefenseClawEnterprise.psm1
+++ b/packaging/windows/DefenseClawEnterprise.psm1
@@ -5039,8 +5039,11 @@ function Initialize-DefenseClawManagedIPCDirectory {
         [Parameter(Mandatory)][string]$GatewayServiceName
     )
     $gatewaySID = Get-DefenseClawServiceSID -ServiceName $GatewayServiceName
+    # AVC release-26.8.4 integration: the UI-IPC UDS socket lives under
+    # Program Files, not ProgramData. Path parity with the Go resolver
+    # in internal/ipc/paths_windows.go is mandatory. Spec 004 REQ-02.
     $expectedIPCDirectory = [IO.Path]::Combine(
-        $script:ProgramData,
+        $script:ProgramFiles,
         'Cisco',
         'Cisco Secure Client',
         'DefenseClaw',
@@ -5064,12 +5067,12 @@ function Initialize-DefenseClawManagedIPCDirectory {
         Initialize-DefenseClawManagedRoot `
             -Path $parent `
             -Label 'managed IPC parent' `
-            -RequiredBase $script:ProgramData
+            -RequiredBase $script:ProgramFiles
     }
     else {
         Assert-DefenseClawTrustedAncestors `
             -Path $parent `
-            -RequiredBase $script:ProgramData
+            -RequiredBase $script:ProgramFiles
     }
 
     if (Microsoft.PowerShell.Management\Test-Path -LiteralPath $ipcDirectory) {
@@ -5293,8 +5296,11 @@ function Revoke-DefenseClawManagedIPCServiceAccess {
             -GatewayServiceSID $GatewayServiceSID
     }
 
+    # AVC release-26.8.4 integration: the UI-IPC UDS socket lives under
+    # Program Files, not ProgramData. Path parity with the Go resolver
+    # in internal/ipc/paths_windows.go is mandatory. Spec 004 REQ-02.
     $expectedIPCDirectory = [IO.Path]::Combine(
-        $script:ProgramData,
+        $script:ProgramFiles,
         'Cisco',
         'Cisco Secure Client',
         'DefenseClaw',
@@ -5315,7 +5321,7 @@ function Revoke-DefenseClawManagedIPCServiceAccess {
     Assert-DefenseClawNoReparsePath -Path $ipcDirectory -AllowMissingLeaf
     Assert-DefenseClawTrustedAncestors `
         -Path ([IO.Path]::GetDirectoryName($ipcDirectory)) `
-        -RequiredBase $script:ProgramData
+        -RequiredBase $script:ProgramFiles
 
     $nativeSecurity = Initialize-DefenseClawNativeSecurity
     # This final-component OPEN_REPARSE_POINT call is the sole absence proof.
@@ -6324,8 +6330,13 @@ function Get-DefenseClawLayout {
     $gatewayLogDirectory = Microsoft.PowerShell.Management\Join-Path $logDirectory 'gateway'
     $brokerLogDirectory = Microsoft.PowerShell.Management\Join-Path $logDirectory 'cmid-broker'
     $guardianLogDirectory = Microsoft.PowerShell.Management\Join-Path $logDirectory 'guardian'
+    # The DefenseClaw managed-IPC UDS socket lives under Program Files
+    # (not ProgramData) as of the AVC release-26.8.4 integration —
+    # Cisco Secure Client's Windows GUI dials the socket under Program
+    # Files so DefenseClaw follows. Path parity with
+    # internal/ipc/paths_windows.go is mandatory. Spec 004 REQ-02.
     $managedIPCDirectory = [IO.Path]::Combine(
-        $script:ProgramData,
+        $script:ProgramFiles,
         'Cisco',
         'Cisco Secure Client',
         'DefenseClaw',

--- a/packaging/windows/tests/enterprise-module-smoke.ps1
+++ b/packaging/windows/tests/enterprise-module-smoke.ps1
@@ -514,7 +514,7 @@ namespace DefenseClaw.Windows.Tests
         -StateRoot (Join-Path $script:ProgramData 'Cisco\Cisco Secure Client\DefenseClaw')
     $expectedCodexParent = Join-Path $script:ProgramData 'OpenAI\Codex'
     $expectedManagedIPCDirectory = Join-Path `
-        $script:ProgramData `
+        $script:ProgramFiles `
         'Cisco\Cisco Secure Client\DefenseClaw\ipc'
     if (-not [string]::Equals(
         [string]$layout.ManagedIPCDirectory,


### PR DESCRIPTION
## Summary
Forward-port all fixes landed on `release-defenseclaw-enterprise-26.8.4` back to `main` so they aren't lost after the release branch stops receiving traffic. All five cherry-picks applied cleanly (only one auto-merge in `internal/gateway/sidecar.go` on the last commit).

Cherry-picks, oldest → newest (order preserved):

| Commit (main) | Original PR | Summary |
|---|---|---|
| `98ed0bb57` | [#781](https://github.com/cisco-ai-defense/defenseclaw/pull/781) | fix(windows): move UI-IPC socket root from ProgramData to Program Files |
| `7b40f9dda` | [#782](https://github.com/cisco-ai-defense/defenseclaw/pull/782) | fix(windows): auto-authorize new users on the enumerator SCM service at parity with macOS |
| `9ab706c65` | [#784](https://github.com/cisco-ai-defense/defenseclaw/pull/784) | fix(windows): scan real user profiles for AI discovery on managed_enterprise |
| `4f8270367` | [#786](https://github.com/cisco-ai-defense/defenseclaw/pull/786) | fix(hooks): presence-based fallback (macOS, cherry-pick of #785) + broaden Windows probe |
| `759304fd0` | [#802](https://github.com/cisco-ai-defense/defenseclaw/pull/802) | fix(inventory): pin managed_enterprise AI Defense publish to 300 s (full-scan cadence) |

Note on #786: it already includes the macOS presence-based fallback from #785 (which was authored against release-26.7.3 and has no separate main commit), so #785 does not need a separate cherry-pick — it rides in on #786.

## Test plan
- [ ] CI green on this PR (unit + integration)
- [ ] Windows managed_enterprise: verify UI-IPC socket lives under Program Files (per #781) after upgrade
- [ ] Windows enumerator SCM: fresh non-admin user sees inventory without manual authorize step (per #782)
- [ ] Windows AI discovery: scan hits real user profiles, not just SYSTEM (per #784)
- [ ] hook-enumerator: macOS presence fallback triggers when version probe is inconclusive; Windows probe covers non-npm install channels (per #786)
- [ ] managed_enterprise: AI Defense publish cadence pins to 300 s (per #802)

🤖 Generated with [Claude Code](https://claude.com/claude-code)