### PR TITLE
feat(connectors): add Windows OSS support for Hermes, Cursor, and OpenCode

### DIFF
--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -449,7 +449,7 @@ jobs:
       # 0.8.7 predates immutable install.ps1 release assets. The compatibility
       # fallback below is review-bound to these exact repository bytes and is
       # refused for every other release/candidate identity.
-      BOOTSTRAP_LEGACY_INSTALLER_SHA256: e6b81405ede0ccdac21e7be94d837925e9f4d59908e0c2ca4b8f7fd2c7d880a3
+      BOOTSTRAP_LEGACY_INSTALLER_SHA256: c3d3c1224a175e00cb252b9608d70dc9254284cb044932c5d7eaa2d5e412510c
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -449,7 +449,7 @@ jobs:
       # 0.8.7 predates immutable install.ps1 release assets. The compatibility
       # fallback below is review-bound to these exact repository bytes and is
       # refused for every other release/candidate identity.
-      BOOTSTRAP_LEGACY_INSTALLER_SHA256: c5f03c7559dd941ca06acdaddeac9262f37911cd8393fe98d4af1aa32b7eb20a
+      BOOTSTRAP_LEGACY_INSTALLER_SHA256: e6b81405ede0ccdac21e7be94d837925e9f4d59908e0c2ca4b8f7fd2c7d880a3
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/cli/defenseclaw/bootstrap.py
+++ b/cli/defenseclaw/bootstrap.py
@@ -1511,7 +1511,7 @@ def _connector_readiness(cfg: Config, connector: str) -> StepResult:
             return StepResult("Connector", "pass", "Hermes config found")
         return StepResult("Connector", "warn", "Hermes config not found yet", "defenseclaw setup hermes")
     if connector == "cursor":
-        path = os.path.expanduser("~/.cursor/hooks.json")
+        path = connector_config_files("cursor")[0]
         if os.path.isfile(path):
             return StepResult("Connector", "pass", "Cursor hooks found")
         return StepResult("Connector", "warn", "Cursor hooks not found yet", "defenseclaw setup cursor")
@@ -1568,7 +1568,7 @@ def _connector_readiness(cfg: Config, connector: str) -> StepResult:
     if connector == "opencode":
         # opencode is governed by a bridge plugin DefenseClaw writes into
         # opencode's auto-load plugin directory (no hooks.json to patch).
-        path = os.path.expanduser("~/.config/opencode/plugins/defenseclaw.js")
+        path = connector_config_files("opencode")[0]
         if os.path.isfile(path):
             return StepResult("Connector", "pass", "OpenCode bridge plugin found")
         return StepResult(

--- a/cli/defenseclaw/commands/cmd_init.py
+++ b/cli/defenseclaw/commands/cmd_init.py
@@ -516,7 +516,7 @@ def init_cmd(  # noqa: PLR0913 - first-run CLI mirrors the setup surface.
     click.echo(f"    {ux.accent('defenseclaw mcp scan --all')}   " + ux.dim("Scan configured MCP servers"))
     click.echo(
         f"    {ux.accent('defenseclaw setup <connector>')} "
-        + ux.dim("Add another agent (codex, claudecode, amp)")
+        + ux.dim("Add another agent (codex, claudecode, amp, hermes)")
     )
 
     store.close()

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -3978,10 +3978,10 @@ _CONNECTOR_CHANGE_SURFACES: dict[str, tuple[str, ...]] = {
         "~/.defenseclaw/hooks/hermes-hook.sh",
     ),
     "cursor": (
-        "~/.cursor/hooks.json hooks",
+        "CURSOR_CONFIG_DIR/hooks.json hooks (defaults to ~/.cursor/hooks.json)",
         "<workspace>/.cursor/mcp.json MCP entries when configured explicitly",
         "<workspace>/.cursor/skills and <workspace>/.cursor/rules install surfaces",
-        "~/.defenseclaw/hooks/cursor-hook.sh",
+        "~/.defenseclaw/hooks/cursor-hook.sh (macOS/Linux) or cursor-hook.ps1 (Windows)",
     ),
     "windsurf": (
         "~/.codeium/windsurf/hooks.json hooks",

--- a/cli/defenseclaw/connector_paths.py
+++ b/cli/defenseclaw/connector_paths.py
@@ -308,6 +308,18 @@ def codex_home() -> str:
     return _connector_env_home("CODEX_HOME", ".codex")
 
 
+def cursor_config_home() -> str:
+    """Return Cursor's effective user configuration directory."""
+
+    return _connector_env_home("CURSOR_CONFIG_DIR", ".cursor")
+
+
+def opencode_config_home() -> str:
+    """Return OpenCode's effective global configuration directory."""
+
+    return _connector_env_home("OPENCODE_CONFIG_DIR", os.path.join(".config", "opencode"))
+
+
 def amp_config_home() -> str:
     """Return Amp's documented system configuration directory.
 
@@ -497,16 +509,13 @@ def connector_home(
         # path agy actually evaluates.
         return os.path.join(home, ".gemini", "antigravity-cli")
     if name == "cursor":
-        return os.path.join(home, ".cursor")
+        return cursor_config_home()
     if name == "windsurf":
         return os.path.join(home, ".codeium", "windsurf")
     if name == "hermes":
         return hermes_home()
     if name == "opencode":
-        # opencode keeps its config under ~/.config/opencode/ (XDG-style).
-        # Surfaced so inventory/doctor render a truthful home label rather
-        # than an empty string or — worse — OpenClaw's path.
-        return os.path.join(home, ".config", "opencode")
+        return opencode_config_home()
     if name == "omnigent":
         return _omnigent_config_home()
     if name == "openclaw":
@@ -595,13 +604,14 @@ def connector_config_files(
         # DefenseClaw installs a single bridge plugin there. There is no
         # command-hook config file to patch.
         paths = [
-            os.path.join(home, ".config", "opencode", "plugins", "defenseclaw.js"),
+            os.path.join(opencode_config_home(), "plugins", "defenseclaw.js"),
         ]
     elif name == "omnigent":
         paths = [omnigent_config_path()]
     elif name == "cursor":
         paths = [
-            os.path.join(home, ".cursor", "mcp.json"),
+            os.path.join(cursor_config_home(), "hooks.json"),
+            os.path.join(cursor_config_home(), "mcp.json"),
             _workspace_path(workspace_dir, ".cursor", "mcp.json"),
         ]
     elif name == "windsurf":
@@ -1238,7 +1248,7 @@ def _cursor_skill_dirs(workspace_dir: str | None = None) -> list[str]:
     home = str(Path.home())
     return _dedup(
         [
-            os.path.join(home, ".cursor", "skills"),
+            os.path.join(cursor_config_home(), "skills"),
             os.path.join(home, ".agents", "skills"),
             _workspace_path(workspace_dir, ".cursor", "skills"),
             _workspace_path(workspace_dir, ".agents", "skills"),
@@ -1620,9 +1630,8 @@ def _hermes_mcp_servers() -> list[MCPServerEntry]:
 
 
 def _cursor_mcp_servers(workspace_dir: str | None = None) -> list[MCPServerEntry]:
-    home = str(Path.home())
     entries: list[MCPServerEntry] = []
-    entries.extend(_read_dotmcp_json(os.path.join(home, ".cursor", "mcp.json")))
+    entries.extend(_read_dotmcp_json(os.path.join(cursor_config_home(), "mcp.json")))
     project_mcp = _workspace_path(workspace_dir, ".cursor", "mcp.json")
     if project_mcp:
         entries.extend(_read_dotmcp_json(project_mcp))
@@ -1698,10 +1707,10 @@ def _opencode_config_paths(workspace_dir: str | None) -> list[str]:
     ``.jsonc``) is added only when an explicit workspace is pinned, so
     the daemon never infers a project file from its own cwd.
     """
-    home = str(Path.home())
+    config_home = opencode_config_home()
     paths = [
-        os.path.join(home, ".config", "opencode", "opencode.json"),
-        os.path.join(home, ".config", "opencode", "opencode.jsonc"),
+        os.path.join(config_home, "opencode.json"),
+        os.path.join(config_home, "opencode.jsonc"),
     ]
     root = _workspace_dir(workspace_dir)
     if root:
@@ -2666,7 +2675,7 @@ def _opencode_write_path(workspace_dir: str | None) -> str:
     root = _workspace_dir(workspace_dir)
     if root:
         return os.path.join(root, "opencode.json")
-    return os.path.join(str(Path.home()), ".config", "opencode", "opencode.json")
+    return os.path.join(opencode_config_home(), "opencode.json")
 
 
 def _opencode_mcp_entry_from_generic(entry: dict[str, Any]) -> dict[str, Any]:

--- a/cli/defenseclaw/inventory/agent_discovery.py
+++ b/cli/defenseclaw/inventory/agent_discovery.py
@@ -53,6 +53,7 @@ from defenseclaw.connector_paths import (
     _expand,
     amp_managed_settings_path,
     connector_config_files,
+    connector_home,
     hermes_config_path,
     omnigent_config_path,
 )
@@ -1026,6 +1027,20 @@ def _scan_agent(
         )
     elif name == "hermes":
         config_candidates = (hermes_config_path(),)
+    elif name == "cursor":
+        config_candidates = tuple(connector_config_files("cursor"))
+    elif name == "opencode":
+        config_home = connector_home("opencode")
+        config_candidates = (
+            os.path.join(config_home, "plugins", "defenseclaw.js"),
+            os.path.join(config_home, "opencode.json"),
+            os.path.join(config_home, "opencode.jsonc"),
+            os.path.join(config_home, "tui.json"),
+            os.path.join(config_home, "tui.jsonc"),
+            "opencode.json",
+            "opencode.jsonc",
+            ".opencode/plugins/defenseclaw.js",
+        )
     elif name == "amp":
         # Enterprise managed settings are valid configuration evidence but
         # are platform-specific and administrator-owned. Keep them read-only

--- a/cli/defenseclaw/inventory/hook_contracts.json
+++ b/cli/defenseclaw/inventory/hook_contracts.json
@@ -727,11 +727,11 @@
         {
           "contract_id": "hermes-hooks-v1",
           "agent_version": {
-            "min_inclusive": "0.11.0",
+            "min_inclusive": "0.20.6",
             "max_exclusive": ""
           },
           "default_for_unversioned": true,
-          "hook_script_version": "v6",
+          "hook_script_version": "v7",
           "hook_script": "hermes-hook.sh",
           "hook_config_path_templates": [
             "$HERMES_HOME/config.yaml",
@@ -740,16 +740,29 @@
           ],
           "response_field": "hook_output",
           "events": [
-            "pre_llm_call",
             "pre_tool_call",
             "post_tool_call",
+            "transform_terminal_output",
+            "transform_tool_result",
+            "transform_llm_output",
+            "pre_llm_call",
             "post_llm_call",
+            "pre_verify",
+            "pre_api_request",
+            "post_api_request",
+            "api_request_error",
             "on_session_start",
             "on_session_end",
             "on_session_finalize",
             "on_session_reset",
             "subagent_start",
-            "subagent_stop"
+            "subagent_stop",
+            "pre_gateway_dispatch",
+            "pre_approval_request",
+            "post_approval_response",
+            "kanban_task_claimed",
+            "kanban_task_completed",
+            "kanban_task_blocked"
           ],
           "aid_surfaces": [
             "prompt",
@@ -810,11 +823,11 @@
               "skills"
             ],
             "official_source_urls": [
-              "https://github.com/NousResearch/hermes-agent/blob/126ff7071b6b755055879648f4e859b3187d0fac/agent/shell_hooks.py",
-              "https://github.com/NousResearch/hermes-agent/blob/126ff7071b6b755055879648f4e859b3187d0fac/model_tools.py"
+              "https://github.com/NousResearch/hermes-agent/blob/5fc308a70719a83cccdbba4c0e39c23f5a8239d5/agent/shell_hooks.py",
+              "https://github.com/NousResearch/hermes-agent/blob/5fc308a70719a83cccdbba4c0e39c23f5a8239d5/model_tools.py"
             ],
             "limitations": [
-              "Only pre_tool_call can block, and hook subprocess errors, timeouts, or malformed output fail open upstream.",
+              "Only pre_tool_call can block; fail_closed=true makes hook subprocess errors, timeouts, and malformed output block upstream.",
               "A post_tool_call commits success only when extra.status is ok; error and blocked statuses must not advance state."
             ]
           },
@@ -825,13 +838,13 @@
             "block_events": [
               "pre_tool_call"
             ],
-            "supports_fail_closed": false,
+            "supports_fail_closed": true,
             "scope": "user"
           },
           "notes": [
-            "Covers the documented shell-hook lifecycle including session start/end/finalize/reset and subagent start/stop telemetry. Hermes nests prompt/result and delegation identity under the per-event extra envelope; the generic decoder lifts those fields into the canonical lifecycle.",
-            "pre_tool_call is the only blockable event; pre_llm_call injects context; confirm verdicts downgrade to a systemMessage alert (no native ask surface); Hermes never blocks on exit code or hook timeout so there is no fail-closed surface.",
-            "Multi-event registration requires hooks_auto_accept in cli-config.yaml on non-TTY/gateway runs; Setup writes it and the managed-backup heals it."
+            "Pinned to Hermes Agent 0.20.6 and the 23-event shell-hook subset adopted from PR #655. Hermes nests prompt/result and delegation identity under the per-event extra envelope; the generic decoder lifts those fields into the canonical lifecycle.",
+            "pre_tool_call is the only blockable event; pre_llm_call injects context; confirm verdicts downgrade to a systemMessage alert (no native ask surface); exit code 2 blocks and fail_closed protects hook failures, malformed output, and timeouts.",
+            "Hermes requires exact per-(event,command) consent on non-TTY/gateway runs. Setup leaves the operator-wide hooks_auto_accept policy untouched and provisions only DefenseClaw-owned entries in shell-hooks-allowlist.json; teardown restores or surgically removes those entries."
           ]
         }
       ]

--- a/cli/defenseclaw/inventory/hook_contracts.json
+++ b/cli/defenseclaw/inventory/hook_contracts.json
@@ -970,19 +970,21 @@
             ],
             "block_events": [
               "preToolUse",
+              "subagentStart",
               "beforeShellExecution",
               "beforeMCPExecution",
               "beforeReadFile",
               "beforeTabFileRead",
-              "beforeSubmitPrompt",
-              "stop"
+              "beforeSubmitPrompt"
             ],
             "supports_fail_closed": true,
             "scope": "user"
           },
           "notes": [
-            "Cursor 1.7 introduced beta hooks for the agent loop.",
-            "Cursor native ask is limited to beforeShellExecution and beforeMCPExecution."
+            "Cursor command hooks use documented per-event payloads; specialized shell, MCP, file, prompt, and result fields are projected into the shared scanner contract.",
+            "Cursor native ask is limited to beforeShellExecution and beforeMCPExecution.",
+            "preToolUse, subagentStart, shell/MCP gates, file-read gates, and beforeSubmitPrompt can deny. stop is follow-up-only and cannot block termination.",
+            "Every command-hook invocation returns a non-empty JSON object; beforeSubmitPrompt uses continue while permission gates use permission."
           ]
         }
       ]

--- a/cli/defenseclaw/inventory/validated_versions.json
+++ b/cli/defenseclaw/inventory/validated_versions.json
@@ -56,8 +56,13 @@
     },
     "hermes": {
       "version_probe": "hermes --version",
-      "live": false,
-      "notes": "contract-only (Layer A); only pre_tool_call is mapped"
+      "live": true,
+      "os": {
+        "linux": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "macos": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "windows": { "last_validated_version": "0.20.6", "last_validated_at": "2026-08-30", "run_url": "" }
+      },
+      "notes": "Windows native hook registration and allow/block/fail-closed/lifecycle paths validated against official Hermes Agent 0.20.6 (release v2026.8.27)"
     },
     "windsurf": {
       "version_probe": "",

--- a/cli/defenseclaw/platform_support.py
+++ b/cli/defenseclaw/platform_support.py
@@ -75,8 +75,9 @@ WINDOWS_CONNECTOR_SUPPORT: dict[str, ConnectorPlatformSupport] = {
         "Claude Code with Git for Windows and native hooks is certified on native Windows x64.",
     ),
     "cursor": ConnectorPlatformSupport(
-        NOT_CERTIFIED,
-        "The DefenseClaw Cursor integration has not completed native Windows x64 certification.",
+        PREVIEW,
+        "Cursor native Windows support is preview pending integrated packaged Setup "
+        "and official-client validation.",
     ),
     "windsurf": ConnectorPlatformSupport(
         NOT_CERTIFIED,
@@ -95,8 +96,10 @@ WINDOWS_CONNECTOR_SUPPORT: dict[str, ConnectorPlatformSupport] = {
         "The DefenseClaw Antigravity integration has not completed native Windows x64 certification.",
     ),
     "opencode": ConnectorPlatformSupport(
-        NOT_CERTIFIED,
-        "The DefenseClaw OpenCode integration has not completed native Windows x64 certification.",
+        PREVIEW,
+        "OpenCode native Windows support is preview pending integrated packaged Setup "
+        "and official-client validation; OpenCode recommends WSL but also supports "
+        "direct Windows use.",
     ),
     "amp": ConnectorPlatformSupport(
         SUPPORTED,

--- a/cli/defenseclaw/platform_support.py
+++ b/cli/defenseclaw/platform_support.py
@@ -103,8 +103,8 @@ WINDOWS_CONNECTOR_SUPPORT: dict[str, ConnectorPlatformSupport] = {
         "Amp and the DefenseClaw system policy plugin are supported on native Windows x64.",
     ),
     "hermes": ConnectorPlatformSupport(
-        NOT_CERTIFIED,
-        "The DefenseClaw Hermes integration has not completed native Windows x64 certification.",
+        SUPPORTED,
+        "Hermes Agent 0.20.6 and DefenseClaw native hooks are supported on native Windows x64.",
     ),
     "openhands": ConnectorPlatformSupport(
         UNSUPPORTED,

--- a/cli/tests/test_bootstrap.py
+++ b/cli/tests/test_bootstrap.py
@@ -186,6 +186,33 @@ class BootstrapEnvTests(unittest.TestCase):
         self.assertEqual(result.status, "pass")
         self.assertIn("Hermes config found", result.detail)
 
+    def test_cursor_readiness_honors_cursor_config_dir(self):
+        cfg = _cfg_for(os.path.join(self._tmp.name, "dchome"))
+        config_home = os.path.join(self._tmp.name, "cursor-config")
+        os.makedirs(config_home)
+        with open(os.path.join(config_home, "hooks.json"), "w", encoding="utf-8") as fh:
+            fh.write('{"version": 1, "hooks": {}}\n')
+
+        with patch.dict(os.environ, {"CURSOR_CONFIG_DIR": config_home}):
+            result = _connector_readiness(cfg, "cursor")
+
+        self.assertEqual(result.status, "pass")
+        self.assertIn("Cursor hooks found", result.detail)
+
+    def test_opencode_readiness_honors_opencode_config_dir(self):
+        cfg = _cfg_for(os.path.join(self._tmp.name, "dchome"))
+        config_home = os.path.join(self._tmp.name, "opencode-config")
+        plugin_dir = os.path.join(config_home, "plugins")
+        os.makedirs(plugin_dir)
+        with open(os.path.join(plugin_dir, "defenseclaw.js"), "w", encoding="utf-8") as fh:
+            fh.write("// DefenseClaw test bridge\n")
+
+        with patch.dict(os.environ, {"OPENCODE_CONFIG_DIR": config_home}):
+            result = _connector_readiness(cfg, "opencode")
+
+        self.assertEqual(result.status, "pass")
+        self.assertIn("OpenCode bridge plugin found", result.detail)
+
     def test_omnigent_readiness_honors_config_home(self):
         cfg = _cfg_for(os.path.join(self._tmp.name, "dchome"))
         config_home = os.path.join(self._tmp.name, "omnigent-config")

--- a/cli/tests/test_connector_paths.py
+++ b/cli/tests/test_connector_paths.py
@@ -1141,6 +1141,27 @@ class TestConnectorHome:
 
         assert connector_paths.connector_home(connector) == str(tmp_path / directory)
 
+    @pytest.mark.parametrize(
+        ("connector", "variable", "config_parts"),
+        [
+            ("cursor", "CURSOR_CONFIG_DIR", ("hooks.json",)),
+            ("opencode", "OPENCODE_CONFIG_DIR", ("plugins", "defenseclaw.js")),
+        ],
+    )
+    def test_windows_preview_connector_homes_follow_official_overrides(
+        self,
+        connector,
+        variable,
+        config_parts,
+        monkeypatch,
+        tmp_path,
+    ):
+        configured = tmp_path / f"custom-{connector}"
+        monkeypatch.setenv(variable, str(configured))
+
+        assert connector_paths.connector_home(connector) == str(configured)
+        assert connector_paths.connector_config_files(connector)[0] == str(configured.joinpath(*config_parts))
+
     def test_opencode_home_is_xdg_config(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HOME", str(tmp_path))
         assert connector_paths.connector_home("opencode") == os.path.join(str(tmp_path), ".config", "opencode")

--- a/cli/tests/test_platform_support.py
+++ b/cli/tests/test_platform_support.py
@@ -62,9 +62,9 @@ from defenseclaw.tui.services.cli_choices import (
 
 from tests.helpers import cleanup_app, make_app_context
 
-WINDOWS_SUPPORTED = {"codex", "claudecode", "amp"}
+WINDOWS_SUPPORTED = {"codex", "claudecode", "amp", "hermes"}
 WINDOWS_PREVIEW: set[str] = set()
-WINDOWS_NOT_CERTIFIED = {"cursor", "windsurf", "geminicli", "copilot", "antigravity", "opencode", "hermes"}
+WINDOWS_NOT_CERTIFIED = {"cursor", "windsurf", "geminicli", "copilot", "antigravity", "opencode"}
 WINDOWS_UNSUPPORTED = {"openhands", "omnigent", "openclaw", "zeptoclaw"}
 ALL_CONNECTORS = WINDOWS_SUPPORTED | WINDOWS_PREVIEW | WINDOWS_NOT_CERTIFIED | WINDOWS_UNSUPPORTED
 
@@ -175,7 +175,7 @@ def test_non_windows_behavior_is_unchanged() -> None:
 
 def test_supported_connectors_preserves_order_and_certified_windows_scope() -> None:
     ordered = ["openclaw", "codex", "amp", "hermes", "openhands", "claudecode"]
-    assert supported_connectors(ordered, "windows") == ["codex", "amp", "claudecode"]
+    assert supported_connectors(ordered, "windows") == ["codex", "amp", "hermes", "claudecode"]
     assert supported_connectors(ordered, "linux") == ordered
 
 

--- a/cli/tests/test_platform_support.py
+++ b/cli/tests/test_platform_support.py
@@ -63,8 +63,8 @@ from defenseclaw.tui.services.cli_choices import (
 from tests.helpers import cleanup_app, make_app_context
 
 WINDOWS_SUPPORTED = {"codex", "claudecode", "amp", "hermes"}
-WINDOWS_PREVIEW: set[str] = set()
-WINDOWS_NOT_CERTIFIED = {"cursor", "windsurf", "geminicli", "copilot", "antigravity", "opencode"}
+WINDOWS_PREVIEW: set[str] = {"opencode", "cursor"}
+WINDOWS_NOT_CERTIFIED = {"windsurf", "geminicli", "copilot", "antigravity"}
 WINDOWS_UNSUPPORTED = {"openhands", "omnigent", "openclaw", "zeptoclaw"}
 ALL_CONNECTORS = WINDOWS_SUPPORTED | WINDOWS_PREVIEW | WINDOWS_NOT_CERTIFIED | WINDOWS_UNSUPPORTED
 
@@ -264,14 +264,16 @@ def test_all_connector_lists_share_one_taxonomy() -> None:
     assert set(_HOOK_ENFORCED_CONNECTORS) == ALL_CONNECTORS - set(PROXY_CONNECTORS)
 
 
-def test_windows_views_hide_unsupported_and_have_no_preview() -> None:
-    expected = WINDOWS_SUPPORTED
+def test_windows_views_include_preview_and_hide_unavailable_connectors() -> None:
+    expected = WINDOWS_SUPPORTED | WINDOWS_PREVIEW
     assert set(supported_connector_choices("windows")) == expected
     assert set(visible_connector_choices("windows")) == expected
 
     win_modes = visible_mode_picker_choices("windows")
     assert {choice.wire for choice in win_modes} == expected
-    assert all("preview" not in choice.label.lower() for choice in win_modes)
+    labels = {choice.wire: choice.label.lower() for choice in win_modes}
+    assert all("preview" in labels[name] for name in WINDOWS_PREVIEW)
+    assert all("preview" not in labels[name] for name in WINDOWS_SUPPORTED)
 
 
 def test_non_windows_views_are_unfiltered() -> None:

--- a/cli/tests/test_windows_release_claims.py
+++ b/cli/tests/test_windows_release_claims.py
@@ -19,7 +19,7 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_windows_release_metadata_is_exact() -> None:
-    assert WINDOWS_SUPPORTED_CONNECTORS == {"codex", "claudecode", "amp"}
+    assert WINDOWS_SUPPORTED_CONNECTORS == {"codex", "claudecode", "amp", "hermes"}
     assert WINDOWS_NOT_CERTIFIED_CONNECTORS == {
         "cursor",
         "windsurf",
@@ -27,7 +27,6 @@ def test_windows_release_metadata_is_exact() -> None:
         "copilot",
         "antigravity",
         "opencode",
-        "hermes",
     }
     assert WINDOWS_UNSUPPORTED_CONNECTORS == {"openhands", "omnigent", "openclaw", "zeptoclaw"}
     assert WINDOWS_CERTIFIED_ARCHITECTURES == {"amd64"}
@@ -53,6 +52,7 @@ def test_windows_guide_has_unambiguous_claims_and_powershell_examples() -> None:
     assert "Windows ARM64" in text and "Not certified" in text
     assert "| Codex | `codex` | **Supported**" in text
     assert "| Claude Code | `claudecode` | **Supported**" in text
+    assert "| Hermes Agent | `hermes` | **Supported**" in text
     assert "local observability" in text
     assert "Local Splunk" in text
     assert "Hyper-V backend" in text
@@ -117,7 +117,7 @@ def test_release_runtime_custody_splits_certified_x64_from_compatibility_arm64()
 
     installer = (ROOT / "scripts/install.ps1").read_text(encoding="utf-8")
     assert '"ARM64" { Die "Windows ARM64 is not certified' in installer
-    assert '"codex",\n    "claudecode",\n    "amp",\n    "none"' in installer
+    assert '"codex",\n    "claudecode",\n    "amp",\n    "hermes",\n    "none"' in installer
 
 
 def test_connector_matrix_delegates_current_support_to_the_website() -> None:

--- a/cli/tests/test_windows_release_claims.py
+++ b/cli/tests/test_windows_release_claims.py
@@ -10,6 +10,7 @@ from defenseclaw.platform_support import (
     WINDOWS_CERTIFIED_ARCHITECTURES,
     WINDOWS_NOT_CERTIFIED_ARCHITECTURES,
     WINDOWS_NOT_CERTIFIED_CONNECTORS,
+    WINDOWS_PREVIEW_CONNECTORS,
     WINDOWS_SUPPORTED_CONNECTORS,
     WINDOWS_UNSUPPORTED_CONNECTORS,
     WINDOWS_UNSUPPORTED_FEATURES,
@@ -20,13 +21,12 @@ ROOT = Path(__file__).resolve().parents[2]
 
 def test_windows_release_metadata_is_exact() -> None:
     assert WINDOWS_SUPPORTED_CONNECTORS == {"codex", "claudecode", "amp", "hermes"}
+    assert WINDOWS_PREVIEW_CONNECTORS == {"cursor", "opencode"}
     assert WINDOWS_NOT_CERTIFIED_CONNECTORS == {
-        "cursor",
         "windsurf",
         "geminicli",
         "copilot",
         "antigravity",
-        "opencode",
     }
     assert WINDOWS_UNSUPPORTED_CONNECTORS == {"openhands", "omnigent", "openclaw", "zeptoclaw"}
     assert WINDOWS_CERTIFIED_ARCHITECTURES == {"amd64"}
@@ -53,6 +53,8 @@ def test_windows_guide_has_unambiguous_claims_and_powershell_examples() -> None:
     assert "| Codex | `codex` | **Supported**" in text
     assert "| Claude Code | `claudecode` | **Supported**" in text
     assert "| Hermes Agent | `hermes` | **Supported**" in text
+    assert "| OpenCode | `opencode` | **Preview**" in text
+    assert "| Cursor | `cursor` | **Preview**" in text
     assert "local observability" in text
     assert "Local Splunk" in text
     assert "Hyper-V backend" in text
@@ -117,7 +119,11 @@ def test_release_runtime_custody_splits_certified_x64_from_compatibility_arm64()
 
     installer = (ROOT / "scripts/install.ps1").read_text(encoding="utf-8")
     assert '"ARM64" { Die "Windows ARM64 is not certified' in installer
-    assert '"codex",\n    "claudecode",\n    "amp",\n    "hermes",\n    "none"' in installer
+    assert (
+        '"codex",\n    "claudecode",\n    "hermes",\n    "cursor",\n'
+        '    "opencode",\n    "amp",\n    "none"'
+        in installer
+    )
 
 
 def test_connector_matrix_delegates_current_support_to_the_website() -> None:

--- a/cmd/defenseclaw-launcher/main_test.go
+++ b/cmd/defenseclaw-launcher/main_test.go
@@ -44,12 +44,14 @@ func TestLauncherArgsRejectsUnknownName(t *testing.T) {
 func TestLauncherEnvRehydratesManagedConnectorHomes(t *testing.T) {
 	t.Setenv("CODEX_HOME", `C:\project\codex`)
 	t.Setenv("CLAUDE_CONFIG_DIR", `C:\project\claude`)
+	t.Setenv("HERMES_HOME", `C:\project\hermes`)
 	t.Setenv("DEFENSECLAW_HOME", `C:\project\defenseclaw`)
 	state := nativeinstallstate.State{
 		InstallRoot:     `C:\Users\tester\Programs\DefenseClaw`,
 		DataRoot:        `C:\Users\tester\.defenseclaw`,
 		CodexHome:       `D:\Agent Profiles\Codex`,
 		ClaudeConfigDir: `D:\Agent Profiles\Claude`,
+		HermesHome:      `D:\Agent Profiles\Hermes`,
 	}
 	env := launcherEnv(
 		`C:\Users\tester\Programs\DefenseClaw\bin`,
@@ -62,6 +64,7 @@ func TestLauncherEnvRehydratesManagedConnectorHomes(t *testing.T) {
 	for _, expected := range []string{
 		"CODEX_HOME=" + state.CodexHome,
 		"CLAUDE_CONFIG_DIR=" + state.ClaudeConfigDir,
+		"HERMES_HOME=" + state.HermesHome,
 		"DEFENSECLAW_HOME=" + state.DataRoot,
 		"DEFENSECLAW_INSTALL_ROOT=" + state.InstallRoot,
 	} {
@@ -69,7 +72,7 @@ func TestLauncherEnvRehydratesManagedConnectorHomes(t *testing.T) {
 			t.Fatalf("launcher environment missing %q: %v", expected, env)
 		}
 	}
-	for _, inherited := range []string{`C:\project\codex`, `C:\project\claude`, `C:\project\defenseclaw`} {
+	for _, inherited := range []string{`C:\project\codex`, `C:\project\claude`, `C:\project\hermes`, `C:\project\defenseclaw`} {
 		if strings.Contains(joined, inherited) {
 			t.Fatalf("launcher retained ambient profile %q: %v", inherited, env)
 		}

--- a/cmd/defenseclaw-setup/connector_lifecycle_home_test.go
+++ b/cmd/defenseclaw-setup/connector_lifecycle_home_test.go
@@ -15,12 +15,16 @@ func TestConnectorLifecycleConfigHomeSelectsExactNativeBinding(t *testing.T) {
 	codexHome := filepath.Join(root, "codex")
 	claudeHome := filepath.Join(root, "claude")
 	hermesHome := filepath.Join(root, "hermes")
+	openCodeHome := filepath.Join(root, "opencode")
+	cursorHome := filepath.Join(root, "cursor")
 	profile := filepath.Join(root, "profile")
 	env := []string{
 		"UNRELATED=preserved",
 		"codex_home=" + codexHome,
 		"CLAUDE_CONFIG_DIR=" + claudeHome,
 		"HERMES_HOME=" + hermesHome,
+		"OPENCODE_CONFIG_DIR=" + openCodeHome,
+		"CURSOR_CONFIG_DIR=" + cursorHome,
 		"USERPROFILE=" + profile,
 	}
 	for _, test := range []struct {
@@ -31,6 +35,8 @@ func TestConnectorLifecycleConfigHomeSelectsExactNativeBinding(t *testing.T) {
 		{connector: "claudecode", want: claudeHome},
 		{connector: "hermes", want: hermesHome},
 		{connector: "amp", want: filepath.Join(profile, ".config", "amp")},
+		{connector: "opencode", want: openCodeHome},
+		{connector: "cursor", want: cursorHome},
 	} {
 		t.Run(test.connector, func(t *testing.T) {
 			got, err := connectorLifecycleConfigHome(env, test.connector)

--- a/cmd/defenseclaw-setup/connector_lifecycle_home_test.go
+++ b/cmd/defenseclaw-setup/connector_lifecycle_home_test.go
@@ -14,11 +14,13 @@ func TestConnectorLifecycleConfigHomeSelectsExactNativeBinding(t *testing.T) {
 	root := t.TempDir()
 	codexHome := filepath.Join(root, "codex")
 	claudeHome := filepath.Join(root, "claude")
+	hermesHome := filepath.Join(root, "hermes")
 	profile := filepath.Join(root, "profile")
 	env := []string{
 		"UNRELATED=preserved",
 		"codex_home=" + codexHome,
 		"CLAUDE_CONFIG_DIR=" + claudeHome,
+		"HERMES_HOME=" + hermesHome,
 		"USERPROFILE=" + profile,
 	}
 	for _, test := range []struct {
@@ -27,6 +29,7 @@ func TestConnectorLifecycleConfigHomeSelectsExactNativeBinding(t *testing.T) {
 	}{
 		{connector: "codex", want: codexHome},
 		{connector: "claudecode", want: claudeHome},
+		{connector: "hermes", want: hermesHome},
 		{connector: "amp", want: filepath.Join(profile, ".config", "amp")},
 	} {
 		t.Run(test.connector, func(t *testing.T) {

--- a/cmd/defenseclaw-setup/connector_reconciliation.go
+++ b/cmd/defenseclaw-setup/connector_reconciliation.go
@@ -101,13 +101,15 @@ func retryPendingConnectorReconciliation(
 		}
 		seen[identity] = true
 		connectorName := strings.ToLower(failure.Connector)
-		codexHome, claudeHome := "", ""
+		codexHome, claudeHome, hermesHome := "", "", ""
 		if connectorName == "codex" {
 			codexHome = failure.ConfigHome
 		} else if connectorName == "claudecode" {
 			claudeHome = failure.ConfigHome
+		} else if connectorName == "hermes" {
+			hermesHome = failure.ConfigHome
 		}
-		env := transactionChildEnvForHomes(transaction, codexHome, claudeHome)
+		env := transactionChildEnvForHomes(transaction, codexHome, claudeHome, hermesHome)
 		verify := func() error {
 			return run(gatewayPath, transaction.DataRoot, connectorName, "verify", env)
 		}
@@ -207,6 +209,8 @@ func connectorCleanupHomes(transaction setupTransaction, connectorName string) [
 			candidates = append(candidates, transaction.PreviousState.CodexHome)
 		case "claudecode":
 			candidates = append(candidates, transaction.PreviousState.ClaudeConfigDir)
+		case "hermes":
+			candidates = append(candidates, transaction.PreviousState.HermesHome)
 		}
 	}
 	candidates = append(candidates, connectorConfigHome(transaction, connectorName, false))
@@ -247,6 +251,12 @@ func connectorCleanupHomes(transaction setupTransaction, connectorName string) [
 }
 
 func connectorManagedBackupExists(dataRoot, connectorName string) bool {
+	if connectorName == "hermes" {
+		backupRoot := filepath.Join(dataRoot, "connector_backups", connectorName)
+		return pathExists(filepath.Join(backupRoot, "config.json")) ||
+			pathExists(filepath.Join(backupRoot, "config.yaml.json")) ||
+			pathExists(filepath.Join(backupRoot, "shell-hooks-allowlist.json.json"))
+	}
 	logicalName := ""
 	switch connectorName {
 	case "codex":
@@ -275,6 +285,11 @@ func connectorDefaultHomeBesideDataRoot(dataRoot, connectorName string) string {
 		directory = ".claude"
 	case "amp":
 		return filepath.Join(filepath.Dir(cleanDataRoot), ".config", "amp")
+	case "hermes":
+		// Hermes defaults to %LOCALAPPDATA%\hermes, which cannot be derived
+		// safely from the profile-bound DefenseClaw data root. Transactions
+		// always persist the Known Folder-resolved home explicitly.
+		return ""
 	default:
 		return ""
 	}
@@ -284,12 +299,15 @@ func connectorDefaultHomeBesideDataRoot(dataRoot, connectorName string) string {
 func connectorLifecycleEnvForHome(transaction setupTransaction, connectorName, configHome string) []string {
 	codexHome := transaction.PreviousCodexHome
 	claudeHome := transaction.PreviousClaudeConfigDir
+	hermesHome := transaction.PreviousHermesHome
 	if connectorName == "codex" {
 		codexHome = configHome
 	} else if connectorName == "claudecode" {
 		claudeHome = configHome
+	} else if connectorName == "hermes" {
+		hermesHome = configHome
 	}
-	return transactionChildEnvForHomes(transaction, codexHome, claudeHome)
+	return transactionChildEnvForHomes(transaction, codexHome, claudeHome, hermesHome)
 }
 
 func reconcilePreservedConnectors(
@@ -469,7 +487,7 @@ func validateConnectorReconciliationState(state *connectorReconciliationState) e
 }
 
 func validateConnectorReconciliationIdentity(connectorName, configHome string) error {
-	if connectorName != "codex" && connectorName != "claudecode" && connectorName != "amp" {
+	if connectorName != "codex" && connectorName != "claudecode" && connectorName != "amp" && connectorName != "hermes" {
 		return fmt.Errorf("invalid connector reconciliation target %q", connectorName)
 	}
 	if configHome == "" || !filepath.IsAbs(configHome) || filepath.Clean(configHome) != configHome {
@@ -538,6 +556,11 @@ func connectorConfigHome(transaction setupTransaction, connectorName string, pre
 		// %USERPROFILE%\.config\amp directory for both previous and target
 		// lifecycle operations.
 		return connectorDefaultHomeBesideDataRoot(transaction.DataRoot, connectorName)
+	case "hermes":
+		if previous {
+			return transaction.PreviousHermesHome
+		}
+		return transaction.HermesHome
 	default:
 		return ""
 	}

--- a/cmd/defenseclaw-setup/connector_reconciliation.go
+++ b/cmd/defenseclaw-setup/connector_reconciliation.go
@@ -101,15 +101,17 @@ func retryPendingConnectorReconciliation(
 		}
 		seen[identity] = true
 		connectorName := strings.ToLower(failure.Connector)
-		codexHome, claudeHome, hermesHome := "", "", ""
+		codexHome, claudeHome, hermesHome, openCodeHome := "", "", "", ""
 		if connectorName == "codex" {
 			codexHome = failure.ConfigHome
 		} else if connectorName == "claudecode" {
 			claudeHome = failure.ConfigHome
 		} else if connectorName == "hermes" {
 			hermesHome = failure.ConfigHome
+		} else if connectorName == "opencode" {
+			openCodeHome = failure.ConfigHome
 		}
-		env := transactionChildEnvForHomes(transaction, codexHome, claudeHome, hermesHome)
+		env := transactionChildEnvForHomes(transaction, codexHome, claudeHome, hermesHome, openCodeHome)
 		verify := func() error {
 			return run(gatewayPath, transaction.DataRoot, connectorName, "verify", env)
 		}
@@ -211,6 +213,8 @@ func connectorCleanupHomes(transaction setupTransaction, connectorName string) [
 			candidates = append(candidates, transaction.PreviousState.ClaudeConfigDir)
 		case "hermes":
 			candidates = append(candidates, transaction.PreviousState.HermesHome)
+		case "opencode":
+			candidates = append(candidates, transaction.PreviousState.OpenCodeConfigDir)
 		}
 	}
 	candidates = append(candidates, connectorConfigHome(transaction, connectorName, false))
@@ -265,6 +269,10 @@ func connectorManagedBackupExists(dataRoot, connectorName string) bool {
 		logicalName = "settings.json"
 	case "amp":
 		logicalName = "config"
+	case "opencode":
+		logicalName = "config"
+	case "cursor":
+		logicalName = "hooks.json"
 	default:
 		return false
 	}
@@ -290,6 +298,10 @@ func connectorDefaultHomeBesideDataRoot(dataRoot, connectorName string) string {
 		// safely from the profile-bound DefenseClaw data root. Transactions
 		// always persist the Known Folder-resolved home explicitly.
 		return ""
+	case "opencode":
+		directory = filepath.Join(".config", "opencode")
+	case "cursor":
+		directory = ".cursor"
 	default:
 		return ""
 	}
@@ -300,14 +312,20 @@ func connectorLifecycleEnvForHome(transaction setupTransaction, connectorName, c
 	codexHome := transaction.PreviousCodexHome
 	claudeHome := transaction.PreviousClaudeConfigDir
 	hermesHome := transaction.PreviousHermesHome
+	openCodeHome := transaction.PreviousOpenCodeConfigDir
+	cursorHome := transaction.PreviousCursorConfigDir
 	if connectorName == "codex" {
 		codexHome = configHome
 	} else if connectorName == "claudecode" {
 		claudeHome = configHome
 	} else if connectorName == "hermes" {
 		hermesHome = configHome
+	} else if connectorName == "opencode" {
+		openCodeHome = configHome
+	} else if connectorName == "cursor" {
+		cursorHome = configHome
 	}
-	return transactionChildEnvForHomes(transaction, codexHome, claudeHome, hermesHome)
+	return transactionChildEnvForHomes(transaction, codexHome, claudeHome, hermesHome, openCodeHome, cursorHome)
 }
 
 func reconcilePreservedConnectors(
@@ -487,7 +505,7 @@ func validateConnectorReconciliationState(state *connectorReconciliationState) e
 }
 
 func validateConnectorReconciliationIdentity(connectorName, configHome string) error {
-	if connectorName != "codex" && connectorName != "claudecode" && connectorName != "amp" && connectorName != "hermes" {
+	if connectorName != "codex" && connectorName != "claudecode" && connectorName != "amp" && connectorName != "hermes" && connectorName != "opencode" && connectorName != "cursor" {
 		return fmt.Errorf("invalid connector reconciliation target %q", connectorName)
 	}
 	if configHome == "" || !filepath.IsAbs(configHome) || filepath.Clean(configHome) != configHome {
@@ -561,6 +579,16 @@ func connectorConfigHome(transaction setupTransaction, connectorName string, pre
 			return transaction.PreviousHermesHome
 		}
 		return transaction.HermesHome
+	case "opencode":
+		if previous {
+			return transaction.PreviousOpenCodeConfigDir
+		}
+		return transaction.OpenCodeConfigDir
+	case "cursor":
+		if previous {
+			return transaction.PreviousCursorConfigDir
+		}
+		return transaction.CursorConfigDir
 	default:
 		return ""
 	}

--- a/cmd/defenseclaw-setup/deferred_uninstall_cleanup.go
+++ b/cmd/defenseclaw-setup/deferred_uninstall_cleanup.go
@@ -158,11 +158,11 @@ func validateDeferredUninstallCleanupRecord(
 	if record.RunValueName != runValueName || record.RunCommand != runCommand {
 		return errors.New("deferred uninstall cleanup does not match the owned startup command")
 	}
-	if len(record.VerifiedConnectors) > 3 || !slices.IsSorted(record.VerifiedConnectors) {
+	if len(record.VerifiedConnectors) > 4 || !slices.IsSorted(record.VerifiedConnectors) {
 		return errors.New("deferred uninstall cleanup has an invalid verified connector set")
 	}
 	for index, connector := range record.VerifiedConnectors {
-		if connector != "amp" && connector != "claudecode" && connector != "codex" {
+		if connector != "amp" && connector != "claudecode" && connector != "codex" && connector != "hermes" {
 			return fmt.Errorf("deferred uninstall cleanup has an invalid connector %q", connector)
 		}
 		if index > 0 && record.VerifiedConnectors[index-1] == connector {

--- a/cmd/defenseclaw-setup/deferred_uninstall_cleanup_windows_test.go
+++ b/cmd/defenseclaw-setup/deferred_uninstall_cleanup_windows_test.go
@@ -642,7 +642,7 @@ func writeDeferredCleanupHookState(t *testing.T, path string, state hookruntime.
 
 func TestValidateDeferredUninstallCleanupRecordAcceptsAllManagedConnectors(t *testing.T) {
 	fixture := newDeferredCleanupFixture(t)
-	fixture.record.VerifiedConnectors = []string{"amp", "claudecode", "codex"}
+	fixture.record.VerifiedConnectors = []string{"amp", "claudecode", "codex", "hermes"}
 	paths := hookruntime.Paths{
 		Root:     fixture.record.RuntimeRoot,
 		Launcher: fixture.record.LauncherPath,

--- a/cmd/defenseclaw-setup/main.go
+++ b/cmd/defenseclaw-setup/main.go
@@ -177,6 +177,8 @@ type options struct {
 	CodexHome          string
 	ClaudeConfigDir    string
 	HermesHome         string
+	OpenCodeConfigDir  string
+	CursorConfigDir    string
 	// PreserveConnectorConfiguration is internal transaction intent, never a
 	// command-line property. Servicing an existing install without an explicit
 	// connector or mode selection must refresh its owned registrations in place
@@ -251,6 +253,8 @@ type installState struct {
 	CodexHome              string            `json:"codex_home,omitempty"`
 	ClaudeConfigDir        string            `json:"claude_config_dir,omitempty"`
 	HermesHome             string            `json:"hermes_home,omitempty"`
+	OpenCodeConfigDir      string            `json:"opencode_config_dir,omitempty"`
+	CursorConfigDir        string            `json:"cursor_config_dir,omitempty"`
 	UnsignedLocalArtifact  bool              `json:"unsigned_local_artifact"`
 	ReleaseSigningRequired bool              `json:"release_signing_required"`
 	Toolchain              map[string]string `json:"toolchain"`
@@ -490,6 +494,8 @@ func runInstallContext(ctx context.Context, opts options, installRoot, dataRoot 
 	opts.CodexHome = transaction.CodexHome
 	opts.ClaudeConfigDir = transaction.ClaudeConfigDir
 	opts.HermesHome = transaction.HermesHome
+	opts.OpenCodeConfigDir = transaction.OpenCodeConfigDir
+	opts.CursorConfigDir = transaction.CursorConfigDir
 	if err := beginSetupTransaction(transaction); err != nil {
 		return retryRequiredCode, err
 	}
@@ -892,9 +898,9 @@ func requestedServices(opts options, previous serviceState) serviceState {
 
 func connectorsForNativeUninstall(state *installState, dataRoot string) ([]string, error) {
 	seen := map[string]bool{}
-	connectors := make([]string, 0, 4)
+	connectors := make([]string, 0, 6)
 	add := func(name string) {
-		if (name == "codex" || name == "claudecode" || name == "amp" || name == "hermes") && !seen[name] {
+		if (name == "codex" || name == "claudecode" || name == "amp" || name == "hermes" || name == "opencode" || name == "cursor") && !seen[name] {
 			seen[name] = true
 			connectors = append(connectors, name)
 		}
@@ -932,6 +938,12 @@ func connectorsForNativeUninstall(state *installState, dataRoot string) ([]strin
 		pathExists(filepath.Join(dataRoot, "connector_backups", "hermes", "config.yaml.json")) ||
 		pathExists(filepath.Join(dataRoot, "connector_backups", "hermes", "shell-hooks-allowlist.json.json")) {
 		add("hermes")
+	}
+	if pathExists(filepath.Join(dataRoot, "connector_backups", "opencode", "config.json")) {
+		add("opencode")
+	}
+	if pathExists(filepath.Join(dataRoot, "connector_backups", "cursor", "hooks.json.json")) {
+		add("cursor")
 	}
 	return connectors, nil
 }
@@ -996,7 +1008,7 @@ func readNativeConfiguredConnectors(dataRoot string) ([]string, error) {
 	seen := map[string]bool{}
 	add := func(value string) {
 		name := normalizeConnector(strings.TrimSpace(value))
-		if name == "codex" || name == "claudecode" || name == "amp" || name == "hermes" {
+		if name == "codex" || name == "claudecode" || name == "amp" || name == "hermes" || name == "opencode" || name == "cursor" {
 			seen[name] = true
 		}
 	}
@@ -1293,6 +1305,10 @@ func connectorLifecycleConfigHome(env []string, connectorName string) (string, e
 		variable = "CLAUDE_CONFIG_DIR"
 	case "hermes":
 		variable = "HERMES_HOME"
+	case "opencode":
+		variable = "OPENCODE_CONFIG_DIR"
+	case "cursor":
+		variable = "CURSOR_CONFIG_DIR"
 	case "amp":
 		// Amp has no config-home override. Bind its documented native Windows
 		// home beneath the current token's USERPROFILE and pass that exact
@@ -1342,7 +1358,7 @@ func samePath(a, b string) bool {
 }
 
 func validConnector(value string) bool {
-	return value == "none" || value == "codex" || value == "claudecode" || value == "amp" || value == "hermes"
+	return value == "none" || value == "codex" || value == "claudecode" || value == "amp" || value == "hermes" || value == "opencode" || value == "cursor"
 }
 
 func validMode(value string) bool {
@@ -1615,6 +1631,8 @@ func stageInstallTree(payload loadedPayload, staging, installRoot, dataRoot, mai
 		CodexHome:              opts.CodexHome,
 		ClaudeConfigDir:        opts.ClaudeConfigDir,
 		HermesHome:             opts.HermesHome,
+		OpenCodeConfigDir:      opts.OpenCodeConfigDir,
+		CursorConfigDir:        opts.CursorConfigDir,
 		UnsignedLocalArtifact:  payload.Manifest.Unsigned,
 		ReleaseSigningRequired: true,
 		Toolchain:              payload.Manifest.Toolchain,
@@ -2603,7 +2621,7 @@ func parseArgs(args []string) (options, error) {
 		return opts, errors.New("only per-user INSTALLSCOPE=user is supported by this installer")
 	}
 	if !validConnector(opts.Connector) {
-		return opts, fmt.Errorf("invalid CONNECTOR %q; expected codex, claudecode, amp, hermes, or none", opts.Connector)
+		return opts, fmt.Errorf("invalid CONNECTOR %q; expected codex, claudecode, amp, hermes, opencode, cursor, or none", opts.Connector)
 	}
 	if opts.Mode != "observe" && opts.Mode != "action" {
 		return opts, fmt.Errorf("invalid MODE %q; expected observe or action", opts.Mode)
@@ -2652,13 +2670,17 @@ func normalizeConnector(value string) string {
 		return "amp"
 	case "hermes", "hermesagent", "hermes-agent":
 		return "hermes"
+	case "opencode", "open-code":
+		return "opencode"
+	case "cursor", "cursoragent", "cursor-agent":
+		return "cursor"
 	default:
 		return strings.ToLower(value)
 	}
 }
 
 func printUsage() {
-	fmt.Println("DefenseClawSetup-x64.exe [/quiet] [/norestart] [INSTALLSCOPE=user] [CONNECTOR=codex|claudecode|amp|hermes|none] [MODE=observe|action] [STARTGATEWAY=1] | /verify")
+	fmt.Println("DefenseClawSetup-x64.exe [/quiet] [/norestart] [INSTALLSCOPE=user] [CONNECTOR=codex|claudecode|amp|hermes|opencode|cursor|none] [MODE=observe|action] [STARTGATEWAY=1] | /verify")
 	fmt.Println("Maintenance: DefenseClawSetup-x64.exe /repair | /upgrade | /uninstall [DELETEUSERDATA=1]")
 }
 

--- a/cmd/defenseclaw-setup/main.go
+++ b/cmd/defenseclaw-setup/main.go
@@ -176,6 +176,7 @@ type options struct {
 	CleanupTransaction string
 	CodexHome          string
 	ClaudeConfigDir    string
+	HermesHome         string
 	// PreserveConnectorConfiguration is internal transaction intent, never a
 	// command-line property. Servicing an existing install without an explicit
 	// connector or mode selection must refresh its owned registrations in place
@@ -249,6 +250,7 @@ type installState struct {
 	Mode                   string            `json:"mode"`
 	CodexHome              string            `json:"codex_home,omitempty"`
 	ClaudeConfigDir        string            `json:"claude_config_dir,omitempty"`
+	HermesHome             string            `json:"hermes_home,omitempty"`
 	UnsignedLocalArtifact  bool              `json:"unsigned_local_artifact"`
 	ReleaseSigningRequired bool              `json:"release_signing_required"`
 	Toolchain              map[string]string `json:"toolchain"`
@@ -487,6 +489,7 @@ func runInstallContext(ctx context.Context, opts options, installRoot, dataRoot 
 	// must never depend on a later process inheriting the same environment.
 	opts.CodexHome = transaction.CodexHome
 	opts.ClaudeConfigDir = transaction.ClaudeConfigDir
+	opts.HermesHome = transaction.HermesHome
 	if err := beginSetupTransaction(transaction); err != nil {
 		return retryRequiredCode, err
 	}
@@ -889,9 +892,9 @@ func requestedServices(opts options, previous serviceState) serviceState {
 
 func connectorsForNativeUninstall(state *installState, dataRoot string) ([]string, error) {
 	seen := map[string]bool{}
-	connectors := make([]string, 0, 3)
+	connectors := make([]string, 0, 4)
 	add := func(name string) {
-		if (name == "codex" || name == "claudecode" || name == "amp") && !seen[name] {
+		if (name == "codex" || name == "claudecode" || name == "amp" || name == "hermes") && !seen[name] {
 			seen[name] = true
 			connectors = append(connectors, name)
 		}
@@ -924,6 +927,11 @@ func connectorsForNativeUninstall(state *installState, dataRoot string) ([]strin
 	}
 	if pathExists(filepath.Join(dataRoot, "connector_backups", "amp", "config.json")) {
 		add("amp")
+	}
+	if pathExists(filepath.Join(dataRoot, "connector_backups", "hermes", "config.json")) ||
+		pathExists(filepath.Join(dataRoot, "connector_backups", "hermes", "config.yaml.json")) ||
+		pathExists(filepath.Join(dataRoot, "connector_backups", "hermes", "shell-hooks-allowlist.json.json")) {
+		add("hermes")
 	}
 	return connectors, nil
 }
@@ -988,7 +996,7 @@ func readNativeConfiguredConnectors(dataRoot string) ([]string, error) {
 	seen := map[string]bool{}
 	add := func(value string) {
 		name := normalizeConnector(strings.TrimSpace(value))
-		if name == "codex" || name == "claudecode" || name == "amp" {
+		if name == "codex" || name == "claudecode" || name == "amp" || name == "hermes" {
 			seen[name] = true
 		}
 	}
@@ -1283,6 +1291,8 @@ func connectorLifecycleConfigHome(env []string, connectorName string) (string, e
 		variable = "CODEX_HOME"
 	case "claudecode":
 		variable = "CLAUDE_CONFIG_DIR"
+	case "hermes":
+		variable = "HERMES_HOME"
 	case "amp":
 		// Amp has no config-home override. Bind its documented native Windows
 		// home beneath the current token's USERPROFILE and pass that exact
@@ -1332,7 +1342,7 @@ func samePath(a, b string) bool {
 }
 
 func validConnector(value string) bool {
-	return value == "none" || value == "codex" || value == "claudecode" || value == "amp"
+	return value == "none" || value == "codex" || value == "claudecode" || value == "amp" || value == "hermes"
 }
 
 func validMode(value string) bool {
@@ -1604,6 +1614,7 @@ func stageInstallTree(payload loadedPayload, staging, installRoot, dataRoot, mai
 		Mode:                   opts.Mode,
 		CodexHome:              opts.CodexHome,
 		ClaudeConfigDir:        opts.ClaudeConfigDir,
+		HermesHome:             opts.HermesHome,
 		UnsignedLocalArtifact:  payload.Manifest.Unsigned,
 		ReleaseSigningRequired: true,
 		Toolchain:              payload.Manifest.Toolchain,
@@ -2592,7 +2603,7 @@ func parseArgs(args []string) (options, error) {
 		return opts, errors.New("only per-user INSTALLSCOPE=user is supported by this installer")
 	}
 	if !validConnector(opts.Connector) {
-		return opts, fmt.Errorf("invalid CONNECTOR %q; expected codex, claudecode, amp, or none", opts.Connector)
+		return opts, fmt.Errorf("invalid CONNECTOR %q; expected codex, claudecode, amp, hermes, or none", opts.Connector)
 	}
 	if opts.Mode != "observe" && opts.Mode != "action" {
 		return opts, fmt.Errorf("invalid MODE %q; expected observe or action", opts.Mode)
@@ -2639,13 +2650,15 @@ func normalizeConnector(value string) string {
 		return "claudecode"
 	case "amp", "ampcode":
 		return "amp"
+	case "hermes", "hermesagent", "hermes-agent":
+		return "hermes"
 	default:
 		return strings.ToLower(value)
 	}
 }
 
 func printUsage() {
-	fmt.Println("DefenseClawSetup-x64.exe [/quiet] [/norestart] [INSTALLSCOPE=user] [CONNECTOR=codex|claudecode|amp|none] [MODE=observe|action] [STARTGATEWAY=1] | /verify")
+	fmt.Println("DefenseClawSetup-x64.exe [/quiet] [/norestart] [INSTALLSCOPE=user] [CONNECTOR=codex|claudecode|amp|hermes|none] [MODE=observe|action] [STARTGATEWAY=1] | /verify")
 	fmt.Println("Maintenance: DefenseClawSetup-x64.exe /repair | /upgrade | /uninstall [DELETEUSERDATA=1]")
 }
 

--- a/cmd/defenseclaw-setup/main_test.go
+++ b/cmd/defenseclaw-setup/main_test.go
@@ -286,7 +286,7 @@ func TestParseArgsDeferredCleanupQuietRestartContract(t *testing.T) {
 }
 
 func TestParseArgsQuietPropertyMatrix(t *testing.T) {
-	for _, connector := range []string{"none", "codex", "claudecode", "amp"} {
+	for _, connector := range []string{"none", "codex", "claudecode", "amp", "hermes"} {
 		for _, mode := range []string{"observe", "action"} {
 			for _, start := range []string{"0", "1"} {
 				t.Run(connector+"/"+mode+"/start-"+start, func(t *testing.T) {
@@ -361,7 +361,7 @@ func TestNoRestartStillRestartsPreviouslyRunningOwnedServices(t *testing.T) {
 }
 
 func TestConfiguredConnectorRequiresPersistentGateway(t *testing.T) {
-	for _, connectorName := range []string{"codex", "claudecode", "amp"} {
+	for _, connectorName := range []string{"codex", "claudecode", "amp", "hermes"} {
 		wanted := requestedServices(options{Connector: connectorName}, serviceState{})
 		if !wanted.Gateway {
 			t.Fatalf("connector %s did not require gateway startup", connectorName)
@@ -598,6 +598,7 @@ func TestConnectorsForNativeUninstallUsesStructuredBackupMarkers(t *testing.T) {
 		filepath.Join("connector_backups", "codex", "config.toml.json"),
 		filepath.Join("connector_backups", "claudecode", "settings.json.json"),
 		filepath.Join("connector_backups", "amp", "config.json"),
+		filepath.Join("connector_backups", "hermes", "config.json"),
 	}
 	for _, marker := range markers {
 		path := filepath.Join(dataRoot, marker)
@@ -613,7 +614,7 @@ func TestConnectorsForNativeUninstallUsesStructuredBackupMarkers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"codex", "claudecode", "amp"}
+	want := []string{"codex", "claudecode", "amp", "hermes"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("connectors = %v, want %v", got, want)
 	}

--- a/cmd/defenseclaw-setup/main_test.go
+++ b/cmd/defenseclaw-setup/main_test.go
@@ -286,7 +286,7 @@ func TestParseArgsDeferredCleanupQuietRestartContract(t *testing.T) {
 }
 
 func TestParseArgsQuietPropertyMatrix(t *testing.T) {
-	for _, connector := range []string{"none", "codex", "claudecode", "amp", "hermes"} {
+	for _, connector := range []string{"none", "codex", "claudecode", "amp", "hermes", "opencode", "cursor"} {
 		for _, mode := range []string{"observe", "action"} {
 			for _, start := range []string{"0", "1"} {
 				t.Run(connector+"/"+mode+"/start-"+start, func(t *testing.T) {
@@ -361,7 +361,7 @@ func TestNoRestartStillRestartsPreviouslyRunningOwnedServices(t *testing.T) {
 }
 
 func TestConfiguredConnectorRequiresPersistentGateway(t *testing.T) {
-	for _, connectorName := range []string{"codex", "claudecode", "amp", "hermes"} {
+	for _, connectorName := range []string{"codex", "claudecode", "amp", "hermes", "opencode", "cursor"} {
 		wanted := requestedServices(options{Connector: connectorName}, serviceState{})
 		if !wanted.Gateway {
 			t.Fatalf("connector %s did not require gateway startup", connectorName)
@@ -599,6 +599,8 @@ func TestConnectorsForNativeUninstallUsesStructuredBackupMarkers(t *testing.T) {
 		filepath.Join("connector_backups", "claudecode", "settings.json.json"),
 		filepath.Join("connector_backups", "amp", "config.json"),
 		filepath.Join("connector_backups", "hermes", "config.json"),
+		filepath.Join("connector_backups", "opencode", "config.json"),
+		filepath.Join("connector_backups", "cursor", "hooks.json.json"),
 	}
 	for _, marker := range markers {
 		path := filepath.Join(dataRoot, marker)
@@ -614,7 +616,7 @@ func TestConnectorsForNativeUninstallUsesStructuredBackupMarkers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"codex", "claudecode", "amp", "hermes"}
+	want := []string{"codex", "claudecode", "amp", "hermes", "opencode", "cursor"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("connectors = %v, want %v", got, want)
 	}

--- a/cmd/defenseclaw-setup/platform_other.go
+++ b/cmd/defenseclaw-setup/platform_other.go
@@ -67,6 +67,7 @@ func gatewayAutoStartValueOwned(gatewayPath, value string) (bool, error) {
 func defaultInstallRoot() (string, error)                   { return "", errors.New("windows-only operation") }
 func defaultDataRoot() (string, error)                      { return "", errors.New("windows-only operation") }
 func defaultProfileRoot() (string, error)                   { return "", errors.New("windows-only operation") }
+func defaultHermesHome() (string, error)                    { return "", errors.New("windows-only operation") }
 func defaultOpenClawRoot() (string, error)                  { return "", errors.New("windows-only operation") }
 func defaultMaintenancePath() (string, error)               { return "", errors.New("windows-only operation") }
 func defaultTransactionRoot() (string, error)               { return "", errors.New("windows-only operation") }

--- a/cmd/defenseclaw-setup/platform_windows.go
+++ b/cmd/defenseclaw-setup/platform_windows.go
@@ -480,6 +480,14 @@ func defaultProfileRoot() (string, error) {
 	return winpath.CurrentUserKnownFolderPath(windows.FOLDERID_Profile)
 }
 
+func defaultHermesHome() (string, error) {
+	local, err := winpath.CurrentUserKnownFolderPath(windows.FOLDERID_LocalAppData)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(local, "hermes"), nil
+}
+
 func defaultOpenClawRoot() (string, error) {
 	profile, err := defaultProfileRoot()
 	if err != nil {

--- a/cmd/defenseclaw-setup/transaction.go
+++ b/cmd/defenseclaw-setup/transaction.go
@@ -89,8 +89,10 @@ type setupTransaction struct {
 	TargetVersion                  string                   `json:"target_version,omitempty"`
 	PreviousCodexHome              string                   `json:"previous_codex_home,omitempty"`
 	PreviousClaudeConfigDir        string                   `json:"previous_claude_config_dir,omitempty"`
+	PreviousHermesHome             string                   `json:"previous_hermes_home,omitempty"`
 	CodexHome                      string                   `json:"codex_home,omitempty"`
 	ClaudeConfigDir                string                   `json:"claude_config_dir,omitempty"`
+	HermesHome                     string                   `json:"hermes_home,omitempty"`
 	MaintenanceSHA256              string                   `json:"maintenance_sha256,omitempty"`
 	DeleteUserData                 bool                     `json:"delete_user_data,omitempty"`
 	UninstallPathEntryOwned        bool                     `json:"uninstall_path_entry_owned,omitempty"`
@@ -274,6 +276,10 @@ func newSetupTransaction(action, installRoot, dataRoot, maintenancePath, fromVer
 	if err != nil {
 		return setupTransaction{}, err
 	}
+	defaultHermesConfigHome, err := defaultHermesHome()
+	if err != nil {
+		return setupTransaction{}, err
+	}
 	codexHome, err := transactionConfigHome("CODEX_HOME", defaultCodexHome)
 	if err != nil {
 		return setupTransaction{}, err
@@ -282,10 +288,15 @@ func newSetupTransaction(action, installRoot, dataRoot, maintenancePath, fromVer
 	if err != nil {
 		return setupTransaction{}, err
 	}
-	previousCodexState, previousClaudeState := "", ""
+	hermesHome, err := transactionConfigHome("HERMES_HOME", defaultHermesConfigHome)
+	if err != nil {
+		return setupTransaction{}, err
+	}
+	previousCodexState, previousClaudeState, previousHermesState := "", "", ""
 	if oldState != nil {
 		previousCodexState = oldState.CodexHome
 		previousClaudeState = oldState.ClaudeConfigDir
+		previousHermesState = oldState.HermesHome
 	}
 	// Pre-home-binding releases can advertise a connector only through their
 	// legacy backup. In that case the validated current override is the sole
@@ -303,12 +314,19 @@ func newSetupTransaction(action, installRoot, dataRoot, maintenancePath, fromVer
 	if err != nil {
 		return setupTransaction{}, err
 	}
+	previousHermesHome, err := resolvePreviousConnectorHome(
+		previousHermesState, previousConnectors, dataRoot, "hermes", "config", hermesHome,
+	)
+	if err != nil {
+		return setupTransaction{}, err
+	}
 	if preserveConnectorConfiguration {
 		// A quiet repair/upgrade without a connector choice services the exact
 		// homes already owned by the installation. Environment drift must not
 		// silently move or collapse connector configuration.
 		codexHome = previousCodexHome
 		claudeConfigDir = previousClaudeConfigDir
+		hermesHome = previousHermesHome
 	}
 	maintenanceSHA256 := ""
 	maintenanceExisted, previousMaintenanceSHA256, err := snapshotMaintenanceFile(maintenancePath)
@@ -357,8 +375,10 @@ func newSetupTransaction(action, installRoot, dataRoot, maintenancePath, fromVer
 		TargetVersion:                  targetVersion,
 		PreviousCodexHome:              previousCodexHome,
 		PreviousClaudeConfigDir:        previousClaudeConfigDir,
+		PreviousHermesHome:             previousHermesHome,
 		CodexHome:                      codexHome,
 		ClaudeConfigDir:                claudeConfigDir,
+		HermesHome:                     hermesHome,
 		MaintenanceSHA256:              maintenanceSHA256,
 		DeleteUserData:                 opts.DeleteUserData,
 		UninstallPathEntryOwned:        uninstallPathOwned,
@@ -400,10 +420,15 @@ func newUninstallHandoffTransaction(source setupTransaction, oldState *installSt
 	if err != nil {
 		return setupTransaction{}, err
 	}
-	configuredCodexHome, configuredClaudeHome := "", ""
+	defaultHermesConfigHome, err := defaultHermesHome()
+	if err != nil {
+		return setupTransaction{}, err
+	}
+	configuredCodexHome, configuredClaudeHome, configuredHermesHome := "", "", ""
 	if oldState != nil {
 		configuredCodexHome = oldState.CodexHome
 		configuredClaudeHome = oldState.ClaudeConfigDir
+		configuredHermesHome = oldState.HermesHome
 	}
 	// The source install transaction already captured validated client homes.
 	// Preserve them across an install-to-uninstall handoff when predecessor
@@ -415,6 +440,10 @@ func newUninstallHandoffTransaction(source setupTransaction, oldState *installSt
 	legacyClaudeFallback := source.ClaudeConfigDir
 	if legacyClaudeFallback == "" {
 		legacyClaudeFallback = defaultClaudeConfigDir
+	}
+	legacyHermesFallback := source.HermesHome
+	if legacyHermesFallback == "" {
+		legacyHermesFallback = defaultHermesConfigHome
 	}
 	previousCodexHome, err := resolvePreviousConnectorHome(
 		configuredCodexHome,
@@ -434,6 +463,17 @@ func newUninstallHandoffTransaction(source setupTransaction, oldState *installSt
 		"claudecode",
 		"settings.json",
 		legacyClaudeFallback,
+	)
+	if err != nil {
+		return setupTransaction{}, err
+	}
+	previousHermesHome, err := resolvePreviousConnectorHome(
+		configuredHermesHome,
+		previousConnectors,
+		source.DataRoot,
+		"hermes",
+		"config",
+		legacyHermesFallback,
 	)
 	if err != nil {
 		return setupTransaction{}, err
@@ -498,8 +538,10 @@ func newUninstallHandoffTransaction(source setupTransaction, oldState *installSt
 		TargetMode:                   opts.Mode,
 		PreviousCodexHome:            previousCodexHome,
 		PreviousClaudeConfigDir:      previousClaudeConfigDir,
+		PreviousHermesHome:           previousHermesHome,
 		CodexHome:                    previousCodexHome,
 		ClaudeConfigDir:              previousClaudeConfigDir,
+		HermesHome:                   previousHermesHome,
 		DeleteUserData:               opts.DeleteUserData,
 		UninstallPathEntryOwned:      pathOwned,
 		UninstallPathSeparatorReused: pathSeparatorReused,
@@ -580,25 +622,35 @@ func transactionConfigHome(name, fallback string) (string, error) {
 }
 
 func inferManagedConnectorHome(dataRoot, connectorName, logicalName, fallback string) (string, error) {
-	backupName := strings.NewReplacer("/", "_", `\`, "_", ":", "_", " ", "_").Replace(logicalName)
-	path := filepath.Join(dataRoot, "connector_backups", connectorName, backupName+".json")
-	data, err := os.ReadFile(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return fallback, nil
+	logicalNames := []string{logicalName}
+	if connectorName == "hermes" && logicalName == "config" {
+		// PR #655 used config.yaml as the logical backup name. Current setup uses
+		// the hook connector's stable "config" name and also owns the adjacent
+		// allowlist. Accept each finite marker so upgrades retain the exact home.
+		logicalNames = append(logicalNames, "config.yaml", "shell-hooks-allowlist.json")
 	}
-	if err != nil {
-		return "", fmt.Errorf("read %s managed backup binding: %w", connectorName, err)
+	for _, candidate := range logicalNames {
+		backupName := strings.NewReplacer("/", "_", `\`, "_", ":", "_", " ", "_").Replace(candidate)
+		path := filepath.Join(dataRoot, "connector_backups", connectorName, backupName+".json")
+		data, err := os.ReadFile(path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return "", fmt.Errorf("read %s managed backup binding: %w", connectorName, err)
+		}
+		var binding struct {
+			Path string `json:"path"`
+		}
+		if err := json.Unmarshal(data, &binding); err != nil {
+			return "", fmt.Errorf("parse %s managed backup binding: %w", connectorName, err)
+		}
+		if strings.TrimSpace(binding.Path) == "" || !filepath.IsAbs(binding.Path) {
+			return "", fmt.Errorf("%s managed backup has an invalid target path", connectorName)
+		}
+		return filepath.Dir(filepath.Clean(binding.Path)), nil
 	}
-	var binding struct {
-		Path string `json:"path"`
-	}
-	if err := json.Unmarshal(data, &binding); err != nil {
-		return "", fmt.Errorf("parse %s managed backup binding: %w", connectorName, err)
-	}
-	if strings.TrimSpace(binding.Path) == "" || !filepath.IsAbs(binding.Path) {
-		return "", fmt.Errorf("%s managed backup has an invalid target path", connectorName)
-	}
-	return filepath.Dir(filepath.Clean(binding.Path)), nil
+	return fallback, nil
 }
 
 func resolvePreviousConnectorHome(
@@ -627,7 +679,12 @@ func resolvePreviousConnectorHome(
 }
 
 func transactionChildEnv(transaction setupTransaction) []string {
-	return transactionChildEnvForHomes(transaction, transaction.CodexHome, transaction.ClaudeConfigDir)
+	return transactionChildEnvForHomes(
+		transaction,
+		transaction.CodexHome,
+		transaction.ClaudeConfigDir,
+		transaction.HermesHome,
+	)
 }
 
 func transactionPreviousChildEnv(transaction setupTransaction) []string {
@@ -635,15 +692,26 @@ func transactionPreviousChildEnv(transaction setupTransaction) []string {
 		transaction,
 		transaction.PreviousCodexHome,
 		transaction.PreviousClaudeConfigDir,
+		transaction.PreviousHermesHome,
 	)
 }
 
-func transactionChildEnvForHomes(transaction setupTransaction, codexHome, claudeConfigDir string) []string {
+func transactionChildEnvForHomes(
+	transaction setupTransaction,
+	codexHome, claudeConfigDir string,
+	hermesHomeOverride ...string,
+) []string {
+	hermesHome := transaction.HermesHome
+	if len(hermesHomeOverride) != 0 {
+		hermesHome = hermesHomeOverride[0]
+	}
 	base := managedChildEnv(transaction.DataRoot)
-	filtered := make([]string, 0, len(base)+2)
+	filtered := make([]string, 0, len(base)+3)
 	for _, entry := range base {
 		name, _, ok := strings.Cut(entry, "=")
-		if ok && (strings.EqualFold(name, "CODEX_HOME") || strings.EqualFold(name, "CLAUDE_CONFIG_DIR")) {
+		if ok && (strings.EqualFold(name, "CODEX_HOME") ||
+			strings.EqualFold(name, "CLAUDE_CONFIG_DIR") ||
+			strings.EqualFold(name, "HERMES_HOME")) {
 			continue
 		}
 		filtered = append(filtered, entry)
@@ -653,6 +721,9 @@ func transactionChildEnvForHomes(transaction setupTransaction, codexHome, claude
 	}
 	if claudeConfigDir != "" {
 		filtered = append(filtered, "CLAUDE_CONFIG_DIR="+claudeConfigDir)
+	}
+	if hermesHome != "" {
+		filtered = append(filtered, "HERMES_HOME="+hermesHome)
 	}
 	return filtered
 }
@@ -843,7 +914,8 @@ func validateSetupTransaction(transaction setupTransaction, expected setupTransa
 			return errors.New("connector-preserving transaction changed the installer selection")
 		}
 		if !samePath(transaction.PreviousCodexHome, transaction.CodexHome) ||
-			!samePath(transaction.PreviousClaudeConfigDir, transaction.ClaudeConfigDir) {
+			!samePath(transaction.PreviousClaudeConfigDir, transaction.ClaudeConfigDir) ||
+			!samePath(transaction.PreviousHermesHome, transaction.HermesHome) {
 			return errors.New("connector-preserving transaction changed a connector configuration home")
 		}
 		if len(transaction.PreviousConnectors) != 0 && !transaction.TargetServices.Gateway {
@@ -863,8 +935,10 @@ func validateSetupTransaction(transaction setupTransaction, expected setupTransa
 	for label, value := range map[string]string{
 		"previous Codex home":               transaction.PreviousCodexHome,
 		"previous Claude configuration dir": transaction.PreviousClaudeConfigDir,
+		"previous Hermes home":              transaction.PreviousHermesHome,
 		"Codex home":                        transaction.CodexHome,
 		"Claude configuration dir":          transaction.ClaudeConfigDir,
+		"Hermes home":                       transaction.HermesHome,
 	} {
 		if value == "" {
 			continue
@@ -892,7 +966,7 @@ func validateSetupTransaction(transaction setupTransaction, expected setupTransa
 	}
 	seenConnectors := map[string]bool{}
 	for _, connectorName := range transaction.PreviousConnectors {
-		if connectorName != "codex" && connectorName != "claudecode" && connectorName != "amp" {
+		if connectorName != "codex" && connectorName != "claudecode" && connectorName != "amp" && connectorName != "hermes" {
 			return fmt.Errorf("setup transaction has an invalid previous connector %q", connectorName)
 		}
 		if seenConnectors[connectorName] {
@@ -950,6 +1024,7 @@ func validateInstallStateForRoots(state *installState, installRoot, dataRoot, ma
 	for label, value := range map[string]string{
 		"Codex home":               state.CodexHome,
 		"Claude configuration dir": state.ClaudeConfigDir,
+		"Hermes home":              state.HermesHome,
 	} {
 		if value != "" && (!filepath.IsAbs(value) || filepath.Clean(value) != value) {
 			return fmt.Errorf("installer state has an invalid %s", label)
@@ -2822,6 +2897,8 @@ func connectorHomeChanged(transaction setupTransaction, connectorName string) bo
 		return !samePath(transaction.PreviousCodexHome, transaction.CodexHome)
 	case "claudecode":
 		return !samePath(transaction.PreviousClaudeConfigDir, transaction.ClaudeConfigDir)
+	case "hermes":
+		return !samePath(transaction.PreviousHermesHome, transaction.HermesHome)
 	default:
 		return false
 	}

--- a/cmd/defenseclaw-setup/transaction.go
+++ b/cmd/defenseclaw-setup/transaction.go
@@ -90,9 +90,13 @@ type setupTransaction struct {
 	PreviousCodexHome              string                   `json:"previous_codex_home,omitempty"`
 	PreviousClaudeConfigDir        string                   `json:"previous_claude_config_dir,omitempty"`
 	PreviousHermesHome             string                   `json:"previous_hermes_home,omitempty"`
+	PreviousOpenCodeConfigDir      string                   `json:"previous_opencode_config_dir,omitempty"`
+	PreviousCursorConfigDir        string                   `json:"previous_cursor_config_dir,omitempty"`
 	CodexHome                      string                   `json:"codex_home,omitempty"`
 	ClaudeConfigDir                string                   `json:"claude_config_dir,omitempty"`
 	HermesHome                     string                   `json:"hermes_home,omitempty"`
+	OpenCodeConfigDir              string                   `json:"opencode_config_dir,omitempty"`
+	CursorConfigDir                string                   `json:"cursor_config_dir,omitempty"`
 	MaintenanceSHA256              string                   `json:"maintenance_sha256,omitempty"`
 	DeleteUserData                 bool                     `json:"delete_user_data,omitempty"`
 	UninstallPathEntryOwned        bool                     `json:"uninstall_path_entry_owned,omitempty"`
@@ -280,6 +284,14 @@ func newSetupTransaction(action, installRoot, dataRoot, maintenancePath, fromVer
 	if err != nil {
 		return setupTransaction{}, err
 	}
+	defaultOpenCodeConfigDir, err := defaultConnectorConfigHome(filepath.Join(".config", "opencode"))
+	if err != nil {
+		return setupTransaction{}, err
+	}
+	defaultCursorConfigDir, err := defaultConnectorConfigHome(".cursor")
+	if err != nil {
+		return setupTransaction{}, err
+	}
 	codexHome, err := transactionConfigHome("CODEX_HOME", defaultCodexHome)
 	if err != nil {
 		return setupTransaction{}, err
@@ -292,11 +304,21 @@ func newSetupTransaction(action, installRoot, dataRoot, maintenancePath, fromVer
 	if err != nil {
 		return setupTransaction{}, err
 	}
-	previousCodexState, previousClaudeState, previousHermesState := "", "", ""
+	openCodeConfigDir, err := transactionConfigHome("OPENCODE_CONFIG_DIR", defaultOpenCodeConfigDir)
+	if err != nil {
+		return setupTransaction{}, err
+	}
+	cursorConfigDir, err := transactionConfigHome("CURSOR_CONFIG_DIR", defaultCursorConfigDir)
+	if err != nil {
+		return setupTransaction{}, err
+	}
+	previousCodexState, previousClaudeState, previousHermesState, previousOpenCodeState, previousCursorState := "", "", "", "", ""
 	if oldState != nil {
 		previousCodexState = oldState.CodexHome
 		previousClaudeState = oldState.ClaudeConfigDir
 		previousHermesState = oldState.HermesHome
+		previousOpenCodeState = oldState.OpenCodeConfigDir
+		previousCursorState = oldState.CursorConfigDir
 	}
 	// Pre-home-binding releases can advertise a connector only through their
 	// legacy backup. In that case the validated current override is the sole
@@ -320,6 +342,18 @@ func newSetupTransaction(action, installRoot, dataRoot, maintenancePath, fromVer
 	if err != nil {
 		return setupTransaction{}, err
 	}
+	previousOpenCodeConfigDir, err := resolvePreviousConnectorHome(
+		previousOpenCodeState, previousConnectors, dataRoot, "opencode", "config", openCodeConfigDir,
+	)
+	if err != nil {
+		return setupTransaction{}, err
+	}
+	previousCursorConfigDir, err := resolvePreviousConnectorHome(
+		previousCursorState, previousConnectors, dataRoot, "cursor", "hooks.json", cursorConfigDir,
+	)
+	if err != nil {
+		return setupTransaction{}, err
+	}
 	if preserveConnectorConfiguration {
 		// A quiet repair/upgrade without a connector choice services the exact
 		// homes already owned by the installation. Environment drift must not
@@ -327,6 +361,8 @@ func newSetupTransaction(action, installRoot, dataRoot, maintenancePath, fromVer
 		codexHome = previousCodexHome
 		claudeConfigDir = previousClaudeConfigDir
 		hermesHome = previousHermesHome
+		openCodeConfigDir = previousOpenCodeConfigDir
+		cursorConfigDir = previousCursorConfigDir
 	}
 	maintenanceSHA256 := ""
 	maintenanceExisted, previousMaintenanceSHA256, err := snapshotMaintenanceFile(maintenancePath)
@@ -376,9 +412,13 @@ func newSetupTransaction(action, installRoot, dataRoot, maintenancePath, fromVer
 		PreviousCodexHome:              previousCodexHome,
 		PreviousClaudeConfigDir:        previousClaudeConfigDir,
 		PreviousHermesHome:             previousHermesHome,
+		PreviousOpenCodeConfigDir:      previousOpenCodeConfigDir,
+		PreviousCursorConfigDir:        previousCursorConfigDir,
 		CodexHome:                      codexHome,
 		ClaudeConfigDir:                claudeConfigDir,
 		HermesHome:                     hermesHome,
+		OpenCodeConfigDir:              openCodeConfigDir,
+		CursorConfigDir:                cursorConfigDir,
 		MaintenanceSHA256:              maintenanceSHA256,
 		DeleteUserData:                 opts.DeleteUserData,
 		UninstallPathEntryOwned:        uninstallPathOwned,
@@ -424,11 +464,21 @@ func newUninstallHandoffTransaction(source setupTransaction, oldState *installSt
 	if err != nil {
 		return setupTransaction{}, err
 	}
-	configuredCodexHome, configuredClaudeHome, configuredHermesHome := "", "", ""
+	defaultOpenCodeConfigDir, err := defaultConnectorConfigHome(filepath.Join(".config", "opencode"))
+	if err != nil {
+		return setupTransaction{}, err
+	}
+	defaultCursorConfigDir, err := defaultConnectorConfigHome(".cursor")
+	if err != nil {
+		return setupTransaction{}, err
+	}
+	configuredCodexHome, configuredClaudeHome, configuredHermesHome, configuredOpenCodeHome, configuredCursorHome := "", "", "", "", ""
 	if oldState != nil {
 		configuredCodexHome = oldState.CodexHome
 		configuredClaudeHome = oldState.ClaudeConfigDir
 		configuredHermesHome = oldState.HermesHome
+		configuredOpenCodeHome = oldState.OpenCodeConfigDir
+		configuredCursorHome = oldState.CursorConfigDir
 	}
 	// The source install transaction already captured validated client homes.
 	// Preserve them across an install-to-uninstall handoff when predecessor
@@ -444,6 +494,14 @@ func newUninstallHandoffTransaction(source setupTransaction, oldState *installSt
 	legacyHermesFallback := source.HermesHome
 	if legacyHermesFallback == "" {
 		legacyHermesFallback = defaultHermesConfigHome
+	}
+	legacyOpenCodeFallback := source.OpenCodeConfigDir
+	if legacyOpenCodeFallback == "" {
+		legacyOpenCodeFallback = defaultOpenCodeConfigDir
+	}
+	legacyCursorFallback := source.CursorConfigDir
+	if legacyCursorFallback == "" {
+		legacyCursorFallback = defaultCursorConfigDir
 	}
 	previousCodexHome, err := resolvePreviousConnectorHome(
 		configuredCodexHome,
@@ -474,6 +532,28 @@ func newUninstallHandoffTransaction(source setupTransaction, oldState *installSt
 		"hermes",
 		"config",
 		legacyHermesFallback,
+	)
+	if err != nil {
+		return setupTransaction{}, err
+	}
+	previousOpenCodeConfigDir, err := resolvePreviousConnectorHome(
+		configuredOpenCodeHome,
+		previousConnectors,
+		source.DataRoot,
+		"opencode",
+		"config",
+		legacyOpenCodeFallback,
+	)
+	if err != nil {
+		return setupTransaction{}, err
+	}
+	previousCursorConfigDir, err := resolvePreviousConnectorHome(
+		configuredCursorHome,
+		previousConnectors,
+		source.DataRoot,
+		"cursor",
+		"hooks.json",
+		legacyCursorFallback,
 	)
 	if err != nil {
 		return setupTransaction{}, err
@@ -539,9 +619,13 @@ func newUninstallHandoffTransaction(source setupTransaction, oldState *installSt
 		PreviousCodexHome:            previousCodexHome,
 		PreviousClaudeConfigDir:      previousClaudeConfigDir,
 		PreviousHermesHome:           previousHermesHome,
+		PreviousOpenCodeConfigDir:    previousOpenCodeConfigDir,
+		PreviousCursorConfigDir:      previousCursorConfigDir,
 		CodexHome:                    previousCodexHome,
 		ClaudeConfigDir:              previousClaudeConfigDir,
 		HermesHome:                   previousHermesHome,
+		OpenCodeConfigDir:            previousOpenCodeConfigDir,
+		CursorConfigDir:              previousCursorConfigDir,
 		DeleteUserData:               opts.DeleteUserData,
 		UninstallPathEntryOwned:      pathOwned,
 		UninstallPathSeparatorReused: pathSeparatorReused,
@@ -648,7 +732,11 @@ func inferManagedConnectorHome(dataRoot, connectorName, logicalName, fallback st
 		if strings.TrimSpace(binding.Path) == "" || !filepath.IsAbs(binding.Path) {
 			return "", fmt.Errorf("%s managed backup has an invalid target path", connectorName)
 		}
-		return filepath.Dir(filepath.Clean(binding.Path)), nil
+		home := filepath.Dir(filepath.Clean(binding.Path))
+		if connectorName == "opencode" && strings.EqualFold(filepath.Base(home), "plugins") {
+			home = filepath.Dir(home)
+		}
+		return home, nil
 	}
 	return fallback, nil
 }
@@ -684,6 +772,8 @@ func transactionChildEnv(transaction setupTransaction) []string {
 		transaction.CodexHome,
 		transaction.ClaudeConfigDir,
 		transaction.HermesHome,
+		transaction.OpenCodeConfigDir,
+		transaction.CursorConfigDir,
 	)
 }
 
@@ -693,25 +783,37 @@ func transactionPreviousChildEnv(transaction setupTransaction) []string {
 		transaction.PreviousCodexHome,
 		transaction.PreviousClaudeConfigDir,
 		transaction.PreviousHermesHome,
+		transaction.PreviousOpenCodeConfigDir,
+		transaction.PreviousCursorConfigDir,
 	)
 }
 
 func transactionChildEnvForHomes(
 	transaction setupTransaction,
 	codexHome, claudeConfigDir string,
-	hermesHomeOverride ...string,
+	connectorHomeOverrides ...string,
 ) []string {
 	hermesHome := transaction.HermesHome
-	if len(hermesHomeOverride) != 0 {
-		hermesHome = hermesHomeOverride[0]
+	openCodeConfigDir := transaction.OpenCodeConfigDir
+	cursorConfigDir := transaction.CursorConfigDir
+	if len(connectorHomeOverrides) > 0 {
+		hermesHome = connectorHomeOverrides[0]
+	}
+	if len(connectorHomeOverrides) > 1 {
+		openCodeConfigDir = connectorHomeOverrides[1]
+	}
+	if len(connectorHomeOverrides) > 2 {
+		cursorConfigDir = connectorHomeOverrides[2]
 	}
 	base := managedChildEnv(transaction.DataRoot)
-	filtered := make([]string, 0, len(base)+3)
+	filtered := make([]string, 0, len(base)+5)
 	for _, entry := range base {
 		name, _, ok := strings.Cut(entry, "=")
 		if ok && (strings.EqualFold(name, "CODEX_HOME") ||
 			strings.EqualFold(name, "CLAUDE_CONFIG_DIR") ||
-			strings.EqualFold(name, "HERMES_HOME")) {
+			strings.EqualFold(name, "HERMES_HOME") ||
+			strings.EqualFold(name, "OPENCODE_CONFIG_DIR") ||
+			strings.EqualFold(name, "CURSOR_CONFIG_DIR")) {
 			continue
 		}
 		filtered = append(filtered, entry)
@@ -724,6 +826,12 @@ func transactionChildEnvForHomes(
 	}
 	if hermesHome != "" {
 		filtered = append(filtered, "HERMES_HOME="+hermesHome)
+	}
+	if openCodeConfigDir != "" {
+		filtered = append(filtered, "OPENCODE_CONFIG_DIR="+openCodeConfigDir)
+	}
+	if cursorConfigDir != "" {
+		filtered = append(filtered, "CURSOR_CONFIG_DIR="+cursorConfigDir)
 	}
 	return filtered
 }
@@ -915,7 +1023,9 @@ func validateSetupTransaction(transaction setupTransaction, expected setupTransa
 		}
 		if !samePath(transaction.PreviousCodexHome, transaction.CodexHome) ||
 			!samePath(transaction.PreviousClaudeConfigDir, transaction.ClaudeConfigDir) ||
-			!samePath(transaction.PreviousHermesHome, transaction.HermesHome) {
+			!samePath(transaction.PreviousHermesHome, transaction.HermesHome) ||
+			!samePath(transaction.PreviousOpenCodeConfigDir, transaction.OpenCodeConfigDir) ||
+			!samePath(transaction.PreviousCursorConfigDir, transaction.CursorConfigDir) {
 			return errors.New("connector-preserving transaction changed a connector configuration home")
 		}
 		if len(transaction.PreviousConnectors) != 0 && !transaction.TargetServices.Gateway {
@@ -933,12 +1043,16 @@ func validateSetupTransaction(transaction setupTransaction, expected setupTransa
 		return errors.New("setup transaction records a digest for an absent previous maintenance executable")
 	}
 	for label, value := range map[string]string{
-		"previous Codex home":               transaction.PreviousCodexHome,
-		"previous Claude configuration dir": transaction.PreviousClaudeConfigDir,
-		"previous Hermes home":              transaction.PreviousHermesHome,
-		"Codex home":                        transaction.CodexHome,
-		"Claude configuration dir":          transaction.ClaudeConfigDir,
-		"Hermes home":                       transaction.HermesHome,
+		"previous Codex home":                 transaction.PreviousCodexHome,
+		"previous Claude configuration dir":   transaction.PreviousClaudeConfigDir,
+		"previous Hermes home":                transaction.PreviousHermesHome,
+		"previous OpenCode configuration dir": transaction.PreviousOpenCodeConfigDir,
+		"previous Cursor configuration dir":   transaction.PreviousCursorConfigDir,
+		"Codex home":                          transaction.CodexHome,
+		"Claude configuration dir":            transaction.ClaudeConfigDir,
+		"Hermes home":                         transaction.HermesHome,
+		"OpenCode configuration dir":          transaction.OpenCodeConfigDir,
+		"Cursor configuration dir":            transaction.CursorConfigDir,
 	} {
 		if value == "" {
 			continue
@@ -1022,9 +1136,11 @@ func validateInstallStateForRoots(state *installState, installRoot, dataRoot, ma
 		}
 	}
 	for label, value := range map[string]string{
-		"Codex home":               state.CodexHome,
-		"Claude configuration dir": state.ClaudeConfigDir,
-		"Hermes home":              state.HermesHome,
+		"Codex home":                 state.CodexHome,
+		"Claude configuration dir":   state.ClaudeConfigDir,
+		"Hermes home":                state.HermesHome,
+		"OpenCode configuration dir": state.OpenCodeConfigDir,
+		"Cursor configuration dir":   state.CursorConfigDir,
 	} {
 		if value != "" && (!filepath.IsAbs(value) || filepath.Clean(value) != value) {
 			return fmt.Errorf("installer state has an invalid %s", label)
@@ -2899,6 +3015,10 @@ func connectorHomeChanged(transaction setupTransaction, connectorName string) bo
 		return !samePath(transaction.PreviousClaudeConfigDir, transaction.ClaudeConfigDir)
 	case "hermes":
 		return !samePath(transaction.PreviousHermesHome, transaction.HermesHome)
+	case "opencode":
+		return !samePath(transaction.PreviousOpenCodeConfigDir, transaction.OpenCodeConfigDir)
+	case "cursor":
+		return !samePath(transaction.PreviousCursorConfigDir, transaction.CursorConfigDir)
 	default:
 		return false
 	}

--- a/cmd/defenseclaw-setup/transaction_test.go
+++ b/cmd/defenseclaw-setup/transaction_test.go
@@ -1296,7 +1296,7 @@ func TestTeardownSupersededConnectorsSwitchesConnector(t *testing.T) {
 func TestTeardownSupersededConnectorsOptOutRemovesEveryPreviousConnector(t *testing.T) {
 	transaction := setupTransaction{
 		DataRoot:           `C:\Users\tester\.defenseclaw`,
-		PreviousConnectors: []string{"codex", "claudecode", "amp"},
+		PreviousConnectors: []string{"codex", "claudecode", "amp", "hermes"},
 		TargetConnector:    "none",
 	}
 	var calls []string
@@ -1311,6 +1311,7 @@ func TestTeardownSupersededConnectorsOptOutRemovesEveryPreviousConnector(t *test
 		"codex:teardown", "codex:verify",
 		"claudecode:teardown", "claudecode:verify",
 		"amp:teardown", "amp:verify",
+		"hermes:teardown", "hermes:verify",
 	}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("connector opt-out calls = %v, want %v", calls, want)
@@ -1391,6 +1392,7 @@ func TestResolvePreviousConnectorHomeUsesBackupBindingWithoutInstallState(t *tes
 	}{
 		{"codex", "config.toml", "codex_config_backup.json"},
 		{"claudecode", "settings.json", "claudecode_backup.json"},
+		{"hermes", "config", "hermes_backup.json"},
 	} {
 		t.Run(test.connector, func(t *testing.T) {
 			dataRoot := t.TempDir()
@@ -1425,6 +1427,29 @@ func TestResolvePreviousConnectorHomeUsesBackupBindingWithoutInstallState(t *tes
 				t.Fatalf("resolved previous connector home = %q, want %q", got, want)
 			}
 		})
+	}
+}
+
+func TestInferManagedHermesHomeAcceptsPR655LegacyBackupName(t *testing.T) {
+	dataRoot := t.TempDir()
+	backupPath := filepath.Join(dataRoot, "connector_backups", "hermes", "config.yaml.json")
+	if err := os.MkdirAll(filepath.Dir(backupPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(t.TempDir(), "hermes-custom-home")
+	if err := os.WriteFile(
+		backupPath,
+		[]byte(fmt.Sprintf(`{"path":%q}`, filepath.Join(want, "config.yaml"))),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	got, err := inferManagedConnectorHome(dataRoot, "hermes", "config", `C:\fallback`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !samePath(got, want) {
+		t.Fatalf("inferred legacy Hermes home = %q, want %q", got, want)
 	}
 }
 

--- a/cmd/defenseclaw-setup/transaction_test.go
+++ b/cmd/defenseclaw-setup/transaction_test.go
@@ -1296,7 +1296,7 @@ func TestTeardownSupersededConnectorsSwitchesConnector(t *testing.T) {
 func TestTeardownSupersededConnectorsOptOutRemovesEveryPreviousConnector(t *testing.T) {
 	transaction := setupTransaction{
 		DataRoot:           `C:\Users\tester\.defenseclaw`,
-		PreviousConnectors: []string{"codex", "claudecode", "amp", "hermes"},
+		PreviousConnectors: []string{"codex", "claudecode", "amp", "hermes", "opencode", "cursor"},
 		TargetConnector:    "none",
 	}
 	var calls []string
@@ -1312,6 +1312,8 @@ func TestTeardownSupersededConnectorsOptOutRemovesEveryPreviousConnector(t *test
 		"claudecode:teardown", "claudecode:verify",
 		"amp:teardown", "amp:verify",
 		"hermes:teardown", "hermes:verify",
+		"opencode:teardown", "opencode:verify",
+		"cursor:teardown", "cursor:verify",
 	}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("connector opt-out calls = %v, want %v", calls, want)
@@ -1450,6 +1452,79 @@ func TestInferManagedHermesHomeAcceptsPR655LegacyBackupName(t *testing.T) {
 	}
 	if !samePath(got, want) {
 		t.Fatalf("inferred legacy Hermes home = %q, want %q", got, want)
+	}
+}
+
+func TestInferManagedOpenCodeHomeUsesPluginDirectoryParent(t *testing.T) {
+	dataRoot := t.TempDir()
+	backupPath := filepath.Join(dataRoot, "connector_backups", "opencode", "config.json")
+	if err := os.MkdirAll(filepath.Dir(backupPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(t.TempDir(), "opencode-custom-home")
+	pluginPath := filepath.Join(want, "plugins", "defenseclaw.js")
+	if err := os.WriteFile(
+		backupPath,
+		[]byte(fmt.Sprintf(`{"path":%q}`, pluginPath)),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	got, err := inferManagedConnectorHome(dataRoot, "opencode", "config", `C:\fallback`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !samePath(got, want) {
+		t.Fatalf("inferred OpenCode home = %q, want %q", got, want)
+	}
+}
+
+func TestInferManagedCursorHomeUsesHooksFileParent(t *testing.T) {
+	dataRoot := t.TempDir()
+	backupPath := filepath.Join(dataRoot, "connector_backups", "cursor", "hooks.json.json")
+	if err := os.MkdirAll(filepath.Dir(backupPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(t.TempDir(), "cursor-custom-home")
+	if err := os.WriteFile(
+		backupPath,
+		[]byte(fmt.Sprintf(`{"path":%q}`, filepath.Join(want, "hooks.json"))),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	got, err := inferManagedConnectorHome(dataRoot, "cursor", "hooks.json", `C:\fallback`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !samePath(got, want) {
+		t.Fatalf("inferred Cursor home = %q, want %q", got, want)
+	}
+}
+
+func TestTransactionChildEnvironmentBindsOpenCodeHome(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "opencode")
+	transaction := setupTransaction{
+		DataRoot:          filepath.Join(root, "data"),
+		OpenCodeConfigDir: home,
+	}
+	joined := strings.Join(transactionChildEnv(transaction), "\n")
+	if !strings.Contains(joined, "OPENCODE_CONFIG_DIR="+home) {
+		t.Fatalf("transaction child environment omitted OpenCode home: %s", joined)
+	}
+}
+
+func TestTransactionChildEnvironmentBindsCursorHome(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "cursor")
+	transaction := setupTransaction{
+		DataRoot:        filepath.Join(root, "data"),
+		CursorConfigDir: home,
+	}
+	joined := strings.Join(transactionChildEnv(transaction), "\n")
+	if !strings.Contains(joined, "CURSOR_CONFIG_DIR="+home) {
+		t.Fatalf("transaction child environment omitted Cursor home: %s", joined)
 	}
 }
 

--- a/cmd/defenseclaw-setup/wizard_windows.go
+++ b/cmd/defenseclaw-setup/wizard_windows.go
@@ -214,6 +214,8 @@ var (
 		{Label: "Claude Code", Value: "claudecode"},
 		{Label: "Amp", Value: "amp"},
 		{Label: "Hermes Agent", Value: "hermes"},
+		{Label: "OpenCode (preview)", Value: "opencode"},
+		{Label: "Cursor (preview)", Value: "cursor"},
 	}
 	wizardModeChoices = []wizardChoice{
 		{Label: "Observe", Value: "observe"},
@@ -738,8 +740,12 @@ func wizardCompletionDescription(connector string) string {
 		return "Amp is configured with the DefenseClaw system policy plugin under %USERPROFILE%\\.config\\amp\\plugins. Use --plugin-ready-timeout 30 with amp -x." + installed
 	case "hermes":
 		return "Hermes Agent is configured with native DefenseClaw hooks under %LOCALAPPDATA%\\hermes. Restart Hermes so it reloads the hook registry." + installed
+	case "opencode":
+		return "OpenCode preview is configured with the native Windows bridge plugin under %USERPROFILE%\\.config\\opencode\\plugins. Restart OpenCode so it loads the plugin." + installed
+	case "cursor":
+		return "Cursor preview is configured with native Windows hooks under %USERPROFILE%\\.cursor. Restart Cursor Agent so it reloads hooks.json." + installed
 	default:
-		return "Open a terminal and run defenseclaw init when you are ready to configure Codex, Claude Code, Amp, Hermes, or another connector." + installed
+		return "Open a terminal and run defenseclaw init when you are ready to configure Codex, Claude Code, Amp, Hermes, OpenCode, Cursor, or another connector." + installed
 	}
 }
 

--- a/cmd/defenseclaw-setup/wizard_windows.go
+++ b/cmd/defenseclaw-setup/wizard_windows.go
@@ -213,6 +213,7 @@ var (
 		{Label: "Codex CLI", Value: "codex"},
 		{Label: "Claude Code", Value: "claudecode"},
 		{Label: "Amp", Value: "amp"},
+		{Label: "Hermes Agent", Value: "hermes"},
 	}
 	wizardModeChoices = []wizardChoice{
 		{Label: "Observe", Value: "observe"},
@@ -735,8 +736,10 @@ func wizardCompletionDescription(connector string) string {
 		return "Claude Code is configured and its native Windows hooks are ready." + installed
 	case "amp":
 		return "Amp is configured with the DefenseClaw system policy plugin under %USERPROFILE%\\.config\\amp\\plugins. Use --plugin-ready-timeout 30 with amp -x." + installed
+	case "hermes":
+		return "Hermes Agent is configured with native DefenseClaw hooks under %LOCALAPPDATA%\\hermes. Restart Hermes so it reloads the hook registry." + installed
 	default:
-		return "Open a terminal and run defenseclaw init when you are ready to configure Codex, Claude Code, Amp, or another connector." + installed
+		return "Open a terminal and run defenseclaw init when you are ready to configure Codex, Claude Code, Amp, Hermes, or another connector." + installed
 	}
 }
 

--- a/cmd/defenseclaw-setup/wizard_windows_test.go
+++ b/cmd/defenseclaw-setup/wizard_windows_test.go
@@ -368,6 +368,7 @@ func TestWizardChoiceMappings(t *testing.T) {
 		{Label: "Codex CLI", Value: "codex"},
 		{Label: "Claude Code", Value: "claudecode"},
 		{Label: "Amp", Value: "amp"},
+		{Label: "Hermes Agent", Value: "hermes"},
 	}
 	modes := []wizardChoice{
 		{Label: "Observe", Value: "observe"},
@@ -498,6 +499,7 @@ func TestWizardCompletionDescriptionMatchesConfiguredConnector(t *testing.T) {
 		{connector: "codex", want: "trusted automatically", reject: "open /hooks"},
 		{connector: "claudecode", want: "Claude Code is configured", reject: "defenseclaw init"},
 		{connector: "amp", want: "--plugin-ready-timeout 30", reject: "defenseclaw init"},
+		{connector: "hermes", want: "Restart Hermes", reject: "defenseclaw init"},
 		{connector: "none", want: "defenseclaw init", reject: "open /hooks"},
 	} {
 		t.Run(tc.connector, func(t *testing.T) {

--- a/cmd/defenseclaw-setup/wizard_windows_test.go
+++ b/cmd/defenseclaw-setup/wizard_windows_test.go
@@ -369,6 +369,8 @@ func TestWizardChoiceMappings(t *testing.T) {
 		{Label: "Claude Code", Value: "claudecode"},
 		{Label: "Amp", Value: "amp"},
 		{Label: "Hermes Agent", Value: "hermes"},
+		{Label: "OpenCode (preview)", Value: "opencode"},
+		{Label: "Cursor (preview)", Value: "cursor"},
 	}
 	modes := []wizardChoice{
 		{Label: "Observe", Value: "observe"},

--- a/docs-site/content/docs/connectors/compatibility.mdx
+++ b/docs-site/content/docs/connectors/compatibility.mdx
@@ -14,7 +14,7 @@ DefenseClaw tracks hook connector compatibility with a packaged JSON manifest at
 <Callout type="warning" title="Version compatibility is not platform certification">
 A connector can have a valid hook contract and still be unsupported or not
 certified on native Windows. The current packaged Windows release contract
-certifies Codex, Claude Code, and Amp; see the
+certifies Codex, Claude Code, Amp, and Hermes; see the
 [native Windows connector matrix](/docs/get-started/windows#certified-connector-scope).
 </Callout>
 
@@ -39,7 +39,7 @@ rollout holds. Existing policy defaults are unchanged.
 | <ConnectorLabel id="codex" /> | hook contract | `>=0.135.0,<0.145.0` | `codex-hooks-v3-generic` / `v6` (10 events, generic local tools) | prompt, tool_call, tool_result |
 | <ConnectorLabel id="codex" /> | hook contract | `>=0.145.0` | `codex-hooks-v4` / `v6` (11 events) | prompt, tool_call, tool_result |
 | <ConnectorLabel id="claudecode" /> | hook contract | `>=2.1.152` | `claudecode-hooks-v1` / `v7` | prompt, tool_call, tool_result, event_content |
-| <ConnectorLabel id="hermes" /> | hook contract | `>=0.11.0` | `hermes-hooks-v1` / `v6` | prompt, tool_call, tool_result, event_content |
+| <ConnectorLabel id="hermes" /> | hook contract | `>=0.20.6` | `hermes-hooks-v1` / `v7` | 23 shell-hook events; `pre_tool_call` can block |
 | <ConnectorLabel id="cursor" /> | hook contract | `>=1.7.0` | `cursor-hooks-v1` / `v8` | prompt, tool_call, tool_result |
 | <ConnectorLabel id="windsurf" /> | hook contract | `>=1.12.41` | `windsurf-hooks-v1` / `v6` | prompt, tool_call, tool_result |
 | <ConnectorLabel id="geminicli" /> | hook contract | `>=0.26.0` | `geminicli-hooks-v1` / `v6` | prompt, tool_call, tool_result |
@@ -63,9 +63,9 @@ Codex `0.124.0` starts the six-event stable contract; `0.129.0` adds
 tools; and `0.145.0` adds the true main-thread `SessionEnd` boundary.
 The per-turn Codex `Stop` event never closes cross-turn chain state. Gemini CLI
 `0.26.0` enabled hooks by default, Cursor `1.7.0`
-introduced beta hooks, and Hermes `0.11.0` added shell hooks. The Hermes
-contract covers ten events: four LLM/tool callbacks, session
-start/end/finalize/reset, and subagent start/stop. Windsurf `1.12.41` added
+introduced beta hooks, and Hermes `0.20.6` is the validated 23-event shell-hook
+baseline covering tool, transform, LLM/API, session, subagent, gateway,
+approval, and kanban lifecycle events. Windsurf `1.12.41` added
 user-prompt hooks to the Cascade pre-hook set, while Copilot CLI `1.0.18` is
 the first release containing every event in the current DefenseClaw contract.
 

--- a/docs-site/content/docs/connectors/compatibility.mdx
+++ b/docs-site/content/docs/connectors/compatibility.mdx
@@ -14,7 +14,8 @@ DefenseClaw tracks hook connector compatibility with a packaged JSON manifest at
 <Callout type="warning" title="Version compatibility is not platform certification">
 A connector can have a valid hook contract and still be unsupported or not
 certified on native Windows. The current packaged Windows release contract
-certifies Codex, Claude Code, Amp, and Hermes; see the
+certifies Codex, Claude Code, Amp, and Hermes, with OpenCode and Cursor
+available as native Windows previews; see the
 [native Windows connector matrix](/docs/get-started/windows#certified-connector-scope).
 </Callout>
 
@@ -46,7 +47,7 @@ rollout holds. Existing policy defaults are unchanged.
 | <ConnectorLabel id="copilot" /> | hook contract | `>=1.0.18` | `copilot-hooks-v1` / `v6` | prompt, tool_call, tool_result |
 | <ConnectorLabel id="openhands" /> | hook contract | unversioned / documented hooks; tested with `OpenHands CLI 1.16.0` | `openhands-hooks-v1` / `v6` | prompt, tool_call, tool_result, event_content |
 | <ConnectorLabel id="antigravity" /> | hook contract | `>=1.1.9` | `antigravity-hooks-v2` / `v7` | prompt, tool_call, tool_result |
-| <ConnectorLabel id="opencode" /> | hook contract | unversioned / plugin API; tested with `opencode 1.16.2` | `opencode-hooks-v1` / `v7` | tool_call, tool_result |
+| <ConnectorLabel id="opencode" /> | hook contract | unversioned / plugin API; tested with `opencode 1.18.14` on native Windows x64 | `opencode-hooks-v1` / `v7` | tool_call, tool_result |
 | <ConnectorLabel id="amp" /> | plugin contract | `>=0.0.1785334225` | `amp-plugin-v1` / `v2` | prompt, tool_call, tool_result, event_content |
 | <ConnectorLabel id="omnigent" /> | hook contract | unversioned / documented custom-policy API | `omnigent-custom-policy-v1` / `v1` | prompt, tool_call, tool_result |
 
@@ -71,7 +72,7 @@ the first release containing every event in the current DefenseClaw contract.
 
 OpenCode's plugin API, OmniGent's six-phase custom-policy API, and OpenHands'
 documented hooks are accepted as unversioned contracts. The manifest records
-validation with `opencode 1.16.2` and `OpenHands CLI 1.16.0`; those are
+validation with `opencode 1.18.14` and `OpenHands CLI 1.16.0`; those are
 validation points, not minimum versions. Amp's normalized `0.0.1785334225`
 value is DefenseClaw's pinned contract snapshot and certification floor for the
 documented five-event API used by `amp-plugin-v1`; Amp does not declare it as

--- a/docs-site/content/docs/connectors/cursor.mdx
+++ b/docs-site/content/docs/connectors/cursor.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cursor
-description: Cursor connector wires hooks.json with native ask on beforeShellExecution and beforeMCPExecution. Block on preToolUse, beforeReadFile, beforeTabFileRead, beforeSubmitPrompt, stop.
+description: Cursor connector wires hooks.json with native ask on beforeShellExecution and beforeMCPExecution. Block on preToolUse, subagentStart, shell/MCP gates, file-read gates, and beforeSubmitPrompt.
 keywords:
   - DefenseClaw Cursor connector
   - Cursor hooks
@@ -17,16 +17,19 @@ defenseclaw setup cursor
 ```
 
 <Callout type="warning">
-Cursor setup is supported on macOS and Linux. The DefenseClaw connector is not
-certified on native Windows x64, so setup rejects it there.
+Cursor setup is supported on macOS and Linux and is available as a native
+Windows x64 preview. On Windows it remains a per-user OSS integration; it does
+not enable the separate managed-enterprise hardening lifecycle.
 </Callout>
 
 This runs the observe-mode template. Cursor talks directly to its native
 upstream; DefenseClaw inspects via hooks. **There is no proxy-enforcement
 path** for Cursor — blocking happens hook-side via `preToolUse`,
-`beforeShellExecution`, `beforeMCPExecution`, `beforeReadFile`,
-`beforeTabFileRead`, `beforeSubmitPrompt`, and `stop`. Native ask is supported
-only on the two `before*Execution` events.
+`subagentStart`, `beforeShellExecution`, `beforeMCPExecution`,
+`beforeReadFile`, `beforeTabFileRead`, and `beforeSubmitPrompt`. Native ask is
+supported only on the two `before*Execution` events. Cursor's `stop` response
+is follow-up-only, so DefenseClaw observes it but does not claim it can block
+termination.
 
 #### What `setup cursor` actually does
 
@@ -58,6 +61,12 @@ defenseclaw setup cursor
 ```
 
 Confirms once, wires the hooks against `~/.cursor/hooks.json`, and restarts the gateway. Findings flow to mandatory SQLite event history and the TUI; configured v8 destinations receive only the buckets/signals their routes select. No traffic is intercepted and no requests are blocked. Pass `--yes` to skip the confirmation in CI.
+
+On native Windows, the default is `%USERPROFILE%\.cursor\hooks.json`.
+`CURSOR_CONFIG_DIR` selects a different Cursor configuration directory when it
+is set explicitly. DefenseClaw writes a same-user PowerShell adapter under its
+own hook directory; the adapter streams Cursor's stdin payload to the native
+`defenseclaw-hook.exe` launcher, so Git Bash, `jq`, and WSL are not required.
 
 </Tab>
 
@@ -102,8 +111,9 @@ defenseclaw setup cursor --mode action --human-approval --fail-mode closed
 
 With `mode=action`, `beforeShellExecution` and `beforeMCPExecution` surface a
 native ask when policy returns an eligible confirmation verdict. The other
-block events use an alert/context fallback with `raw_action` preserved; the
-TUI can review but not resume them.
+block events return deny when policy blocks. They cannot pause for approval, so
+an eligible confirmation verdict uses an alert/context fallback with
+`raw_action` preserved; the TUI can review but not resume it.
 
 </Tab>
 
@@ -131,6 +141,7 @@ Not sure what to pick? Run `defenseclaw setup guardrail` (no flags) — the [int
   <Folder name="~/.defenseclaw" defaultOpen>
     <Folder name="hooks">
       <File name="cursor-hook.sh" />
+      <File name="cursor-hook.ps1 (native Windows only)" />
     </Folder>
   </Folder>
 </Files>
@@ -143,9 +154,10 @@ Cursor's MCP / skills / rules surfaces are discovered from user-global Cursor lo
 
 <Callout type="info">
 Cursor supports native ask only on `beforeShellExecution` and
-`beforeMCPExecution`. The other block events (`preToolUse`, `beforeReadFile`,
-`beforeTabFileRead`, `beforeSubmitPrompt`, `stop`) return an alert/context
-fallback and retain the original confirm intent in audit.
+`beforeMCPExecution`. The other block events (`preToolUse`, `subagentStart`,
+`beforeReadFile`, `beforeTabFileRead`, and `beforeSubmitPrompt`) return an
+alert/context fallback for confirm verdicts and retain the original confirm
+intent in audit. The `stop` hook is telemetry/follow-up-only.
 </Callout>
 
 ## Disable

--- a/docs-site/content/docs/connectors/hermes.mdx
+++ b/docs-site/content/docs/connectors/hermes.mdx
@@ -7,7 +7,7 @@ keywords:
   - Hermes agent runtime
 ---
 
-The Hermes connector wires DefenseClaw into the Hermes agent runtime via `~/.hermes/config.yaml` hooks and discovery surfaces for MCP servers, skills, and plugins.
+The Hermes connector wires DefenseClaw into the Hermes agent runtime via its `config.yaml` hooks and discovery surfaces for MCP servers, skills, and plugins. Native Windows x64 support starts at Hermes Agent 0.20.6.
 
 <Video
   src="hermes"
@@ -20,14 +20,16 @@ The Hermes connector wires DefenseClaw into the Hermes agent runtime via `~/.her
 defenseclaw setup hermes
 ```
 
-<Callout type="warning">
-Hermes setup is supported on macOS and Linux. The DefenseClaw connector is not
-certified on native Windows x64, so setup rejects it there.
+<Callout>
+Hermes setup is supported on macOS, Linux, and native Windows x64. On Windows,
+DefenseClaw writes `%LOCALAPPDATA%\hermes\config.yaml`, registers the exact
+native `defenseclaw-hook.exe` command, and requires Hermes Agent 0.20.6 or newer.
+Restart Hermes after setup or teardown so a running process reloads its hooks.
 </Callout>
 
 `setup hermes` is the dedicated Hermes alias. It uses the shared guardrail
-setup backend, wires the effective Hermes config (`$HERMES_HOME/config.yaml`
-or `~/.hermes/config.yaml`), and discovers existing MCP servers, skills, and
+setup backend, wires the effective Hermes config (`$HERMES_HOME/config.yaml`,
+`%LOCALAPPDATA%\hermes\config.yaml` on native Windows, or `~/.hermes/config.yaml`), and discovers existing MCP servers, skills, and
 plugins. **There is no proxy-enforcement path** — only `pre_tool_call` can
 block. Hermes has no native human-approval surface, so confirm verdicts use an
 immediate system-message fallback with `raw_action` preserved for audit.
@@ -59,7 +61,12 @@ The alias defaults Hermes to observe mode and can join an existing hook-connecto
 defenseclaw setup hermes
 ```
 
-Confirms once, wires the hooks block in `~/.hermes/config.yaml`, and restarts the gateway. Findings flow to mandatory SQLite event history and the TUI; configured v8 destinations receive only the buckets/signals their routes select. No traffic is intercepted and no requests are blocked. Pass `--yes` to skip the confirmation in CI.
+Confirms once, wires all 23 supported events in the Hermes config plus exact
+DefenseClaw-owned consent entries in `shell-hooks-allowlist.json`, and restarts
+the gateway. Findings flow to mandatory SQLite event history and the TUI;
+configured v8 destinations receive only the buckets/signals their routes
+select. No traffic is intercepted and no requests are blocked. Pass `--yes` to
+skip the confirmation in CI.
 
 </Tab>
 
@@ -104,8 +111,9 @@ defenseclaw setup hermes --mode action
 
 With `mode=action`, `pre_tool_call` blocks when policy returns `block`. A
 `confirm` result falls back to a system message because Hermes has no native
-ask surface. Hermes does not provide a fail-closed hook transport surface, so
-`--fail-mode closed` cannot make an unavailable hook block the agent.
+ask surface. With `--fail-mode closed`, a gateway transport failure or invalid
+gateway response blocks `pre_tool_call`; Hermes 0.20.6 also treats hook spawn,
+timeout, and malformed-output failures as a canonical block for that event.
 
 </Tab>
 
@@ -129,6 +137,7 @@ Not sure what to pick? Run `defenseclaw setup guardrail` (no flags) — the [int
 <Files>
   <Folder name="~/.hermes" defaultOpen>
     <File name="config.yaml (hooks block)" />
+    <File name="shell-hooks-allowlist.json (exact DefenseClaw approvals)" />
   </Folder>
   <Folder name="~/.defenseclaw" defaultOpen>
     <Folder name="hooks">
@@ -136,6 +145,10 @@ Not sure what to pick? Run `defenseclaw setup guardrail` (no flags) — the [int
     </Folder>
   </Folder>
 </Files>
+
+On native Windows, the first folder is `%LOCALAPPDATA%\hermes` and the hook
+entry is a direct `defenseclaw-hook.exe hook --connector hermes` command; no
+POSIX shell, WSL, or PowerShell wrapper is involved.
 
 ## Hook capabilities
 

--- a/docs-site/content/docs/connectors/opencode.mdx
+++ b/docs-site/content/docs/connectors/opencode.mdx
@@ -16,11 +16,13 @@ The OpenCode connector wires DefenseClaw into [opencode](https://opencode.ai). U
 />
 
 <Callout type="info">
-**No `opencode.json` edit, no shell shim.** Local plugins under `~/.config/opencode/plugins/` are loaded automatically, so installing the connector is just writing one file. The bridge uses the runtime's global `fetch`, so it needs no npm dependencies (and never triggers a `bun install`). The JavaScript plugin is supported on macOS and Linux. The DefenseClaw OpenCode integration is not certified on Windows.
+**No `opencode.json` edit, no shell shim.** Local plugins under `~/.config/opencode/plugins/` are loaded automatically, so installing the connector is just writing one file. The bridge uses the runtime's global `fetch`, so it needs no npm dependencies (and never triggers a `bun install`). The JavaScript plugin is supported on macOS and Linux. Native Windows x64 is available as preview and uses the same documented plugin callbacks.
 </Callout>
 
-Native Windows x64 setup rejects this connector; use a supported macOS or
-Linux host.
+On Windows, the plugin lives under `%OPENCODE_CONFIG_DIR%\plugins`; the default
+configuration directory is `%USERPROFILE%\.config\opencode`. OpenCode supports
+direct Windows execution even though its documentation recommends WSL for the
+best experience. DefenseClaw does not mix native and WSL connector homes.
 
 ## Setup
 
@@ -29,7 +31,7 @@ defenseclaw setup opencode                # observe (default) - record only
 defenseclaw setup opencode --mode action  # block on policy hits by throwing
 ```
 
-This connector is **global/user-scoped only**. DefenseClaw writes the bridge plugin to `~/.config/opencode/plugins/defenseclaw.js` (owner-only, `0o600`, because it carries the gateway token) with the gateway address, token, and fail mode substituted in at setup time. There is **no proxy-enforcement path** for OpenCode — blocking happens plugin-side by throwing inside `tool.execute.before`.
+This connector is **global/user-scoped only**. DefenseClaw writes the bridge plugin to `~/.config/opencode/plugins/defenseclaw.js` (owner-only `0o600` on macOS/Linux, or a protected current-user/SYSTEM DACL on Windows). The stable plugin contains the gateway address, scoped-token sidecar path, and fail mode; it reads the token sidecar for each request so token rotation does not rewrite the plugin. There is **no proxy-enforcement path** for OpenCode — blocking happens plugin-side by throwing inside `tool.execute.before`. The thrown error begins `DefenseClaw blocked this tool before execution:` and aborts the tool, but OpenCode may continue the conversational turn after receiving that failed-tool result. Continued model narration is not evidence that the command ran; a blocked call has no matching `tool.execute.after` event.
 
 `setup opencode` is the dedicated OpenCode alias. See the
 [quick-alias reference](/docs/setup/guardrail/aliases) for its common setup
@@ -38,14 +40,14 @@ and judge configuration.
 
 #### Version contract
 
-The current contract is `opencode-hooks-v1` (the plugin API is documented as a stable contract rather than a versioned floor, so the contract is unbounded — `min 0.0.0`). `tool.execute.before` is the only blockable event; `tool.execute.after` is observe-only telemetry.
+The current contract is `opencode-hooks-v1` (the plugin API is documented as a stable contract rather than a versioned floor, so the contract is unbounded — `min 0.0.0`). `tool.execute.before` is the only blockable event; `tool.execute.after` is observe-only telemetry. Native Windows preview validation uses the official signed OpenCode `1.18.14` x64 client.
 
 ## Lifecycle events
 
 | Event | When it fires | DefenseClaw role | Action verdict → behavior |
 | --- | --- | --- | --- |
 | `tool.execute.before` | Right before a tool (`bash`, `read`, `edit`, …) executes | Inspect tool args; intercept risky commands | `block` → gateway returns `{decision: "deny", reason}`; the bridge `throw`s `new Error(reason)`, aborting the tool |
-| `tool.execute.after` | Immediately after a tool returns | Capture diagnostics / flag secrets in output. **Cannot block** — tool already ran. | Observe-only (fire-and-forget; never adds latency) |
+| `tool.execute.after` | Immediately after a tool returns | Capture diagnostics / flag secrets in output. **Cannot block** — tool already ran. | Observe-only; awaited so outcome attribution is recorded before the callback returns |
 
 opencode has no hook-driven ask or context-injection surface, so `confirm` verdicts fall back to allow and findings on `tool.execute.after` are telemetry only.
 
@@ -71,6 +73,10 @@ thrown `Error` is authoritative for `tool.execute.before`.
     <File name="defenseclaw.js" />
   </Folder>
 </Files>
+
+On native Windows the equivalent path is
+`%OPENCODE_CONFIG_DIR%\plugins\defenseclaw.js`, defaulting to
+`%USERPROFILE%\.config\opencode\plugins\defenseclaw.js`.
 
 DefenseClaw v1 governs opencode tool execution via the bridge plugin. opencode's MCP servers live in `opencode.json`; `defenseclaw mcp list --connector opencode`, `defenseclaw mcp set <name> --connector opencode`, and `defenseclaw mcp unset <name> --connector opencode` read or update the top-level `mcp` map. For local MCP servers, `mcp set` refuses commands outside trusted install prefixes unless you add the directory to `DEFENSECLAW_TRUSTED_BIN_PREFIXES` or pass `--force-untrusted-command` for that one write, because OpenCode will execute the stored command. Skills / rules / plugins / agents surfaces remain unsupported and their panels are hidden while `claw.mode=opencode`.
 

--- a/docs-site/content/docs/get-started/windows/capabilities-commands.mdx
+++ b/docs-site/content/docs/get-started/windows/capabilities-commands.mdx
@@ -16,8 +16,8 @@ the release actually qualifies.
 
 | Capability | Status | Native Windows boundary |
 | --- | --- | --- |
-| Codex, Claude Code, and Amp connector setup | **Supported** | Same-user native agent, native hook or owner-only Amp system plugin, authenticated loopback gateway. |
-| Cursor, Windsurf, Gemini CLI, Copilot CLI, Antigravity, OpenCode, and Hermes setup | **Not certified** | Cross-platform setup code exists, but the native Windows release does not qualify it. |
+| Codex, Claude Code, Amp, and Hermes connector setup | **Supported** | Same-user native agent, native hook or owner-only Amp system plugin, authenticated loopback gateway. Hermes requires Agent 0.20.6 or newer. |
+| Cursor, Windsurf, Gemini CLI, Copilot CLI, Antigravity, and OpenCode setup | **Not certified** | Cross-platform setup code exists, but the native Windows release does not qualify it. |
 | OpenHands, OmniGent, OpenClaw, and ZeptoClaw setup | **Unsupported** | Their required WSL, terminal/sandbox, or proxy topology is not hosted by native Windows DefenseClaw. |
 | Python CLI | **Supported** | Packaged launcher and embedded runtime; PowerShell and cmd. Individual optional/network subcommands retain their caveats below. |
 | TUI | **Supported** | Native console input, UTF-8 output, clipboard support, managed process cancellation, and safe fallback when redraw is unavailable. |
@@ -27,8 +27,8 @@ the release actually qualifies.
 | Watchdog | **Limited** | Config-enabled detached process with protected identity. Not a service or Scheduled Task. |
 | Observe and action modes | **Supported** | Action applies only to declared connector/event response surfaces. |
 | Fail open/fail closed | **Supported** | Effective connector setting covers transport and invalid response failures. Internal evaluator panic remains a reported fail-open boundary. |
-| Native hooks and policy plugin | **Supported** | Codex and Claude Code use `defenseclaw-hook.exe`; Amp loads `%USERPROFILE%\.config\amp\plugins\defenseclaw.ts` directly. No Bash, cmd wrapper, `jq`, WSL, or proxy is required. |
-| Native OTLP ingress | **Supported** | Codex logs/metrics/traces; Claude Code logs/metrics with traces disabled. Observation only. Amp has no documented native-OTLP channel and uses hook-generated telemetry. |
+| Native hooks and policy plugin | **Supported** | Codex, Claude Code, and Hermes use `defenseclaw-hook.exe`; Amp loads `%USERPROFILE%\.config\amp\plugins\defenseclaw.ts` directly. No Bash, cmd wrapper, `jq`, WSL, or proxy is required. |
+| Native OTLP ingress | **Supported** | Codex logs/metrics/traces; Claude Code logs/metrics with traces disabled. Observation only. Amp and Hermes have no documented native-OTLP channel and use callback-generated telemetry. |
 | Mandatory local audit | **Supported** | SQLite persists locally even without an outbound destination. |
 | Remote telemetry destinations | **Limited** | Supported when explicitly configured and reachable; credentials, network policy, and destination capabilities remain operator responsibilities. |
 | Redaction policy CLI and TUI | **Supported** | `setup redaction` uses the canonical v8 compiler for status, dry-run, and writes. The TUI provides safe quick actions plus all bucket/profile/destination/route commands; the guided workflow accepts prompt input in Activity. Backups use a protected current-user/SYSTEM DACL and durable atomic replacement. |
@@ -51,7 +51,7 @@ the release actually qualifies.
 | Offline install/servicing | **Limited** | Self-contained Setup after authenticated staging; remote registries/providers/destinations are not offline features. |
 | Local observability and Local Splunk | **Limited** | Optional Hyper-V Docker Desktop/Linux-container path on x64 Pro/Enterprise/Education only. |
 | OpenShell sandbox | **Unsupported** | Linux-only lifecycle. |
-| Model proxy/rerouting for supported connectors | **Not applicable** | Codex, Claude Code, and Amp keep their direct upstream path; Windows enforcement is hook/plugin-native. |
+| Model proxy/rerouting for supported connectors | **Not applicable** | Codex, Claude Code, Amp, and Hermes keep their direct upstream path; Windows enforcement is hook/plugin-native. |
 | POSIX services and hook shells | **Not applicable** | Windows uses native processes, HKCU startup, and the native hook runner. |
 
 ## Public `defenseclaw` command inventory
@@ -69,7 +69,7 @@ or an advanced operation; it does not mean every listed subcommand is broken.
 | `codeguard` | `install`, `install-skill`, `status` | **Limited** explicit opt-in; agent/network requirements apply. |
 | `config` | `path`, `reference`, `show`, `validate` | **Supported**. Configuration v8 rejects `config show --reveal`; effective and source views remain masked. |
 | `doctor` | no subcommands | **Supported**. Use `--fix --dry-run` before approving fixes. |
-| `guardrail` | `block-message`, `disable`, `enable`, `fail-mode`, `hilt`; `judge add/list/remove`; `list-packs`; `status` | **Supported** for Codex, Claude Code, and Amp; event limits still apply. |
+| `guardrail` | `block-message`, `disable`, `enable`, `fail-mode`, `hilt`; `judge add/list/remove`; `list-packs`; `status` | **Supported** for Codex, Claude Code, Amp, and Hermes; event limits still apply. |
 | `init` | no subcommands | **Limited** to supported native connector choices; sandbox setup is unsupported. |
 | `keys` | `check`, `fill-missing`, `list`, `set` | **Supported**, but secret values must not be pasted into support output. |
 | `mcp` | `allow`, `block`, `list`, `scan`, `set`, `unblock`, `unset` | **Supported** for certified connector roots; remote scans are optional network operations. |
@@ -126,7 +126,7 @@ optional and retain their own prerequisites.
 | `start`, `status`, `restart`, `stop` | no child commands | **Supported** current-user daemon lifecycle. |
 | `watchdog` | `start`, `status`, `stop` | **Limited** config-enabled detached monitor, not an OS service. |
 | `audit` | `export` | **Supported**. Exported content can be sensitive; handle it as audit data. |
-| `connector` | `list-backups`, `reconcile`, `teardown`, `verify` | **Supported** for Codex, Claude Code, and Amp; low-level operator/recovery surface. |
+| `connector` | `list-backups`, `reconcile`, `teardown`, `verify` | **Supported** for Codex, Claude Code, Amp, and Hermes; low-level operator/recovery surface. |
 | `policy` | `domains`, `evaluate`, `evaluate-firewall`, `reload`, `show`, `validate` | **Supported**. |
 | `provenance` | `show` | **Supported**. |
 | `scan` | `code` | **Supported** CodeGuard/ClawShield source scan. |

--- a/docs-site/content/docs/get-started/windows/capabilities-commands.mdx
+++ b/docs-site/content/docs/get-started/windows/capabilities-commands.mdx
@@ -17,7 +17,8 @@ the release actually qualifies.
 | Capability | Status | Native Windows boundary |
 | --- | --- | --- |
 | Codex, Claude Code, Amp, and Hermes connector setup | **Supported** | Same-user native agent, native hook or owner-only Amp system plugin, authenticated loopback gateway. Hermes requires Agent 0.20.6 or newer. |
-| Cursor, Windsurf, Gemini CLI, Copilot CLI, Antigravity, and OpenCode setup | **Not certified** | Cross-platform setup code exists, but the native Windows release does not qualify it. |
+| Cursor and OpenCode setup | **Preview** | Native Windows hooks/plugins are available while integrated packaged Setup and official-client validation complete. |
+| Windsurf, Gemini CLI, Copilot CLI, and Antigravity setup | **Not certified** | Cross-platform setup code exists, but the native Windows release does not qualify it. |
 | OpenHands, OmniGent, OpenClaw, and ZeptoClaw setup | **Unsupported** | Their required WSL, terminal/sandbox, or proxy topology is not hosted by native Windows DefenseClaw. |
 | Python CLI | **Supported** | Packaged launcher and embedded runtime; PowerShell and cmd. Individual optional/network subcommands retain their caveats below. |
 | TUI | **Supported** | Native console input, UTF-8 output, clipboard support, managed process cancellation, and safe fallback when redraw is unavailable. |

--- a/docs-site/content/docs/get-started/windows/connectors-enforcement.mdx
+++ b/docs-site/content/docs/get-started/windows/connectors-enforcement.mdx
@@ -1,23 +1,24 @@
 ---
 title: Connectors and enforcement
-description: Exact native Windows Codex, Claude Code, and Amp event coverage, action boundaries, fail modes, and runtime controls.
+description: Exact native Windows Codex, Claude Code, Amp, and Hermes event coverage, action boundaries, fail modes, and runtime controls.
 keywords:
   - DefenseClaw Windows Codex
   - DefenseClaw Windows Claude Code
   - DefenseClaw Windows Amp
+  - DefenseClaw Windows Hermes
   - DefenseClaw Windows action mode
   - DefenseClaw Windows fail closed
   - DefenseClaw Windows hooks
 ---
 
-Native Windows enforcement is connector-native and hook/plugin-only. Codex and
-Claude Code invoke `defenseclaw-hook.exe`; Amp loads an owner-only TypeScript
+Native Windows enforcement is connector-native and hook/plugin-only. Codex,
+Claude Code, and Hermes invoke `defenseclaw-hook.exe`; Amp loads an owner-only TypeScript
 system-policy plugin. The hook or plugin authenticates to the same-user
 loopback gateway, and the gateway maps a policy verdict back into that event's
 documented response shape.
 
 <Callout type="warning" title="Coverage stops at the agent surface">
-DefenseClaw does not proxy Codex, Claude Code, or Amp model traffic on Windows.
+DefenseClaw does not proxy Codex, Claude Code, Amp, or Hermes model traffic on Windows.
 A prompt, tool, subprocess, file change, or response that the agent does not
 emit through a registered hook, Amp plugin callback, or native telemetry
 surface is not silently intercepted by DefenseClaw.
@@ -36,6 +37,7 @@ Start with observe:
 defenseclaw setup codex --mode observe
 defenseclaw setup claude-code --mode observe
 defenseclaw setup amp --mode observe
+defenseclaw setup hermes --mode observe
 ```
 
 After reviewing the event inventory and policy, promote one connector at a
@@ -45,6 +47,7 @@ time:
 defenseclaw setup codex --mode action
 defenseclaw setup claude-code --mode action
 defenseclaw setup amp --mode action
+defenseclaw setup hermes --mode action
 defenseclaw guardrail status
 ```
 
@@ -166,6 +169,35 @@ and can govern a `tool.call`; it cannot retroactively cover earlier host
 activity. Fully exit and relaunch Amp after setup, removal, or repair so every
 new thread gets the intended plugin generation.
 
+## Hermes Agent
+
+DefenseClaw manages the `hooks` block and exact shell-hook consent entries in:
+
+```text
+%LOCALAPPDATA%\hermes\config.yaml
+%LOCALAPPDATA%\hermes\shell-hooks-allowlist.json
+```
+
+`HERMES_HOME` overrides that directory when explicitly configured. The native
+Windows command is a direct process invocation of
+`defenseclaw-hook.exe hook --connector hermes`; Hermes parses it with Windows
+command-line rules and does not invoke PowerShell or a POSIX shell.
+
+The validated Hermes Agent 0.20.6 contract registers 23 events: tool pre/post,
+terminal/tool/LLM transforms, LLM and API request lifecycle, session lifecycle,
+subagent lifecycle, gateway/approval lifecycle, and three kanban lifecycle
+events. DefenseClaw can block only `pre_tool_call` and can inject context only
+at `pre_llm_call`. Its other 21 registrations are telemetry-only. That includes
+`pre_verify`: Hermes itself defines a bounded continue response there, but this
+DefenseClaw contract deliberately does not use it to prolong execution. None of
+those telemetry events can undo an action.
+
+DefenseClaw leaves Hermes's global `hooks_auto_accept` policy untouched. It
+owns only its exact `(event, command)` approvals, preserves foreign approvals,
+and restores or surgically removes its entries during teardown. Restart Hermes
+after setup, removal, or repair because a running process retains its loaded
+callbacks.
+
 ## Fail behavior
 
 A fresh installation defaults to `closed`; a migrated older configuration may
@@ -187,6 +219,7 @@ defenseclaw guardrail fail-mode
 defenseclaw guardrail fail-mode closed --connector codex --yes
 defenseclaw guardrail fail-mode closed --connector claudecode --yes
 defenseclaw guardrail fail-mode closed --connector amp --yes
+defenseclaw guardrail fail-mode closed --connector hermes --yes
 defenseclaw guardrail status
 ```
 
@@ -227,12 +260,12 @@ These controls are not the same as skill or plugin runtime disable.
 
 Runtime disable is proven only on exact agent events:
 
-| Asset control | Codex | Claude Code | Amp |
-| --- | --- | --- | --- |
-| Skill runtime disable | **Limited** — blocks an exact disabled skill identity at a leading `$skill` selection in `UserPromptSubmit`. | **Limited** — blocks an exact disabled skill identity at the native `UserPromptExpansion` load. | **Limited** — skills are inventoried and scanned, but Amp exposes no separate skill-load callback. `tool.call` policy still applies to tools invoked after skill guidance loads. |
-| Plugin runtime disable | **Limited** — policy is recorded, but no certified hard plugin-expansion event exists. Use quarantine for hard filesystem enforcement. | **Limited** — blocks the native slash-command/plugin expansion event. | **Limited** — Amp executes plugin top-level code while loading, before a DefenseClaw callback can govern it. Use quarantine for filesystem enforcement. |
-| Skill quarantine/restore | **Supported** — validated root, journaled provenance/content hash, copy-verify-remove, and verified restore. | **Supported** with the same DefenseClaw quarantine contract. | **Supported** with the same DefenseClaw quarantine contract for exact inventoried AgentSkills. |
-| Plugin quarantine/restore | **Limited** — validated filesystem move/restore; do not assume the stronger skill transaction/hash guarantees. | **Limited** for the same reason. | **Limited** for the same reason; relaunch Amp after a plugin move. |
+| Asset control | Codex | Claude Code | Amp | Hermes |
+| --- | --- | --- | --- | --- |
+| Skill runtime disable | **Limited** — blocks an exact disabled skill identity at a leading `$skill` selection in `UserPromptSubmit`. | **Limited** — blocks an exact disabled skill identity at the native `UserPromptExpansion` load. | **Limited** — skills are inventoried and scanned, but Amp exposes no separate skill-load callback. `tool.call` policy still applies to tools invoked after skill guidance loads. | **Limited** — skills are inventoried and scanned, but Hermes exposes no separate skill-load enforcement event. |
+| Plugin runtime disable | **Limited** — policy is recorded, but no certified hard plugin-expansion event exists. Use quarantine for hard filesystem enforcement. | **Limited** — blocks the native slash-command/plugin expansion event. | **Limited** — Amp executes plugin top-level code while loading, before a DefenseClaw callback can govern it. Use quarantine for filesystem enforcement. | **Limited** — plugin inventory is available, but no certified hard plugin-load event exists. Use quarantine for hard filesystem enforcement. |
+| Skill quarantine/restore | **Supported** — validated root, journaled provenance/content hash, copy-verify-remove, and verified restore. | **Supported** with the same DefenseClaw quarantine contract. | **Supported** with the same DefenseClaw quarantine contract for exact inventoried AgentSkills. | **Supported** with the same DefenseClaw quarantine contract for exact inventoried skills. |
+| Plugin quarantine/restore | **Limited** — validated filesystem move/restore; do not assume the stronger skill transaction/hash guarantees. | **Limited** for the same reason. | **Limited** for the same reason; relaunch Amp after a plugin move. | **Limited** for the same reason; restart Hermes after a plugin move. |
 
 Runtime disable does not block future installation and does not move files.
 Restore removes only quarantine; a separate install block or runtime-disable
@@ -260,7 +293,7 @@ Use `defenseclaw-gateway connector verify --connector <name>` only after
 teardown or removal: it verifies that DefenseClaw-owned connector state is
 absent. On an active connector, that state is expected, so use `doctor` and
 `guardrail status` instead. After setup or mode changes, fully restart Codex
-or Claude Code, or fully exit and relaunch Amp, so the agent reloads the
+or Claude Code, fully exit and relaunch Amp, or restart Hermes, so the agent reloads the
 managed registration.
 
 Protection is established only when all of the following agree:
@@ -272,5 +305,6 @@ Protection is established only when all of the following agree:
 5. a new non-sensitive prompt produces connector-attributed local activity.
 
 For configuration details, see [Codex](/docs/connectors/codex),
-[Claude Code](/docs/connectors/claudecode), [Amp](/docs/connectors/amp), and
+[Claude Code](/docs/connectors/claudecode), [Amp](/docs/connectors/amp),
+[Hermes](/docs/connectors/hermes), and
 [multi-connector setup](/docs/setup/guardrail/multi-connector).

--- a/docs-site/content/docs/get-started/windows/connectors-enforcement.mdx
+++ b/docs-site/content/docs/get-started/windows/connectors-enforcement.mdx
@@ -1,11 +1,13 @@
 ---
 title: Connectors and enforcement
-description: Exact native Windows Codex, Claude Code, Amp, and Hermes event coverage, action boundaries, fail modes, and runtime controls.
+description: Exact native Windows Codex, Claude Code, Amp, Hermes, OpenCode, and Cursor event coverage, action boundaries, fail modes, and runtime controls.
 keywords:
   - DefenseClaw Windows Codex
   - DefenseClaw Windows Claude Code
   - DefenseClaw Windows Amp
   - DefenseClaw Windows Hermes
+  - DefenseClaw Windows OpenCode
+  - DefenseClaw Windows Cursor
   - DefenseClaw Windows action mode
   - DefenseClaw Windows fail closed
   - DefenseClaw Windows hooks
@@ -13,7 +15,10 @@ keywords:
 
 Native Windows enforcement is connector-native and hook/plugin-only. Codex,
 Claude Code, and Hermes invoke `defenseclaw-hook.exe`; Amp loads an owner-only TypeScript
-system-policy plugin. The hook or plugin authenticates to the same-user
+system-policy plugin, OpenCode loads an owner-only JavaScript bridge plugin,
+and Cursor invokes a same-user PowerShell adapter that streams into the native
+hook launcher.
+The hook or plugin authenticates to the same-user
 loopback gateway, and the gateway maps a policy verdict back into that event's
 documented response shape.
 
@@ -38,6 +43,8 @@ defenseclaw setup codex --mode observe
 defenseclaw setup claude-code --mode observe
 defenseclaw setup amp --mode observe
 defenseclaw setup hermes --mode observe
+defenseclaw setup opencode --mode observe
+defenseclaw setup cursor --mode observe
 ```
 
 After reviewing the event inventory and policy, promote one connector at a
@@ -48,6 +55,8 @@ defenseclaw setup codex --mode action
 defenseclaw setup claude-code --mode action
 defenseclaw setup amp --mode action
 defenseclaw setup hermes --mode action
+defenseclaw setup opencode --mode action
+defenseclaw setup cursor --mode action
 defenseclaw guardrail status
 ```
 
@@ -198,6 +207,53 @@ and restores or surgically removes its entries during teardown. Restart Hermes
 after setup, removal, or repair because a running process retains its loaded
 callbacks.
 
+## OpenCode (preview)
+
+DefenseClaw installs the native Windows bridge at:
+
+```text
+%USERPROFILE%\.config\opencode\plugins\defenseclaw.js
+```
+
+`OPENCODE_CONFIG_DIR` overrides the configuration directory. OpenCode loads
+global JavaScript/TypeScript plugins directly, so this path needs no shell,
+Git Bash, `jq`, WSL, or `defenseclaw-hook.exe`. The plugin reads its
+connector-scoped token sidecar for each request and talks only to the
+same-user loopback gateway.
+
+`tool.execute.before` awaits the local verdict and throws an error when action
+mode returns a block, preventing the tool from executing. `tool.execute.after`
+is awaited for reliable outcome attribution but remains telemetry-only because
+the tool has already run. OpenCode exposes no native ask or context-injection
+response through this plugin contract. The preview validation point is the
+official signed OpenCode `1.18.14` Windows x64 client.
+
+## Cursor (preview)
+
+DefenseClaw appends its managed entries to Cursor's user-scoped hook file:
+
+```text
+%USERPROFILE%\.cursor\hooks.json
+```
+
+The official `CURSOR_CONFIG_DIR` override selects a different Cursor
+configuration directory. On native Windows the hook command launches
+`%USERPROFILE%\.defenseclaw\hooks\cursor-hook.ps1` by default; that adapter streams Cursor's
+stdin JSON directly to `defenseclaw-hook.exe hook --connector cursor` through
+an absolute same-user process boundary. It does not require Git Bash, `jq`, or
+WSL.
+
+`beforeShellExecution` and `beforeMCPExecution` can return Cursor's native
+allow, deny, or ask verdict before execution. `preToolUse`, `subagentStart`,
+`beforeReadFile`, `beforeTabFileRead`, and `beforeSubmitPrompt` can deny but do
+not provide a resumable native ask. `stop` is follow-up-only and is observed,
+not treated as a termination block. Post-execution events remain
+telemetry-only. Cursor's specialized top-level shell command, string-encoded
+MCP parameters, file content/edits, prompt text, and result fields are decoded
+into the same typed local scanner contract used by the other connectors.
+The Windows preview does not imply managed-enterprise installation or
+hardening.
+
 ## Fail behavior
 
 A fresh installation defaults to `closed`; a migrated older configuration may
@@ -220,6 +276,8 @@ defenseclaw guardrail fail-mode closed --connector codex --yes
 defenseclaw guardrail fail-mode closed --connector claudecode --yes
 defenseclaw guardrail fail-mode closed --connector amp --yes
 defenseclaw guardrail fail-mode closed --connector hermes --yes
+defenseclaw guardrail fail-mode closed --connector opencode --yes
+defenseclaw guardrail fail-mode closed --connector cursor --yes
 defenseclaw guardrail status
 ```
 

--- a/docs-site/content/docs/get-started/windows/index.mdx
+++ b/docs-site/content/docs/get-started/windows/index.mdx
@@ -12,7 +12,9 @@ keywords:
 DefenseClaw has a native, per-user Windows x64 (`amd64`) distribution. It installs a
 local gateway, native hook launcher, CLI, TUI, scanners, and managed Python
 runtime. The certified connector scope is deliberately narrow: **Codex**,
-**Claude Code**, **Amp**, and **Hermes Agent**.
+**Claude Code**, **Amp**, and **Hermes Agent**. **OpenCode** and **Cursor** are
+available as previews while their integrated packaged and official-client
+validation completes.
 
 For centrally managed endpoints, the separate
 [managed-enterprise lifecycle](/docs/get-started/windows/managed-enterprise)
@@ -43,10 +45,12 @@ native agent at a WSL installation, or mix native and WSL connector homes.
 | Claude Code | `claudecode` | **Supported** | Native hooks to the loopback gateway; native OTLP is observation-only. |
 | Amp | `amp` | **Supported** | Owner-only TypeScript system-policy plugin to the loopback gateway; `tool.call` gates execution and `tool.result` gates model-bound output. Amp has no documented native OTLP. |
 | Hermes Agent | `hermes` | **Supported** | Native direct-exec hooks to the loopback gateway. `pre_tool_call` can block; the remaining registered lifecycle events are observation-only. Hermes has no documented native OTLP. |
-| Cursor, Windsurf, Gemini CLI, Copilot CLI, Antigravity, OpenCode | — | **Not certified** | Their setup code is not a Windows support commitment. |
+| OpenCode | `opencode` | **Preview** | Owner-only JavaScript bridge plugin to the loopback gateway. `tool.execute.before` can block by throwing; post-tool events are telemetry-only. |
+| Cursor | `cursor` | **Preview** | User-scoped `hooks.json` invokes a same-user PowerShell adapter and native hook launcher. Pre-shell and pre-MCP events support native ask/block; post-tool events are telemetry-only. |
+| Windsurf, Gemini CLI, Copilot CLI, Antigravity | — | **Not certified** | Their setup code is not a Windows support commitment. |
 | OpenHands, OmniGent, OpenClaw, ZeptoClaw | — | **Unsupported** | Their required sandbox, terminal, or proxy topology is not hosted by native Windows DefenseClaw. |
 
-All four supported connectors remain connected directly to their normal
+All four supported connectors and the OpenCode and Cursor previews remain connected directly to their normal
 upstream service. DefenseClaw does **not** insert a model proxy on Windows. It
 can only protect and observe events the installed agent emits through its
 documented hooks, plugin callbacks, and native telemetry surfaces.
@@ -54,7 +58,7 @@ documented hooks, plugin callbacks, and native telemetry surfaces.
 <Cards>
   <Card title="Install and maintain" href="/docs/get-started/windows/install-lifecycle" description="Requirements, authenticated release Setup, repair, upgrade qualification, recovery, and uninstall." />
   <Card title="Managed enterprise" href="/docs/get-started/windows/managed-enterprise" description="Protected Windows services, guardian auto-heal, non-admin guarantees, and the enterprise CLI lifecycle." />
-  <Card title="Connectors and enforcement" href="/docs/get-started/windows/connectors-enforcement" description="Exact Codex, Claude Code, Amp, and Hermes events, observe/action behavior, fail modes, and enable/disable controls." />
+  <Card title="Connectors and enforcement" href="/docs/get-started/windows/connectors-enforcement" description="Exact Codex, Claude Code, Amp, Hermes, OpenCode, and Cursor events, observe/action behavior, fail modes, and enable/disable controls." />
   <Card title="Capabilities and commands" href="/docs/get-started/windows/capabilities-commands" description="Windows-specific capability and complete public command-family matrices." />
   <Card title="Telemetry and security" href="/docs/get-started/windows/telemetry-security" description="Native OTLP, local audit, scoped credentials, loopback boundaries, release provenance, and recovery guarantees." />
   <Card title="Paths and troubleshooting" href="/docs/get-started/windows/paths-troubleshooting" description="Filesystem reference, safe diagnostics, terminal guidance, and verification checklists." />
@@ -67,8 +71,11 @@ The normal installation is one current-user application:
 1. `DefenseClawSetup-x64.exe` installs product-owned files and an embedded
    runtime below the current user's Programs directory.
 2. Connector setup registers `defenseclaw-hook.exe` in Codex, Claude Code, or Hermes,
-   or installs Amp's owner-only TypeScript policy plugin at
-   `%USERPROFILE%\.config\amp\plugins\defenseclaw.ts`.
+   installs Amp's owner-only TypeScript policy plugin at
+   `%USERPROFILE%\.config\amp\plugins\defenseclaw.ts`, or installs OpenCode's
+   owner-only JavaScript bridge at
+   `%USERPROFILE%\.config\opencode\plugins\defenseclaw.js`, or wires Cursor's
+   `%USERPROFILE%\.cursor\hooks.json` to its native Windows adapter.
 3. The hook or plugin sends supported lifecycle events to an authenticated
    gateway API on loopback. Action mode can return a decision only where that
    agent event supports one.

--- a/docs-site/content/docs/get-started/windows/index.mdx
+++ b/docs-site/content/docs/get-started/windows/index.mdx
@@ -12,7 +12,7 @@ keywords:
 DefenseClaw has a native, per-user Windows x64 (`amd64`) distribution. It installs a
 local gateway, native hook launcher, CLI, TUI, scanners, and managed Python
 runtime. The certified connector scope is deliberately narrow: **Codex**,
-**Claude Code**, and **Amp**.
+**Claude Code**, **Amp**, and **Hermes Agent**.
 
 For centrally managed endpoints, the separate
 [managed-enterprise lifecycle](/docs/get-started/windows/managed-enterprise)
@@ -42,10 +42,11 @@ native agent at a WSL installation, or mix native and WSL connector homes.
 | Codex | `codex` | **Supported** | Native hooks to the loopback gateway; native OTLP is observation-only. |
 | Claude Code | `claudecode` | **Supported** | Native hooks to the loopback gateway; native OTLP is observation-only. |
 | Amp | `amp` | **Supported** | Owner-only TypeScript system-policy plugin to the loopback gateway; `tool.call` gates execution and `tool.result` gates model-bound output. Amp has no documented native OTLP. |
-| Cursor, Windsurf, Gemini CLI, Copilot CLI, Antigravity, OpenCode, Hermes | — | **Not certified** | Their setup code is not a Windows support commitment. |
+| Hermes Agent | `hermes` | **Supported** | Native direct-exec hooks to the loopback gateway. `pre_tool_call` can block; the remaining registered lifecycle events are observation-only. Hermes has no documented native OTLP. |
+| Cursor, Windsurf, Gemini CLI, Copilot CLI, Antigravity, OpenCode | — | **Not certified** | Their setup code is not a Windows support commitment. |
 | OpenHands, OmniGent, OpenClaw, ZeptoClaw | — | **Unsupported** | Their required sandbox, terminal, or proxy topology is not hosted by native Windows DefenseClaw. |
 
-All three supported connectors remain connected directly to their normal
+All four supported connectors remain connected directly to their normal
 upstream service. DefenseClaw does **not** insert a model proxy on Windows. It
 can only protect and observe events the installed agent emits through its
 documented hooks, plugin callbacks, and native telemetry surfaces.
@@ -53,7 +54,7 @@ documented hooks, plugin callbacks, and native telemetry surfaces.
 <Cards>
   <Card title="Install and maintain" href="/docs/get-started/windows/install-lifecycle" description="Requirements, authenticated release Setup, repair, upgrade qualification, recovery, and uninstall." />
   <Card title="Managed enterprise" href="/docs/get-started/windows/managed-enterprise" description="Protected Windows services, guardian auto-heal, non-admin guarantees, and the enterprise CLI lifecycle." />
-  <Card title="Connectors and enforcement" href="/docs/get-started/windows/connectors-enforcement" description="Exact Codex, Claude Code, and Amp events, observe/action behavior, fail modes, and enable/disable controls." />
+  <Card title="Connectors and enforcement" href="/docs/get-started/windows/connectors-enforcement" description="Exact Codex, Claude Code, Amp, and Hermes events, observe/action behavior, fail modes, and enable/disable controls." />
   <Card title="Capabilities and commands" href="/docs/get-started/windows/capabilities-commands" description="Windows-specific capability and complete public command-family matrices." />
   <Card title="Telemetry and security" href="/docs/get-started/windows/telemetry-security" description="Native OTLP, local audit, scoped credentials, loopback boundaries, release provenance, and recovery guarantees." />
   <Card title="Paths and troubleshooting" href="/docs/get-started/windows/paths-troubleshooting" description="Filesystem reference, safe diagnostics, terminal guidance, and verification checklists." />
@@ -65,16 +66,16 @@ The normal installation is one current-user application:
 
 1. `DefenseClawSetup-x64.exe` installs product-owned files and an embedded
    runtime below the current user's Programs directory.
-2. Connector setup registers `defenseclaw-hook.exe` in Codex or Claude Code,
+2. Connector setup registers `defenseclaw-hook.exe` in Codex, Claude Code, or Hermes,
    or installs Amp's owner-only TypeScript policy plugin at
    `%USERPROFILE%\.config\amp\plugins\defenseclaw.ts`.
 3. The hook or plugin sends supported lifecycle events to an authenticated
    gateway API on loopback. Action mode can return a decision only where that
    agent event supports one.
 4. Native OTLP from Codex or Claude Code enters a connector-scoped loopback
-   receiver. It adds telemetry; it is never an enforcement path. Amp has no
-   documented native-OTLP surface, so DefenseClaw generates its telemetry from
-   the five plugin callbacks.
+   receiver. It adds telemetry; it is never an enforcement path. Amp and Hermes
+   have no documented native-OTLP surface, so their telemetry comes from the
+   supported plugin or hook callbacks.
 5. The gateway evaluates policy and persists mandatory local audit data. Any
    outbound observability destination is an additional, explicit choice.
 
@@ -93,7 +94,7 @@ the authentication, redaction, and local-storage boundaries.
 | Windows model-proxy connectors | **Unsupported** | The native Windows gateway is hook/plugin-only. |
 | A remote agent-to-DefenseClaw gateway topology | **Not certified** | The certified connector path is same-user native hooks to loopback. Remote observability destinations are separate. |
 | OpenShell sandbox and `sandbox` commands | **Unsupported** | The Windows release does not host the Linux sandbox lifecycle. |
-| `systemd`, `launchd`, Unix sockets, and POSIX hook shells | **Not applicable** | Windows uses native processes and Windows process identity. Codex and Claude Code use a native hook executable; Amp loads its TypeScript system plugin directly without a shell or WSL. |
+| `systemd`, `launchd`, Unix sockets, and POSIX hook shells | **Not applicable** | Windows uses native processes and Windows process identity. Codex, Claude Code, and Hermes use a native hook executable; Amp loads its TypeScript system plugin directly without a shell or WSL. |
 | Machine services from the public per-user Setup | **Unsupported** | The current-user Setup never elevates or installs services. Use the separate [managed-enterprise lifecycle](/docs/get-started/windows/managed-enterprise) for the supported SCM gateway and guardian. |
 | Docker Desktop WSL2 backend for bundled local stacks | **Not certified** | The optional certified local-stack path uses Linux containers on the Hyper-V backend. |
 
@@ -107,7 +108,7 @@ identity instead of PID-only signaling, and a native hook executable or Amp
 system plugin instead of Bash hooks. Sandbox and proxy connector features do
 not move with you.
 
-From WSL, perform a fresh native install. Install Codex, Claude Code, or Amp
+From WSL, perform a fresh native install. Install Codex, Claude Code, Amp, or Hermes
 natively for the same Windows user, then run native connector setup. Do not
 copy a WSL data directory, hook scripts, plugins, tokens, virtual environment,
 gateway binary, or connector configuration into the Windows profile.

--- a/docs-site/content/docs/get-started/windows/install-lifecycle.mdx
+++ b/docs-site/content/docs/get-started/windows/install-lifecycle.mdx
@@ -86,7 +86,7 @@ is a stop condition; do not bypass it.
 
 Double-click the EXE without **Run as administrator**. Choose one of:
 
-- **Codex**, **Claude Code**, or **Amp** to configure that native connector.
+- **Codex**, **Claude Code**, **Amp**, or **Hermes Agent** to configure that native connector.
 - **Configure later** for a CLI-only installation with no agent changes.
 
 Start in **Observe** mode. Choose **Action** only after reviewing observed
@@ -132,10 +132,11 @@ DefenseClawSetup-x64.exe /quiet /norestart INSTALLSCOPE=user CONNECTOR=codex MOD
   </Tab>
 </Tabs>
 
-Use `CONNECTOR=claudecode` for Claude Code or `CONNECTOR=amp` for Amp. To
+Use `CONNECTOR=claudecode` for Claude Code, `CONNECTOR=amp` for Amp, or
+`CONNECTOR=hermes` for Hermes Agent. To
 install without configuring an agent or starting the gateway, use
 `CONNECTOR=none STARTGATEWAY=0`. `STARTGATEWAY=0` cannot leave a Codex, Claude
-Code, or Amp installation stopped: those connectors require gateway startup
+Code, Amp, or Hermes installation stopped: those connectors require gateway startup
 and current-user logon integration.
 
 Public Setup properties are:
@@ -145,7 +146,7 @@ Public Setup properties are:
 | Action | fresh install, `/repair`, `/upgrade`, or `/uninstall` |
 | UI | interactive or `/quiet` (`/qn` alias); `/norestart` is accepted |
 | Scope | `INSTALLSCOPE=user` only |
-| Connector | `CONNECTOR=codex`, `claudecode`, `amp`, or `none` |
+| Connector | `CONNECTOR=codex`, `claudecode`, `amp`, `hermes`, or `none` |
 | Policy mode | `MODE=observe` or `action` |
 | Gateway | `STARTGATEWAY=1` or `0`, subject to the connector rule above |
 | User data on uninstall | `DELETEUSERDATA=0` (default) or `1` |
@@ -167,9 +168,10 @@ For explicit supported connectors:
 defenseclaw setup codex --mode observe
 defenseclaw setup claude-code --mode observe
 defenseclaw setup amp --mode observe
+defenseclaw setup hermes --mode observe
 ```
 
-One local gateway can host any or all three. Add connectors without removing
+One local gateway can host any or all four. Add connectors without removing
 an existing one:
 
 ```powershell
@@ -177,6 +179,7 @@ defenseclaw setup `
   --connector codex `
   --connector claudecode `
   --connector amp `
+  --connector hermes `
   --mode observe `
   --restart `
   --yes

--- a/docs-site/content/docs/get-started/windows/paths-troubleshooting.mdx
+++ b/docs-site/content/docs/get-started/windows/paths-troubleshooting.mdx
@@ -201,13 +201,14 @@ residue automatically.
     registration; repair Setup if it is missing. The watchdog runs only when
     `gateway.watchdog.enabled` is configured and is not a Windows service.
   </Accordion>
-  <Accordion title="Codex or Claude Code hooks, or the Amp plugin, do not appear">
+  <Accordion title="Codex, Claude Code, or Hermes hooks, or the Amp plugin, do not appear">
     Confirm the selected product runs natively as the same Windows user. Run
     `defenseclaw guardrail status` and `defenseclaw doctor`, then re-run the
     supported connector setup in observe mode. Fully restart Codex or Claude
-    Code; fully exit and relaunch Amp. For headless Amp execution, include
+    Code; fully exit and relaunch Amp; restart Hermes. For headless Amp execution, include
     `--plugin-ready-timeout 30`. Do not copy entries between `config.toml`,
-    `managed_config.toml`, `settings.json`, and `defenseclaw.ts` by hand.
+    `managed_config.toml`, `settings.json`, `config.yaml`,
+    `shell-hooks-allowlist.json`, and `defenseclaw.ts` by hand.
   </Accordion>
   <Accordion title="A connector is disabled or status disagrees with configuration">
     Use `defenseclaw guardrail status` to compare desired and runtime posture.
@@ -233,11 +234,12 @@ residue automatically.
     rotation. Never print, compare, copy, or manually replace token files or
     OTLP headers.
 
-    Amp has no documented native-OTLP channel, so this diagnostic does not
-    apply to Amp callback telemetry. Run `defenseclaw doctor`,
+    Amp and Hermes have no documented native-OTLP channel, so this diagnostic does not
+    apply to their callback telemetry. Run `defenseclaw doctor`,
     `defenseclaw guardrail status`, and `defenseclaw-gateway status`; reconcile
     the plugin with `defenseclaw setup amp --mode observe`, then fully exit and
-    relaunch Amp.
+    relaunch Amp, or reconcile Hermes with `defenseclaw setup hermes --mode observe`
+    and restart Hermes.
   </Accordion>
   <Accordion title="Upgrade is refused or interrupted">
     A source not listed in the target release's authenticated Windows baseline matrix
@@ -272,10 +274,10 @@ Complete this without real secrets or destructive tools:
 - Run `defenseclaw version`; require the CLI and gateway generation to agree.
 - Run `defenseclaw-gateway status`, `defenseclaw status`, and
   `defenseclaw guardrail status`; require the intended Codex, Claude Code,
-  and/or Amp rows, mode, fail mode, and enabled state.
+  Amp, and/or Hermes rows, mode, fail mode, and enabled state.
 - Run `defenseclaw config validate` and `defenseclaw doctor`; resolve every
   connector registration or authentication failure.
-- Restart each configured Codex or Claude Code agent; fully exit and relaunch
+- Restart each configured Codex, Claude Code, or Hermes agent; fully exit and relaunch
   Amp. In an empty disposable directory, submit a non-sensitive prompt such as
   “Reply with the word ready.” For `amp -x`, include
   `--plugin-ready-timeout 30`. An authenticated Amp live turn additionally
@@ -297,7 +299,7 @@ Complete this without real secrets or destructive tools:
   modes, fail modes, enabled state, and optional watchdog state.
 - Confirm the command path still resolves to the installed product directory,
   not a stale checkout or copied binary.
-- Restart Codex and Claude Code, fully exit and relaunch Amp, then repeat the
+- Restart Codex, Claude Code, and Hermes, fully exit and relaunch Amp, then repeat the
   harmless per-connector event check above.
 - Verify optional destinations with `defenseclaw observability plan` and the
   destination-specific test command. A destination failure does not erase the

--- a/docs-site/content/docs/get-started/windows/telemetry-security.mdx
+++ b/docs-site/content/docs/get-started/windows/telemetry-security.mdx
@@ -151,7 +151,7 @@ The current `0.8.10` Windows release trust chain is:
    signing state; and
 4. verify that Windows observes the matching Authenticode state; and
 5. certify that exact signed Setup through the
-   deterministic native Windows x64 matrix for Codex, Claude Code, and Amp.
+   deterministic native Windows x64 matrix for Codex, Claude Code, Amp, and Hermes.
 
 The deterministic native gate is the certification basis. A separately
 configured real-agent run can add upstream smoke evidence, but it is not a

--- a/docs-site/content/docs/reference/cli.mdx
+++ b/docs-site/content/docs/reference/cli.mdx
@@ -16,7 +16,7 @@ Authoritative source for any flag is `defenseclaw <command> --help`. These group
 
 <Callout title="Command availability is platform-specific">
 A registered command or connector alias is not, by itself, a native Windows
-support claim. Native Windows certifies Codex, Claude Code, and Amp, and some
+support claim. Native Windows certifies Codex, Claude Code, Amp, and Hermes, and some
 commands require optional configuration or are unavailable there. Use the
 [native Windows command matrix](/docs/get-started/windows/capabilities-commands)
 for the certified Windows classification and safe examples.

--- a/docs-site/content/docs/stories/cursor-secret-exfil.mdx
+++ b/docs-site/content/docs/stories/cursor-secret-exfil.mdx
@@ -24,9 +24,9 @@ defenseclaw setup cursor
 ```
 
 DefenseClaw appends entries to `~/.cursor/hooks.json` for the current 21-event
-contract. Its blocking set is `preToolUse`, `beforeShellExecution`,
-`beforeMCPExecution`, `beforeReadFile`, `beforeTabFileRead`,
-`beforeSubmitPrompt`, and `stop`; see the
+contract. Its blocking set is `preToolUse`, `subagentStart`,
+`beforeShellExecution`, `beforeMCPExecution`, `beforeReadFile`,
+`beforeTabFileRead`, and `beforeSubmitPrompt`; `stop` is follow-up-only. See the
 [Cursor connector](/docs/connectors/cursor).
 
 </Step>

--- a/docs-site/data/capability-matrix.json
+++ b/docs-site/data/capability-matrix.json
@@ -95,11 +95,11 @@
         "canAskNative": false,
         "askEvents": [],
         "blockEvents": ["pre_tool_call"],
-        "supportsFailClosed": false,
+        "supportsFailClosed": true,
         "scope": "user"
       },
       "hilt": "Can block supported hook events but has no native human-approval surface; confirm verdicts fall back explicitly.",
-      "notes": "Hooks live in ~/.hermes/config.yaml (hermes-hooks-v1; generic decoder lifts content from the per-event extra envelope). Full shell-hook lifecycle: pre_tool_call blocks, pre_llm_call injects context, post_tool_call/post_llm_call/on_session_start/on_session_end/subagent_stop observe. Setup sets hooks_auto_accept so events register on non-TTY/gateway runs. Discovery surfaces for MCP, skills, plugins."
+      "notes": "Hooks live in ~/.hermes/config.yaml (hermes-hooks-v1; generic decoder lifts content from the per-event extra envelope). DefenseClaw can block only pre_tool_call and can inject context only at pre_llm_call; its other 21 registrations are telemetry-only, including pre_verify even though Hermes itself defines a bounded continue response there. Setup leaves the operator-wide hooks_auto_accept policy untouched and provisions exact DefenseClaw-owned approvals in shell-hooks-allowlist.json. Discovery surfaces for MCP, skills, plugins."
     },
     {
       "id": "opencode",

--- a/docs-site/data/capability-matrix.json
+++ b/docs-site/data/capability-matrix.json
@@ -70,12 +70,12 @@
         "askEvents": ["beforeShellExecution", "beforeMCPExecution"],
         "blockEvents": [
           "preToolUse",
+          "subagentStart",
           "beforeShellExecution",
           "beforeMCPExecution",
           "beforeReadFile",
           "beforeTabFileRead",
-          "beforeSubmitPrompt",
-          "stop"
+          "beforeSubmitPrompt"
         ],
         "supportsFailClosed": true,
         "scope": "user"

--- a/internal/cli/connector_cmd.go
+++ b/internal/cli/connector_cmd.go
@@ -274,6 +274,10 @@ func bindConnectorLifecycleConfigHome(connectorName string) (func(), error) {
 		variable = "CLAUDE_CONFIG_DIR"
 	case "hermes":
 		variable = "HERMES_HOME"
+	case "opencode":
+		variable = "OPENCODE_CONFIG_DIR"
+	case "cursor":
+		variable = "CURSOR_CONFIG_DIR"
 	case "amp":
 		// Amp does not expose a config-home environment override. The
 		// validated path is carried in SetupOpts.ConfigHome instead, so this
@@ -345,7 +349,7 @@ func resolveConnectorOpts(dataDir string) connector.SetupOpts {
 		Interactive: false,
 	}
 	name := resolveActiveConnectorName(dataDir)
-	if name == "amp" {
+	if name == "amp" || name == "cursor" {
 		opts.ConfigHome = strings.TrimSpace(connectorFlagConfigHome)
 	}
 	if cfg == nil {
@@ -381,8 +385,8 @@ func runConnectorReconcile(cmd *cobra.Command, _ []string) error {
 	if !ok {
 		return fmt.Errorf("connector reconcile: unknown connector %q", name)
 	}
-	if name != "claudecode" && name != "codex" && name != "amp" {
-		return fmt.Errorf("connector reconcile: selected refresh is supported only for claudecode, codex, and amp")
+	if name != "claudecode" && name != "codex" && name != "amp" && name != "hermes" && name != "opencode" && name != "cursor" {
+		return fmt.Errorf("connector reconcile: selected refresh is unsupported for %s", name)
 	}
 	if warning, supportErr := connector.CheckPlatformSupportOnHost(name); supportErr != nil {
 		return fmt.Errorf("connector reconcile %s: %w", name, supportErr)

--- a/internal/cli/connector_cmd.go
+++ b/internal/cli/connector_cmd.go
@@ -272,6 +272,8 @@ func bindConnectorLifecycleConfigHome(connectorName string) (func(), error) {
 		variable = "CODEX_HOME"
 	case "claudecode":
 		variable = "CLAUDE_CONFIG_DIR"
+	case "hermes":
+		variable = "HERMES_HOME"
 	case "amp":
 		// Amp does not expose a config-home environment override. The
 		// validated path is carried in SetupOpts.ConfigHome instead, so this

--- a/internal/cli/connector_config_home_test.go
+++ b/internal/cli/connector_config_home_test.go
@@ -40,6 +40,27 @@ func TestBindConnectorLifecycleConfigHomeOverridesAmbientAndRestoresIt(t *testin
 	}
 }
 
+func TestBindHermesLifecycleConfigHomeOverridesAmbientAndRestoresIt(t *testing.T) {
+	root := t.TempDir()
+	ambient := filepath.Join(root, "ambient-hermes")
+	bound := filepath.Join(root, "bound-hermes")
+	t.Setenv("HERMES_HOME", ambient)
+	connectorFlagConfigHome = bound
+	t.Cleanup(func() { connectorFlagConfigHome = "" })
+
+	restore, err := bindConnectorLifecycleConfigHome("hermes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv("HERMES_HOME"); got != bound {
+		t.Fatalf("bound HERMES_HOME = %q, want %q", got, bound)
+	}
+	restore()
+	if got := os.Getenv("HERMES_HOME"); got != ambient {
+		t.Fatalf("restored HERMES_HOME = %q, want %q", got, ambient)
+	}
+}
+
 func TestBindAmpLifecycleConfigHomeDoesNotMutateUserProfile(t *testing.T) {
 	root, err := filepath.EvalSymlinks(t.TempDir())
 	if err != nil {

--- a/internal/cli/dotenv_security_regression_test.go
+++ b/internal/cli/dotenv_security_regression_test.go
@@ -44,6 +44,7 @@ func TestLoadDotEnvIntoOSRejectsProcessControlAndMalformedEntries(t *testing.T) 
 		"DEFENSECLAW_DISABLE_REDACTION",
 		"DEFENSECLAW_DAEMON",
 		"CLAUDE_CONFIG_DIR",
+		"HERMES_HOME",
 		"NODE_OPTIONS",
 		"SSL_CERT_DIR",
 		"SSL_CERT_FILE",
@@ -69,6 +70,7 @@ func TestLoadDotEnvIntoOSRejectsProcessControlAndMalformedEntries(t *testing.T) 
 			"DEFENSECLAW_DISABLE_REDACTION=1\n" +
 			"DEFENSECLAW_DAEMON=1\n" +
 			"CLAUDE_CONFIG_DIR=/tmp/attacker-claude-home\n" +
+			"HERMES_HOME=/tmp/attacker-hermes-home\n" +
 			"NODE_OPTIONS=--require=/tmp/attacker.js\n" +
 			"SSL_CERT_DIR=/tmp/attacker-ca-directory\n" +
 			"SSL_CERT_FILE=/tmp/attacker-ca.pem\n" +

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -96,7 +96,7 @@ func newHookCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&connector, "connector", "", "connector name (e.g. claudecode, codex, amp, cursor)")
+	cmd.Flags().StringVar(&connector, "connector", "", "connector name (e.g. claudecode, codex, amp, hermes, cursor)")
 	cmd.Flags().StringVar(&event, "event", "", "agent hook event name (selects the request deadline; inferred when omitted)")
 	cmd.Flags().StringVar(&apiAddr, "api-addr", "", "gateway host:port (defaults to the hook sidecar / local gateway)")
 	cmd.Flags().StringVar(&failMode, "fail-mode", "", "response-failure policy: open or closed (defaults to the hook sidecar / open)")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -444,7 +444,7 @@ func loadDotEnvIntoOS(path string) {
 func dotEnvKeyIsProcessControl(key string) bool {
 	normalized := strings.ToUpper(strings.TrimSpace(key))
 	switch normalized {
-	case "ALL_PROXY", "BASH_ENV", "CLAUDE_CONFIG_DIR", "CODEX_HOME", "COMSPEC",
+	case "ALL_PROXY", "BASH_ENV", "CLAUDE_CONFIG_DIR", "CODEX_HOME", "HERMES_HOME", "COMSPEC",
 		"CURL_CA_BUNDLE",
 		"DEFENSECLAW_CODEX_LOOPBACK_TRUST",
 		"DEFENSECLAW_CONFIG", "DEFENSECLAW_DATA_DIR", "DEFENSECLAW_GATEWAY_BIN",

--- a/internal/gateway/agent_hook_e2e_test.go
+++ b/internal/gateway/agent_hook_e2e_test.go
@@ -78,8 +78,8 @@ func TestHandleAgentHook_FullChain_PerConnector(t *testing.T) {
 			expectAction:   "block",
 		},
 		{
-			connector:      "hermes",
-			event:          "pre_tool_call",
+			connector: "hermes",
+			event:     "pre_tool_call",
 			// Hermes exposes shell execution as the native `terminal` tool.
 			// Keep the full-chain test on that real wire alias so a generic
 			// execution-tool alias cannot hide Hermes-specific drift.

--- a/internal/gateway/agent_hook_e2e_test.go
+++ b/internal/gateway/agent_hook_e2e_test.go
@@ -80,7 +80,10 @@ func TestHandleAgentHook_FullChain_PerConnector(t *testing.T) {
 		{
 			connector:      "hermes",
 			event:          "pre_tool_call",
-			toolName:       "execute_command",
+			// Hermes exposes shell execution as the native `terminal` tool.
+			// Keep the full-chain test on that real wire alias so a generic
+			// execution-tool alias cannot hide Hermes-specific drift.
+			toolName:       "terminal",
 			topLevelOutput: "hook_output",
 			expectAction:   "block",
 		},

--- a/internal/gateway/agent_hook_test.go
+++ b/internal/gateway/agent_hook_test.go
@@ -75,6 +75,76 @@ func TestNormalizeAgentHookMode_EnforceAlias(t *testing.T) {
 	}
 }
 
+func TestNormalizeAgentHookRequestCursorSpecializedEventsStayTyped(t *testing.T) {
+	profile := connector.NewCursorConnector().HookProfile(connector.SetupOpts{})
+
+	shellRaw := []byte(`{"hook_event_name":"beforeShellExecution","conversation_id":"cursor-session","generation_id":"cursor-turn","command":"az account show","cwd":"C:\\work"}`)
+	var shellPayload map[string]interface{}
+	if err := json.Unmarshal(shellRaw, &shellPayload); err != nil {
+		t.Fatal(err)
+	}
+	shell := normalizeAgentHookRequestWithRawProfile("cursor", shellPayload, shellRaw, profile)
+	if shell.ToolName != "Shell" || shell.CWD != `C:\work` || shell.ToolArgsProjectionUncertain {
+		t.Fatalf("specialized shell projection=%+v", shell)
+	}
+	var shellArgs map[string]interface{}
+	if err := json.Unmarshal(shell.ToolArgs, &shellArgs); err != nil {
+		t.Fatal(err)
+	}
+	if shellArgs["command"] != "az account show" {
+		t.Fatalf("shell args=%#v", shellArgs)
+	}
+
+	// The official Windows Cursor Agent emits cwd:"" today. Blank optional
+	// context must not poison an otherwise authoritative command projection.
+	emptyCWDRaw := []byte(`{"hook_event_name":"beforeShellExecution","conversation_id":"cursor-session","generation_id":"cursor-turn","command":"az keyvault secret show --vault-name missing --name test","cwd":"","sandbox":false}`)
+	var emptyCWDPayload map[string]interface{}
+	if err := json.Unmarshal(emptyCWDRaw, &emptyCWDPayload); err != nil {
+		t.Fatal(err)
+	}
+	emptyCWD := normalizeAgentHookRequestWithRawProfile("cursor", emptyCWDPayload, emptyCWDRaw, profile)
+	if emptyCWD.CWD != "" || emptyCWD.ToolArgsProjectionUncertain {
+		t.Fatalf("blank optional cwd projection=%+v", emptyCWD)
+	}
+	var emptyCWDArgs map[string]interface{}
+	if err := json.Unmarshal(emptyCWD.ToolArgs, &emptyCWDArgs); err != nil {
+		t.Fatal(err)
+	}
+	if emptyCWDArgs["command"] != "az keyvault secret show --vault-name missing --name test" {
+		t.Fatalf("blank cwd shell args=%#v", emptyCWDArgs)
+	}
+	if _, exists := emptyCWDArgs["cwd"]; exists {
+		t.Fatalf("blank optional cwd was forwarded: %#v", emptyCWDArgs)
+	}
+	if _, exists := emptyCWDArgs["sandbox"]; exists {
+		t.Fatalf("Cursor control metadata was forwarded as command input: %#v", emptyCWDArgs)
+	}
+
+	mcpRaw := []byte(`{"hook_event_name":"beforeMCPExecution","conversation_id":"cursor-session","generation_id":"cursor-turn","tool_name":"search","tool_input":"{\"query\":\"status\"}","mcp_server_name":"local-docs"}`)
+	var mcpPayload map[string]interface{}
+	if err := json.Unmarshal(mcpRaw, &mcpPayload); err != nil {
+		t.Fatal(err)
+	}
+	mcp := normalizeAgentHookRequestWithRawProfile("cursor", mcpPayload, mcpRaw, profile)
+	var mcpArgs map[string]interface{}
+	if err := json.Unmarshal(mcp.ToolArgs, &mcpArgs); err != nil {
+		t.Fatal(err)
+	}
+	if mcp.ToolName != "search" || mcpArgs["query"] != "status" {
+		t.Fatalf("specialized MCP projection tool=%q args=%#v", mcp.ToolName, mcpArgs)
+	}
+
+	resultRaw := []byte(`{"hook_event_name":"afterShellExecution","conversation_id":"cursor-session","generation_id":"cursor-turn","command":"Write-Output ok","output":"ok"}`)
+	var resultPayload map[string]interface{}
+	if err := json.Unmarshal(resultRaw, &resultPayload); err != nil {
+		t.Fatal(err)
+	}
+	result := normalizeAgentHookRequestWithRawProfile("cursor", resultPayload, resultRaw, profile)
+	if result.Content != "ok" || result.Direction != "tool_result" {
+		t.Fatalf("shell result projection content=%q direction=%q", result.Content, result.Direction)
+	}
+}
+
 func TestNormalizeAgentHookRequest_AntigravityNilToolArgsProjectionUsesEmptyObject(t *testing.T) {
 	raw := []byte(`{"hookEventName":"PreToolUse","toolCall":{"name":"run_command"}}`)
 	var payload map[string]interface{}

--- a/internal/gateway/connector/cursor_hook_profile.go
+++ b/internal/gateway/connector/cursor_hook_profile.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// cursorProfileDecode projects Cursor's documented per-event payloads onto
+// DefenseClaw's canonical inspection request. Cursor's specialized shell,
+// MCP, and file hooks do not use the generic tool_name/tool_input pair:
+// beforeShellExecution carries a top-level command, beforeMCPExecution carries
+// JSON parameters as a string, and file hooks carry file_path/content/edits.
+// Leaving those shapes to the generic decoder labels shell requests as "tool"
+// and turns MCP parameters into a JSON string, which records findings but does
+// not provide the typed, enforceable facts used by action mode.
+//
+// Cursor documents generation_id as the identifier for one user-message
+// generation. Preserve that connector-native turn mapping here as well as in
+// the shared CorrelationSpec so callers that use the profile decoder directly
+// observe the same identity semantics. conversation_id remains owned by the
+// shared normalizer.
+func cursorProfileDecode(payload map[string]interface{}) HookProfileRequest {
+	req := HookProfileRequest{
+		ConnectorName: "cursor",
+		HookEventName: hookFirstString(payload,
+			"hook_event_name", "hookEventName",
+			"event_type", "eventType",
+			"event_name", "eventName",
+			"agent_action_name",
+		),
+		TurnID: hookFirstString(payload,
+			"generation_id", "generationId",
+			"turn_id", "turnId", "turnID",
+		),
+		CWD:     hookFirstString(payload, "cwd", "working_directory", "workingDirectory"),
+		Payload: payload,
+	}
+
+	switch canonicalHookEvent(req.HookEventName) {
+	case "pretooluse":
+		req.ToolName = hookFirstString(payload, "tool_name", "toolName")
+		req.ToolArgs = cursorToolInput(cursorFirstValue(payload, "tool_input", "toolInput"))
+		req.ToolArgsAuthoritative = true
+	case "posttooluse":
+		req.ToolName = hookFirstString(payload, "tool_name", "toolName")
+		req.ToolArgs = cursorToolInput(cursorFirstValue(payload, "tool_input", "toolInput"))
+		req.ToolArgsAuthoritative = true
+		req.Content = hookFirstString(payload, "tool_output", "toolOutput")
+		req.Direction = "tool_result"
+	case "posttoolusefailure":
+		req.ToolName = hookFirstString(payload, "tool_name", "toolName")
+		req.ToolArgs = cursorToolInput(cursorFirstValue(payload, "tool_input", "toolInput"))
+		req.ToolArgsAuthoritative = true
+		req.Content = hookFirstString(payload, "error_message", "errorMessage")
+		req.Direction = "tool_result"
+	case "beforeshellexecution":
+		req.ToolName = "Shell"
+		// sandbox is Cursor execution-control metadata, not shell input. It
+		// remains available in Payload for audit, but putting it in ToolArgs
+		// would make the closed ActionFacts command schema intentionally partial.
+		req.ToolArgs = cursorProjectedArgs(payload,
+			cursorProjection{target: "command", sources: []string{"command"}},
+			cursorProjection{target: "cwd", sources: []string{"cwd"}},
+		)
+		req.ToolArgsAuthoritative = true
+	case "aftershellexecution":
+		req.ToolName = "Shell"
+		req.ToolArgs = cursorProjectedArgs(payload,
+			cursorProjection{target: "command", sources: []string{"command"}},
+			cursorProjection{target: "cwd", sources: []string{"cwd"}},
+		)
+		req.ToolArgsAuthoritative = true
+		req.Content = hookFirstString(payload, "output")
+		req.Direction = "tool_result"
+	case "beforemcpexecution":
+		req.ToolName = hookFirstString(payload, "tool_name", "toolName")
+		req.ToolArgs = cursorToolInput(cursorFirstValue(payload, "tool_input", "toolInput"))
+		req.ToolArgsAuthoritative = true
+	case "aftermcpexecution":
+		req.ToolName = hookFirstString(payload, "tool_name", "toolName")
+		req.ToolArgs = cursorToolInput(cursorFirstValue(payload, "tool_input", "toolInput"))
+		req.ToolArgsAuthoritative = true
+		req.Content = hookFirstString(payload, "result_json", "resultJson")
+		req.Direction = "tool_result"
+	case "beforereadfile", "beforetabfileread":
+		if canonicalHookEvent(req.HookEventName) == "beforetabfileread" {
+			req.ToolName = "TabRead"
+		} else {
+			req.ToolName = "Read"
+		}
+		req.ToolArgs = cursorProjectedArgs(payload,
+			cursorProjection{target: "path", sources: []string{"file_path", "filePath"}},
+			cursorProjection{target: "file_path", sources: []string{"file_path", "filePath"}},
+			cursorProjection{target: "content", sources: []string{"content"}},
+			cursorProjection{target: "attachments", sources: []string{"attachments"}},
+		)
+		req.ToolArgsAuthoritative = true
+	case "afterfileedit", "aftertabfileedit":
+		if canonicalHookEvent(req.HookEventName) == "aftertabfileedit" {
+			req.ToolName = "TabWrite"
+		} else {
+			req.ToolName = "Write"
+		}
+		req.ToolArgs = cursorProjectedArgs(payload,
+			cursorProjection{target: "path", sources: []string{"file_path", "filePath"}},
+			cursorProjection{target: "file_path", sources: []string{"file_path", "filePath"}},
+			cursorProjection{target: "edits", sources: []string{"edits"}},
+		)
+		req.ToolArgsAuthoritative = true
+		req.Content = cursorJSONString(cursorFirstValue(payload, "edits"))
+		req.Direction = "tool_result"
+	case "beforesubmitprompt":
+		req.ToolName = "message"
+		req.Content = hookFirstString(payload, "prompt")
+		req.Direction = "prompt"
+	case "subagentstart":
+		req.ToolName = "Task"
+		req.Content = hookFirstString(payload, "task")
+		req.Direction = "prompt"
+	case "subagentstop":
+		req.ToolName = "Task"
+		req.Content = hookFirstString(payload, "summary", "error_message", "errorMessage")
+		req.Direction = "tool_result"
+	case "afteragentresponse", "afteragentthought":
+		req.ToolName = "message"
+		req.Content = hookFirstString(payload, "text")
+		req.Direction = "tool_result"
+	}
+
+	return req
+}
+
+type cursorProjection struct {
+	target  string
+	sources []string
+}
+
+func cursorProjectedArgs(payload map[string]interface{}, fields ...cursorProjection) json.RawMessage {
+	projected := make(map[string]interface{}, len(fields))
+	for _, field := range fields {
+		value := cursorFirstValue(payload, field.sources...)
+		if value == nil {
+			continue
+		}
+		// The Windows Cursor Agent currently emits cwd:"" for shell hooks.
+		// CWD is optional context, not part of the command itself. Forwarding the
+		// blank value would correctly make ActionFacts reject cwd as malformed,
+		// but would also downgrade an otherwise complete, authoritative command
+		// to detection-only. Omit only this blank optional field; keep blank
+		// command, path, and content values so malformed action material remains
+		// visible to the normal conservative parser.
+		if field.target == "cwd" {
+			if text, ok := value.(string); ok && strings.TrimSpace(text) == "" {
+				continue
+			}
+		}
+		projected[field.target] = value
+	}
+	return cursorJSON(projected)
+}
+
+func cursorFirstValue(payload map[string]interface{}, keys ...string) interface{} {
+	for _, key := range keys {
+		if value, ok := payload[key]; ok && value != nil {
+			return value
+		}
+	}
+	return nil
+}
+
+// Cursor documents MCP tool_input as a JSON params string, while preToolUse
+// carries an object. Decode valid JSON strings so policy and MCP asset scanners
+// receive the same typed map in both cases. Preserve malformed strings in a
+// valid object so deterministic scanners can still inspect their exact text.
+func cursorToolInput(value interface{}) json.RawMessage {
+	if raw, ok := value.(string); ok {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			return json.RawMessage(`{}`)
+		}
+		candidate := []byte(trimmed)
+		if json.Valid(candidate) {
+			return append(json.RawMessage(nil), candidate...)
+		}
+		return cursorJSON(map[string]interface{}{"raw_input": raw})
+	}
+	if value == nil {
+		return json.RawMessage(`{}`)
+	}
+	return cursorJSON(value)
+}
+
+func cursorJSONString(value interface{}) string {
+	if value == nil {
+		return ""
+	}
+	if text, ok := value.(string); ok {
+		return text
+	}
+	return string(cursorJSON(value))
+}
+
+func cursorJSON(value interface{}) json.RawMessage {
+	encoded, err := json.Marshal(value)
+	if err != nil || len(bytes.TrimSpace(encoded)) == 0 {
+		return json.RawMessage(`{}`)
+	}
+	return json.RawMessage(encoded)
+}

--- a/internal/gateway/connector/cursor_hook_profile_test.go
+++ b/internal/gateway/connector/cursor_hook_profile_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCursorProfileDecodeDocumentedSpecializedPayloads(t *testing.T) {
+	tests := []struct {
+		name        string
+		payload     map[string]interface{}
+		wantTool    string
+		wantContent string
+		wantDir     string
+		wantArgs    map[string]interface{}
+	}{
+		{
+			name: "shell pre-execution becomes an authoritative shell call",
+			payload: map[string]interface{}{
+				"hook_event_name": "beforeShellExecution",
+				"command":         "az account show",
+				"cwd":             `C:\work`,
+				"sandbox":         false,
+			},
+			wantTool: "Shell",
+			wantArgs: map[string]interface{}{
+				"command": "az account show",
+				"cwd":     `C:\work`,
+			},
+		},
+		{
+			name: "Windows shell pre-execution omits blank optional cwd",
+			payload: map[string]interface{}{
+				"hook_event_name": "beforeShellExecution",
+				"command":         "az keyvault secret show --vault-name missing --name test",
+				"cwd":             "",
+				"sandbox":         false,
+			},
+			wantTool: "Shell",
+			wantArgs: map[string]interface{}{
+				"command": "az keyvault secret show --vault-name missing --name test",
+			},
+		},
+		{
+			name: "MCP params JSON string becomes a typed argument object",
+			payload: map[string]interface{}{
+				"hook_event_name": "beforeMCPExecution",
+				"tool_name":       "search",
+				"tool_input":      `{"query":"status"}`,
+				"mcp_server_name": "local-docs",
+			},
+			wantTool: "search",
+			wantArgs: map[string]interface{}{"query": "status"},
+		},
+		{
+			name: "file read exposes both canonical path and content",
+			payload: map[string]interface{}{
+				"hook_event_name": "beforeReadFile",
+				"file_path":       `C:\work\notes.txt`,
+				"content":         "reviewed content",
+			},
+			wantTool: "Read",
+			wantArgs: map[string]interface{}{
+				"path":      `C:\work\notes.txt`,
+				"file_path": `C:\work\notes.txt`,
+				"content":   "reviewed content",
+			},
+		},
+		{
+			name: "shell output reaches result scanning",
+			payload: map[string]interface{}{
+				"hook_event_name": "afterShellExecution",
+				"command":         "Write-Output ok",
+				"output":          "ok",
+			},
+			wantTool:    "Shell",
+			wantContent: "ok",
+			wantDir:     "tool_result",
+			wantArgs:    map[string]interface{}{"command": "Write-Output ok"},
+		},
+		{
+			name: "MCP result reaches result scanning",
+			payload: map[string]interface{}{
+				"hook_event_name": "afterMCPExecution",
+				"tool_name":       "search",
+				"tool_input":      `{"query":"status"}`,
+				"result_json":     `{"items":[]}`,
+			},
+			wantTool:    "search",
+			wantContent: `{"items":[]}`,
+			wantDir:     "tool_result",
+			wantArgs:    map[string]interface{}{"query": "status"},
+		},
+		{
+			name: "subagent task reaches prompt scanning",
+			payload: map[string]interface{}{
+				"hook_event_name": "subagentStart",
+				"task":            "Review the authentication flow",
+			},
+			wantTool:    "Task",
+			wantContent: "Review the authentication flow",
+			wantDir:     "prompt",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := cursorProfileDecode(test.payload)
+			if req.ToolName != test.wantTool {
+				t.Fatalf("ToolName=%q want %q", req.ToolName, test.wantTool)
+			}
+			if req.Content != test.wantContent {
+				t.Fatalf("Content=%q want %q", req.Content, test.wantContent)
+			}
+			if req.Direction != test.wantDir {
+				t.Fatalf("Direction=%q want %q", req.Direction, test.wantDir)
+			}
+			if test.wantArgs == nil {
+				if req.ToolArgsAuthoritative {
+					t.Fatal("non-tool payload unexpectedly claimed authoritative args")
+				}
+				return
+			}
+			if !req.ToolArgsAuthoritative {
+				t.Fatal("specialized tool payload did not claim authoritative args")
+			}
+			var got map[string]interface{}
+			if err := json.Unmarshal(req.ToolArgs, &got); err != nil {
+				t.Fatalf("ToolArgs are not an object: %v (%s)", err, req.ToolArgs)
+			}
+			wantJSON, _ := json.Marshal(test.wantArgs)
+			gotJSON, _ := json.Marshal(got)
+			if string(gotJSON) != string(wantJSON) {
+				t.Fatalf("ToolArgs=%s want %s", gotJSON, wantJSON)
+			}
+		})
+	}
+}
+
+func TestCursorProfileDecodePreservesMalformedMCPInputForScanning(t *testing.T) {
+	req := cursorProfileDecode(map[string]interface{}{
+		"hook_event_name": "beforeMCPExecution",
+		"tool_name":       "search",
+		"tool_input":      "not-json but still inspectable",
+	})
+	var args map[string]interface{}
+	if err := json.Unmarshal(req.ToolArgs, &args); err != nil {
+		t.Fatal(err)
+	}
+	if args["raw_input"] != "not-json but still inspectable" {
+		t.Fatalf("malformed input was dropped: %#v", args)
+	}
+}
+
+func TestCursorCurrentEnforcementEventsMatchDocumentedWireSemantics(t *testing.T) {
+	profile := NewCursorConnector().HookProfile(SetupOpts{})
+	if got := profile.MapVerdict(HookVerdictInput{
+		RawAction: "block", Event: "subagentStart", Mode: "action", Caps: profile.Capabilities,
+	}); got.Action != "block" || got.WouldBlock {
+		t.Fatalf("subagentStart block mapping=%+v, want enforced block", got)
+	}
+	if got := profile.MapVerdict(HookVerdictInput{
+		RawAction: "block", Event: "stop", Mode: "action", Caps: profile.Capabilities,
+	}); got.Action != "allow" || !got.WouldBlock {
+		t.Fatalf("stop block mapping=%+v, want follow-up-only allow/would-block", got)
+	}
+}

--- a/internal/gateway/connector/helpers.go
+++ b/internal/gateway/connector/helpers.go
@@ -149,6 +149,14 @@ func hookInvocationCommandFor(goos, connector, unixCommand string) string {
 	if connector == "antigravity" {
 		return windowsAntigravityHookCommand()
 	}
+	// Hermes parses the configured command into argv and launches it with
+	// shell=False. A PowerShell call operator is therefore an executable name,
+	// not syntax. Keep the native launcher as the first quoted argv token and
+	// use forward slashes so both the current Windows-aware splitter and older
+	// shlex-based Hermes releases preserve the path byte-for-byte.
+	if connector == "hermes" {
+		return windowsHermesDirectHookCommand(defenseclawHookBinary())
+	}
 	// Cursor 3.9.x feeds hook payloads through Windows PowerShell's object
 	// pipeline. A native executable on that boundary receives encoding
 	// preambles instead of the JSON. The generated PowerShell adapter accepts
@@ -163,6 +171,16 @@ func hookInvocationCommandFor(goos, connector, unixCommand string) string {
 	// call operator is required to invoke it. Use a single-quoted literal so an
 	// install path cannot introduce PowerShell interpolation.
 	return "& " + powershellQuoteLiteral(defenseclawHookBinary()) + " " + nativeHookFlag + connector
+}
+
+func windowsHermesDirectHookCommand(binary string) string {
+	binary = strings.TrimSpace(binary)
+	if binary == "" || strings.ContainsAny(binary, "\"\x00\r\n") ||
+		(!filepath.IsAbs(binary) && !isWindowsDriveAbsolutePath(binary)) {
+		return ""
+	}
+	binary = strings.ReplaceAll(binary, `\`, "/")
+	return `"` + binary + `" ` + nativeHookFlag + "hermes"
 }
 
 // defenseclawHookBinary returns the stable native HookRuntime launcher on

--- a/internal/gateway/connector/helpers.go
+++ b/internal/gateway/connector/helpers.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -695,11 +696,29 @@ func isDefenseClawManagedHookExecutable(exe string) bool {
 		canonicalNativeWindowsHookBinary(),
 		canonicalNativeWindowsInstalledHookBinary(),
 	}) {
-		if pathidentity.Same(exe, owned) {
+		if sameManagedHookExecutablePath(exe, owned) {
 			return true
 		}
 	}
 	return false
+}
+
+func sameManagedHookExecutablePath(left, right string) bool {
+	if pathidentity.Same(left, right) {
+		return true
+	}
+	// Hermes normalizes the exact managed Windows executable to forward
+	// slashes before passing it to its shell-free argv parser. Keep ownership
+	// recognition host-independent for contract tests without accepting a
+	// foreign Windows path: both sides must be drive-absolute, cleaned, and
+	// equal case-insensitively after separator normalization.
+	if !isWindowsDriveAbsolutePath(left) || !isWindowsDriveAbsolutePath(right) {
+		return false
+	}
+	cleanWindows := func(value string) string {
+		return path.Clean(strings.ReplaceAll(value, `\`, "/"))
+	}
+	return strings.EqualFold(cleanWindows(left), cleanWindows(right))
 }
 
 // isWindowsDriveAbsolutePath keeps host-independent connector tests faithful

--- a/internal/gateway/connector/hook_config_paths_test.go
+++ b/internal/gateway/connector/hook_config_paths_test.go
@@ -46,6 +46,30 @@ func TestHookConfigPathsForConnector_ResolvesOverride(t *testing.T) {
 	}
 }
 
+func TestCursorHooksPathPrecedence(t *testing.T) {
+	previous := CursorHooksPathOverride
+	t.Cleanup(func() { CursorHooksPathOverride = previous })
+
+	root := t.TempDir()
+	environmentHome := filepath.Join(root, "environment")
+	explicitHome := filepath.Join(root, "explicit")
+	overridePath := filepath.Join(root, "override", "hooks.json")
+	t.Setenv("CURSOR_CONFIG_DIR", environmentHome)
+
+	CursorHooksPathOverride = ""
+	if got, want := cursorHooksPath(SetupOpts{}), filepath.Join(environmentHome, "hooks.json"); got != want {
+		t.Fatalf("environment path = %q, want %q", got, want)
+	}
+	if got, want := cursorHooksPath(SetupOpts{ConfigHome: explicitHome}), filepath.Join(explicitHome, "hooks.json"); got != want {
+		t.Fatalf("explicit path = %q, want %q", got, want)
+	}
+
+	CursorHooksPathOverride = overridePath
+	if got := cursorHooksPath(SetupOpts{ConfigHome: explicitHome}); got != overridePath {
+		t.Fatalf("override path = %q, want %q", got, overridePath)
+	}
+}
+
 func TestHookConfigPathsForConnector_ProxyConnectorsAreInert(t *testing.T) {
 	opts := SetupOpts{DataDir: t.TempDir(), ProxyAddr: "127.0.0.1:4000", APIAddr: "127.0.0.1:18970"}
 	for _, conn := range []Connector{NewOpenClawConnector(), NewZeptoClawConnector()} {

--- a/internal/gateway/connector/hook_contract.go
+++ b/internal/gateway/connector/hook_contract.go
@@ -480,12 +480,12 @@ var builtinHookContracts = map[string][]HookContract{
 			},
 			BlockEvents: []string{
 				"preToolUse",
+				"subagentStart",
 				"beforeShellExecution",
 				"beforeMCPExecution",
 				"beforeReadFile",
 				"beforeTabFileRead",
 				"beforeSubmitPrompt",
-				"stop",
 			},
 			SupportsFailClosed: true,
 			Scope:              "user",
@@ -493,8 +493,9 @@ var builtinHookContracts = map[string][]HookContract{
 		SupportsTraceparent: true,
 		ToolCallLifecycle:   cursorToolCallLifecycle(),
 		Notes: []string{
-			"Cursor 1.7 introduced beta hooks for the agent loop.",
+			"Cursor command hooks use documented per-event payloads; specialized shell, MCP, file, prompt, and result fields are projected into the shared scanner contract.",
 			"Cursor native ask is limited to beforeShellExecution and beforeMCPExecution.",
+			"preToolUse, subagentStart, shell/MCP gates, file-read gates, and beforeSubmitPrompt can deny. stop is follow-up-only and cannot block termination.",
 			"Every command-hook invocation returns a non-empty JSON object; beforeSubmitPrompt uses continue while permission gates use permission.",
 		},
 	}},
@@ -741,6 +742,7 @@ var builtinHookContracts = map[string][]HookContract{
 		ToolCallLifecycle:   openCodeToolCallLifecycle(),
 		Notes: []string{
 			"opencode (https://opencode.ai) auto-loads JS/TS plugins from ~/.config/opencode/plugins/ — there is no command-hook config file to patch. DefenseClaw writes a dependency-free bridge plugin (defenseclaw.js) whose tool.execute.before POSTs to /api/v1/opencode/hook and throws new Error(reason) on a block decision, aborting the tool.",
+			"The bridge prefixes a blocked-tool error with 'DefenseClaw blocked this tool before execution'. OpenCode may continue the conversational turn after the failed tool; the absence of tool.execute.after is the authoritative proof that execution was prevented.",
 			"Block is the only active verdict: opencode has no hook-driven ask or context-injection surface. tool.execute.after is observe-only. The bridge honors fail-closed by throwing when the gateway is unreachable and FAIL_MODE=closed.",
 			"Contract is unbounded (min 0.0.0): the plugin hook API is documented as a stable contract rather than a versioned floor, matching the OpenHands precedent.",
 		},

--- a/internal/gateway/connector/hook_contract.go
+++ b/internal/gateway/connector/hook_contract.go
@@ -377,26 +377,39 @@ var builtinHookContracts = map[string][]HookContract{
 	"hermes": {{
 		Connector:               "hermes",
 		ContractID:              "hermes-hooks-v1",
-		MinAgentVersion:         "0.11.0",
+		MinAgentVersion:         "0.20.6",
 		DefaultForUnversioned:   true,
-		HookScriptVersion:       "v6",
+		HookScriptVersion:       "v7",
 		HookConfigPathTemplates: []string{"$HERMES_HOME/config.yaml", "%LOCALAPPDATA%/hermes/config.yaml", "~/.hermes/config.yaml"},
 		ResponseFieldName:       "hook_output",
-		// Hermes' shell-hook surface (cli-config.yaml `hooks:` block).
+		// Hermes' shell-hook surface (config.yaml `hooks:` block).
 		// Only pre_tool_call can block; pre_llm_call injects context;
 		// the remaining events are observe-only telemetry decoded for
 		// inspection/audit. Order follows the agent lifecycle.
 		Events: []string{
-			"pre_llm_call",
 			"pre_tool_call",
 			"post_tool_call",
+			"transform_terminal_output",
+			"transform_tool_result",
+			"transform_llm_output",
+			"pre_llm_call",
 			"post_llm_call",
+			"pre_verify",
+			"pre_api_request",
+			"post_api_request",
+			"api_request_error",
 			"on_session_start",
 			"on_session_end",
 			"on_session_finalize",
 			"on_session_reset",
 			"subagent_start",
 			"subagent_stop",
+			"pre_gateway_dispatch",
+			"pre_approval_request",
+			"post_approval_response",
+			"kanban_task_claimed",
+			"kanban_task_completed",
+			"kanban_task_blocked",
 		},
 		// pre_llm_call → prompt; pre/post_tool_call → tool_call/tool_result;
 		// session + subagent lifecycle → event_content (audit envelope).
@@ -406,11 +419,11 @@ var builtinHookContracts = map[string][]HookContract{
 			CanAskNative: false,
 			// Only pre_tool_call honors a blocking stdout response;
 			// pre_llm_call can inject context but cannot veto, and the
-			// post/session/subagent events are read-only on Hermes' side
-			// (their stdout is ignored). Hermes never blocks on exit code
-			// or hook timeout, so SupportsFailClosed stays false.
+			// post/session/subagent events are read-only on Hermes' side.
+			// Hermes 0.20.6 supports exit-code-2 blocking and fail_closed
+			// for pre_tool_call hook failures and timeouts.
 			BlockEvents:        []string{"pre_tool_call"},
-			SupportsFailClosed: false,
+			SupportsFailClosed: true,
 			Scope:              "user",
 		},
 		SupportsTraceparent: true,
@@ -421,9 +434,9 @@ var builtinHookContracts = map[string][]HookContract{
 		ContentEnvelopeKey: "extra",
 		ToolCallLifecycle:  hermesToolCallLifecycle(),
 		Notes: []string{
-			"Covers the documented shell-hook lifecycle including session start/end/finalize/reset and subagent start/stop telemetry. Hermes nests prompt/result and delegation identity under the per-event `extra` envelope; the generic decoder lifts those fields into the canonical lifecycle.",
-			"pre_tool_call is the only blockable event: Hermes accepts both {\"action\":\"block\",\"message\"} (canonical) and {\"decision\":\"block\",\"reason\"} (Claude-Code style) and normalizes internally. pre_llm_call injects via {\"context\":...}. Confirm verdicts (no native ask surface) downgrade to a {\"systemMessage\":...} alert via the shared responder epilogue. Non-zero exit codes and hook timeouts only log a warning upstream, so there is no fail-closed surface; Hermes remains live-smoke pending (https://cisco-ai-defense.github.io/defenseclaw/docs/connectors/hermes/).",
-			"Multi-event registration requires hooks_auto_accept in cli-config.yaml on non-TTY/gateway runs; otherwise Hermes prompts for per-(event,command) consent on first use and silently skips unaccepted hooks. Setup writes hooks_auto_accept so all events register, and the managed-backup heals it.",
+			"Pinned to Hermes Agent 0.20.6 and the 23-event shell-hook subset adopted from PR #655. Hermes nests prompt/result and delegation identity under the per-event `extra` envelope; the generic decoder lifts those fields into the canonical lifecycle.",
+			"pre_tool_call is the only blockable event: Hermes accepts both {\"action\":\"block\",\"message\"} (canonical) and {\"decision\":\"block\",\"reason\"} (Claude-Code style), exit code 2 blocks, and fail_closed protects hook failures, malformed output, and timeouts. pre_llm_call injects via {\"context\":...}. Confirm verdicts (no native ask surface) downgrade to a {\"systemMessage\":...} alert via the shared responder epilogue.",
+			"Hermes requires exact per-(event,command) consent on non-TTY/gateway runs. Setup leaves the operator-wide hooks_auto_accept policy untouched and provisions only DefenseClaw-owned entries in shell-hooks-allowlist.json; teardown restores or surgically removes those entries.",
 		},
 	}},
 	"cursor": {{

--- a/internal/gateway/connector/hook_only.go
+++ b/internal/gateway/connector/hook_only.go
@@ -184,12 +184,12 @@ func NewCursorConnector() *hookOnlyConnector {
 				},
 				BlockEvents: []string{
 					"preToolUse",
+					"subagentStart",
 					"beforeShellExecution",
 					"beforeMCPExecution",
 					"beforeReadFile",
 					"beforeTabFileRead",
 					"beforeSubmitPrompt",
-					"stop",
 				},
 				SupportsFailClosed: true,
 				Scope:              "user",
@@ -414,26 +414,6 @@ func (c *hookOnlyConnector) HookProfile(opts SetupOpts) HookProfile {
 	// (declared on the hermes hook contract), and its wire replies are
 	// shaped by the hermes case in hookOnlyProfileRespond.
 	return ApplyHookContract(profile, opts)
-}
-
-// Cursor documents generation_id as the identifier for one user-message
-// generation. Keep that connector-native turn mapping out of the generic
-// decoder so another connector's generation identifier cannot become a turn.
-func cursorProfileDecode(payload map[string]interface{}) HookProfileRequest {
-	return HookProfileRequest{
-		ConnectorName: "cursor",
-		HookEventName: hookFirstString(payload,
-			"hook_event_name", "hookEventName",
-			"event_type", "eventType",
-			"event_name", "eventName",
-			"agent_action_name",
-		),
-		TurnID: hookFirstString(payload,
-			"generation_id", "generationId",
-			"turn_id", "turnId", "turnID",
-		),
-		Payload: payload,
-	}
 }
 
 // Windsurf documents execution_id as one Cascade agent turn. This is a
@@ -1366,16 +1346,30 @@ func hermesConfigPath(SetupOpts) string {
 // plugin in opencode's global auto-load directory. opencode loads any
 // JS/TS file under ~/.config/opencode/plugins/ at startup, so writing
 // the file is the entire install — no opencode.json edit is required.
-func opencodePluginPath(SetupOpts) string {
+func opencodePluginPath(opts SetupOpts) string {
 	if OpenCodePluginPathOverride != "" {
 		return OpenCodePluginPathOverride
+	}
+	if configDir := strings.TrimSpace(opts.ConfigHome); configDir != "" {
+		return filepath.Join(configDir, "plugins", "defenseclaw.js")
+	}
+	if configDir := strings.TrimSpace(os.Getenv("OPENCODE_CONFIG_DIR")); configDir != "" {
+		if absolute, err := filepath.Abs(configDir); err == nil {
+			return filepath.Join(absolute, "plugins", "defenseclaw.js")
+		}
 	}
 	return homePath(".config", "opencode", "plugins", "defenseclaw.js")
 }
 
-func cursorHooksPath(SetupOpts) string {
+func cursorHooksPath(opts SetupOpts) string {
 	if CursorHooksPathOverride != "" {
 		return CursorHooksPathOverride
+	}
+	if configHome := strings.TrimSpace(opts.ConfigHome); configHome != "" {
+		return filepath.Join(configHome, "hooks.json")
+	}
+	if configHome := strings.TrimSpace(os.Getenv("CURSOR_CONFIG_DIR")); configHome != "" {
+		return filepath.Join(configHome, "hooks.json")
 	}
 	return homePath(".cursor", "hooks.json")
 }

--- a/internal/gateway/connector/hook_only.go
+++ b/internal/gateway/connector/hook_only.go
@@ -29,6 +29,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/defenseclaw/defenseclaw/internal/hermespath"
 	"github.com/defenseclaw/defenseclaw/internal/safefile"
@@ -46,6 +47,46 @@ var (
 	OpenHandsWorkspaceDirOverride string
 	AntigravityHooksPathOverride  string
 	OpenCodePluginPathOverride    string
+)
+
+// hermesHookEvents is the stable shell-hook subset DefenseClaw owns for the
+// Hermes v0.20.x contract. Only pre_tool_call can block and only pre_llm_call
+// accepts advisory context; the remaining events are audit/telemetry inputs.
+// The list intentionally matches the 23-event shell-hook inventory adopted
+// from PR #655 rather than claiming every newer plugin-only event.
+var hermesHookEvents = []struct {
+	event   string
+	matcher string
+}{
+	{"pre_tool_call", ".*"},
+	{"post_tool_call", ".*"},
+	{"transform_terminal_output", ""},
+	{"transform_tool_result", ""},
+	{"transform_llm_output", ""},
+	{"pre_llm_call", ""},
+	{"post_llm_call", ""},
+	{"pre_verify", ""},
+	{"pre_api_request", ""},
+	{"post_api_request", ""},
+	{"api_request_error", ""},
+	{"on_session_start", ""},
+	{"on_session_end", ""},
+	{"on_session_finalize", ""},
+	{"on_session_reset", ""},
+	{"subagent_start", ""},
+	{"subagent_stop", ""},
+	{"pre_gateway_dispatch", ""},
+	{"pre_approval_request", ""},
+	{"post_approval_response", ""},
+	{"kanban_task_claimed", ""},
+	{"kanban_task_completed", ""},
+	{"kanban_task_blocked", ""},
+}
+
+const (
+	hermesAllowlistLogicalName = "shell-hooks-allowlist.json"
+	hermesAllowlistFileName    = "shell-hooks-allowlist.json"
+	hermesAllowlistOwnerField  = "defenseclaw_managed"
 )
 
 type hookOnlyConnector struct {
@@ -118,7 +159,7 @@ func NewHermesConnector() *hookOnlyConnector {
 				CanBlock:           true,
 				CanAskNative:       false,
 				BlockEvents:        []string{"pre_tool_call"},
-				SupportsFailClosed: false,
+				SupportsFailClosed: true,
 				Scope:              "user",
 				ConfigPath:         hermesConfigPath(opts),
 			}
@@ -822,6 +863,12 @@ func (c *hookOnlyConnector) Setup(ctx context.Context, opts SetupOpts) error {
 	if err := WriteHookScriptsForConnectorObjectWithOpts(hookDir, opts, c); err != nil {
 		return fmt.Errorf("%s hook script: %w", c.name, err)
 	}
+	if c.name == "hermes" {
+		if err := c.setupHermesFiles(opts, c.hookCommand(opts)); err != nil {
+			return fmt.Errorf("%s hook config: %w", c.name, err)
+		}
+		return nil
+	}
 	if err := c.patchConfig(opts, c.hookCommand(opts)); err != nil {
 		return fmt.Errorf("%s hook config: %w", c.name, err)
 	}
@@ -995,6 +1042,11 @@ func (c *hookOnlyConnector) Teardown(ctx context.Context, opts SetupOpts) error 
 			discardManagedFileBackup(opts.DataDir, c.name, "config")
 		}
 	}
+	if c.name == "hermes" {
+		if err := teardownHermesAllowlist(opts, path, shellWord(c.hookCommand(opts))); err != nil {
+			errs = append(errs, fmt.Sprintf("restore shell hook allowlist: %v", err))
+		}
+	}
 
 	if err := writeDisabledHookTombstone(opts, c.scriptName, c.name); err != nil {
 		errs = append(errs, fmt.Sprintf("disabled hook tombstone: %v", err))
@@ -1031,6 +1083,11 @@ func (c *hookOnlyConnector) teardownPluginArtifact(opts SetupOpts) error {
 }
 
 func (c *hookOnlyConnector) VerifyClean(opts SetupOpts) error {
+	if c.name == "hermes" {
+		if err := verifyHermesAllowlistClean(c.configPath(opts)); err != nil {
+			return err
+		}
+	}
 	path := managedFileBackupTargetPath(opts.DataDir, c.name, "config", c.configPath(opts))
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -1160,9 +1217,14 @@ func (c *hookOnlyConnector) AgentPaths(opts SetupOpts) AgentPaths {
 	if c.pluginArtifact {
 		hookScripts = []string{c.configPath(opts)}
 	}
+	backups := []string{managedFileBackupPath(opts.DataDir, c.name, "config")}
+	if c.name == "hermes" {
+		patched = append(patched, filepath.Join(filepath.Dir(c.configPath(opts)), hermesAllowlistFileName))
+		backups = append(backups, managedFileBackupPath(opts.DataDir, c.name, hermesAllowlistLogicalName))
+	}
 	return AgentPaths{
 		PatchedFiles: patched,
-		BackupFiles:  []string{managedFileBackupPath(opts.DataDir, c.name, "config")},
+		BackupFiles:  backups,
 		HookScripts:  hookScripts,
 	}
 }
@@ -1239,7 +1301,7 @@ func (c *hookOnlyConnector) patchConfig(opts SetupOpts, hookScript string) error
 	var err error
 	switch c.name {
 	case "hermes":
-		err = patchHermesHooks(path, hookScript)
+		err = patchHermesHooks(path, hookScript, c.effectiveFailClosed(opts))
 	case "cursor":
 		err = patchCursorHooks(
 			path,
@@ -1587,7 +1649,317 @@ func addSurfaceTargets(targets map[string][]string, key string, cap SurfaceCapab
 	targets[key] = uniqueNonEmptyStrings(append(append([]string{}, cap.ReadPaths...), cap.ConfigPaths...))
 }
 
-func patchHermesHooks(path, hookScript string) error {
+type hermesSetupSnapshot struct {
+	path    string
+	existed bool
+	mode    os.FileMode
+	data    []byte
+}
+
+func snapshotHermesSetupFile(path string) (hermesSetupSnapshot, error) {
+	snapshot := hermesSetupSnapshot{path: path}
+	data, info, err := readManagedTarget(path)
+	if err != nil {
+		return snapshot, err
+	}
+	if info != nil {
+		snapshot.existed = true
+		snapshot.mode = info.Mode().Perm()
+		snapshot.data = append([]byte(nil), data...)
+	}
+	return snapshot, nil
+}
+
+func rollbackHermesSetupFiles(snapshots []hermesSetupSnapshot) error {
+	var errs []string
+	for i := len(snapshots) - 1; i >= 0; i-- {
+		snapshot := snapshots[i]
+		if snapshot.existed {
+			mode := snapshot.mode
+			if mode == 0 {
+				mode = 0o600
+			}
+			if err := atomicWriteFile(snapshot.path, snapshot.data, mode); err != nil {
+				errs = append(errs, fmt.Sprintf("restore %s: %v", snapshot.path, err))
+			}
+			continue
+		}
+		if err := os.Remove(snapshot.path); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, fmt.Sprintf("remove %s: %v", snapshot.path, err))
+		}
+	}
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// setupHermesFiles treats Hermes' config and exact per-(event, command)
+// consent registry as one transaction. Hermes deliberately skips unapproved
+// shell hooks in non-interactive sessions, so publishing only config.yaml would
+// produce an installed-looking connector that never runs.
+func (c *hookOnlyConnector) setupHermesFiles(opts SetupOpts, hookScript string) (err error) {
+	configPath := c.configPath(opts)
+	if strings.TrimSpace(configPath) == "" {
+		return fmt.Errorf("Hermes setup could not resolve a hook config path")
+	}
+	allowlistPath := filepath.Join(filepath.Dir(configPath), hermesAllowlistFileName)
+	paths := []string{
+		configPath,
+		allowlistPath,
+		managedFileBackupPath(opts.DataDir, c.name, "config"),
+		managedFileBackupPath(opts.DataDir, c.name, hermesAllowlistLogicalName),
+	}
+	snapshots := make([]hermesSetupSnapshot, 0, len(paths))
+	for _, path := range paths {
+		snapshot, snapshotErr := snapshotHermesSetupFile(path)
+		if snapshotErr != nil {
+			return snapshotErr
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+	defer func() {
+		if err == nil {
+			return
+		}
+		if rollbackErr := rollbackHermesSetupFiles(snapshots); rollbackErr != nil {
+			err = fmt.Errorf("%w; Hermes setup rollback: %v", err, rollbackErr)
+		}
+	}()
+
+	if err = captureManagedFileBackup(opts.DataDir, c.name, "config", configPath); err != nil {
+		return err
+	}
+	if err = captureManagedFileBackup(opts.DataDir, c.name, hermesAllowlistLogicalName, allowlistPath); err != nil {
+		return err
+	}
+	if err = patchHermesHooks(configPath, hookScript, c.effectiveFailClosed(opts)); err != nil {
+		return err
+	}
+	command := shellWord(hookScript)
+	executablePath := filepath.Join(opts.DataDir, "hooks", c.scriptName)
+	if runtime.GOOS == "windows" && windowsHermesDirectHookCommand(defenseclawHookBinary()) == hookScript {
+		executablePath = defenseclawHookBinary()
+	}
+	if err = patchHermesAllowlist(allowlistPath, command, executablePath); err != nil {
+		return err
+	}
+	if err = updateManagedFileBackupPostHash(opts.DataDir, c.name, "config", configPath); err != nil {
+		return err
+	}
+	return updateManagedFileBackupPostHash(opts.DataDir, c.name, hermesAllowlistLogicalName, allowlistPath)
+}
+
+func readHermesAllowlist(path string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]interface{}{"approvals": []interface{}{}}, nil
+		}
+		return nil, err
+	}
+	var document map[string]interface{}
+	if err := json.Unmarshal(data, &document); err != nil {
+		return nil, fmt.Errorf("parse Hermes shell hook allowlist: %w", err)
+	}
+	if document == nil {
+		return nil, fmt.Errorf("Hermes shell hook allowlist is not a JSON object")
+	}
+	if _, ok := document["approvals"].([]interface{}); !ok {
+		return nil, fmt.Errorf("Hermes shell hook allowlist approvals is not an array")
+	}
+	return document, nil
+}
+
+func hermesHookEventSet() map[string]struct{} {
+	events := make(map[string]struct{}, len(hermesHookEvents))
+	for _, spec := range hermesHookEvents {
+		events[spec.event] = struct{}{}
+	}
+	return events
+}
+
+// hermesTimestamp matches Python datetime.isoformat(timespec="auto") after
+// shell_hooks.py reads an mtime through os.path.getmtime: UTC, no fractional
+// component for exact seconds, otherwise exactly six microsecond digits.
+func hermesTimestamp(value time.Time) string {
+	value = value.UTC().Truncate(time.Microsecond)
+	if value.Nanosecond() == 0 {
+		return value.Format("2006-01-02T15:04:05Z")
+	}
+	return value.Format("2006-01-02T15:04:05.000000Z")
+}
+
+func patchHermesAllowlist(path, command, executablePath string) error {
+	if strings.TrimSpace(command) == "" {
+		return fmt.Errorf("Hermes hook command is empty")
+	}
+	document, err := readHermesAllowlist(path)
+	if err != nil {
+		return err
+	}
+	approvals := document["approvals"].([]interface{})
+	events := hermesHookEventSet()
+	approvedAt := hermesTimestamp(time.Now())
+	var scriptMTime interface{}
+	if info, statErr := os.Stat(executablePath); statErr == nil && info.Mode().IsRegular() {
+		scriptMTime = hermesTimestamp(info.ModTime())
+	}
+	managedCurrent := map[string]bool{}
+	kept := make([]interface{}, 0, len(approvals)+len(events))
+	for _, raw := range approvals {
+		entry, ok := raw.(map[string]interface{})
+		if !ok {
+			kept = append(kept, raw)
+			continue
+		}
+		event, _ := entry["event"].(string)
+		entryCommand, _ := entry["command"].(string)
+		_, requiredEvent := events[event]
+		owned, _ := entry[hermesAllowlistOwnerField].(bool)
+		if owned {
+			if entryCommand != command {
+				return fmt.Errorf("Hermes allowlist entry %q has a tampered DefenseClaw command; refusing non-exact repair", event)
+			}
+			if !requiredEvent || managedCurrent[event] {
+				continue
+			}
+			// A stable command path can survive an in-place launcher upgrade.
+			// Refresh only DefenseClaw-owned approval evidence so Hermes doctor
+			// does not report the newly installed launcher as unapproved drift.
+			if scriptMTime != nil && entry["script_mtime_at_approval"] != scriptMTime {
+				entry["approved_at"] = approvedAt
+				entry["script_mtime_at_approval"] = scriptMTime
+			}
+			managedCurrent[event] = true
+			kept = append(kept, raw)
+			continue
+		}
+		if requiredEvent && entryCommand == command {
+			return fmt.Errorf("Hermes allowlist entry %q lost its DefenseClaw ownership marker; refusing ambiguous repair", event)
+		}
+		kept = append(kept, raw)
+	}
+	for _, spec := range hermesHookEvents {
+		if managedCurrent[spec.event] {
+			continue
+		}
+		kept = append(kept, map[string]interface{}{
+			"event":                    spec.event,
+			"command":                  command,
+			"approved_at":              approvedAt,
+			"script_mtime_at_approval": scriptMTime,
+			hermesAllowlistOwnerField:  true,
+		})
+	}
+	document["approvals"] = kept
+	data, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if current, readErr := os.ReadFile(path); readErr == nil && bytes.Equal(current, data) {
+		return nil
+	}
+	return atomicWriteFile(path, data, 0o600)
+}
+
+func teardownHermesAllowlist(opts SetupOpts, configPath, command string) error {
+	path := filepath.Join(filepath.Dir(configPath), hermesAllowlistFileName)
+	restored, err := restoreManagedFileBackupIfUnchanged(opts.DataDir, "hermes", hermesAllowlistLogicalName, path)
+	if err != nil {
+		return err
+	}
+	if restored {
+		return nil
+	}
+	backup, err := loadManagedFileBackupForTransform(opts.DataDir, "hermes", hermesAllowlistLogicalName, path)
+	if err != nil {
+		return err
+	}
+	if backup == nil {
+		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+			return nil
+		} else if statErr != nil {
+			return statErr
+		}
+	}
+	document, err := readHermesAllowlist(path)
+	if err != nil {
+		return err
+	}
+	pristinePairs := map[string]bool{}
+	if backup != nil && backup.Existed && len(bytes.TrimSpace(backup.PristineBytes)) > 0 {
+		var pristine map[string]interface{}
+		if err := json.Unmarshal(backup.PristineBytes, &pristine); err != nil {
+			return fmt.Errorf("parse Hermes pristine allowlist custody: %w", err)
+		}
+		if approvals, ok := pristine["approvals"].([]interface{}); ok {
+			for _, raw := range approvals {
+				if entry, ok := raw.(map[string]interface{}); ok {
+					event, _ := entry["event"].(string)
+					entryCommand, _ := entry["command"].(string)
+					pristinePairs[event+"\x00"+entryCommand] = true
+				}
+			}
+		}
+	}
+	events := hermesHookEventSet()
+	approvals := document["approvals"].([]interface{})
+	kept := make([]interface{}, 0, len(approvals))
+	for _, raw := range approvals {
+		entry, ok := raw.(map[string]interface{})
+		if !ok {
+			kept = append(kept, raw)
+			continue
+		}
+		event, _ := entry["event"].(string)
+		entryCommand, _ := entry["command"].(string)
+		owned, _ := entry[hermesAllowlistOwnerField].(bool)
+		_, requiredEvent := events[event]
+		pair := event + "\x00" + entryCommand
+		if owned && requiredEvent && !pristinePairs[pair] {
+			if entryCommand != command {
+				return fmt.Errorf("Hermes allowlist entry %s has a tampered DefenseClaw command; refusing non-exact cleanup", event)
+			}
+			continue
+		}
+		if backup != nil && requiredEvent && entryCommand == command && !pristinePairs[pair] {
+			return fmt.Errorf("Hermes allowlist entry %s lost its DefenseClaw ownership marker; refusing ambiguous cleanup", event)
+		}
+		kept = append(kept, raw)
+	}
+	document["approvals"] = kept
+	data, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := atomicWriteFile(path, append(data, '\n'), 0o600); err != nil {
+		return err
+	}
+	discardManagedFileBackup(opts.DataDir, "hermes", hermesAllowlistLogicalName)
+	return nil
+}
+
+func verifyHermesAllowlistClean(configPath string) error {
+	path := filepath.Join(filepath.Dir(configPath), hermesAllowlistFileName)
+	document, err := readHermesAllowlist(path)
+	if err != nil {
+		return err
+	}
+	for _, raw := range document["approvals"].([]interface{}) {
+		entry, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if owned, _ := entry[hermesAllowlistOwnerField].(bool); owned {
+			return fmt.Errorf("hermes teardown incomplete: managed shell hook approval remains at %s", path)
+		}
+	}
+	return nil
+}
+
+func patchHermesHooks(path, hookScript string, failClosed bool) error {
 	cfg, err := readYAMLObject(path)
 	if err != nil {
 		return err
@@ -1597,34 +1969,10 @@ func patchHermesHooks(path, hookScript string) error {
 		hooks = map[string]interface{}{}
 		cfg["hooks"] = hooks
 	}
-	// Hermes prompts for per-(event, command) consent the first time it
-	// sees a shell hook and persists the decision to
-	// ~/.hermes/shell-hooks-allowlist.json. On non-TTY runs (the gateway
-	// daemon, cron, CI) there is no prompt, so an un-accepted hook is
-	// silently skipped and never fires. hooks_auto_accept is the
-	// documented escape hatch that lets all of DefenseClaw's lifecycle
-	// hooks register without an interactive prompt. We only set it when
-	// the operator has not made an explicit choice, so a deliberate
-	// `hooks_auto_accept: false` is preserved (and surfaced by doctor).
-	// The managed-file backup captures and heals this key on teardown.
-	if _, ok := cfg["hooks_auto_accept"]; !ok {
-		cfg["hooks_auto_accept"] = true
-	}
-	for _, spec := range []struct {
-		event   string
-		matcher string
-	}{
-		{"pre_tool_call", ".*"},
-		{"post_tool_call", ".*"},
-		{"pre_llm_call", ""},
-		{"post_llm_call", ""},
-		{"on_session_start", ""},
-		{"on_session_end", ""},
-		{"on_session_finalize", ""},
-		{"on_session_reset", ""},
-		{"subagent_start", ""},
-		{"subagent_stop", ""},
-	} {
+	// hooks_auto_accept is an operator-wide policy switch. DefenseClaw leaves
+	// it untouched and separately owns only its exact (event, command) entries
+	// in shell-hooks-allowlist.json.
+	for _, spec := range hermesHookEvents {
 		entry := map[string]interface{}{
 			"command": shellWord(hookScript),
 			"timeout": 30,
@@ -1632,13 +1980,46 @@ func patchHermesHooks(path, hookScript string) error {
 		if spec.matcher != "" {
 			entry["matcher"] = spec.matcher
 		}
-		hooks[spec.event] = appendUniqueFlatHook(hooks[spec.event], hookScript, entry)
+		if spec.event == "pre_tool_call" {
+			entry["fail_closed"] = failClosed
+		}
+		hooks[spec.event] = replaceManagedHermesHooks(hooks[spec.event], hookScript, entry)
 	}
 	data, err := yaml.Marshal(cfg)
 	if err != nil {
 		return err
 	}
 	return atomicWriteFile(path, data, 0o600)
+}
+
+func replaceManagedHermesHooks(raw interface{}, hookScript string, entry map[string]interface{}) []interface{} {
+	list, _ := raw.([]interface{})
+	out := make([]interface{}, 0, len(list)+1)
+	for _, item := range list {
+		if managedHookCommandEntry(item, hookScript) ||
+			managedHermesNativeHookEntry(item) {
+			continue
+		}
+		out = append(out, item)
+	}
+	return append(out, entry)
+}
+
+// managedHermesNativeHookEntry recognizes a DefenseClaw native Hermes hook
+// from an older installation path. Windows upgrades can move the launcher
+// from ~/.local/bin into a native install root.
+// Keeping both commands is unsafe for pre_tool_call: a missing stale command
+// is a fail-closed error and blocks otherwise harmless tools. The executable
+// predicate is deliberately strict, so a foreign command that merely ends in
+// "hook --connector hermes" remains untouched.
+func managedHermesNativeHookEntry(raw interface{}) bool {
+	entry, ok := raw.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	command, _ := entry["command"].(string)
+	command = strings.TrimSpace(command)
+	return strings.HasSuffix(command, nativeHookFlag+"hermes") && isNativeHookCommand(command)
 }
 
 func removeHermesHooks(path, hookScript string) error {

--- a/internal/gateway/connector/hook_only_profile.go
+++ b/internal/gateway/connector/hook_only_profile.go
@@ -143,7 +143,7 @@ func cursorHookOutputForProfile(event, action, reason, additional string) map[st
 		}
 	}
 	switch event {
-	case "pretooluse", "beforeshellexecution", "beforemcpexecution", "beforereadfile", "beforetabfileread", "stop":
+	case "pretooluse", "subagentstart", "beforeshellexecution", "beforemcpexecution", "beforereadfile", "beforetabfileread":
 		return map[string]interface{}{"continue": true, "permission": "allow"}
 	default:
 		return map[string]interface{}{"continue": true}

--- a/internal/gateway/connector/hook_only_profile.go
+++ b/internal/gateway/connector/hook_only_profile.go
@@ -50,19 +50,20 @@ func hookOnlyProfileRespond(in HookRespondInput) HookRespondOutput {
 	var output map[string]interface{}
 	switch in.Req.ConnectorName {
 	case "hermes":
-		// Hermes shell-hook lifecycle (cli-config.yaml `hooks:` block):
+		// Hermes shell-hook lifecycle (config.yaml `hooks:` block):
 		//
 		//	pre_llm_call     → inspect prompt; inject {"context":...}
 		//	pre_tool_call    → inspect tool args; BLOCK (only blockable event)
 		//	post_tool_call   → inspect tool output (observe)
-		//	post_llm_call    → inspect model output (observe)
-		//	on_session_*     → lifecycle telemetry (observe)
-		//	subagent_start/stop → delegate-task telemetry (observe)
+		//	pre_verify       → telemetry only in DefenseClaw (Hermes itself
+		//	                   can consume a bounded continue response)
+		//	remaining events → lifecycle telemetry (observe)
 		//
 		// Hermes reads a blocking stdout response only for
 		// pre_tool_call and a {"context":...} injection for
-		// pre_llm_call; it ignores the stdout of every other event, so
-		// those return a nil body. Hermes accepts both
+		// pre_llm_call. Hermes can also consume a pre_verify continue
+		// response, but DefenseClaw deliberately does not use that surface;
+		// the remaining events therefore return a nil body. Hermes accepts both
 		// {"action":"block","message"} (its canonical shape) and
 		// {"decision":"block","reason"} (the Claude-Code style it
 		// normalizes internally); we emit the latter for wire parity

--- a/internal/gateway/connector/hook_only_test.go
+++ b/internal/gateway/connector/hook_only_test.go
@@ -17,6 +17,7 @@
 package connector
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -28,6 +29,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/defenseclaw/defenseclaw/internal/testenv"
 )
@@ -41,7 +43,7 @@ func TestHookOnlyConnector_CapabilityMatrix(t *testing.T) {
 		scope      string
 		configBase string
 	}{
-		{NewHermesConnector(), false, false, "user", "config.yaml"},
+		{NewHermesConnector(), false, true, "user", "config.yaml"},
 		{NewCursorConnector(), true, true, "user", "hooks.json"},
 		{NewWindsurfConnector(), false, false, "user", "hooks.json"},
 		{NewGeminiCLIConnector(), false, true, "user", "settings.json"},
@@ -758,13 +760,11 @@ func TestHookOnlyConnector_SetupTeardown_BackupRestore(t *testing.T) {
 	}
 }
 
-// TestHermesSetup_WritesFullLifecycleAndAutoAccept pins the
-// hermes-hooks-v1 setup contract: Setup must register every lifecycle
-// event in the cli-config.yaml `hooks:` block AND set hooks_auto_accept
-// so the hooks actually register on non-TTY/gateway runs (Hermes
-// silently skips un-accepted hooks there). Teardown must heal a
-// previously-missing config back to absent.
-func TestHermesSetup_WritesFullLifecycleAndAutoAccept(t *testing.T) {
+// TestHermesSetup_WritesFullLifecycleAndScopedApprovals pins the
+// hermes-hooks-v7 setup contract: Setup registers all 23 events and provisions
+// only the corresponding exact consent records. The operator-wide
+// hooks_auto_accept switch remains untouched.
+func TestHermesSetup_WritesFullLifecycleAndScopedApprovals(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, ".hermes", "config.yaml")
 	prev := HermesConfigPathOverride
@@ -772,7 +772,10 @@ func TestHermesSetup_WritesFullLifecycleAndAutoAccept(t *testing.T) {
 	t.Cleanup(func() { HermesConfigPathOverride = prev })
 
 	conn := NewHermesConnector()
-	opts := SetupOpts{DataDir: filepath.Join(dir, "dc"), APIAddr: "127.0.0.1:18970", APIToken: "tok-test"}
+	opts := SetupOpts{
+		DataDir: filepath.Join(dir, "dc"), APIAddr: "127.0.0.1:18970",
+		APIToken: "tok-test", HookFailMode: "closed",
+	}
 	if err := conn.Setup(context.Background(), opts); err != nil {
 		t.Fatalf("Setup: %v", err)
 	}
@@ -781,20 +784,52 @@ func TestHermesSetup_WritesFullLifecycleAndAutoAccept(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read hermes config after setup: %v", err)
 	}
-	if v, _ := cfg["hooks_auto_accept"].(bool); !v {
-		t.Fatalf("hooks_auto_accept not set true after setup: %#v", cfg["hooks_auto_accept"])
+	if _, ok := cfg["hooks_auto_accept"]; ok {
+		t.Fatalf("setup manufactured operator-wide hooks_auto_accept: %#v", cfg["hooks_auto_accept"])
 	}
 	hooks, ok := cfg["hooks"].(map[string]interface{})
 	if !ok {
 		t.Fatalf("hooks block missing or wrong type: %#v", cfg["hooks"])
 	}
-	for _, event := range []string{
-		"pre_llm_call", "pre_tool_call", "post_tool_call", "post_llm_call",
-		"on_session_start", "on_session_end", "on_session_finalize", "on_session_reset",
-		"subagent_start", "subagent_stop",
-	} {
+	if got, want := len(hooks), len(hermesHookEvents); got != want {
+		t.Fatalf("Hermes hook event count = %d, want %d; got keys %v", got, want, mapKeys(hooks))
+	}
+	for _, spec := range hermesHookEvents {
+		event := spec.event
 		if _, ok := hooks[event]; !ok {
 			t.Errorf("hooks block missing lifecycle event %q; got keys %v", event, mapKeys(hooks))
+		}
+	}
+	preTool, ok := hooks["pre_tool_call"].([]interface{})
+	if !ok || len(preTool) != 1 {
+		t.Fatalf("pre_tool_call hooks = %#v, want one managed entry", hooks["pre_tool_call"])
+	}
+	preToolEntry, ok := preTool[0].(map[string]interface{})
+	if !ok || preToolEntry["fail_closed"] != true {
+		t.Fatalf("pre_tool_call fail_closed = %#v, want true", preToolEntry)
+	}
+	allowlistPath := filepath.Join(filepath.Dir(cfgPath), hermesAllowlistFileName)
+	allowlist, err := readHermesAllowlist(allowlistPath)
+	if err != nil {
+		t.Fatalf("read Hermes allowlist after setup: %v", err)
+	}
+	approvals := allowlist["approvals"].([]interface{})
+	if got, want := len(approvals), len(hermesHookEvents); got != want {
+		t.Fatalf("Hermes approval count = %d, want %d", got, want)
+	}
+	wantCommand := shellWord(conn.hookCommand(opts))
+	seen := map[string]bool{}
+	for _, raw := range approvals {
+		entry, ok := raw.(map[string]interface{})
+		if !ok || entry[hermesAllowlistOwnerField] != true || entry["command"] != wantCommand {
+			t.Fatalf("invalid scoped Hermes approval: %#v", raw)
+		}
+		event, _ := entry["event"].(string)
+		seen[event] = true
+	}
+	for _, spec := range hermesHookEvents {
+		if !seen[spec.event] {
+			t.Errorf("allowlist missing scoped approval for %q", spec.event)
 		}
 	}
 
@@ -805,6 +840,11 @@ func TestHermesSetup_WritesFullLifecycleAndAutoAccept(t *testing.T) {
 		t.Fatalf("config still exists after teardown of previously-missing config")
 	} else if !os.IsNotExist(err) {
 		t.Fatalf("stat after teardown: %v", err)
+	}
+	if _, err := os.Stat(allowlistPath); err == nil {
+		t.Fatalf("allowlist still exists after teardown of previously-missing file")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat allowlist after teardown: %v", err)
 	}
 }
 
@@ -822,6 +862,11 @@ func TestHermesSetup_RespectsExplicitAutoAcceptAndHealsUserConfig(t *testing.T) 
 	pristine := "hooks_auto_accept: false\nhooks:\n  pre_tool_call:\n    - command: /usr/local/bin/my-own-hook.sh\n"
 	if err := os.WriteFile(cfgPath, []byte(pristine), 0o600); err != nil {
 		t.Fatalf("write pristine config: %v", err)
+	}
+	allowlistPath := filepath.Join(filepath.Dir(cfgPath), hermesAllowlistFileName)
+	pristineAllowlist := "{\n  \"approvals\": [\n    {\"event\": \"pre_tool_call\", \"command\": \"foreign-hook\", \"approved_at\": \"2026-01-01T00:00:00Z\"}\n  ]\n}\n"
+	if err := os.WriteFile(allowlistPath, []byte(pristineAllowlist), 0o600); err != nil {
+		t.Fatalf("write pristine allowlist: %v", err)
 	}
 	prev := HermesConfigPathOverride
 	HermesConfigPathOverride = cfgPath
@@ -850,6 +895,230 @@ func TestHermesSetup_RespectsExplicitAutoAcceptAndHealsUserConfig(t *testing.T) 
 	}
 	if string(got) != pristine {
 		t.Fatalf("teardown did not heal config to pristine bytes\n got: %q\nwant: %q", string(got), pristine)
+	}
+	gotAllowlist, err := os.ReadFile(allowlistPath)
+	if err != nil {
+		t.Fatalf("read allowlist after teardown: %v", err)
+	}
+	if string(gotAllowlist) != pristineAllowlist {
+		t.Fatalf("teardown did not heal allowlist to pristine bytes\n got: %q\nwant: %q", string(gotAllowlist), pristineAllowlist)
+	}
+}
+
+func TestPatchHermesHooksAndAllowlistAreScopedAndIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	pristineConfig := "hooks_auto_accept: false\nhooks:\n  pre_tool_call:\n    - command: foreign-hook\n"
+	if err := os.WriteFile(configPath, []byte(pristineConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	executablePath := filepath.Join(dir, "managed", windowsHookBinaryName)
+	if err := os.MkdirAll(filepath.Dir(executablePath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(executablePath, []byte("test executable"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	setHookBinaryOverride(t, executablePath)
+	command := windowsHermesDirectHookCommand(defenseclawHookBinary())
+	if err := patchHermesHooks(configPath, command, true); err != nil {
+		t.Fatalf("patch Hermes hooks: %v", err)
+	}
+	firstConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := patchHermesHooks(configPath, command, true); err != nil {
+		t.Fatalf("repeat Hermes hook patch: %v", err)
+	}
+	secondConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(firstConfig, secondConfig) {
+		t.Fatal("repeated Hermes hook patch changed the managed config")
+	}
+	cfg, err := readYAMLObject(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if autoAccept, ok := cfg["hooks_auto_accept"].(bool); !ok || autoAccept {
+		t.Fatalf("hooks_auto_accept changed: %#v", cfg["hooks_auto_accept"])
+	}
+	hooks, ok := cfg["hooks"].(map[string]interface{})
+	if !ok || len(hooks) != len(hermesHookEvents) {
+		t.Fatalf("Hermes hooks = %#v, want %d events", hooks, len(hermesHookEvents))
+	}
+	preTool, ok := hooks["pre_tool_call"].([]interface{})
+	if !ok || len(preTool) != 2 {
+		t.Fatalf("pre_tool_call hooks = %#v, want foreign plus managed", hooks["pre_tool_call"])
+	}
+	managed, ok := preTool[1].(map[string]interface{})
+	if !ok || managed["command"] != command || managed["fail_closed"] != true {
+		t.Fatalf("managed pre_tool_call hook = %#v", preTool[1])
+	}
+
+	allowlistPath := filepath.Join(dir, hermesAllowlistFileName)
+	pristineAllowlist := "{\n  \"approvals\": [\n    {\"event\": \"pre_tool_call\", \"command\": \"foreign-hook\"}\n  ]\n}\n"
+	if err := os.WriteFile(allowlistPath, []byte(pristineAllowlist), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := patchHermesAllowlist(allowlistPath, command, executablePath); err != nil {
+		t.Fatalf("patch Hermes allowlist: %v", err)
+	}
+	firstAllowlist, err := os.ReadFile(allowlistPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := patchHermesAllowlist(allowlistPath, command, executablePath); err != nil {
+		t.Fatalf("repeat Hermes allowlist patch: %v", err)
+	}
+	secondAllowlist, err := os.ReadFile(allowlistPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(firstAllowlist, secondAllowlist) {
+		t.Fatal("repeated Hermes allowlist patch changed the consent registry")
+	}
+	allowlist, err := readHermesAllowlist(allowlistPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	approvals := allowlist["approvals"].([]interface{})
+	if got, want := len(approvals), len(hermesHookEvents)+1; got != want {
+		t.Fatalf("approval count = %d, want %d", got, want)
+	}
+	ownedEvents := map[string]bool{}
+	for index, raw := range approvals {
+		entry, ok := raw.(map[string]interface{})
+		if !ok {
+			t.Fatalf("approval %d = %#v", index, raw)
+		}
+		if index == 0 {
+			if entry["command"] != "foreign-hook" || entry[hermesAllowlistOwnerField] != nil {
+				t.Fatalf("foreign approval changed: %#v", entry)
+			}
+			continue
+		}
+		if entry["command"] != command || entry[hermesAllowlistOwnerField] != true ||
+			entry["script_mtime_at_approval"] == nil {
+			t.Fatalf("managed approval = %#v", entry)
+		}
+		event, _ := entry["event"].(string)
+		ownedEvents[event] = true
+	}
+	for _, spec := range hermesHookEvents {
+		if !ownedEvents[spec.event] {
+			t.Errorf("missing managed approval for %q", spec.event)
+		}
+	}
+}
+
+func TestPatchHermesAllowlistRefreshesOwnedLauncherEvidence(t *testing.T) {
+	dir := t.TempDir()
+	allowlistPath := filepath.Join(dir, hermesAllowlistFileName)
+	executablePath := filepath.Join(dir, windowsHookBinaryName)
+	if err := os.WriteFile(executablePath, []byte("first launcher"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	command := windowsHermesDirectHookCommand(executablePath)
+	if err := patchHermesAllowlist(allowlistPath, command, executablePath); err != nil {
+		t.Fatal(err)
+	}
+	before, err := readHermesAllowlist(allowlistPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeEntry := before["approvals"].([]interface{})[0].(map[string]interface{})
+	beforeMTime, _ := beforeEntry["script_mtime_at_approval"].(string)
+
+	upgradedAt := time.Now().Add(2 * time.Minute)
+	if err := os.Chtimes(executablePath, upgradedAt, upgradedAt); err != nil {
+		t.Fatal(err)
+	}
+	if err := patchHermesAllowlist(allowlistPath, command, executablePath); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(executablePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantMTime := hermesTimestamp(info.ModTime())
+	after, err := readHermesAllowlist(allowlistPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, raw := range after["approvals"].([]interface{}) {
+		entry := raw.(map[string]interface{})
+		if got := entry["script_mtime_at_approval"]; got != wantMTime {
+			t.Fatalf("event %v launcher evidence = %v, want %q", entry["event"], got, wantMTime)
+		}
+	}
+	if beforeMTime == wantMTime {
+		t.Fatalf("launcher mtime did not change: %q", wantMTime)
+	}
+	refreshedBytes, err := os.ReadFile(allowlistPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := patchHermesAllowlist(allowlistPath, command, executablePath); err != nil {
+		t.Fatal(err)
+	}
+	idempotentBytes, err := os.ReadFile(allowlistPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(refreshedBytes, idempotentBytes) {
+		t.Fatal("unchanged upgraded launcher rewrote Hermes approvals")
+	}
+}
+
+func TestPatchHermesHooksReplacesStaleDefenseClawNativeCommand(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	staleCommand := windowsQuoteExe(filepath.Join(userHomeDir(), ".local", "bin", windowsHookBinaryName)) +
+		" " + nativeHookFlag + "hermes"
+	foreignCommand := `/usr/local/bin/operator-hook`
+	pristineConfig := fmt.Sprintf(
+		"hooks:\n  pre_tool_call:\n    - command: '%s'\n    - command: '%s'\n",
+		strings.ReplaceAll(foreignCommand, "'", "''"),
+		strings.ReplaceAll(staleCommand, "'", "''"),
+	)
+	if err := os.WriteFile(configPath, []byte(pristineConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	currentBinary := filepath.Join(dir, "current", windowsHookBinaryName)
+	setHookBinaryOverride(t, currentBinary)
+	currentCommand := windowsHermesDirectHookCommand(defenseclawHookBinary())
+	if err := patchHermesHooks(configPath, currentCommand, true); err != nil {
+		t.Fatalf("patch Hermes hooks: %v", err)
+	}
+	cfg, err := readYAMLObject(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hooks, ok := cfg["hooks"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("hooks = %#v", cfg["hooks"])
+	}
+	preTool, ok := hooks["pre_tool_call"].([]interface{})
+	if !ok || len(preTool) != 2 {
+		t.Fatalf("pre_tool_call hooks = %#v, want foreign plus current", hooks["pre_tool_call"])
+	}
+	foreign, _ := preTool[0].(map[string]interface{})
+	current, _ := preTool[1].(map[string]interface{})
+	if foreign["command"] != foreignCommand {
+		t.Fatalf("foreign hook changed: %#v", foreign)
+	}
+	if current["command"] != currentCommand || current["fail_closed"] != true {
+		t.Fatalf("current managed hook = %#v", current)
+	}
+	for _, raw := range preTool {
+		entry, _ := raw.(map[string]interface{})
+		if entry["command"] == staleCommand {
+			t.Fatalf("stale DefenseClaw hook survived reconciliation: %#v", entry)
+		}
 	}
 }
 
@@ -1612,7 +1881,7 @@ func TestHookOnlyHookScripts_RespectFailClosedCapability(t *testing.T) {
 		{name: "cursor_supports_fail_closed", connector: NewCursorConnector(), wantFailMode: "closed"},
 		{name: "geminicli_supports_fail_closed", connector: NewGeminiCLIConnector(), wantFailMode: "closed"},
 		{name: "openhands_supports_fail_closed", connector: NewOpenHandsConnector(), wantFailMode: "closed"},
-		{name: "hermes_downgrades_to_fail_open", connector: NewHermesConnector(), wantFailMode: "open"},
+		{name: "hermes_supports_fail_closed", connector: NewHermesConnector(), wantFailMode: "closed"},
 		{name: "copilot_downgrades_to_fail_open", connector: NewCopilotConnector(), wantFailMode: "open"},
 	}
 

--- a/internal/gateway/connector/hook_only_test.go
+++ b/internal/gateway/connector/hook_only_test.go
@@ -27,6 +27,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1775,6 +1776,36 @@ func TestCursorHooks_FailClosedOnlyWhenExplicit(t *testing.T) {
 	}
 	if !strings.Contains(string(data), `"failClosed": true`) {
 		t.Fatalf("cursor hooks did not enable failClosed when explicitly requested:\n%s", string(data))
+	}
+	configured, err := readJSONObject(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configuredHooks, _ := configured["hooks"].(map[string]interface{})
+	if len(configuredHooks) != len(cursorHookEvents) {
+		t.Fatalf("Cursor configured %d hook events, want the complete %d-event contract: %#v", len(configuredHooks), len(cursorHookEvents), configuredHooks)
+	}
+	wantScript := "cursor-hook.sh"
+	if runtime.GOOS == "windows" {
+		wantScript = "cursor-hook.ps1"
+	}
+	for _, event := range cursorHookEvents {
+		entries, ok := configuredHooks[event].([]interface{})
+		if !ok || len(entries) != 1 {
+			t.Fatalf("Cursor %s entries = %#v, want exactly one managed hook", event, configuredHooks[event])
+		}
+		entry, _ := entries[0].(map[string]interface{})
+		command, _ := entry["command"].(string)
+		if !strings.Contains(command, wantScript) {
+			t.Fatalf("Cursor %s command = %q, want %s adapter", event, command, wantScript)
+		}
+		if entry["failClosed"] != true {
+			t.Fatalf("Cursor %s failClosed = %#v, want true", event, entry["failClosed"])
+		}
+		timeout, ok := entry["timeout"].(json.Number)
+		if !ok || timeout.String() != strconv.Itoa(windowsCursorEnterpriseHookTimeoutSeconds) {
+			t.Fatalf("Cursor %s timeout = %#v, want %d seconds", event, entry["timeout"], windowsCursorEnterpriseHookTimeoutSeconds)
+		}
 	}
 
 	// Refreshing the same connector in observe/fail-open mode must replace the

--- a/internal/gateway/connector/hook_profile_test.go
+++ b/internal/gateway/connector/hook_profile_test.go
@@ -55,7 +55,7 @@ func TestHookProfileMatrix(t *testing.T) {
 		{"openhands", true, "", true, false, true, true},
 		{"cursor", true, "", true, true, true, true},
 		{"windsurf", true, "", true, false, false, true},
-		{"hermes", true, "", true, false, false, true},
+		{"hermes", true, "", true, false, true, true},
 		// opencode's JS bridge does not propagate W3C traceparent, so
 		// SupportsTraceparent is false; it can block and fail closed.
 		{"opencode", false, "", true, false, true, true},

--- a/internal/gateway/connector/hookexec/hookexec.go
+++ b/internal/gateway/connector/hookexec/hookexec.go
@@ -411,10 +411,42 @@ func doRequest(ctx context.Context, opts Options, sp spec, failMode string, payl
 	case resp.StatusCode >= 500 && resp.StatusCode < 600:
 		return failUnreachable(opts, sp, failMode, fmt.Sprintf("gateway returned HTTP %d", resp.StatusCode))
 	case resp.StatusCode < 200 || resp.StatusCode >= 300:
-		return failResponse(opts, sp, failMode, fmt.Sprintf("gateway returned HTTP %d", resp.StatusCode))
+		return failResponse(opts, sp, failMode, hookHTTPResponseError(resp.StatusCode, body))
 	}
 
 	return sp.decide(opts, body)
+}
+
+// hookHTTPResponseError retains the gateway's bounded machine error on 4xx
+// responses without echoing arbitrary response bodies into an agent console.
+// The local hook API emits {"error":"..."}; anything else falls back to the
+// status-only diagnostic. This distinguishes malformed native stdin from a
+// missing event or an authentication/configuration rejection while keeping
+// payload content and credentials out of logs.
+func hookHTTPResponseError(status int, body []byte) string {
+	base := fmt.Sprintf("gateway returned HTTP %d", status)
+	var envelope struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return base
+	}
+	detail := strings.TrimSpace(envelope.Error)
+	if detail == "" {
+		return base
+	}
+	detail = strings.Map(func(r rune) rune {
+		if r == '\r' || r == '\n' || r == '\t' || r < 0x20 || r == 0x7f {
+			return ' '
+		}
+		return r
+	}, detail)
+	const maxRunes = 160
+	runes := []rune(detail)
+	if len(runes) > maxRunes {
+		detail = string(runes[:maxRunes])
+	}
+	return base + ": " + detail
 }
 
 func sendHookRequest(

--- a/internal/gateway/connector/hookexec/hookexec_test.go
+++ b/internal/gateway/connector/hookexec/hookexec_test.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -70,6 +71,20 @@ type runResult struct {
 	stderr string
 	code   int
 	rt     *stubRT
+}
+
+func TestHookHTTPResponseErrorUsesOnlyBoundedMachineError(t *testing.T) {
+	if got := hookHTTPResponseError(400, []byte(`{"error":"hook event name is required"}`)); got != "gateway returned HTTP 400: hook event name is required" {
+		t.Fatalf("machine error=%q", got)
+	}
+	if got := hookHTTPResponseError(400, []byte(`{"private":"must not surface"}`)); got != "gateway returned HTTP 400" {
+		t.Fatalf("unrecognized body surfaced: %q", got)
+	}
+	long := strings.Repeat("x", 200) + "\nsecret"
+	got := hookHTTPResponseError(403, []byte(`{"error":`+strconv.Quote(long)+`}`))
+	if strings.Contains(got, "secret") || strings.ContainsAny(got, "\r\n") {
+		t.Fatalf("machine error was not bounded/single-line: %q", got)
+	}
 }
 
 // run executes a hook against a stub gateway with a temp Home + .token file.

--- a/internal/gateway/connector/hooks/hermes-hook.sh
+++ b/internal/gateway/connector/hooks/hermes-hook.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# defenseclaw-managed-hook v6
+# defenseclaw-managed-hook v7
 # DefenseClaw Hermes hook — forwards Hermes shell-hook payloads to the
 # DefenseClaw gateway.
 set -euo pipefail

--- a/internal/gateway/connector/hooks/opencode-plugin.js
+++ b/internal/gateway/connector/hooks/opencode-plugin.js
@@ -89,7 +89,8 @@ async function defenseclawPost(event, toolName, toolInput, toolResponse, cwd, co
     const data = await res.json();
     const out = data && data.hook_output;
     if (out && (out.decision === "deny" || out.decision === "block")) {
-      return { reason: out.reason || "DefenseClaw blocked this tool call." };
+      const detail = out.reason || "policy denied this tool call";
+      return { reason: "DefenseClaw blocked this tool before execution: " + detail };
     }
     return null;
   } catch (err) {

--- a/internal/gateway/connector/hookwiring_test.go
+++ b/internal/gateway/connector/hookwiring_test.go
@@ -1595,6 +1595,18 @@ func TestWindowsDriveAbsoluteHookPath(t *testing.T) {
 	if !isWindowsDriveAbsolutePath(`C:\Program Files\DefenseClaw\defenseclaw-hook.exe`) {
 		t.Fatal("drive-rooted Windows hook path was not recognized as absolute")
 	}
+	if !sameManagedHookExecutablePath(
+		`C:/Program Files/DefenseClaw/defenseclaw-hook.exe`,
+		`c:\Program Files\DefenseClaw\defenseclaw-hook.exe`,
+	) {
+		t.Fatal("Hermes-normalized Windows hook path did not match the managed executable")
+	}
+	if sameManagedHookExecutablePath(
+		`C:/Tools/defenseclaw-hook.exe`,
+		`C:\Program Files\DefenseClaw\defenseclaw-hook.exe`,
+	) {
+		t.Fatal("foreign Windows hook path was recognized as the managed executable")
+	}
 	setHookBinaryOverride(t, `C:defenseclaw-hook.exe`)
 	if isDefenseClawManagedHookExecutable(defenseclawHookBinaryOverride) {
 		t.Fatal("drive-relative Windows hook path was recognized as managed")

--- a/internal/gateway/connector/hookwiring_test.go
+++ b/internal/gateway/connector/hookwiring_test.go
@@ -937,6 +937,22 @@ func TestHookInvocationCommand(t *testing.T) {
 		t.Errorf("isNativeHookCommand(%q) = false, want true", claude)
 	}
 
+	// Hermes splits the command into argv itself and executes with shell=false.
+	// The first token must therefore be the executable, not PowerShell's `&`
+	// call operator. Forward slashes also preserve the path on Hermes releases
+	// that used POSIX shlex parsing on Windows.
+	hermes := hookInvocationCommandFor("windows", "hermes", unix)
+	wantHermes := `"C:/Program Files/DefenseClaw/defenseclaw-hook.exe" hook --connector hermes`
+	if hermes != wantHermes {
+		t.Errorf("hermes command = %q, want %q", hermes, wantHermes)
+	}
+	if strings.HasPrefix(hermes, "& ") || strings.Contains(hermes, "powershell") {
+		t.Errorf("hermes direct-exec command contains a shell boundary: %q", hermes)
+	}
+	if !isNativeHookCommand(hermes) {
+		t.Errorf("isNativeHookCommand(%q) = false, want true", hermes)
+	}
+
 	// Antigravity's direct-exec parser does not dequote command paths. Keep the
 	// visible command tokenizer-safe and put the absolute managed hook path in a
 	// PowerShell encoded command so install roots containing spaces still work.
@@ -1652,7 +1668,7 @@ func TestCodexNativeNotifyOwnership(t *testing.T) {
 }
 
 // TestWindowsNativeConfigMatrix exercises the generated on-disk configs for
-// every WIN-016 native target plus the Hermes preview. OpenCode is intentionally
+// every WIN-016 native target including Hermes. OpenCode is intentionally
 // absent: its bridge remains a JavaScript plugin and has separate tests.
 func TestWindowsNativeConfigMatrix(t *testing.T) {
 	if runtime.GOOS != "windows" {
@@ -1673,7 +1689,7 @@ func TestWindowsNativeConfigMatrix(t *testing.T) {
 		{"geminicli", NewGeminiCLIConnector(), &GeminiSettingsPathOverride, ".json"},
 		{"copilot", NewCopilotConnector(), &CopilotHooksPathOverride, ".json"},
 		{"antigravity", NewAntigravityConnector(), &AntigravityHooksPathOverride, ".json"},
-		{"hermes-preview", NewHermesConnector(), &HermesConfigPathOverride, ".yaml"},
+		{"hermes", NewHermesConnector(), &HermesConfigPathOverride, ".yaml"},
 	}
 
 	for _, tt := range tests {
@@ -1756,6 +1772,14 @@ func TestWindowsNativeConfigMatrix(t *testing.T) {
 				decoded := decodePowerShellEncodedCommandForTest(t, wantCommand)
 				if !strings.Contains(decoded, powershellQuoteLiteral(defenseclawHookBinary())) {
 					t.Errorf("Antigravity encoded command missing managed launcher path:\n%s", decoded)
+				}
+			} else if connectorName == "hermes" {
+				wantCommand := windowsHermesDirectHookCommand(defenseclawHookBinary())
+				if !strings.Contains(text, wantCommand) {
+					t.Errorf("Hermes config missing direct native command %q:\n%s", wantCommand, text)
+				}
+				if strings.Contains(text, "& ") || strings.Contains(strings.ToLower(text), "powershell") {
+					t.Errorf("Hermes config contains an incompatible shell command:\n%s", text)
 				}
 			} else if connectorName == "claudecode" {
 				var cfg map[string]interface{}

--- a/internal/gateway/connector/opencode_test.go
+++ b/internal/gateway/connector/opencode_test.go
@@ -31,6 +31,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -48,6 +49,25 @@ func TestManagedPluginTokenPathJavaScriptEscapingIsCrossPlatform(t *testing.T) {
 		if decoded != path {
 			t.Fatalf("escaped path round trip = %q, want %q", decoded, path)
 		}
+	}
+}
+
+func TestOpenCodePluginPathHonorsExplicitAndEnvironmentHomes(t *testing.T) {
+	previous := OpenCodePluginPathOverride
+	OpenCodePluginPathOverride = ""
+	t.Cleanup(func() { OpenCodePluginPathOverride = previous })
+
+	environmentHome := filepath.Join(t.TempDir(), "environment-opencode")
+	explicitHome := filepath.Join(t.TempDir(), "explicit-opencode")
+	t.Setenv("OPENCODE_CONFIG_DIR", environmentHome)
+
+	wantEnvironment := filepath.Join(environmentHome, "plugins", "defenseclaw.js")
+	if got := opencodePluginPath(SetupOpts{}); got != wantEnvironment {
+		t.Fatalf("environment plugin path = %q, want %q", got, wantEnvironment)
+	}
+	wantExplicit := filepath.Join(explicitHome, "plugins", "defenseclaw.js")
+	if got := opencodePluginPath(SetupOpts{ConfigHome: explicitHome}); got != wantExplicit {
+		t.Fatalf("explicit plugin path = %q, want %q", got, wantExplicit)
 	}
 }
 
@@ -104,6 +124,7 @@ func TestOpenCodeSetup_WritesBridgePlugin(t *testing.T) {
 		`if (offset > DC_MAX_TOKEN_FILE_BYTES)`,
 		`/^[0-9a-f]{64}$/`,
 		`if (actionable) return { reason: "DefenseClaw hook credential is unavailable." }`,
+		`DefenseClaw blocked this tool before execution: `,
 		"tool.execute.before",         // block hook wired
 		"input && input.args",         // after-hook preserves exact executed args
 		"tool_response: toolResponse", // after-hook forwards the result
@@ -290,6 +311,159 @@ for await (const _ of lines) {
 	}
 	if string(pluginAfter) != string(pluginBytes) {
 		t.Fatal("sidecar rotation rewrote the stable OpenCode plugin")
+	}
+}
+
+func TestOpenCodePluginAllOwnedHooksUseReviewedWireShapes(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required for the OpenCode owned-hook contract test")
+	}
+
+	const sessionID = "session-owned-hooks"
+	token := strings.Repeat("c", 64)
+	var (
+		mu       sync.Mutex
+		requests []map[string]interface{}
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Header.Get("Authorization"), "Bearer "+token; got != want {
+			t.Errorf("Authorization = %q, want %q", got, want)
+		}
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode OpenCode hook request: %v", err)
+			http.Error(w, "invalid JSON", http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		requests = append(requests, payload)
+		mu.Unlock()
+
+		decision := "allow"
+		reason := ""
+		if input, ok := payload["tool_input"].(map[string]interface{}); ok &&
+			input["command"] == "strict-block-probe" {
+			decision = "deny"
+			reason = "matched: strict-owned-hook-probe"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"hook_output": map[string]interface{}{"decision": decision, "reason": reason},
+		})
+	}))
+	defer server.Close()
+
+	root := t.TempDir()
+	pluginPath := filepath.Join(root, "plugins", "defenseclaw.mjs")
+	previous := OpenCodePluginPathOverride
+	OpenCodePluginPathOverride = pluginPath
+	t.Cleanup(func() { OpenCodePluginPathOverride = previous })
+	opts := SetupOpts{
+		DataDir:      filepath.Join(root, "dc"),
+		APIAddr:      strings.TrimPrefix(server.URL, "http://"),
+		APIToken:     token,
+		HookFailMode: "closed",
+	}
+	tokenPath, err := HookAPITokenFilePath(opts.DataDir, "opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(tokenPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicWriteFile(tokenPath, []byte(token+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	conn := NewOpenCodeConnector()
+	if err := conn.Setup(context.Background(), opts); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Teardown(context.Background(), opts) })
+
+	harness := `
+import { pathToFileURL } from "node:url";
+const loaded = await import(pathToFileURL(process.argv[1]).href);
+const plugin = await loaded.DefenseClaw({ directory: "C:/owned-hooks", worktree: "C:/owned-hooks" });
+const lifecycle = [
+  "session.created", "session.updated", "session.status", "session.idle",
+  "session.compacted", "session.error", "session.deleted",
+];
+for (const type of lifecycle) {
+  await plugin.event({ event: { type, properties: { info: { id: "session-owned-hooks" } } } });
+}
+await plugin["tool.execute.before"](
+  { tool: "bash", sessionID: "session-owned-hooks", messageID: "turn-owned-hooks", callID: "call-owned-hooks" },
+  { args: { command: "Write-Output safe-owned-hook-probe" } },
+);
+await plugin["tool.execute.after"](
+  { tool: "bash", sessionID: "session-owned-hooks", messageID: "turn-owned-hooks", callID: "call-owned-hooks", args: { command: "Write-Output safe-owned-hook-probe" } },
+  { title: "safe", output: "safe-owned-hook-probe", metadata: { exit: 0 } },
+);
+let blocked = "";
+try {
+  await plugin["tool.execute.before"](
+    { tool: "bash", sessionID: "session-owned-hooks", messageID: "turn-block", callID: "call-block" },
+    { args: { command: "strict-block-probe" } },
+  );
+} catch (error) {
+  blocked = String(error && error.message || error);
+}
+console.log(JSON.stringify({ blocked }));
+`
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, node, "--input-type=module", "-e", harness, pluginPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run OpenCode owned-hook harness: %v\n%s", err, output)
+	}
+	var result struct {
+		Blocked string `json:"blocked"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(output), &result); err != nil {
+		t.Fatalf("decode OpenCode owned-hook harness output: %v\n%s", err, output)
+	}
+	wantBlock := "DefenseClaw blocked this tool before execution: matched: strict-owned-hook-probe"
+	if result.Blocked != wantBlock {
+		t.Fatalf("blocking callback error = %q, want %q", result.Blocked, wantBlock)
+	}
+
+	mu.Lock()
+	got := append([]map[string]interface{}(nil), requests...)
+	mu.Unlock()
+	if len(got) != 10 {
+		t.Fatalf("OpenCode hook request count = %d, want 10", len(got))
+	}
+	lifecycle := []string{
+		"session.created", "session.updated", "session.status", "session.idle",
+		"session.compacted", "session.error", "session.deleted",
+	}
+	for index, event := range lifecycle {
+		if got[index]["hook_event_name"] != event || got[index]["event_type"] != event {
+			t.Errorf("lifecycle request %d = %#v, want event %q", index, got[index], event)
+		}
+		if got[index]["session_id"] != sessionID {
+			t.Errorf("lifecycle request %d session_id = %#v, want %q", index, got[index]["session_id"], sessionID)
+		}
+	}
+	before := got[7]
+	if before["hook_event_name"] != "tool.execute.before" || before["tool_name"] != "bash" ||
+		before["session_id"] != sessionID || before["turn_id"] != "turn-owned-hooks" ||
+		before["tool_call_id"] != "call-owned-hooks" {
+		t.Errorf("pre-tool wire shape = %#v", before)
+	}
+	if input, ok := before["tool_input"].(map[string]interface{}); !ok ||
+		input["command"] != "Write-Output safe-owned-hook-probe" {
+		t.Errorf("pre-tool input = %#v", before["tool_input"])
+	}
+	after := got[8]
+	if after["hook_event_name"] != "tool.execute.after" || after["tool_name"] != "bash" {
+		t.Errorf("post-tool wire shape = %#v", after)
+	}
+	if response, ok := after["tool_response"].(map[string]interface{}); !ok ||
+		response["output"] != "safe-owned-hook-probe" {
+		t.Errorf("post-tool response = %#v", after["tool_response"])
 	}
 }
 

--- a/internal/gateway/connector/platform_support.go
+++ b/internal/gateway/connector/platform_support.go
@@ -89,8 +89,8 @@ var windowsConnectorSupport = map[string]PlatformSupport{
 		Reason: "Amp and the DefenseClaw system policy plugin are supported on native Windows x64.",
 	},
 	"hermes": {
-		Status: PlatformNotCertified,
-		Reason: "The DefenseClaw Hermes integration has not completed native Windows x64 certification.",
+		Status: PlatformSupported,
+		Reason: "Hermes Agent 0.20.6 and DefenseClaw native hooks are supported on native Windows x64.",
 	},
 	"openhands": {
 		Status: PlatformUnsupported,

--- a/internal/gateway/connector/platform_support.go
+++ b/internal/gateway/connector/platform_support.go
@@ -61,8 +61,8 @@ var windowsConnectorSupport = map[string]PlatformSupport{
 		Reason: "Claude Code with Git for Windows and native hooks is certified on native Windows x64.",
 	},
 	"cursor": {
-		Status: PlatformNotCertified,
-		Reason: "The DefenseClaw Cursor integration has not completed native Windows x64 certification.",
+		Status: PlatformPreview,
+		Reason: "Cursor native Windows support is preview pending integrated packaged Setup and official-client validation.",
 	},
 	"windsurf": {
 		Status: PlatformNotCertified,
@@ -81,8 +81,8 @@ var windowsConnectorSupport = map[string]PlatformSupport{
 		Reason: "The DefenseClaw Antigravity integration has not completed native Windows x64 certification.",
 	},
 	"opencode": {
-		Status: PlatformNotCertified,
-		Reason: "The DefenseClaw OpenCode integration has not completed native Windows x64 certification.",
+		Status: PlatformPreview,
+		Reason: "OpenCode native Windows support is preview pending integrated packaged Setup and official-client validation; OpenCode recommends WSL but also supports direct Windows use.",
 	},
 	"amp": {
 		Status: PlatformSupported,

--- a/internal/gateway/connector/platform_support_test.go
+++ b/internal/gateway/connector/platform_support_test.go
@@ -26,12 +26,13 @@ var windowsSupportedConnectorNames = []string{
 	"amp",
 	"claudecode",
 	"codex",
+	"hermes",
 }
 
 var windowsPreviewConnectorNames = []string{}
 
 var windowsNotCertifiedConnectorNames = []string{
-	"antigravity", "copilot", "cursor", "geminicli", "hermes", "opencode", "windsurf",
+	"antigravity", "copilot", "cursor", "geminicli", "opencode", "windsurf",
 }
 
 var windowsUnsupportedConnectorNames = []string{
@@ -149,8 +150,8 @@ func TestConnectorSupportOnOS(t *testing.T) {
 }
 
 func TestValidateConnectorSupportedOnOS(t *testing.T) {
-	if err := validateConnectorSupportedOnOS("hermes", "windows"); err == nil || !strings.Contains(err.Error(), "not certified") {
-		t.Fatalf("not-certified connector should fail: %v", err)
+	if err := validateConnectorSupportedOnOS("hermes", "windows"); err != nil {
+		t.Fatalf("supported Hermes connector should pass: %v", err)
 	}
 	err := validateConnectorSupportedOnOS("openhands", "windows")
 	if err == nil || !strings.Contains(err.Error(), "requires WSL") {
@@ -160,8 +161,8 @@ func TestValidateConnectorSupportedOnOS(t *testing.T) {
 
 func TestCheckPlatformSupportPreservesOperatorWording(t *testing.T) {
 	warning, err := CheckPlatformSupport("hermes", "windows")
-	if warning != "" || err == nil || !strings.Contains(err.Error(), "not certified") {
-		t.Fatalf("not-certified result warning=%q err=%v", warning, err)
+	if warning != "" || err != nil {
+		t.Fatalf("supported Hermes result warning=%q err=%v", warning, err)
 	}
 
 	warning, err = CheckPlatformSupport("openhands", "windows")

--- a/internal/gateway/connector/platform_support_test.go
+++ b/internal/gateway/connector/platform_support_test.go
@@ -29,10 +29,10 @@ var windowsSupportedConnectorNames = []string{
 	"hermes",
 }
 
-var windowsPreviewConnectorNames = []string{}
+var windowsPreviewConnectorNames = []string{"cursor", "opencode"}
 
 var windowsNotCertifiedConnectorNames = []string{
-	"antigravity", "copilot", "cursor", "geminicli", "opencode", "windsurf",
+	"antigravity", "copilot", "geminicli", "windsurf",
 }
 
 var windowsUnsupportedConnectorNames = []string{
@@ -175,7 +175,7 @@ func TestCheckPlatformSupportPreservesOperatorWording(t *testing.T) {
 	}
 }
 
-func TestRegistryWindowsFilterKeepsSupportedOnly(t *testing.T) {
+func TestRegistryWindowsFilterKeepsSupportedAndPreview(t *testing.T) {
 	reg := NewDefaultRegistry()
 	var got []string
 	for _, name := range reg.Names() {
@@ -185,6 +185,7 @@ func TestRegistryWindowsFilterKeepsSupportedOnly(t *testing.T) {
 	}
 	sort.Strings(got)
 	want := append([]string(nil), windowsSupportedConnectorNames...)
+	want = append(want, windowsPreviewConnectorNames...)
 	sort.Strings(want)
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("windows-filtered connectors=%v, want %v", got, want)

--- a/internal/gateway/connector/tool_call_lifecycle.go
+++ b/internal/gateway/connector/tool_call_lifecycle.go
@@ -797,11 +797,11 @@ func hermesToolCallLifecycle() ToolCallLifecycleContract {
 			ToolSurfaceSkills,
 		},
 		OfficialSourceURLs: []string{
-			"https://github.com/NousResearch/hermes-agent/blob/126ff7071b6b755055879648f4e859b3187d0fac/agent/shell_hooks.py",
-			"https://github.com/NousResearch/hermes-agent/blob/126ff7071b6b755055879648f4e859b3187d0fac/model_tools.py",
+			"https://github.com/NousResearch/hermes-agent/blob/5fc308a70719a83cccdbba4c0e39c23f5a8239d5/agent/shell_hooks.py",
+			"https://github.com/NousResearch/hermes-agent/blob/5fc308a70719a83cccdbba4c0e39c23f5a8239d5/model_tools.py",
 		},
 		Limitations: []string{
-			"Only pre_tool_call can block, and hook subprocess errors, timeouts, or malformed output fail open upstream.",
+			"Only pre_tool_call can block; fail_closed=true makes hook subprocess errors, timeouts, and malformed output block upstream.",
 			"A post_tool_call commits success only when extra.status is ok; error and blocked statuses must not advance state.",
 		},
 	}

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"os"
 	"os/exec"
@@ -2800,6 +2801,62 @@ func ampWatcherSkillDirs(cfg *config.Config) []string {
 	return filtered
 }
 
+// expandHermesSkillWatchDirs preserves Hermes' top-level skill root for flat
+// user-installed skills and also watches the direct parent of every nested
+// skill. Hermes' bundled catalog uses both shallow and deep taxonomies:
+//
+//	skills/my-skill/SKILL.md
+//	skills/category/my-skill/SKILL.md
+//	skills/category/subcategory/my-skill/SKILL.md
+//
+// InstallWatcher watches direct children of each configured root, so category
+// roots must be registered explicitly for native install events and rescans to
+// reach the nested skills. Walking marker files instead of assuming a fixed
+// category depth keeps taxonomy folders out of the scanner input.
+func expandHermesSkillWatchDirs(conn connector.Connector, skillDirs []string) []string {
+	if conn == nil || !strings.EqualFold(strings.TrimSpace(conn.Name()), "hermes") {
+		return skillDirs
+	}
+
+	expanded := make([]string, 0, len(skillDirs))
+	seen := make(map[string]struct{}, len(skillDirs))
+	appendDir := func(dir string) {
+		cleaned := filepath.Clean(dir)
+		if _, ok := seen[cleaned]; ok {
+			return
+		}
+		seen[cleaned] = struct{}{}
+		expanded = append(expanded, dir)
+	}
+
+	for _, root := range skillDirs {
+		appendDir(root)
+		_ = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				if entry != nil && entry.IsDir() {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			if path != root && entry.IsDir() && strings.HasPrefix(entry.Name(), ".") {
+				return fs.SkipDir
+			}
+			if entry.IsDir() || entry.Name() != "SKILL.md" {
+				return nil
+			}
+			skillDir := filepath.Dir(path)
+			watchRoot := filepath.Dir(skillDir)
+			rel, err := filepath.Rel(root, watchRoot)
+			if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+				appendDir(watchRoot)
+			}
+			return nil
+		})
+	}
+
+	return expanded
+}
+
 // runWatcher starts the skill/MCP install watcher if enabled in config.
 func (s *Sidecar) runWatcher(ctx context.Context) error {
 	wcfg := s.currentConfig().Gateway.Watcher
@@ -2827,6 +2884,7 @@ func (s *Sidecar) runWatcher(ctx context.Context) error {
 	}
 
 	skillDirs, pluginDirs, _ := resolveWatcherDirs(s.currentConfig(), conn, wcfg)
+	skillDirs = expandHermesSkillWatchDirs(conn, skillDirs)
 
 	if !wcfg.Skill.Enabled {
 		fmt.Fprintf(os.Stderr, "[sidecar] watcher: skill watching disabled\n")

--- a/internal/gateway/sidecar_watcher_matrix_test.go
+++ b/internal/gateway/sidecar_watcher_matrix_test.go
@@ -405,6 +405,48 @@ func TestResolveWatcherDirs_AMPDoesNotMaterializeOptionalClaudeRoots(t *testing.
 	}
 }
 
+func TestExpandHermesSkillWatchDirs_IncludesNestedCategoryRoots(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "skills")
+	flat := filepath.Join(root, "flat-skill")
+	category := filepath.Join(root, "productivity")
+	nested := filepath.Join(category, "nested-skill")
+	deepParent := filepath.Join(root, "mlops", "models", "vendor")
+	deepNested := filepath.Join(deepParent, "deep-skill")
+	markerless := filepath.Join(root, "not-a-category", "child")
+	for _, dir := range []string{flat, nested, deepNested, markerless} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, dir := range []string{flat, nested, deepNested} {
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("# Test skill\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := expandHermesSkillWatchDirs(connector.NewHermesConnector(), []string{root})
+	if !containsExactPath(got, root) {
+		t.Fatalf("expanded dirs = %v, missing top-level Hermes skill root", got)
+	}
+	if !containsExactPath(got, category) {
+		t.Fatalf("expanded dirs = %v, missing nested-skill category root", got)
+	}
+	if !containsExactPath(got, deepParent) {
+		t.Fatalf("expanded dirs = %v, missing deep nested-skill parent root", got)
+	}
+	if containsExactPath(got, flat) {
+		t.Fatalf("expanded dirs = %v, flat skill must not become a watch root", got)
+	}
+	if containsExactPath(got, filepath.Dir(markerless)) {
+		t.Fatalf("expanded dirs = %v, markerless grouping directory must not become a watch root", got)
+	}
+
+	nonHermes := expandHermesSkillWatchDirs(connector.NewCodexConnector(), []string{root})
+	if len(nonHermes) != 1 || !containsExactPath(nonHermes, root) {
+		t.Fatalf("non-Hermes dirs changed: %v", nonHermes)
+	}
+}
+
 func anyContains(haystack []string, needle string) bool {
 	for _, h := range haystack {
 		if strings.Contains(h, needle) {

--- a/internal/nativeinstallstate/state.go
+++ b/internal/nativeinstallstate/state.go
@@ -33,6 +33,7 @@ type State struct {
 	Runtime         string `json:"runtime"`
 	CodexHome       string `json:"codex_home,omitempty"`
 	ClaudeConfigDir string `json:"claude_config_dir,omitempty"`
+	HermesHome      string `json:"hermes_home,omitempty"`
 }
 
 // Environment removes ambient profile selectors and restores the exact
@@ -44,8 +45,9 @@ func (state State) Environment(base []string) []string {
 		"DEFENSECLAW_HOME":         true,
 		"CODEX_HOME":               true,
 		"CLAUDE_CONFIG_DIR":        true,
+		"HERMES_HOME":              true,
 	}
-	result := make([]string, 0, len(base)+4)
+	result := make([]string, 0, len(base)+5)
 	for _, entry := range base {
 		name, _, ok := strings.Cut(entry, "=")
 		if !ok || owned[strings.ToUpper(name)] {
@@ -62,6 +64,9 @@ func (state State) Environment(base []string) []string {
 	}
 	if state.ClaudeConfigDir != "" {
 		result = append(result, "CLAUDE_CONFIG_DIR="+state.ClaudeConfigDir)
+	}
+	if state.HermesHome != "" {
+		result = append(result, "HERMES_HOME="+state.HermesHome)
 	}
 	return result
 }
@@ -139,7 +144,7 @@ func loadAt(executable, installRoot string) (State, error) {
 			return State{}, errors.New("native install state does not match its physical installation")
 		}
 	}
-	for _, value := range []string{state.DataRoot, state.CodexHome, state.ClaudeConfigDir} {
+	for _, value := range []string{state.DataRoot, state.CodexHome, state.ClaudeConfigDir, state.HermesHome} {
 		if value != "" && !absoluteCleanPath(value) {
 			return State{}, errors.New("native install state contains an invalid profile path")
 		}

--- a/internal/nativeinstallstate/state.go
+++ b/internal/nativeinstallstate/state.go
@@ -24,16 +24,18 @@ const maxStateBytes = 128 << 10
 var nativeInstallStateBeforeOpen func(string) error
 
 type State struct {
-	SchemaVersion   int    `json:"schema_version"`
-	InstallKind     string `json:"install_kind"`
-	InstallScope    string `json:"install_scope"`
-	InstallRoot     string `json:"install_root"`
-	CommandDir      string `json:"command_dir"`
-	DataRoot        string `json:"data_root"`
-	Runtime         string `json:"runtime"`
-	CodexHome       string `json:"codex_home,omitempty"`
-	ClaudeConfigDir string `json:"claude_config_dir,omitempty"`
-	HermesHome      string `json:"hermes_home,omitempty"`
+	SchemaVersion     int    `json:"schema_version"`
+	InstallKind       string `json:"install_kind"`
+	InstallScope      string `json:"install_scope"`
+	InstallRoot       string `json:"install_root"`
+	CommandDir        string `json:"command_dir"`
+	DataRoot          string `json:"data_root"`
+	Runtime           string `json:"runtime"`
+	CodexHome         string `json:"codex_home,omitempty"`
+	ClaudeConfigDir   string `json:"claude_config_dir,omitempty"`
+	HermesHome        string `json:"hermes_home,omitempty"`
+	OpenCodeConfigDir string `json:"opencode_config_dir,omitempty"`
+	CursorConfigDir   string `json:"cursor_config_dir,omitempty"`
 }
 
 // Environment removes ambient profile selectors and restores the exact
@@ -46,6 +48,8 @@ func (state State) Environment(base []string) []string {
 		"CODEX_HOME":               true,
 		"CLAUDE_CONFIG_DIR":        true,
 		"HERMES_HOME":              true,
+		"OPENCODE_CONFIG_DIR":      true,
+		"CURSOR_CONFIG_DIR":        true,
 	}
 	result := make([]string, 0, len(base)+5)
 	for _, entry := range base {
@@ -67,6 +71,12 @@ func (state State) Environment(base []string) []string {
 	}
 	if state.HermesHome != "" {
 		result = append(result, "HERMES_HOME="+state.HermesHome)
+	}
+	if state.OpenCodeConfigDir != "" {
+		result = append(result, "OPENCODE_CONFIG_DIR="+state.OpenCodeConfigDir)
+	}
+	if state.CursorConfigDir != "" {
+		result = append(result, "CURSOR_CONFIG_DIR="+state.CursorConfigDir)
 	}
 	return result
 }
@@ -144,7 +154,7 @@ func loadAt(executable, installRoot string) (State, error) {
 			return State{}, errors.New("native install state does not match its physical installation")
 		}
 	}
-	for _, value := range []string{state.DataRoot, state.CodexHome, state.ClaudeConfigDir, state.HermesHome} {
+	for _, value := range []string{state.DataRoot, state.CodexHome, state.ClaudeConfigDir, state.HermesHome, state.OpenCodeConfigDir, state.CursorConfigDir} {
 		if value != "" && !absoluteCleanPath(value) {
 			return State{}, errors.New("native install state contains an invalid profile path")
 		}

--- a/internal/nativeinstallstate/state_test.go
+++ b/internal/nativeinstallstate/state_test.go
@@ -27,16 +27,18 @@ func fixtureState(t *testing.T) (State, string) {
 		t.Fatal(err)
 	}
 	state := State{
-		SchemaVersion:   1,
-		InstallKind:     "native-windows-exe",
-		InstallScope:    "user",
-		InstallRoot:     root,
-		CommandDir:      bin,
-		DataRoot:        filepath.Join(t.TempDir(), ".defenseclaw"),
-		Runtime:         filepath.Join(root, "runtime", "python"),
-		CodexHome:       filepath.Join(t.TempDir(), "codex-home"),
-		ClaudeConfigDir: filepath.Join(t.TempDir(), "claude-home"),
-		HermesHome:      filepath.Join(t.TempDir(), "hermes-home"),
+		SchemaVersion:     1,
+		InstallKind:       "native-windows-exe",
+		InstallScope:      "user",
+		InstallRoot:       root,
+		CommandDir:        bin,
+		DataRoot:          filepath.Join(t.TempDir(), ".defenseclaw"),
+		Runtime:           filepath.Join(root, "runtime", "python"),
+		CodexHome:         filepath.Join(t.TempDir(), "codex-home"),
+		ClaudeConfigDir:   filepath.Join(t.TempDir(), "claude-home"),
+		HermesHome:        filepath.Join(t.TempDir(), "hermes-home"),
+		OpenCodeConfigDir: filepath.Join(t.TempDir(), "opencode-home"),
+		CursorConfigDir:   filepath.Join(t.TempDir(), "cursor-home"),
 	}
 	body, err := json.Marshal(state)
 	if err != nil {
@@ -59,6 +61,8 @@ func TestLoadAtAndEnvironmentRehydrateConnectorHomes(t *testing.T) {
 		"CODEX_HOME=project-codex",
 		"claude_config_dir=project-claude",
 		"HERMES_HOME=project-hermes",
+		"OPENCODE_CONFIG_DIR=project-opencode",
+		"CURSOR_CONFIG_DIR=project-cursor",
 		"DEFENSECLAW_HOME=project-data",
 	})
 	joined := strings.Join(env, "\n")
@@ -66,6 +70,8 @@ func TestLoadAtAndEnvironmentRehydrateConnectorHomes(t *testing.T) {
 		"CODEX_HOME=" + want.CodexHome,
 		"CLAUDE_CONFIG_DIR=" + want.ClaudeConfigDir,
 		"HERMES_HOME=" + want.HermesHome,
+		"OPENCODE_CONFIG_DIR=" + want.OpenCodeConfigDir,
+		"CURSOR_CONFIG_DIR=" + want.CursorConfigDir,
 		"DEFENSECLAW_HOME=" + want.DataRoot,
 		"DEFENSECLAW_INSTALL_ROOT=" + want.InstallRoot,
 	} {
@@ -85,11 +91,15 @@ func TestEnvironmentRemovesAmbientConnectorHomesFromLegacyState(t *testing.T) {
 		"CODEX_HOME=project-codex",
 		"claude_config_dir=project-claude",
 		"HERMES_HOME=project-hermes",
+		"OPENCODE_CONFIG_DIR=project-opencode",
+		"CURSOR_CONFIG_DIR=project-cursor",
 	})
 	joined := strings.Join(env, "\n")
 	if strings.Contains(strings.ToUpper(joined), "CODEX_HOME=") ||
 		strings.Contains(strings.ToUpper(joined), "CLAUDE_CONFIG_DIR=") ||
-		strings.Contains(strings.ToUpper(joined), "HERMES_HOME=") {
+		strings.Contains(strings.ToUpper(joined), "HERMES_HOME=") ||
+		strings.Contains(strings.ToUpper(joined), "OPENCODE_CONFIG_DIR=") ||
+		strings.Contains(strings.ToUpper(joined), "CURSOR_CONFIG_DIR=") {
 		t.Fatalf("ambient connector home survived legacy state: %v", env)
 	}
 }

--- a/internal/nativeinstallstate/state_test.go
+++ b/internal/nativeinstallstate/state_test.go
@@ -36,6 +36,7 @@ func fixtureState(t *testing.T) (State, string) {
 		Runtime:         filepath.Join(root, "runtime", "python"),
 		CodexHome:       filepath.Join(t.TempDir(), "codex-home"),
 		ClaudeConfigDir: filepath.Join(t.TempDir(), "claude-home"),
+		HermesHome:      filepath.Join(t.TempDir(), "hermes-home"),
 	}
 	body, err := json.Marshal(state)
 	if err != nil {
@@ -57,12 +58,14 @@ func TestLoadAtAndEnvironmentRehydrateConnectorHomes(t *testing.T) {
 		"PATH=fixture",
 		"CODEX_HOME=project-codex",
 		"claude_config_dir=project-claude",
+		"HERMES_HOME=project-hermes",
 		"DEFENSECLAW_HOME=project-data",
 	})
 	joined := strings.Join(env, "\n")
 	for _, expected := range []string{
 		"CODEX_HOME=" + want.CodexHome,
 		"CLAUDE_CONFIG_DIR=" + want.ClaudeConfigDir,
+		"HERMES_HOME=" + want.HermesHome,
 		"DEFENSECLAW_HOME=" + want.DataRoot,
 		"DEFENSECLAW_INSTALL_ROOT=" + want.InstallRoot,
 	} {
@@ -81,10 +84,12 @@ func TestEnvironmentRemovesAmbientConnectorHomesFromLegacyState(t *testing.T) {
 		"PATH=fixture",
 		"CODEX_HOME=project-codex",
 		"claude_config_dir=project-claude",
+		"HERMES_HOME=project-hermes",
 	})
 	joined := strings.Join(env, "\n")
 	if strings.Contains(strings.ToUpper(joined), "CODEX_HOME=") ||
-		strings.Contains(strings.ToUpper(joined), "CLAUDE_CONFIG_DIR=") {
+		strings.Contains(strings.ToUpper(joined), "CLAUDE_CONFIG_DIR=") ||
+		strings.Contains(strings.ToUpper(joined), "HERMES_HOME=") {
 		t.Fatalf("ambient connector home survived legacy state: %v", env)
 	}
 }

--- a/internal/watcher/rescan.go
+++ b/internal/watcher/rescan.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -146,10 +147,16 @@ func (w *InstallWatcher) runRescanCycle(ctx context.Context) {
 		fmt.Sprintf("targets=%d scanned=%d skipped=%d", len(targets), scanned, skipped))
 }
 
-// enumerateTargets lists all direct child directories under watched roots plus
-// configured MCP servers from openclaw.json.
+// enumerateTargets lists installed components under watched roots plus
+// configured MCP servers. Some clients (notably Hermes) group skills under
+// category directories. A markerless directory with descendant skills is
+// therefore a grouping root, not a scanner target. Markerless flat directories
+// without any nested skill marker are preserved for backward compatibility
+// with clients whose scanners support layouts that do not require SKILL.md.
 func (w *InstallWatcher) enumerateTargets() []InstallEvent {
 	var targets []InstallEvent
+	hermesSkillsRequireMarker := w.cfg != nil &&
+		strings.EqualFold(strings.TrimSpace(w.cfg.Guardrail.Connector), "hermes")
 
 	for _, dir := range w.skillDirs {
 		entries, err := os.ReadDir(dir)
@@ -161,10 +168,17 @@ func (w *InstallWatcher) enumerateTargets() []InstallEvent {
 			if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
 				continue
 			}
+			skillPath := filepath.Join(dir, e.Name())
+			info, err := os.Stat(filepath.Join(skillPath, "SKILL.md"))
+			if err != nil || info.IsDir() {
+				if hermesSkillsRequireMarker || containsNestedSkillMarker(skillPath) {
+					continue
+				}
+			}
 			targets = append(targets, InstallEvent{
 				Type:      InstallSkill,
 				Name:      e.Name(),
-				Path:      filepath.Join(dir, e.Name()),
+				Path:      skillPath,
 				Timestamp: time.Now().UTC(),
 			})
 		}
@@ -207,6 +221,27 @@ func (w *InstallWatcher) enumerateTargets() []InstallEvent {
 	}
 
 	return targets
+}
+
+func containsNestedSkillMarker(root string) bool {
+	found := false
+	_ = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if entry != nil && entry.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if path != root && entry.IsDir() && strings.HasPrefix(entry.Name(), ".") {
+			return fs.SkipDir
+		}
+		if !entry.IsDir() && entry.Name() == "SKILL.md" {
+			found = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	return found
 }
 
 // rescanTarget snapshots a single target, decides whether a fresh scan is

--- a/internal/watcher/rescan_test.go
+++ b/internal/watcher/rescan_test.go
@@ -424,6 +424,9 @@ func TestEnumerateTargets_IncludesConfiguredMCPServers(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(skillDir, "watched-skill"), 0o700); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(skillDir, "watched-skill", "SKILL.md"), []byte("# Watched skill\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.MkdirAll(filepath.Join(pluginDir, "watched-plugin"), 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -468,6 +471,63 @@ func TestEnumerateTargets_IncludesConfiguredMCPServers(t *testing.T) {
 		t.Fatalf("expected stdio MCP in targets, got %+v", targets)
 	} else if evt.Path != "stdio-mcp" {
 		t.Fatalf("stdio MCP path = %q, want server name", evt.Path)
+	}
+}
+
+func TestEnumerateTargets_SkipsSkillGroupingDirectories(t *testing.T) {
+	cfg, store, logger, skillDir := setupTestEnv(t)
+	t.Setenv("PATH", "")
+	cfg.Guardrail.Connector = "hermes"
+
+	flatSkill := filepath.Join(skillDir, "flat-skill")
+	nestedSkill := filepath.Join(skillDir, "category", "nested-skill")
+	deepSkill := filepath.Join(skillDir, "mlops", "models", "vendor", "deep-skill")
+	markerless := filepath.Join(skillDir, "markerless")
+	for _, dir := range []string{flatSkill, nestedSkill, deepSkill, markerless} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if dir == markerless {
+			continue
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("# Test skill\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	w := New(cfg, []string{
+		skillDir,
+		filepath.Join(skillDir, "category"),
+		filepath.Dir(deepSkill),
+	}, nil, store, logger, nil, nil, nil)
+	targets := w.enumerateTargets()
+
+	seen := make(map[string]InstallEvent)
+	for _, target := range targets {
+		if target.Type == InstallSkill {
+			seen[target.Name] = target
+		}
+	}
+	if _, ok := seen["category"]; ok {
+		t.Fatalf("markerless category directory was enumerated as a skill: %+v", targets)
+	}
+	if _, ok := seen["flat-skill"]; !ok {
+		t.Fatalf("flat skill missing from targets: %+v", targets)
+	}
+	if evt, ok := seen["nested-skill"]; !ok {
+		t.Fatalf("nested skill missing from targets: %+v", targets)
+	} else if evt.Path != nestedSkill {
+		t.Fatalf("nested skill path = %q, want %q", evt.Path, nestedSkill)
+	}
+	if evt, ok := seen["deep-skill"]; !ok {
+		t.Fatalf("deep skill missing from targets: %+v", targets)
+	} else if evt.Path != deepSkill {
+		t.Fatalf("deep skill path = %q, want %q", evt.Path, deepSkill)
+	}
+	for _, groupingName := range []string{"mlops", "models", "vendor", "markerless"} {
+		if _, ok := seen[groupingName]; ok {
+			t.Fatalf("grouping directory %q was enumerated as a skill: %+v", groupingName, targets)
+		}
 	}
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -86,6 +86,7 @@ $ConnectorChoices = @(
     "codex",
     "claudecode",
     "amp",
+    "hermes",
     "none"
 )
 $HookConnectors = @()

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -87,6 +87,8 @@ $ConnectorChoices = @(
     "claudecode",
     "amp",
     "hermes",
+    "opencode",
+    "cursor",
     "none"
 )
 $HookConnectors = @()

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -85,10 +85,10 @@ $CosignUrl = "https://github.com/sigstore/cosign/releases/download/v$CosignVersi
 $ConnectorChoices = @(
     "codex",
     "claudecode",
-    "amp",
     "hermes",
-    "opencode",
     "cursor",
+    "opencode",
+    "amp",
     "none"
 )
 $HookConnectors = @()

--- a/scripts/test-windows-setup-wizard.ps1
+++ b/scripts/test-windows-setup-wizard.ps1
@@ -22,7 +22,7 @@ param(
     [string]$StateRoot = (Join-Path ([IO.Path]::GetTempPath()) "defenseclaw-wizard-smoke-$PID"),
     [ValidateRange(1, 60)]
     [int]$TimeoutSeconds = 15,
-    [ValidateSet('none', 'codex', 'claudecode', 'amp')]
+    [ValidateSet('none', 'codex', 'claudecode', 'amp', 'hermes')]
     [string]$Connector = 'claudecode',
     [ValidateSet('observe', 'action')]
     [string]$Mode = 'observe',
@@ -364,7 +364,7 @@ function Get-WizardObservation(
     }
 }
 
-$connectorIndices = @{ none = 0; codex = 1; claudecode = 2; amp = 3 }
+$connectorIndices = @{ none = 0; codex = 1; claudecode = 2; amp = 3; hermes = 4 }
 $modeIndices = @{ observe = 0; action = 1 }
 $process = $null
 $finished = $false


### PR DESCRIPTION
## Summary

- Add native Windows OSS support for Hermes.
- Add Windows preview support for Cursor (all 21 official hooks) and OpenCode.
- Route enforcement through the existing local gateway and real skill, plugin, MCP, content, tool-policy, and CodeGuard scanners.
- Add Windows setup, path handling, lifecycle tests, support-matrix updates, and documentation.

## Why Antigravity is not included

Antigravity's upstream Windows hook execution is not yet reliable ([google-antigravity/antigravity-cli#222](https://github.com/google-antigravity/antigravity-cli/issues/222)). Shipping action mode before that is fixed could produce false fail-closed results or missed enforcement, so Antigravity remains unsupported here.

## Validation

- Hermes: real strict-rule, skill, plugin, and MCP scanner acceptance passed.
- OpenCode: real strict-rule blocking passed in the official client.
- Cursor: all 21 hook events passed and the official client blocked a real strict rule before execution.
- No synthetic `deny-me` rule or demo enforcement is included.

## Required TODO

- [ ] Complete packaged Windows installer validation for Cursor and OpenCode.
- [ ] Add/complete Windows CI and official-client certification before promoting preview support.
- [ ] Revisit Antigravity after upstream Windows hooks are reliable.
