### PR TITLE
fix(audit): deduplicate persistent finding lifecycle

### DIFF
--- a/docs-site/content/docs/reference/cli.mdx
+++ b/docs-site/content/docs/reference/cli.mdx
@@ -202,6 +202,7 @@ These list/inventory verbs read across the full active roster:
 | `defenseclaw alerts acknowledge` / `dismiss` | Acknowledge or dismiss alerts (writes an `audit_log_activity` mutation). `--severity all\|CRITICAL\|HIGH\|MEDIUM\|LOW`. |
 | `defenseclaw audit log-activity --payload-file <f>` | Record a config/operator mutation through the gateway's audit logger. Used internally by the TUI on save. |
 | `defenseclaw-gateway audit export` | JSONL export of `audit_events` from the SQLite DB, including `structured` when `structured_json` is present. Rows are emitted oldest-first; `--limit N` therefore returns the earliest N matching rows, not the newest N. Omit `--limit` and pipe to `tail` for the most recent rows. `--include-activity` also dumps `activity_events`. |
+| `defenseclaw-gateway audit findings [--since RFC3339] [--new-only] [--include-resolved] [--scanner NAME] [--target PATH] [--limit N]` | Report the deduplicated finding lifecycle. Active current findings are the default; `--include-resolved` adds resolved state, while `--since` selects lifecycle changes and `--new-only` narrows that window to fingerprints first observed since the timestamp. JSON reports both the total distinct count and the returned page. |
 | `tail -f ~/.defenseclaw/gateway.jsonl \| jq` | Tail the optional v8 JSONL destination when configured at that path. Mandatory local history is SQLite; JSONL is not an implicit mirror. |
 
 ## AI discovery

--- a/internal/audit/finding_state.go
+++ b/internal/audit/finding_state.go
@@ -1,0 +1,815 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package audit
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/defenseclaw/defenseclaw/internal/scanner"
+)
+
+const (
+	findingStateActive   = "active"
+	findingStateResolved = "resolved"
+)
+
+var _ scanner.ScanLifecyclePersistence = (*Store)(nil)
+
+// migrateFindingLifecycleState adds a compact mutable projection beside the
+// scan_findings transition ledger. Runtime findings remain append-only forensic
+// occurrences. Successful static scans persist only meaningful transitions in
+// scan_findings and upsert every observation into finding_states, so an
+// unchanged rescan does not grow one detail row per finding. No historical rows
+// are backfilled: the first complete post-upgrade scan establishes an honest
+// current baseline instead of guessing resolution state from incomplete legacy
+// history.
+func migrateFindingLifecycleState(ex dbExecer) error {
+	scanFindingsPresent, err := tableExists(ex, "scan_findings")
+	if err != nil {
+		return fmt.Errorf("inspect scan finding occurrence table: %w", err)
+	}
+	if scanFindingsPresent {
+		present, columnErr := hasColumnDB(ex, "scan_findings", "finding_fingerprint")
+		if columnErr != nil {
+			return fmt.Errorf("inspect scan finding lifecycle identity: %w", columnErr)
+		}
+		if !present {
+			if _, alterErr := ex.Exec(`ALTER TABLE scan_findings ADD COLUMN finding_fingerprint TEXT
+				CHECK (finding_fingerprint IS NULL OR length(finding_fingerprint) = 64)`); alterErr != nil {
+				return fmt.Errorf("add scan finding lifecycle identity: %w", alterErr)
+			}
+		}
+		hasTimestamp, timestampErr := hasColumnDB(ex, "scan_findings", "timestamp")
+		hasID, idErr := hasColumnDB(ex, "scan_findings", "id")
+		if timestampErr != nil {
+			return fmt.Errorf("inspect scan finding lifecycle timestamp: %w", timestampErr)
+		}
+		if idErr != nil {
+			return fmt.Errorf("inspect scan finding lifecycle occurrence ID: %w", idErr)
+		}
+		if hasTimestamp && hasID {
+			if _, indexErr := ex.Exec(`CREATE INDEX IF NOT EXISTS idx_scan_findings_finding_fingerprint
+				ON scan_findings(finding_fingerprint, timestamp DESC, id DESC)`); indexErr != nil {
+				return fmt.Errorf("index scan finding lifecycle identity: %w", indexErr)
+			}
+		}
+	}
+	_, err = ex.Exec(`
+		CREATE TABLE IF NOT EXISTS finding_scopes (
+			scope_scanner TEXT NOT NULL,
+			target_type TEXT NOT NULL,
+			normalized_target TEXT NOT NULL,
+			target TEXT NOT NULL,
+			last_completed_at DATETIME NOT NULL,
+			last_completed_unix_nano INTEGER NOT NULL,
+			last_scan_id TEXT NOT NULL,
+			PRIMARY KEY (scope_scanner, target_type, normalized_target)
+		);
+		CREATE TABLE IF NOT EXISTS finding_states (
+			fingerprint TEXT PRIMARY KEY CHECK (length(fingerprint) = 64),
+			scope_scanner TEXT NOT NULL,
+			finding_scanner TEXT NOT NULL,
+			target TEXT NOT NULL,
+			normalized_target TEXT NOT NULL,
+			target_type TEXT NOT NULL,
+			rule_id TEXT NOT NULL,
+			file_path TEXT NOT NULL,
+			normalized_file_path TEXT NOT NULL,
+			line_number INTEGER NOT NULL DEFAULT 0 CHECK (line_number >= 0),
+			content_digest TEXT NOT NULL CHECK (length(content_digest) = 64),
+			severity TEXT NOT NULL,
+			title TEXT NOT NULL DEFAULT '',
+			description TEXT,
+			evidence_summary TEXT,
+			location TEXT,
+			remediation TEXT,
+			tags TEXT NOT NULL DEFAULT '[]',
+			first_seen DATETIME NOT NULL,
+			first_seen_unix_nano INTEGER NOT NULL,
+			last_seen DATETIME NOT NULL,
+			last_seen_unix_nano INTEGER NOT NULL,
+			resolved_at DATETIME,
+			resolved_at_unix_nano INTEGER,
+			occurrence_count INTEGER NOT NULL DEFAULT 1 CHECK (occurrence_count > 0),
+			state TEXT NOT NULL CHECK (state IN ('active','resolved')),
+			first_scan_id TEXT NOT NULL,
+			last_scan_id TEXT NOT NULL,
+			last_occurrence_id TEXT NOT NULL,
+			CHECK (
+				(state = 'active' AND resolved_at IS NULL AND resolved_at_unix_nano IS NULL) OR
+				(state = 'resolved' AND resolved_at IS NOT NULL AND resolved_at_unix_nano IS NOT NULL)
+			)
+		);
+		CREATE INDEX IF NOT EXISTS idx_finding_states_scope_state
+			ON finding_states(scope_scanner, target_type, normalized_target, state);
+		CREATE INDEX IF NOT EXISTS idx_finding_states_last_seen
+			ON finding_states(last_seen_unix_nano DESC, fingerprint);
+		CREATE INDEX IF NOT EXISTS idx_finding_states_first_seen
+			ON finding_states(first_seen_unix_nano DESC, fingerprint);
+		CREATE INDEX IF NOT EXISTS idx_finding_states_resolved_at
+			ON finding_states(resolved_at_unix_nano DESC, fingerprint);
+		CREATE INDEX IF NOT EXISTS idx_finding_states_rule_state
+			ON finding_states(rule_id, state);
+	`)
+	if err != nil {
+		return fmt.Errorf("create finding lifecycle state: %w", err)
+	}
+	return nil
+}
+
+// FindingStateRow is the default distinct-finding reporting projection.
+// Runtime occurrences and meaningful static transitions remain available
+// through ListScanFindings.
+type FindingStateRow struct {
+	Fingerprint        string     `json:"fingerprint"`
+	ScopeScanner       string     `json:"scope_scanner"`
+	Scanner            string     `json:"scanner"`
+	Target             string     `json:"target"`
+	NormalizedTarget   string     `json:"normalized_target"`
+	TargetType         string     `json:"target_type"`
+	RuleID             string     `json:"rule_id"`
+	FilePath           string     `json:"file_path"`
+	NormalizedFilePath string     `json:"normalized_file_path"`
+	LineNumber         int        `json:"line_number,omitempty"`
+	ContentDigest      string     `json:"content_digest"`
+	Severity           string     `json:"severity"`
+	Title              string     `json:"title"`
+	Description        string     `json:"description,omitempty"`
+	EvidenceSummary    string     `json:"evidence_summary,omitempty"`
+	Location           string     `json:"location,omitempty"`
+	Remediation        string     `json:"remediation,omitempty"`
+	Tags               []string   `json:"tags,omitempty"`
+	FirstSeen          time.Time  `json:"first_seen"`
+	LastSeen           time.Time  `json:"last_seen"`
+	ResolvedAt         *time.Time `json:"resolved_at,omitempty"`
+	OccurrenceCount    int64      `json:"occurrence_count"`
+	State              string     `json:"state"`
+	FirstScanID        string     `json:"first_scan_id"`
+	LastScanID         string     `json:"last_scan_id"`
+	LastOccurrenceID   string     `json:"last_occurrence_id"`
+}
+
+// FindingStateQuery selects the distinct lifecycle projection used for
+// operator reporting. Active current state is the default. Since selects any
+// state observed or resolved at/after the cutoff; NewOnly narrows that to
+// fingerprints whose first observation is at/after the cutoff.
+type FindingStateQuery struct {
+	Scanner         string
+	Target          string
+	IncludeResolved bool
+	Since           *time.Time
+	NewOnly         bool
+	Limit           int
+}
+
+type findingStateQuerier interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+}
+
+// QueryFindingStates returns distinct finding state newest-first.
+func (s *Store) QueryFindingStates(query FindingStateQuery) ([]FindingStateRow, error) {
+	return queryFindingStates(s.db, query)
+}
+
+func queryFindingStates(source findingStateQuerier, query FindingStateQuery) ([]FindingStateRow, error) {
+	if query.Limit <= 0 {
+		query.Limit = 100
+	}
+	if query.Limit > 10_000 {
+		query.Limit = 10_000
+	}
+	where, args := findingStatePredicates(query)
+	args = append(args, query.Limit)
+	rows, err := source.Query(`
+		SELECT fingerprint, scope_scanner, finding_scanner, target, normalized_target,
+		       target_type, rule_id, file_path, normalized_file_path, line_number,
+		       content_digest, severity, title, description, evidence_summary, location,
+		       remediation, tags, first_seen_unix_nano, last_seen_unix_nano,
+		       resolved_at_unix_nano, occurrence_count, state, first_scan_id,
+		       last_scan_id, last_occurrence_id
+		FROM finding_states WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY MAX(last_seen_unix_nano, COALESCE(resolved_at_unix_nano, 0)) DESC,
+		         fingerprint ASC LIMIT ?`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("audit: list finding states: %w", err)
+	}
+	defer rows.Close()
+
+	result := make([]FindingStateRow, 0)
+	for rows.Next() {
+		var row FindingStateRow
+		var description, evidence, location, remediation sql.NullString
+		var tagsJSON string
+		var firstSeen, lastSeen int64
+		var resolvedAt sql.NullInt64
+		if err := rows.Scan(
+			&row.Fingerprint, &row.ScopeScanner, &row.Scanner, &row.Target,
+			&row.NormalizedTarget, &row.TargetType, &row.RuleID, &row.FilePath,
+			&row.NormalizedFilePath, &row.LineNumber, &row.ContentDigest, &row.Severity,
+			&row.Title, &description, &evidence, &location, &remediation, &tagsJSON,
+			&firstSeen, &lastSeen, &resolvedAt, &row.OccurrenceCount, &row.State,
+			&row.FirstScanID, &row.LastScanID, &row.LastOccurrenceID,
+		); err != nil {
+			return nil, fmt.Errorf("audit: scan finding state: %w", err)
+		}
+		row.Description = description.String
+		row.EvidenceSummary = evidence.String
+		row.Location = location.String
+		row.Remediation = remediation.String
+		if err := json.Unmarshal([]byte(tagsJSON), &row.Tags); err != nil {
+			return nil, fmt.Errorf("audit: decode finding state tags: %w", err)
+		}
+		row.FirstSeen = time.Unix(0, firstSeen).UTC()
+		row.LastSeen = time.Unix(0, lastSeen).UTC()
+		if resolvedAt.Valid {
+			value := time.Unix(0, resolvedAt.Int64).UTC()
+			row.ResolvedAt = &value
+		}
+		result = append(result, row)
+	}
+	return result, rows.Err()
+}
+
+// CountFindingStates returns the complete distinct count for the same filters
+// as QueryFindingStates. Limit is intentionally ignored so reports can expose
+// an honest headline count alongside a bounded result page.
+func (s *Store) CountFindingStates(query FindingStateQuery) (int64, error) {
+	return countFindingStates(s.db, query)
+}
+
+func countFindingStates(source findingStateQuerier, query FindingStateQuery) (int64, error) {
+	where, args := findingStatePredicates(query)
+	var count int64
+	if err := source.QueryRow(`SELECT COUNT(*) FROM finding_states WHERE `+
+		strings.Join(where, " AND "), args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("audit: count finding states: %w", err)
+	}
+	return count, nil
+}
+
+// QueryFindingStatesWithCount returns a bounded page and its complete count
+// from one SQLite read snapshot, so a concurrent scanner cannot make the
+// headline count disagree with the returned lifecycle rows.
+func (s *Store) QueryFindingStatesWithCount(
+	ctx context.Context,
+	query FindingStateQuery,
+) ([]FindingStateRow, int64, error) {
+	if ctx == nil {
+		return nil, 0, fmt.Errorf("audit: finding state query context is required")
+	}
+	release, err := s.acquireReady()
+	if err != nil {
+		return nil, 0, err
+	}
+	defer release()
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, 0, fmt.Errorf("audit: begin finding state read snapshot: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+	rows, err := queryFindingStates(tx, query)
+	if err != nil {
+		return nil, 0, err
+	}
+	count, err := countFindingStates(tx, query)
+	if err != nil {
+		return nil, 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, 0, fmt.Errorf("audit: commit finding state read snapshot: %w", err)
+	}
+	return rows, count, nil
+}
+
+func findingStatePredicates(query FindingStateQuery) ([]string, []any) {
+	where := []string{"1=1"}
+	args := make([]any, 0, 6)
+	if scannerName := strings.ToLower(strings.TrimSpace(query.Scanner)); scannerName != "" {
+		where = append(where, "scope_scanner = ?")
+		args = append(args, scannerName)
+	}
+	if target := scanner.NormalizeFindingStateTarget(query.Target); target != "" {
+		where = append(where, "normalized_target = ?")
+		args = append(args, target)
+	}
+	if !query.IncludeResolved {
+		where = append(where, "state = 'active'")
+	}
+	if query.Since != nil {
+		cutoff := query.Since.UTC().UnixNano()
+		if query.NewOnly {
+			where = append(where, "first_seen_unix_nano >= ?")
+			args = append(args, cutoff)
+		} else {
+			// A finding can disappear after its last observation. Include that
+			// resolution transition in a since report even when last_seen is older.
+			where = append(where, "(last_seen_unix_nano >= ? OR COALESCE(resolved_at_unix_nano, 0) >= ?)")
+			args = append(args, cutoff, cutoff)
+		}
+	}
+	return where, args
+}
+
+// ListFindingStates preserves the compact call site used by existing APIs and
+// tests. New reporting surfaces should use QueryFindingStates.
+func (s *Store) ListFindingStates(scannerName, target string, includeResolved bool, limit int) ([]FindingStateRow, error) {
+	return s.QueryFindingStates(FindingStateQuery{
+		Scanner: scannerName, Target: target, IncludeResolved: includeResolved, Limit: limit,
+	})
+}
+
+// PersistScanLifecycle atomically commits the scan summary and either a compact
+// static lifecycle transition or every runtime/failed forensic occurrence.
+// Successful classic asset scans always upsert current state; an unchanged
+// repeat therefore updates last_seen/occurrence_count without adding another
+// scan_findings row.
+func (s *Store) PersistScanLifecycle(
+	summary scanner.ScanSummaryParams,
+	findings []scanner.Finding,
+	meta scanner.ScanFindingMeta,
+) (scanner.FindingLifecycleDelta, error) {
+	delta := scanner.FindingLifecycleDelta{}
+	s.findingLifecycleMu.Lock()
+	defer s.findingLifecycleMu.Unlock()
+	if summary.Timestamp.IsZero() {
+		summary.Timestamp = meta.Timestamp
+		if summary.Timestamp.IsZero() {
+			summary.Timestamp = time.Now().UTC()
+		}
+	}
+	meta.Timestamp = summary.Timestamp
+	tx, err := s.db.Begin()
+	if err != nil {
+		return delta, fmt.Errorf("audit: begin scan lifecycle: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if err := insertScanSummary(tx, summary); err != nil {
+		return delta, err
+	}
+	if findingLifecycleEligible(summary) {
+		delta, err = applyFindingLifecycle(tx, summary, findings, meta)
+		if err != nil {
+			return scanner.FindingLifecycleDelta{}, err
+		}
+		if err := insertFindingLifecycleTransitions(tx, summary, findings, meta, delta); err != nil {
+			return scanner.FindingLifecycleDelta{}, err
+		}
+	} else if err := insertScanFindings(tx, summary.ScanID, summary.Target, findings, meta); err != nil {
+		return delta, err
+	}
+	if err := tx.Commit(); err != nil {
+		return scanner.FindingLifecycleDelta{}, fmt.Errorf("audit: commit scan lifecycle: %w", err)
+	}
+	if delta.Managed {
+		scopeKey := findingLifecycleScopeKey(summary.Scanner, summary.TargetType, summary.Target)
+		if s.findingGaugeInitialized == nil {
+			s.findingGaugeInitialized = make(map[string]struct{})
+		}
+		if _, initialized := s.findingGaugeInitialized[scopeKey]; !initialized {
+			// Up/down counters reset with the metric runtime. The first complete
+			// scan of each durable scope therefore publishes its current absolute
+			// contribution; subsequent scans publish only lifecycle deltas.
+			delta.GaugeDelta = make(map[scanner.Severity]int64, len(delta.CurrentBySeverity))
+			for severity, count := range delta.CurrentBySeverity {
+				if count != 0 {
+					delta.GaugeDelta[severity] = count
+				}
+			}
+			s.findingGaugeInitialized[scopeKey] = struct{}{}
+		}
+	}
+	return delta, nil
+}
+
+// insertFindingLifecycleTransitions keeps scan_findings useful as a forensic
+// transition ledger without repeating the same static finding on every scan.
+// New, reopened, and materially updated findings are emitted by the canonical
+// log/metric path and retain a matching occurrence row. Repeated observations
+// are represented solely by the finding_states upsert.
+func insertFindingLifecycleTransitions(
+	tx *sql.Tx,
+	summary scanner.ScanSummaryParams,
+	findings []scanner.Finding,
+	meta scanner.ScanFindingMeta,
+	delta scanner.FindingLifecycleDelta,
+) error {
+	byOccurrence := make(map[string]scanner.FindingLifecycleObservation, len(delta.Observations))
+	for _, observation := range delta.Observations {
+		if observation.PersistOccurrence {
+			byOccurrence[observation.OccurrenceID] = observation
+		}
+	}
+	transitions := make([]scanner.Finding, 0, len(byOccurrence))
+	for index := range findings {
+		if _, ok := byOccurrence[findings[index].FindingOccurrenceID]; ok {
+			transitions = append(transitions, findings[index])
+		}
+	}
+	if err := insertScanFindings(tx, summary.ScanID, summary.Target, transitions, meta); err != nil {
+		return err
+	}
+	for _, finding := range transitions {
+		observation := byOccurrence[finding.FindingOccurrenceID]
+		result, err := tx.Exec(`UPDATE scan_findings SET finding_fingerprint = ?
+			WHERE scan_id = ? AND id = ?`, observation.Fingerprint, summary.ScanID, finding.FindingOccurrenceID)
+		if err != nil {
+			return fmt.Errorf("audit: link finding transition state: %w", err)
+		}
+		if affected, rowsErr := result.RowsAffected(); rowsErr != nil || affected != 1 {
+			if rowsErr != nil {
+				return fmt.Errorf("audit: confirm finding transition state link: %w", rowsErr)
+			}
+			return fmt.Errorf("audit: finding transition state link matched %d rows", affected)
+		}
+	}
+	return nil
+}
+
+func (s *Store) resetFindingGaugeBaselines() {
+	if s == nil {
+		return
+	}
+	s.findingLifecycleMu.Lock()
+	s.findingGaugeInitialized = nil
+	s.findingLifecycleMu.Unlock()
+}
+
+func findingLifecycleScopeKey(scannerName, targetType, target string) string {
+	if targetType = scanner.NormalizeFindingStateTargetType(targetType); targetType == "" {
+		targetType = scanner.NormalizeFindingStateTargetType(scanner.InferTargetType(scannerName))
+	}
+	parts := []string{
+		strings.ToLower(strings.TrimSpace(scannerName)),
+		targetType,
+		scanner.NormalizeFindingStateTarget(target),
+	}
+	return strings.Join(parts, "\x00")
+}
+
+func findingLifecycleEligible(summary scanner.ScanSummaryParams) bool {
+	if summary.ExitCode != 0 || strings.TrimSpace(summary.ScanError) != "" ||
+		strings.TrimSpace(summary.EvaluationID) != "" {
+		return false
+	}
+	scannerName := strings.ToLower(strings.TrimSpace(summary.Scanner))
+	switch scannerName {
+	case "hook-rules", "inline-codeguard", "ai-defense", "asset-policy",
+		"tool-call-inspect", "inspect-http", "guardrail-llm", "mid-stream", "rescan":
+		return false
+	}
+	targetType := strings.ToLower(strings.TrimSpace(summary.TargetType))
+	switch targetType {
+	case "file", "code", "skill", "mcp", "plugin", "aibom", "inventory":
+		return true
+	case "tool_call", "prompt", "completion", "tool_response", "inspect":
+		return false
+	}
+	if targetType != "" && targetType != "unknown" {
+		return false
+	}
+	switch scannerName {
+	case "skill", "skill-scanner", "skill_scanner",
+		"mcp", "mcp-scanner", "mcp_scanner",
+		"plugin", "plugin-scanner", "plugin_scanner", "defenseclaw-plugin-scanner",
+		"aibom", "aibom-claw", "codeguard", "clawshield-vuln",
+		"clawshield-secrets", "clawshield-pii", "clawshield-malware", "clawshield-injection":
+		return true
+	default:
+		return false
+	}
+}
+
+type persistedFindingState struct {
+	State             string
+	Severity          scanner.Severity
+	FirstSeenUnixNano int64
+	LastSeenUnixNano  int64
+}
+
+func applyFindingLifecycle(
+	tx *sql.Tx,
+	summary scanner.ScanSummaryParams,
+	findings []scanner.Finding,
+	meta scanner.ScanFindingMeta,
+) (scanner.FindingLifecycleDelta, error) {
+	delta := scanner.FindingLifecycleDelta{
+		Managed:           true,
+		Observations:      make([]scanner.FindingLifecycleObservation, 0, len(findings)),
+		GaugeDelta:        make(map[scanner.Severity]int64),
+		CurrentBySeverity: make(map[scanner.Severity]int64),
+	}
+	scopeScanner := strings.ToLower(strings.TrimSpace(summary.Scanner))
+	targetType := scanner.NormalizeFindingStateTargetType(summary.TargetType)
+	if targetType == "" {
+		targetType = scanner.NormalizeFindingStateTargetType(scanner.InferTargetType(summary.Scanner))
+	}
+	normalizedTarget := scanner.NormalizeFindingStateTarget(summary.Target)
+	observedAt := summary.Timestamp.UTC()
+	if observedAt.IsZero() {
+		observedAt = meta.Timestamp.UTC()
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	}
+	observedUnixNano := observedAt.UnixNano()
+	observedText := observedAt.Format(time.RFC3339Nano)
+
+	var priorScopeUnixNano int64
+	var priorScopeScanID string
+	scopeErr := tx.QueryRow(`
+		SELECT last_completed_unix_nano, last_scan_id FROM finding_scopes
+		WHERE scope_scanner = ? AND target_type = ? AND normalized_target = ?`,
+		scopeScanner, targetType, normalizedTarget,
+	).Scan(&priorScopeUnixNano, &priorScopeScanID)
+	if scopeErr != nil && !errors.Is(scopeErr, sql.ErrNoRows) {
+		return scanner.FindingLifecycleDelta{}, fmt.Errorf("audit: read finding scope: %w", scopeErr)
+	}
+	isNewestCompleteScan := errors.Is(scopeErr, sql.ErrNoRows) || observedUnixNano >= priorScopeUnixNano
+	seen := make(map[string]struct{}, len(findings))
+
+	for index := range findings {
+		finding := findings[index]
+		identity := scanner.StableFindingStateIdentity(summary.Scanner, targetType, summary.Target, finding)
+		seen[identity.Fingerprint] = struct{}{}
+		observation := scanner.FindingLifecycleObservation{
+			OccurrenceID: finding.FindingOccurrenceID,
+			Fingerprint:  identity.Fingerprint,
+			RuleID:       finding.RuleID,
+			Severity:     finding.Severity,
+			Status:       scanner.FindingLifecycleRepeated,
+		}
+
+		prior, found, readErr := readPersistedFindingState(tx, identity.Fingerprint)
+		if readErr != nil {
+			return scanner.FindingLifecycleDelta{}, readErr
+		}
+		if !isNewestCompleteScan {
+			if found {
+				firstSeen := prior.FirstSeenUnixNano
+				if observedUnixNano < firstSeen {
+					firstSeen = observedUnixNano
+				}
+				if _, err := tx.Exec(`UPDATE finding_states
+					SET occurrence_count = occurrence_count + 1,
+					    first_seen = ?, first_seen_unix_nano = ?
+					WHERE fingerprint = ?`,
+					time.Unix(0, firstSeen).UTC().Format(time.RFC3339Nano), firstSeen,
+					identity.Fingerprint,
+				); err != nil {
+					return scanner.FindingLifecycleDelta{}, fmt.Errorf("audit: count stale finding occurrence: %w", err)
+				}
+			} else if err := insertFindingState(
+				tx, summary, targetType, finding, identity, observedText, observedUnixNano,
+				findingStateResolved, time.Unix(0, priorScopeUnixNano).UTC(), priorScopeScanID,
+			); err != nil {
+				return scanner.FindingLifecycleDelta{}, err
+			} else {
+				// A previously unknown observation from an older completed scan is
+				// historical rather than current, but it is still a distinct forensic
+				// transition and must retain its matching scan_findings row.
+				observation.PersistOccurrence = true
+			}
+			delta.Observations = append(delta.Observations, observation)
+			continue
+		}
+
+		switch {
+		case !found:
+			if err := insertFindingState(
+				tx, summary, targetType, finding, identity, observedText, observedUnixNano,
+				findingStateActive, time.Time{}, "",
+			); err != nil {
+				return scanner.FindingLifecycleDelta{}, err
+			}
+			observation.Status = scanner.FindingLifecycleNew
+			observation.PersistOccurrence = true
+			delta.GaugeDelta[finding.Severity]++
+		case observedUnixNano < prior.LastSeenUnixNano:
+			firstSeen := prior.FirstSeenUnixNano
+			if observedUnixNano < firstSeen {
+				firstSeen = observedUnixNano
+			}
+			if _, err := tx.Exec(`UPDATE finding_states
+				SET occurrence_count = occurrence_count + 1,
+				    first_seen = ?, first_seen_unix_nano = ?
+				WHERE fingerprint = ?`,
+				time.Unix(0, firstSeen).UTC().Format(time.RFC3339Nano), firstSeen,
+				identity.Fingerprint,
+			); err != nil {
+				return scanner.FindingLifecycleDelta{}, fmt.Errorf("audit: count out-of-order finding occurrence: %w", err)
+			}
+		default:
+			if prior.State == findingStateResolved {
+				observation.Status = scanner.FindingLifecycleReopened
+				observation.PersistOccurrence = true
+				delta.GaugeDelta[finding.Severity]++
+			} else if prior.Severity != finding.Severity {
+				observation.Status = scanner.FindingLifecycleUpdated
+				observation.PersistOccurrence = true
+				delta.GaugeDelta[prior.Severity]--
+				delta.GaugeDelta[finding.Severity]++
+			}
+			if err := updateFindingState(
+				tx, summary, finding, identity, observedText, observedUnixNano,
+				observation.Status != scanner.FindingLifecycleRepeated,
+			); err != nil {
+				return scanner.FindingLifecycleDelta{}, err
+			}
+		}
+		delta.Observations = append(delta.Observations, observation)
+	}
+
+	if isNewestCompleteScan {
+		rows, err := tx.Query(`SELECT fingerprint, rule_id, severity
+			FROM finding_states
+			WHERE scope_scanner = ? AND target_type = ? AND normalized_target = ?
+			  AND state = 'active'`, scopeScanner, targetType, normalizedTarget)
+		if err != nil {
+			return scanner.FindingLifecycleDelta{}, fmt.Errorf("audit: list active finding states: %w", err)
+		}
+		type activeState struct {
+			fingerprint string
+			ruleID      string
+			severity    scanner.Severity
+		}
+		active := make([]activeState, 0)
+		for rows.Next() {
+			var state activeState
+			if err := rows.Scan(&state.fingerprint, &state.ruleID, &state.severity); err != nil {
+				rows.Close()
+				return scanner.FindingLifecycleDelta{}, fmt.Errorf("audit: scan active finding state: %w", err)
+			}
+			active = append(active, state)
+		}
+		if err := rows.Close(); err != nil {
+			return scanner.FindingLifecycleDelta{}, fmt.Errorf("audit: close active finding states: %w", err)
+		}
+		for _, state := range active {
+			if _, present := seen[state.fingerprint]; present {
+				continue
+			}
+			if _, err := tx.Exec(`UPDATE finding_states
+				SET state = 'resolved', resolved_at = ?, resolved_at_unix_nano = ?,
+				    last_scan_id = ? WHERE fingerprint = ? AND state = 'active'`,
+				observedText, observedUnixNano, summary.ScanID, state.fingerprint,
+			); err != nil {
+				return scanner.FindingLifecycleDelta{}, fmt.Errorf("audit: resolve finding state: %w", err)
+			}
+			delta.Resolved = append(delta.Resolved, scanner.FindingLifecycleResolution{
+				Fingerprint: state.fingerprint, RuleID: state.ruleID, Severity: state.severity,
+			})
+			delta.GaugeDelta[state.severity]--
+		}
+
+		if _, err := tx.Exec(`INSERT INTO finding_scopes (
+			scope_scanner, target_type, normalized_target, target,
+			last_completed_at, last_completed_unix_nano, last_scan_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(scope_scanner, target_type, normalized_target) DO UPDATE SET
+			target = excluded.target,
+			last_completed_at = excluded.last_completed_at,
+			last_completed_unix_nano = excluded.last_completed_unix_nano,
+			last_scan_id = excluded.last_scan_id`,
+			scopeScanner, targetType, normalizedTarget, summary.Target,
+			observedText, observedUnixNano, summary.ScanID,
+		); err != nil {
+			return scanner.FindingLifecycleDelta{}, fmt.Errorf("audit: update finding scope: %w", err)
+		}
+	}
+
+	countRows, err := tx.Query(`SELECT severity, COUNT(*) FROM finding_states
+		WHERE scope_scanner = ? AND target_type = ? AND normalized_target = ?
+		  AND state = 'active' GROUP BY severity`, scopeScanner, targetType, normalizedTarget)
+	if err != nil {
+		return scanner.FindingLifecycleDelta{}, fmt.Errorf("audit: count current finding states: %w", err)
+	}
+	for countRows.Next() {
+		var severity scanner.Severity
+		var count int64
+		if err := countRows.Scan(&severity, &count); err != nil {
+			countRows.Close()
+			return scanner.FindingLifecycleDelta{}, fmt.Errorf("audit: scan current finding count: %w", err)
+		}
+		delta.CurrentBySeverity[severity] = count
+	}
+	if err := countRows.Close(); err != nil {
+		return scanner.FindingLifecycleDelta{}, fmt.Errorf("audit: close current finding counts: %w", err)
+	}
+	return delta, nil
+}
+
+func readPersistedFindingState(tx *sql.Tx, fingerprint string) (persistedFindingState, bool, error) {
+	var state persistedFindingState
+	err := tx.QueryRow(`SELECT state, severity, first_seen_unix_nano, last_seen_unix_nano
+		FROM finding_states WHERE fingerprint = ?`, fingerprint).Scan(
+		&state.State, &state.Severity, &state.FirstSeenUnixNano, &state.LastSeenUnixNano,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return persistedFindingState{}, false, nil
+	}
+	if err != nil {
+		return persistedFindingState{}, false, fmt.Errorf("audit: read finding state: %w", err)
+	}
+	return state, true, nil
+}
+
+func insertFindingState(
+	tx *sql.Tx,
+	summary scanner.ScanSummaryParams,
+	targetType string,
+	finding scanner.Finding,
+	identity scanner.FindingStateIdentity,
+	observedText string,
+	observedUnixNano int64,
+	state string,
+	resolvedAt time.Time,
+	resolvedScanID string,
+) error {
+	tags, _ := json.Marshal(finding.Tags)
+	findingScanner := strings.TrimSpace(finding.Scanner)
+	if findingScanner == "" {
+		findingScanner = summary.Scanner
+	}
+	var resolvedText any
+	var resolvedUnixNano any
+	if state == findingStateResolved {
+		resolvedText = resolvedAt.UTC().Format(time.RFC3339Nano)
+		resolvedUnixNano = resolvedAt.UnixNano()
+	}
+	lastScanID := summary.ScanID
+	if resolvedScanID != "" {
+		lastScanID = resolvedScanID
+	}
+	_, err := tx.Exec(`INSERT INTO finding_states (
+		fingerprint, scope_scanner, finding_scanner, target, normalized_target,
+		target_type, rule_id, file_path, normalized_file_path, line_number,
+		content_digest, severity, title, description, evidence_summary, location,
+		remediation, tags, first_seen, first_seen_unix_nano, last_seen,
+		last_seen_unix_nano, resolved_at, resolved_at_unix_nano, occurrence_count,
+		state, first_scan_id, last_scan_id, last_occurrence_id
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?)`,
+		identity.Fingerprint, strings.ToLower(strings.TrimSpace(summary.Scanner)), findingScanner,
+		summary.Target, identity.NormalizedTarget, targetType,
+		finding.RuleID, identity.FilePath, identity.NormalizedFilePath, identity.LineNumber,
+		identity.ContentDigest, string(finding.Severity), finding.Title, nullStr(finding.Description),
+		nullStr(finding.EvidenceSummary), nullStr(finding.Location), nullStr(finding.Remediation),
+		string(tags), observedText, observedUnixNano, observedText, observedUnixNano,
+		resolvedText, resolvedUnixNano, state, summary.ScanID, lastScanID,
+		finding.FindingOccurrenceID,
+	)
+	if err != nil {
+		return fmt.Errorf("audit: insert finding state: %w", err)
+	}
+	return nil
+}
+
+func updateFindingState(
+	tx *sql.Tx,
+	summary scanner.ScanSummaryParams,
+	finding scanner.Finding,
+	identity scanner.FindingStateIdentity,
+	observedText string,
+	observedUnixNano int64,
+	meaningfulTransition bool,
+) error {
+	tags, _ := json.Marshal(finding.Tags)
+	findingScanner := strings.TrimSpace(finding.Scanner)
+	if findingScanner == "" {
+		findingScanner = summary.Scanner
+	}
+	lastOccurrenceID := "last_occurrence_id"
+	args := []any{
+		findingScanner, summary.Target, finding.RuleID, identity.FilePath,
+		identity.NormalizedFilePath, identity.LineNumber, identity.ContentDigest,
+		string(finding.Severity), finding.Title, nullStr(finding.Description),
+		nullStr(finding.EvidenceSummary), nullStr(finding.Location), nullStr(finding.Remediation),
+		string(tags), observedText, observedUnixNano, summary.ScanID,
+	}
+	if meaningfulTransition {
+		lastOccurrenceID = "?"
+		args = append(args, finding.FindingOccurrenceID)
+	}
+	args = append(args, identity.Fingerprint)
+	_, err := tx.Exec(`UPDATE finding_states SET
+		finding_scanner = ?, target = ?, rule_id = ?, file_path = ?,
+		normalized_file_path = ?, line_number = ?, content_digest = ?, severity = ?,
+		title = ?, description = ?, evidence_summary = ?, location = ?, remediation = ?,
+		tags = ?, last_seen = ?, last_seen_unix_nano = ?, resolved_at = NULL,
+		resolved_at_unix_nano = NULL, occurrence_count = occurrence_count + 1,
+		state = 'active', last_scan_id = ?, last_occurrence_id = `+lastOccurrenceID+`
+		WHERE fingerprint = ?`, args...)
+	if err != nil {
+		return fmt.Errorf("audit: update finding state: %w", err)
+	}
+	return nil
+}

--- a/internal/audit/finding_state_test.go
+++ b/internal/audit/finding_state_test.go
@@ -1,0 +1,368 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package audit
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/defenseclaw/defenseclaw/internal/scanner"
+)
+
+func emitFindingLifecycleScan(
+	t *testing.T,
+	store *Store,
+	result *scanner.ScanResult,
+	agent scanner.AgentIdentity,
+) string {
+	t.Helper()
+	scanID, err := scanner.EmitScanResult(context.Background(), store, result, agent)
+	if err != nil {
+		t.Fatalf("EmitScanResult: %v", err)
+	}
+	return scanID
+}
+
+func lifecycleFinding(evidence string, severity scanner.Severity) scanner.Finding {
+	line := 7
+	return scanner.Finding{
+		Scanner: "codeguard", RuleID: "CG-LIFECYCLE", Severity: severity,
+		Title: "Lifecycle finding", Description: "presentation", EvidenceSummary: evidence,
+		Location: `C:\repo\main.go:7`, LineNumber: &line, Tags: []string{"code"},
+	}
+}
+
+func lifecycleResult(at time.Time, findings ...scanner.Finding) *scanner.ScanResult {
+	return &scanner.ScanResult{
+		Scanner: "codeguard", Target: `C:\repo`, TargetType: "code", Timestamp: at,
+		Duration: time.Millisecond, Findings: findings,
+	}
+}
+
+func TestFindingLifecycleMigrationCreatesIdentityProjection(t *testing.T) {
+	store := newTestLogger(t).store
+	if present, err := store.hasColumn("scan_findings", "finding_fingerprint"); err != nil || !present {
+		t.Fatalf("scan occurrence fingerprint column present=%t err=%v", present, err)
+	}
+	for _, object := range []struct {
+		kind string
+		name string
+	}{
+		{kind: "table", name: "finding_scopes"},
+		{kind: "table", name: "finding_states"},
+		{kind: "index", name: "idx_scan_findings_finding_fingerprint"},
+		{kind: "index", name: "idx_finding_states_scope_state"},
+		{kind: "index", name: "idx_finding_states_resolved_at"},
+	} {
+		var count int
+		if err := store.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type=? AND name=?`,
+			object.kind, object.name).Scan(&count); err != nil || count != 1 {
+			t.Errorf("migration object %s/%s count=%d err=%v", object.kind, object.name, count, err)
+		}
+	}
+}
+
+func TestFindingLifecycleCompactsRepeatedStaticStorageAndDeduplicatesCurrentState(t *testing.T) {
+	store := newTestLogger(t).store
+	base := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	first := lifecycleResult(base, lifecycleFinding("same matched bytes", scanner.SeverityHigh))
+	firstScanID := emitFindingLifecycleScan(t, store, first, scanner.AgentIdentity{})
+	if first.FindingLifecycle == nil || !first.FindingLifecycle.Managed ||
+		len(first.FindingLifecycle.Observations) != 1 ||
+		first.FindingLifecycle.Observations[0].Status != scanner.FindingLifecycleNew ||
+		first.FindingLifecycle.GaugeDelta[scanner.SeverityHigh] != 1 {
+		t.Fatalf("first lifecycle delta=%+v", first.FindingLifecycle)
+	}
+
+	second := lifecycleResult(base.Add(time.Minute), lifecycleFinding("same matched bytes", scanner.SeverityHigh))
+	secondScanID := emitFindingLifecycleScan(t, store, second, scanner.AgentIdentity{})
+	if second.FindingLifecycle == nil || len(second.FindingLifecycle.Observations) != 1 ||
+		second.FindingLifecycle.Observations[0].Status != scanner.FindingLifecycleRepeated ||
+		len(second.FindingLifecycle.GaugeDelta) != 0 {
+		t.Fatalf("repeat lifecycle delta=%+v", second.FindingLifecycle)
+	}
+	lastScanID := secondScanID
+	for scanNumber := 3; scanNumber <= 263; scanNumber++ {
+		repeated := lifecycleResult(
+			base.Add(time.Duration(scanNumber-1)*time.Minute),
+			lifecycleFinding("same matched bytes", scanner.SeverityHigh),
+		)
+		lastScanID = emitFindingLifecycleScan(t, store, repeated, scanner.AgentIdentity{})
+		if got := repeated.FindingLifecycle; got == nil || len(got.Observations) != 1 ||
+			got.Observations[0].Status != scanner.FindingLifecycleRepeated {
+			t.Fatalf("repeat %d lifecycle delta=%+v", scanNumber, got)
+		}
+	}
+
+	states, err := store.ListFindingStates("codeguard", `C:\repo`, false, 10)
+	if err != nil || len(states) != 1 {
+		t.Fatalf("active distinct states=%+v err=%v", states, err)
+	}
+	if states[0].OccurrenceCount != 263 || states[0].FirstSeen != base ||
+		states[0].LastSeen != base.Add(262*time.Minute) || states[0].FirstScanID != firstScanID ||
+		states[0].LastScanID != lastScanID || states[0].State != findingStateActive {
+		t.Fatalf("deduplicated state=%+v", states[0])
+	}
+	if states[0].LastOccurrenceID != first.Findings[0].FindingOccurrenceID ||
+		first.Findings[0].FindingOccurrenceID == second.Findings[0].FindingOccurrenceID {
+		t.Fatalf("transition/repeat identities mismatch: first=%q second=%q state=%q",
+			first.Findings[0].FindingOccurrenceID, second.Findings[0].FindingOccurrenceID,
+			states[0].LastOccurrenceID)
+	}
+	firstRows, listErr := store.ListScanFindings(firstScanID)
+	if listErr != nil || len(firstRows) != 1 || !firstRows[0].FindingFingerprint.Valid ||
+		firstRows[0].FindingFingerprint.String != states[0].Fingerprint {
+		t.Fatalf("first transition rows=%+v err=%v", firstRows, listErr)
+	}
+	secondRows, listErr := store.ListScanFindings(secondScanID)
+	if listErr != nil || len(secondRows) != 0 {
+		t.Fatalf("repeat scan added detail rows=%+v err=%v", secondRows, listErr)
+	}
+	var detailCount int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM scan_findings`).Scan(&detailCount); err != nil || detailCount != 1 {
+		t.Fatalf("static transition detail count=%d err=%v", detailCount, err)
+	}
+}
+
+func TestQueryFindingStatesDefaultsCurrentAndSupportsSinceAndNewOnly(t *testing.T) {
+	store := newTestLogger(t).store
+	base := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	first := lifecycleFinding("first bytes", scanner.SeverityHigh)
+	first.RuleID = "CG-FIRST"
+	emitFindingLifecycleScan(t, store, lifecycleResult(base, first), scanner.AgentIdentity{})
+
+	second := lifecycleFinding("second bytes", scanner.SeverityMedium)
+	second.RuleID = "CG-SECOND"
+	emitFindingLifecycleScan(t, store, lifecycleResult(base.Add(time.Hour), first, second), scanner.AgentIdentity{})
+	emitFindingLifecycleScan(t, store, lifecycleResult(base.Add(2*time.Hour), second), scanner.AgentIdentity{})
+
+	current, err := store.QueryFindingStates(FindingStateQuery{})
+	if err != nil || len(current) != 1 || current[0].RuleID != "CG-SECOND" || current[0].State != findingStateActive {
+		t.Fatalf("default current state=%+v err=%v", current, err)
+	}
+	cutoff := base.Add(30 * time.Minute)
+	changed, err := store.QueryFindingStates(FindingStateQuery{
+		IncludeResolved: true, Since: &cutoff, Limit: 10,
+	})
+	if err != nil || len(changed) != 2 {
+		t.Fatalf("states changed since cutoff=%+v err=%v", changed, err)
+	}
+	total, err := store.CountFindingStates(FindingStateQuery{
+		IncludeResolved: true, Since: &cutoff, Limit: 1,
+	})
+	if err != nil || total != 2 {
+		t.Fatalf("distinct total ignoring page limit=%d err=%v", total, err)
+	}
+	limited, err := store.QueryFindingStates(FindingStateQuery{
+		IncludeResolved: true, Since: &cutoff, Limit: 1,
+	})
+	if err != nil || len(limited) != 1 {
+		t.Fatalf("bounded distinct page=%+v err=%v", limited, err)
+	}
+	snapshotRows, snapshotCount, err := store.QueryFindingStatesWithCount(
+		context.Background(),
+		FindingStateQuery{IncludeResolved: true, Since: &cutoff, Limit: 1},
+	)
+	if err != nil || len(snapshotRows) != 1 || snapshotCount != 2 {
+		t.Fatalf("snapshot page=%+v count=%d err=%v", snapshotRows, snapshotCount, err)
+	}
+	newOnly, err := store.QueryFindingStates(FindingStateQuery{
+		IncludeResolved: true, Since: &cutoff, NewOnly: true, Limit: 10,
+	})
+	if err != nil || len(newOnly) != 1 || newOnly[0].RuleID != "CG-SECOND" {
+		t.Fatalf("new states since cutoff=%+v err=%v", newOnly, err)
+	}
+	lateCutoff := base.Add(90 * time.Minute)
+	resolvedDelta, err := store.QueryFindingStates(FindingStateQuery{
+		IncludeResolved: true, Since: &lateCutoff, Limit: 10,
+	})
+	if err != nil || len(resolvedDelta) != 2 {
+		t.Fatalf("last-seen/resolution delta=%+v err=%v", resolvedDelta, err)
+	}
+}
+
+func TestFindingLifecycleResolvesChangesEmptyScansAndReopens(t *testing.T) {
+	store := newTestLogger(t).store
+	base := time.Date(2026, 8, 2, 10, 0, 0, 0, time.UTC)
+	original := lifecycleResult(base, lifecycleFinding("original bytes", scanner.SeverityHigh))
+	emitFindingLifecycleScan(t, store, original, scanner.AgentIdentity{})
+
+	changed := lifecycleResult(base.Add(time.Minute), lifecycleFinding("changed bytes", scanner.SeverityHigh))
+	emitFindingLifecycleScan(t, store, changed, scanner.AgentIdentity{})
+	if got := changed.FindingLifecycle; got == nil || len(got.Observations) != 1 ||
+		got.Observations[0].Status != scanner.FindingLifecycleNew || len(got.Resolved) != 1 {
+		t.Fatalf("content-change delta=%+v", got)
+	}
+	all, err := store.ListFindingStates("codeguard", `C:\repo`, true, 10)
+	if err != nil || len(all) != 2 {
+		t.Fatalf("content-addressed history=%+v err=%v", all, err)
+	}
+
+	empty := lifecycleResult(base.Add(2 * time.Minute))
+	emitFindingLifecycleScan(t, store, empty, scanner.AgentIdentity{})
+	if got := empty.FindingLifecycle; got == nil || len(got.Resolved) != 1 ||
+		got.GaugeDelta[scanner.SeverityHigh] != -1 {
+		t.Fatalf("empty-scan resolution=%+v", got)
+	}
+	active, err := store.ListFindingStates("codeguard", `C:\repo`, false, 10)
+	if err != nil || len(active) != 0 {
+		t.Fatalf("active states after complete empty scan=%+v err=%v", active, err)
+	}
+
+	reopened := lifecycleResult(base.Add(3*time.Minute), lifecycleFinding("changed bytes", scanner.SeverityHigh))
+	emitFindingLifecycleScan(t, store, reopened, scanner.AgentIdentity{})
+	if got := reopened.FindingLifecycle; got == nil || len(got.Observations) != 1 ||
+		got.Observations[0].Status != scanner.FindingLifecycleReopened ||
+		got.GaugeDelta[scanner.SeverityHigh] != 1 {
+		t.Fatalf("reopen delta=%+v", got)
+	}
+	active, err = store.ListFindingStates("codeguard", `C:\repo`, false, 10)
+	if err != nil || len(active) != 1 || active[0].OccurrenceCount != 2 || active[0].ResolvedAt != nil {
+		t.Fatalf("reopened state=%+v err=%v", active, err)
+	}
+}
+
+func TestFindingLifecycleSeverityUpdateAndOutOfOrderScan(t *testing.T) {
+	store := newTestLogger(t).store
+	base := time.Date(2026, 8, 3, 10, 0, 0, 0, time.UTC)
+	current := lifecycleResult(base.Add(2*time.Minute),
+		lifecycleFinding("same bytes", scanner.SeverityHigh),
+		lifecycleFinding("second bytes", scanner.SeverityMedium),
+	)
+	current.Findings[1].RuleID = "CG-SECOND"
+	emitFindingLifecycleScan(t, store, current, scanner.AgentIdentity{})
+
+	older := lifecycleResult(base, lifecycleFinding("same bytes", scanner.SeverityLow))
+	emitFindingLifecycleScan(t, store, older, scanner.AgentIdentity{})
+	if got := older.FindingLifecycle; got == nil || len(got.Resolved) != 0 ||
+		len(got.Observations) != 1 || got.Observations[0].Status != scanner.FindingLifecycleRepeated {
+		t.Fatalf("out-of-order delta=%+v", got)
+	}
+	active, err := store.ListFindingStates("codeguard", `C:\repo`, false, 10)
+	if err != nil || len(active) != 2 {
+		t.Fatalf("out-of-order active states=%+v err=%v", active, err)
+	}
+	for _, state := range active {
+		if state.RuleID == "CG-LIFECYCLE" &&
+			(state.Severity != string(scanner.SeverityHigh) || state.FirstSeen != base ||
+				state.LastSeen != base.Add(2*time.Minute) || state.OccurrenceCount != 2) {
+			t.Fatalf("out-of-order scan overwrote current state: %+v", state)
+		}
+		if state.State != findingStateActive {
+			t.Fatalf("out-of-order scan resolved current state: %+v", state)
+		}
+	}
+
+	updated := lifecycleResult(base.Add(3*time.Minute), lifecycleFinding("same bytes", scanner.SeverityCritical))
+	emitFindingLifecycleScan(t, store, updated, scanner.AgentIdentity{})
+	if got := updated.FindingLifecycle; got == nil || len(got.Observations) != 1 ||
+		got.Observations[0].Status != scanner.FindingLifecycleUpdated ||
+		got.GaugeDelta[scanner.SeverityHigh] != -1 ||
+		got.GaugeDelta[scanner.SeverityCritical] != 1 || len(got.Resolved) != 1 {
+		t.Fatalf("severity update delta=%+v", got)
+	}
+}
+
+func TestFindingLifecycleFailedAndRuntimeScansDoNotMutateCurrentState(t *testing.T) {
+	store := newTestLogger(t).store
+	base := time.Date(2026, 8, 4, 10, 0, 0, 0, time.UTC)
+	initial := lifecycleResult(base, lifecycleFinding("same bytes", scanner.SeverityHigh))
+	emitFindingLifecycleScan(t, store, initial, scanner.AgentIdentity{})
+
+	failed := lifecycleResult(base.Add(time.Minute))
+	failed.ExitCode = 2
+	failed.ScanError = "scanner failed"
+	emitFindingLifecycleScan(t, store, failed, scanner.AgentIdentity{})
+	if failed.FindingLifecycle == nil || failed.FindingLifecycle.Managed {
+		t.Fatalf("failed scan entered lifecycle=%+v", failed.FindingLifecycle)
+	}
+	active, err := store.ListFindingStates("codeguard", `C:\repo`, false, 10)
+	if err != nil || len(active) != 1 || active[0].OccurrenceCount != 1 {
+		t.Fatalf("failed scan changed current state=%+v err=%v", active, err)
+	}
+
+	for i := 0; i < 2; i++ {
+		runtime := &scanner.ScanResult{
+			Scanner: "hook-rules", Target: "codex:PreToolUse", TargetType: "tool_call",
+			Timestamp: base.Add(time.Duration(i+2) * time.Minute),
+			Findings: []scanner.Finding{{
+				Scanner: "hook-rules", RuleID: "RUNTIME-RULE", Severity: scanner.SeverityHigh,
+				EvidenceSummary: "same runtime bytes",
+			}},
+		}
+		emitFindingLifecycleScan(t, store, runtime, scanner.AgentIdentity{EvaluationID: "runtime-evaluation"})
+		if runtime.FindingLifecycle == nil || runtime.FindingLifecycle.Managed {
+			t.Fatalf("runtime occurrence entered lifecycle=%+v", runtime.FindingLifecycle)
+		}
+	}
+	misclassifiedRuntime := &scanner.ScanResult{
+		Scanner: "hook-rules", Target: "runtime-target", TargetType: "file",
+		Timestamp: base.Add(4 * time.Minute),
+		Findings:  []scanner.Finding{lifecycleFinding("runtime bytes", scanner.SeverityHigh)},
+	}
+	emitFindingLifecycleScan(t, store, misclassifiedRuntime, scanner.AgentIdentity{})
+	if misclassifiedRuntime.FindingLifecycle == nil || misclassifiedRuntime.FindingLifecycle.Managed {
+		t.Fatalf("runtime scanner name was overridden by asset-looking target type: %+v",
+			misclassifiedRuntime.FindingLifecycle)
+	}
+	var runtimeOccurrences int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM scan_findings WHERE evaluation_id = ?`,
+		"runtime-evaluation").Scan(&runtimeOccurrences); err != nil || runtimeOccurrences != 2 {
+		t.Fatalf("runtime occurrences=%d err=%v", runtimeOccurrences, err)
+	}
+	var runtimeStates int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM finding_states WHERE scope_scanner='hook-rules'`).Scan(&runtimeStates); err != nil || runtimeStates != 0 {
+		t.Fatalf("runtime distinct states=%d err=%v", runtimeStates, err)
+	}
+}
+
+func TestFindingLifecyclePersistenceRollsBackAllRowsOnStateFailure(t *testing.T) {
+	store := newTestLogger(t).store
+	base := time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC)
+	initial := lifecycleResult(base, lifecycleFinding("same bytes", scanner.SeverityHigh))
+	emitFindingLifecycleScan(t, store, initial, scanner.AgentIdentity{})
+	if _, err := store.db.Exec(`CREATE TRIGGER reject_finding_state_update
+		BEFORE UPDATE ON finding_states BEGIN SELECT RAISE(ABORT, 'state update rejected'); END`); err != nil {
+		t.Fatal(err)
+	}
+	repeated := lifecycleResult(base.Add(time.Minute), lifecycleFinding("same bytes", scanner.SeverityHigh))
+	_, err := scanner.EmitScanResult(context.Background(), store, repeated, scanner.AgentIdentity{})
+	if err == nil || !strings.Contains(err.Error(), "state update rejected") {
+		t.Fatalf("state failure was not returned: %v", err)
+	}
+	for table, want := range map[string]int{"scan_results": 1, "scan_findings": 1, "finding_states": 1} {
+		var got int
+		if queryErr := store.db.QueryRow(`SELECT COUNT(*) FROM ` + table).Scan(&got); queryErr != nil || got != want {
+			t.Errorf("atomic rollback %s count=%d want=%d err=%v", table, got, want, queryErr)
+		}
+	}
+	states, err := store.ListFindingStates("codeguard", `C:\repo`, false, 10)
+	if err != nil || len(states) != 1 || states[0].OccurrenceCount != 1 {
+		t.Fatalf("state changed after rollback=%+v err=%v", states, err)
+	}
+}
+
+func TestFindingLifecycleStateSurvivesOccurrenceRetention(t *testing.T) {
+	store, judge := newRetentionStores(t)
+	now := time.Date(2026, 8, 6, 10, 0, 0, 0, time.UTC)
+	result := lifecycleResult(now.Add(-60*24*time.Hour), lifecycleFinding("retained state", scanner.SeverityHigh))
+	emitFindingLifecycleScan(t, store, result, scanner.AgentIdentity{})
+	reaper := newRetentionReaperAt(t, store, judge, 30, now, RetentionOptions{}, retentionHooks{})
+	if _, err := reaper.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for _, table := range []string{"scan_results", "scan_findings"} {
+		var count int
+		if err := store.db.QueryRow(`SELECT COUNT(*) FROM ` + table).Scan(&count); err != nil || count != 0 {
+			t.Errorf("retained occurrence table %s count=%d err=%v", table, count, err)
+		}
+	}
+	states, err := store.ListFindingStates("codeguard", `C:\repo`, false, 10)
+	if err != nil || len(states) != 1 || states[0].State != findingStateActive {
+		t.Fatalf("protected current state=%+v err=%v", states, err)
+	}
+}

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -90,9 +90,11 @@ func stampAuditEventEnvelope(e *Event) {
 }
 
 // Logger is the audit choke point for generated v8 records and metrics.
-// SQLite persistence and destination fanout are owned by the bound v8 runtime;
-// the removed v7 sink, gateway.jsonl, and structured-emitter bridges cannot be
-// re-enabled by configuration or by temporarily detaching the runtime.
+// Destination fanout is owned by the bound v8 runtime; the removed v7 sink,
+// gateway.jsonl, and structured-emitter bridges cannot be re-enabled by
+// configuration or by temporarily detaching the runtime. Short-lived operator
+// commands that intentionally do not start that runtime use
+// PersistStandaloneScan to commit only the canonical forensic scan state.
 type Logger struct {
 	store *Store
 
@@ -121,6 +123,9 @@ func (l *Logger) SetRuntimeV8Emitter(emitter RuntimeV8Emitter) {
 	l.mu.Lock()
 	l.runtimeV8 = emitter
 	l.mu.Unlock()
+	if l.store != nil {
+		l.store.resetFindingGaugeBaselines()
+	}
 }
 
 func (l *Logger) runtimeV8Snapshot() RuntimeV8Emitter {
@@ -214,6 +219,28 @@ func (l *Logger) LogScanWithVerdict(result *scanner.ScanResult, verdict string) 
 	return l.LogScanWithCorrelation(context.Background(), result, verdict, ScanCorrelation{})
 }
 
+// PersistStandaloneScan commits the canonical forensic rows and finding
+// lifecycle for a short-lived operator scan without requiring or invoking the
+// observability runtime. The caller supplies the installation-keyed
+// fingerprinter used to sanitize sensitive finding identities. A nil
+// fingerprinter is accepted for compatibility, but sensitive findings then use
+// a redacted.<kind>.unknown rule identity without a content fingerprint, which
+// weakens lifecycle identity and correlation. Long-lived runtime producers
+// must use LogScanWithCorrelation so generated logs and metrics cannot be
+// silently omitted after a runtime detach.
+func (l *Logger) PersistStandaloneScan(
+	result *scanner.ScanResult,
+	fingerprinter RuntimeV8FindingContentFingerprinter,
+) error {
+	if l == nil || l.store == nil {
+		return fmt.Errorf("audit: standalone scan store is unavailable")
+	}
+	_, err := l.persistScanWithCorrelation(
+		context.Background(), result, "", ScanCorrelation{}, fingerprinter,
+	)
+	return err
+}
+
 // LogScanWithCorrelation is the canonical scan emission entry point with
 // explicit correlation + identity. It threads run_id / request_id /
 // session_id / trace_id and the three-tier agent identity onto the forensic
@@ -233,8 +260,30 @@ func (l *Logger) LogScanWithCorrelation(
 	if binding.logBatch == nil {
 		return fmt.Errorf("audit: v8 scan log batch runtime is unavailable")
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	scanID, err := l.persistScanWithCorrelation(
+		ctx, result, verdict, corr, binding.findingContentFingerprinter,
+	)
+	if err != nil {
+		return err
+	}
+	return l.emitScanV8(ctx, binding, result, scanID, verdict, corr)
+}
+
+func (l *Logger) persistScanWithCorrelation(
+	ctx context.Context,
+	result *scanner.ScanResult,
+	verdict string,
+	corr ScanCorrelation,
+	fingerprinter RuntimeV8FindingContentFingerprinter,
+) (string, error) {
+	if l == nil {
+		return "", fmt.Errorf("audit: scan logger is unavailable")
+	}
 	if result == nil {
-		return fmt.Errorf("audit: cannot log a nil scan result")
+		return "", fmt.Errorf("audit: cannot log a nil scan result")
 	}
 
 	if verdict != "" {
@@ -255,7 +304,7 @@ func (l *Logger) LogScanWithCorrelation(
 				finding.EvidenceSummary = summary
 			}
 		}
-		fingerprintPersistedFindingEvidence(finding, binding.findingContentFingerprinter)
+		fingerprintPersistedFindingEvidence(finding, fingerprinter)
 		// This is the final in-memory boundary before forensic persistence
 		// and generated audit projection. Literal credentials and executable
 		// trust directives never cross it in cleartext, even when a producer
@@ -271,7 +320,7 @@ func (l *Logger) LogScanWithCorrelation(
 				finding,
 				result.Scanner,
 				sensitiveFindingKindSecret,
-				binding.findingContentFingerprinter,
+				fingerprinter,
 			)
 			redactPersistedCredentialFinding(finding)
 		} else if isPIIFinding(*finding) {
@@ -279,7 +328,7 @@ func (l *Logger) LogScanWithCorrelation(
 				finding,
 				result.Scanner,
 				sensitiveFindingKindPII,
-				binding.findingContentFingerprinter,
+				fingerprinter,
 			)
 			redactPersistedPIIFinding(finding)
 		} else if isTrustExploitFinding(*finding) {
@@ -287,7 +336,7 @@ func (l *Logger) LogScanWithCorrelation(
 				finding,
 				result.Scanner,
 				sensitiveFindingKindTrust,
-				binding.findingContentFingerprinter,
+				fingerprinter,
 			)
 			redactPersistedTrustExploitFinding(finding)
 		}
@@ -318,9 +367,9 @@ func (l *Logger) LogScanWithCorrelation(
 	// being revived by configuration or a concurrent reload.
 	scanID, err := scanner.EmitScanResult(ctx, l.store, result, agent)
 	if err != nil {
-		return err
+		return "", err
 	}
-	return l.emitScanV8(ctx, binding, result, scanID, verdict, corr)
+	return scanID, nil
 }
 
 // fingerprintPersistedFindingEvidence replaces every producer-supplied

--- a/internal/audit/retention_v8.go
+++ b/internal/audit/retention_v8.go
@@ -412,6 +412,7 @@ var retentionAuditMigrationCatalog = map[string]retentionOwnership{
 	"scan_findings": retentionOwnedHistory, "findings": retentionOwnedHistory,
 	"scan_results": retentionOwnedHistory, "judge_responses": retentionOwnedHistory,
 	"actions": retentionOwnedProtected, "target_snapshots": retentionOwnedProtected,
+	"finding_scopes": retentionOwnedProtected, "finding_states": retentionOwnedProtected,
 	"schema_version": retentionOwnedProtected, "observability_store_readiness": retentionOwnedProtected,
 	"alert_acknowledgement_projection":   retentionOwnedProtected,
 	"alert_acknowledgement_operations":   retentionOwnedProtected,

--- a/internal/audit/scan_persist.go
+++ b/internal/audit/scan_persist.go
@@ -21,12 +21,16 @@ var _ scanner.ScanPersistence = (*Store)(nil)
 
 // InsertScanSummary persists a v7 scan_results row (scan_id == id).
 func (s *Store) InsertScanSummary(p scanner.ScanSummaryParams) error {
+	return insertScanSummary(s.db, p)
+}
+
+func insertScanSummary(ex dbExecer, p scanner.ScanSummaryParams) error {
 	runID := p.RunID
 	if runID == "" {
 		runID = currentRunID()
 	}
 	ts := p.Timestamp.UTC().Format(time.RFC3339Nano)
-	_, err := s.db.Exec(`
+	_, err := ex.Exec(`
 INSERT INTO scan_results (
   id, scanner, target, timestamp, duration_ms, finding_count, max_severity, raw_json, run_id,
   verdict, exit_code, error,
@@ -66,6 +70,10 @@ INSERT INTO scan_results (
 
 // InsertScanFindings writes one row per finding into scan_findings.
 func (s *Store) InsertScanFindings(scanID, target string, findings []scanner.Finding, meta scanner.ScanFindingMeta) error {
+	return insertScanFindings(s.db, scanID, target, findings, meta)
+}
+
+func insertScanFindings(ex dbExecer, scanID, target string, findings []scanner.Finding, meta scanner.ScanFindingMeta) error {
 	if len(findings) == 0 {
 		return nil
 	}
@@ -107,8 +115,9 @@ func (s *Store) InsertScanFindings(scanID, target string, findings []scanner.Fin
 		id := f.FindingOccurrenceID
 		if id == "" {
 			id = uuid.New().String()
+			f.FindingOccurrenceID = id
 		}
-		_, err := s.db.Exec(`
+		_, err := ex.Exec(`
 INSERT INTO scan_findings (
   id, scan_id, scanner, target, rule_id, category, severity, title, description, evidence_summary, location, line_number,
   remediation, tags, timestamp,
@@ -160,20 +169,21 @@ INSERT INTO scan_findings (
 
 // ScanFindingRow is a scan_findings table projection for tests and APIs.
 type ScanFindingRow struct {
-	ID              string
-	ScanID          string
-	Scanner         string
-	Target          string
-	RuleID          sql.NullString
-	Category        sql.NullString
-	Severity        string
-	Title           sql.NullString
-	Description     sql.NullString
-	EvidenceSummary sql.NullString
-	Location        sql.NullString
-	LineNumber      sql.NullInt64
-	Remediation     sql.NullString
-	Tags            sql.NullString
+	ID                 string
+	ScanID             string
+	Scanner            string
+	Target             string
+	RuleID             sql.NullString
+	Category           sql.NullString
+	Severity           string
+	Title              sql.NullString
+	Description        sql.NullString
+	EvidenceSummary    sql.NullString
+	Location           sql.NullString
+	LineNumber         sql.NullInt64
+	Remediation        sql.NullString
+	Tags               sql.NullString
+	FindingFingerprint sql.NullString
 	// Confidence is the per-finding model/heuristic score (0.0-1.0).
 	// Populated for runtime detections (hooks, inspect, proxy
 	// guardrail, mid-stream); zero for classic scanner CLIs that
@@ -189,7 +199,7 @@ type ScanFindingRow struct {
 func (s *Store) ListScanFindings(scanID string) ([]ScanFindingRow, error) {
 	rows, err := s.db.Query(`
 SELECT id, scan_id, scanner, target, rule_id, category, severity, title, description, evidence_summary, location, line_number,
-       remediation, tags, confidence, evaluation_id
+       remediation, tags, finding_fingerprint, confidence, evaluation_id
 FROM scan_findings WHERE scan_id = ? ORDER BY severity`, scanID)
 	if err != nil {
 		return nil, fmt.Errorf("audit: list scan findings: %w", err)
@@ -204,6 +214,7 @@ FROM scan_findings WHERE scan_id = ? ORDER BY severity`, scanID)
 		if err := rows.Scan(
 			&r.ID, &r.ScanID, &r.Scanner, &r.Target, &r.RuleID, &r.Category,
 			&r.Severity, &r.Title, &r.Description, &r.EvidenceSummary, &r.Location, &r.LineNumber, &r.Remediation, &r.Tags,
+			&r.FindingFingerprint,
 			&confidence, &evaluationID,
 		); err != nil {
 			return nil, fmt.Errorf("audit: scan finding row: %w", err)

--- a/internal/audit/scan_v8.go
+++ b/internal/audit/scan_v8.go
@@ -20,10 +20,13 @@ import (
 	"github.com/google/uuid"
 )
 
-// emitScanV8 emits every finding before the finalized scan summary on one
-// immutable runtime generation. Each operation retains its own collection
-// decision; disabling security.finding does not suppress asset.scan and vice
-// versa. The scanner's forensic tables have already committed before entry.
+// emitScanV8 emits new or materially changed asset findings before the
+// finalized scan summary on one immutable runtime generation. Repeated asset
+// observations update the compact lifecycle state without growing the static
+// transition ledger or default event stream; runtime inspection occurrences
+// are always emitted. Each operation retains its own collection decision;
+// disabling security.finding does not suppress asset.scan and vice versa. The
+// scanner's forensic tables have already committed before entry.
 func (l *Logger) emitScanV8(
 	ctx context.Context,
 	binding runtimeV8Binding,
@@ -45,6 +48,10 @@ func (l *Logger) emitScanV8(
 	operations := make([]RuntimeV8LogOperation, 0, len(result.Findings)+1)
 	for index := range result.Findings {
 		finding := result.Findings[index]
+		if result.FindingLifecycle != nil &&
+			!result.FindingLifecycle.ShouldEmitOccurrence(finding.FindingOccurrenceID) {
+			continue
+		}
 		operation, err := scanFindingV8Operation(
 			ctx, finding, result, scanID, observedAt, correlation,
 		)
@@ -383,6 +390,23 @@ func newScanRuntimeV8GeneratedMetrics(
 	targetType := result.EffectiveTargetType()
 	durationMS := float64(result.Duration) / float64(time.Millisecond)
 	counts := scanV8SeverityCounts(result)
+	gaugeValues := counts
+	if lifecycle := result.FindingLifecycle; lifecycle != nil {
+		if lifecycle.Managed {
+			counts = make(map[scanner.Severity]int64)
+			for _, observation := range lifecycle.Observations {
+				if observation.Status != scanner.FindingLifecycleRepeated {
+					counts[observation.Severity]++
+				}
+			}
+			gaugeValues = lifecycle.GaugeDelta
+		} else {
+			// Runtime and failed scans are immutable occurrences rather than
+			// open asset state. They keep occurrence counters and logs, but must
+			// not accumulate forever in the current-open up/down counter.
+			gaugeValues = nil
+		}
+	}
 	type metricInput struct {
 		family                                                    observability.EventName
 		valueInt                                                  int64
@@ -398,17 +422,26 @@ func newScanRuntimeV8GeneratedMetrics(
 		scanner.SeverityCritical, scanner.SeverityHigh, scanner.SeverityMedium,
 		scanner.SeverityLow, scanner.SeverityInfo,
 	} {
-		count := counts[severity]
-		if count == 0 {
-			continue
+		if count := counts[severity]; count != 0 {
+			inputs = append(inputs, metricInput{
+				family:   observability.EventName(observability.TelemetryInstrumentDefenseClawScanFindings),
+				valueInt: count, scanner: result.Scanner, targetType: targetType,
+				connector: connector, severity: string(severity),
+			})
 		}
-		inputs = append(inputs,
-			metricInput{family: observability.EventName(observability.TelemetryInstrumentDefenseClawScanFindings), valueInt: count, scanner: result.Scanner, targetType: targetType, connector: connector, severity: string(severity)},
-			metricInput{family: observability.EventName(observability.TelemetryInstrumentDefenseClawScanFindingsGauge), valueInt: count, targetType: targetType, severity: string(severity)},
-		)
+		if value := gaugeValues[severity]; value != 0 {
+			inputs = append(inputs, metricInput{
+				family:   observability.EventName(observability.TelemetryInstrumentDefenseClawScanFindingsGauge),
+				valueInt: value, targetType: targetType, severity: string(severity),
+			})
+		}
 	}
 	for index := range result.Findings {
 		finding := result.Findings[index]
+		if result.FindingLifecycle != nil &&
+			!result.FindingLifecycle.ShouldEmitOccurrence(finding.FindingOccurrenceID) {
+			continue
+		}
 		inputs = append(inputs, metricInput{
 			family:   observability.EventName(observability.TelemetryInstrumentDefenseClawScanFindingsByRule),
 			valueInt: 1, scanner: result.Scanner, connector: connector,

--- a/internal/audit/scan_v8_test.go
+++ b/internal/audit/scan_v8_test.go
@@ -152,6 +152,144 @@ func TestScanV8FailureUsesFailedFamilyWithoutInventingFindingStatus(t *testing.T
 	}
 }
 
+func TestScanV8RepeatedAssetFindingOnlyEmitsLifecycleChanges(t *testing.T) {
+	logger := newTestLogger(t)
+	runtime := newTestRuntimeV8Emitter(t, logger.store, router.AdmissionOrdinary)
+	logger.SetRuntimeV8Emitter(runtime)
+	base := time.Date(2026, 8, 7, 10, 0, 0, 0, time.UTC)
+	newResult := func(at time.Time, findings ...scanner.Finding) *scanner.ScanResult {
+		return &scanner.ScanResult{
+			Scanner: "codeguard", Target: "asset/distinct", TargetType: "code",
+			Timestamp: at, Duration: time.Millisecond, Findings: findings,
+		}
+	}
+	newFinding := func() scanner.Finding {
+		return scanner.Finding{
+			Scanner: "codeguard", RuleID: "CG-DISTINCT", Severity: scanner.SeverityHigh,
+			Title: "Distinct finding", Description: "same matched source", Location: "main.go:7",
+		}
+	}
+
+	first := newResult(base, newFinding())
+	if err := logger.LogScan(first); err != nil {
+		t.Fatal(err)
+	}
+	_, firstRecords := runtime.snapshot()
+	firstMetrics := runtime.metricSnapshot()
+	if len(firstRecords) != 2 || firstRecords[0].EventName() != observability.EventName(observability.TelemetryEventFindingObserved) {
+		t.Fatalf("first records=%#v", firstRecords)
+	}
+
+	second := newResult(base.Add(time.Minute), newFinding())
+	if err := logger.LogScan(second); err != nil {
+		t.Fatal(err)
+	}
+	_, records := runtime.snapshot()
+	if len(records) != len(firstRecords)+1 ||
+		records[len(records)-1].EventName() != observability.EventName(observability.TelemetryEventScanCompleted) {
+		t.Fatalf("repeat emitted finding instead of summary only: before=%d after=%d", len(firstRecords), len(records))
+	}
+	repeatMetrics := runtime.metricSnapshot()[len(firstMetrics):]
+	for _, metric := range repeatMetrics {
+		switch metric.EventName() {
+		case observability.EventName(observability.TelemetryInstrumentDefenseClawScanFindings),
+			observability.EventName(observability.TelemetryInstrumentDefenseClawScanFindingsGauge),
+			observability.EventName(observability.TelemetryInstrumentDefenseClawScanFindingsByRule):
+			t.Fatalf("repeat emitted finding metric %s value=%v", metric.EventName(), metricValue(t, metric))
+		}
+	}
+	events, err := logger.store.ListEvents(100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	findingEvents := 0
+	for _, event := range events {
+		if event.Action == string(ActionScanFinding) {
+			findingEvents++
+		}
+	}
+	if findingEvents != 1 {
+		t.Fatalf("default event history has %d repeated finding events, want 1", findingEvents)
+	}
+	firstRows, listErr := logger.store.ListScanFindings(first.ScanID)
+	if listErr != nil || len(firstRows) != 1 {
+		t.Fatalf("first static transition %s=%+v err=%v", first.ScanID, firstRows, listErr)
+	}
+	repeatRows, listErr := logger.store.ListScanFindings(second.ScanID)
+	if listErr != nil || len(repeatRows) != 0 {
+		t.Fatalf("repeated static detail storage %s=%+v err=%v", second.ScanID, repeatRows, listErr)
+	}
+
+	beforeResolutionMetrics := len(runtime.metricSnapshot())
+	empty := newResult(base.Add(2 * time.Minute))
+	if err := logger.LogScan(empty); err != nil {
+		t.Fatal(err)
+	}
+	resolutionMetrics := runtime.metricSnapshot()[beforeResolutionMetrics:]
+	resolvedGauge := false
+	for _, metric := range resolutionMetrics {
+		switch metric.EventName() {
+		case observability.EventName(observability.TelemetryInstrumentDefenseClawScanFindings),
+			observability.EventName(observability.TelemetryInstrumentDefenseClawScanFindingsByRule):
+			t.Fatalf("resolution invented a finding counter %s", metric.EventName())
+		case observability.EventName(observability.TelemetryInstrumentDefenseClawScanFindingsGauge):
+			if fmt.Sprint(metricValue(t, metric)) != "-1" {
+				t.Fatalf("resolution gauge=%v, want -1", metricValue(t, metric))
+			}
+			resolvedGauge = true
+		}
+	}
+	if !resolvedGauge {
+		t.Fatal("empty successful scan omitted current-state resolution gauge")
+	}
+}
+
+func TestScanV8RebuildsCurrentFindingGaugeAfterRuntimeRebind(t *testing.T) {
+	logger := newTestLogger(t)
+	firstRuntime := newTestRuntimeV8Emitter(t, logger.store, router.AdmissionOrdinary)
+	logger.SetRuntimeV8Emitter(firstRuntime)
+	base := time.Date(2026, 8, 7, 11, 0, 0, 0, time.UTC)
+	newResult := func(at time.Time) *scanner.ScanResult {
+		return &scanner.ScanResult{
+			Scanner: "codeguard", Target: "asset/rebind", TargetType: "code",
+			Timestamp: at, Duration: time.Millisecond,
+			Findings: []scanner.Finding{{
+				Scanner: "codeguard", RuleID: "CG-REBIND", Severity: scanner.SeverityHigh,
+				Description: "same matched source", Location: "main.go:9",
+			}},
+		}
+	}
+	if err := logger.LogScan(newResult(base)); err != nil {
+		t.Fatal(err)
+	}
+
+	secondRuntime := newTestRuntimeV8Emitter(t, logger.store, router.AdmissionOrdinary)
+	logger.SetRuntimeV8Emitter(secondRuntime)
+	if err := logger.LogScan(newResult(base.Add(time.Minute))); err != nil {
+		t.Fatal(err)
+	}
+	_, records := secondRuntime.snapshot()
+	if len(records) != 1 || records[0].EventName() != observability.EventName(observability.TelemetryEventScanCompleted) {
+		t.Fatalf("runtime rebind replayed repeated finding logs: %#v", records)
+	}
+	foundBaseline := false
+	for _, metric := range secondRuntime.metricSnapshot() {
+		switch metric.EventName() {
+		case observability.EventName(observability.TelemetryInstrumentDefenseClawScanFindings),
+			observability.EventName(observability.TelemetryInstrumentDefenseClawScanFindingsByRule):
+			t.Fatalf("runtime rebind replayed finding counter %s", metric.EventName())
+		case observability.EventName(observability.TelemetryInstrumentDefenseClawScanFindingsGauge):
+			if fmt.Sprint(metricValue(t, metric)) != "1" {
+				t.Fatalf("rebuilt finding gauge=%v, want 1", metricValue(t, metric))
+			}
+			foundBaseline = true
+		}
+	}
+	if !foundBaseline {
+		t.Fatal("runtime rebind did not rebuild the current distinct finding gauge")
+	}
+}
+
 func TestScanV8DerivedEvidenceMatchesForensicAndCanonicalRecords(t *testing.T) {
 	logger := newTestLogger(t)
 	runtime := newTestRuntimeV8Emitter(t, logger.store, router.AdmissionOrdinary)

--- a/internal/audit/standalone_scan_test.go
+++ b/internal/audit/standalone_scan_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package audit
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/defenseclaw/defenseclaw/internal/scanner"
+)
+
+func TestPersistStandaloneScanCommitsLifecycleWithoutRuntimeFanout(t *testing.T) {
+	if err := NewLogger(nil).PersistStandaloneScan(&scanner.ScanResult{}, nil); err == nil ||
+		!strings.Contains(err.Error(), "store is unavailable") {
+		t.Fatalf("missing standalone store error = %v", err)
+	}
+	logger := newTestLogger(t)
+	base := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	line := 7
+	result := func(at time.Time) *scanner.ScanResult {
+		return &scanner.ScanResult{
+			Scanner: "codeguard", Target: "/repo", TargetType: "code",
+			Timestamp: at, Duration: time.Millisecond,
+			Findings: []scanner.Finding{{
+				Scanner: "codeguard", RuleID: "CG-EXEC-001",
+				Severity: scanner.SeverityHigh, Title: "Unsafe shell execution",
+				Description: "os.system(cmd)", Location: "/repo/main.py:7",
+				LineNumber: &line,
+			}},
+		}
+	}
+
+	first := result(base)
+	if err := logger.PersistStandaloneScan(first, nil); err != nil {
+		t.Fatalf("first standalone persistence: %v", err)
+	}
+	second := result(base.Add(time.Minute))
+	if err := logger.PersistStandaloneScan(second, nil); err != nil {
+		t.Fatalf("repeated standalone persistence: %v", err)
+	}
+
+	counts, err := logger.store.GetCounts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counts.TotalScans != 2 {
+		t.Fatalf("scan_results count = %d, want 2", counts.TotalScans)
+	}
+	states, err := logger.store.ListFindingStates("codeguard", "/repo", false, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 1 || states[0].RuleID != "CG-EXEC-001" ||
+		states[0].OccurrenceCount != 2 || states[0].LastScanID != second.ScanID {
+		t.Fatalf("distinct finding lifecycle = %+v", states)
+	}
+	firstTransitions, err := logger.store.ListScanFindings(first.ScanID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondTransitions, err := logger.store.ListScanFindings(second.ScanID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(firstTransitions) != 1 || len(secondTransitions) != 0 {
+		t.Fatalf("transition rows first/repeat = %d/%d, want 1/0",
+			len(firstTransitions), len(secondTransitions))
+	}
+	events, err := logger.store.ListEvents(10)
+	if err != nil || len(events) != 0 {
+		t.Fatalf("standalone persistence generated runtime event history: count=%d err=%v",
+			len(events), err)
+	}
+
+	// The dedicated method must not weaken the runtime producer contract:
+	// LogScan still fails before persistence when the v8 runtime is detached.
+	detached := result(base.Add(2 * time.Minute))
+	if err := logger.LogScan(detached); err == nil ||
+		!strings.Contains(err.Error(), "runtime is unavailable") {
+		t.Fatalf("detached runtime LogScan error = %v", err)
+	}
+	counts, err = logger.store.GetCounts()
+	if err != nil || counts.TotalScans != 2 {
+		t.Fatalf("detached runtime changed forensic count = %d err=%v", counts.TotalScans, err)
+	}
+}

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -215,6 +215,13 @@ type Store struct {
 
 	sqliteBusyMu       sync.RWMutex
 	sqliteBusyObserver SQLiteBusyObservabilityV8
+
+	// findingLifecycleMu serializes the one mutable state projection and its
+	// process-local up/down-counter baselines. SQLite serializes these writers
+	// too, but owning the boundary here also keeps concurrent first scans from
+	// publishing two current-state baselines after a runtime restart/reload.
+	findingLifecycleMu      sync.Mutex
+	findingGaugeInitialized map[string]struct{}
 }
 
 // SQLiteBusyObservabilityV8 is the generated metric capability used by audit,
@@ -1748,6 +1755,10 @@ var migrations = []migration{
 		description: historicalEvidencePurgeMigrationDescription,
 		apply:       purgeHistoricalEvidence,
 	},
+	{
+		description: "scan findings: add compact distinct lifecycle projection",
+		apply:       migrateFindingLifecycleState,
+	},
 }
 
 // tableExists reports whether the given SQLite table is present.
@@ -1862,6 +1873,8 @@ func (s *Store) Init() error {
 		"guardrail_chain_pending_boundaries",
 		"guardrail_chain_terminal_resets",
 		"guardrail_chain_cutoff_barriers",
+		"finding_scopes",
+		"finding_states",
 	} {
 		present, err := tableExists(s.db, table)
 		if err != nil {
@@ -1870,6 +1883,11 @@ func (s *Store) Init() error {
 		if !present {
 			return fmt.Errorf("audit: mandatory SQLite table %s is missing", table)
 		}
+	}
+	if present, err := s.hasColumn("scan_findings", "finding_fingerprint"); err != nil {
+		return fmt.Errorf("audit: verify mandatory finding lifecycle identity: %w", err)
+	} else if !present {
+		return fmt.Errorf("audit: mandatory finding lifecycle identity is missing")
 	}
 	if err := s.verifyMandatoryPragmas(context.Background()); err != nil {
 		return err
@@ -2055,6 +2073,8 @@ var knownTables = map[string]bool{
 	"schema_version":        true,
 	// v7 additions
 	"scan_findings":   true,
+	"finding_states":  true,
+	"finding_scopes":  true,
 	"activity_events": true,
 	"sink_health":     true,
 	// Observability v8 alert acknowledgement protected state.

--- a/internal/cli/audit_findings.go
+++ b/internal/cli/audit_findings.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/defenseclaw/defenseclaw/internal/audit"
+	"github.com/defenseclaw/defenseclaw/internal/scanner"
+)
+
+var (
+	auditFindingsScanner         string
+	auditFindingsTarget          string
+	auditFindingsSince           string
+	auditFindingsNewOnly         bool
+	auditFindingsIncludeResolved bool
+	auditFindingsLimit           int
+)
+
+type auditFindingsReport struct {
+	SchemaVersion    int                     `json:"schema_version"`
+	CurrentOnly      bool                    `json:"current_only"`
+	Since            string                  `json:"since,omitempty"`
+	NewOnly          bool                    `json:"new_only"`
+	Count            int64                   `json:"count"`
+	Returned         int                     `json:"returned"`
+	DistinctFindings []audit.FindingStateRow `json:"findings"`
+}
+
+var auditFindingsCmd = &cobra.Command{
+	Use:   "findings",
+	Short: "Report distinct current scan findings",
+	Long: `Report the deduplicated scan-finding lifecycle as JSON. Active current
+state is the default. --since selects findings observed at/after an RFC3339
+timestamp and, with --include-resolved, resolutions in that interval. Combine
+--new-only with --since to select only fingerprints first observed then.`,
+	RunE: runAuditFindings,
+}
+
+func init() {
+	auditFindingsCmd.Flags().StringVar(&auditFindingsScanner, "scanner", "", "Only findings from this scanner")
+	auditFindingsCmd.Flags().StringVar(&auditFindingsTarget, "target", "", "Only findings for this exact normalized scan target")
+	auditFindingsCmd.Flags().StringVar(&auditFindingsSince, "since", "", "Only lifecycle changes at/after this RFC3339 timestamp")
+	auditFindingsCmd.Flags().BoolVar(&auditFindingsNewOnly, "new-only", false, "Only fingerprints first observed since --since")
+	auditFindingsCmd.Flags().BoolVar(&auditFindingsIncludeResolved, "include-resolved", false, "Include resolved findings (active current state is the default)")
+	auditFindingsCmd.Flags().IntVar(&auditFindingsLimit, "limit", 100, "Maximum distinct findings to return (1-10000)")
+	auditCmd.AddCommand(auditFindingsCmd)
+}
+
+func runAuditFindings(cmd *cobra.Command, _ []string) error {
+	if auditStore == nil {
+		return fmt.Errorf("audit findings: audit store not loaded")
+	}
+	if auditFindingsLimit < 1 || auditFindingsLimit > 10_000 {
+		return fmt.Errorf("audit findings: --limit must be between 1 and 10000")
+	}
+	since, err := parseAuditFindingsSince(auditFindingsSince)
+	if err != nil {
+		return err
+	}
+	if auditFindingsNewOnly && since == nil {
+		return fmt.Errorf("audit findings: --new-only requires --since")
+	}
+	if auditFindingsTarget != "" && scanner.NormalizeFindingStateTarget(auditFindingsTarget) == "" {
+		return fmt.Errorf("audit findings: --target must identify a usable scan target")
+	}
+	query := audit.FindingStateQuery{
+		Scanner:         auditFindingsScanner,
+		Target:          auditFindingsTarget,
+		IncludeResolved: auditFindingsIncludeResolved,
+		Since:           since,
+		NewOnly:         auditFindingsNewOnly,
+		Limit:           auditFindingsLimit,
+	}
+	queryContext := cmd.Context()
+	if queryContext == nil {
+		queryContext = context.Background()
+	}
+	rows, count, err := auditStore.QueryFindingStatesWithCount(queryContext, query)
+	if err != nil {
+		return fmt.Errorf("audit findings: %w", err)
+	}
+	report := auditFindingsReport{
+		SchemaVersion:    1,
+		CurrentOnly:      !auditFindingsIncludeResolved,
+		NewOnly:          auditFindingsNewOnly,
+		Count:            count,
+		Returned:         len(rows),
+		DistinctFindings: rows,
+	}
+	if since != nil {
+		report.Since = since.UTC().Format(time.RFC3339Nano)
+	}
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(report); err != nil {
+		return fmt.Errorf("audit findings: encode report: %w", err)
+	}
+	return nil
+}
+
+func parseAuditFindingsSince(value string) (*time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return nil, fmt.Errorf("audit findings: invalid --since %q (expected RFC3339): %w", value, err)
+	}
+	parsed = parsed.UTC()
+	return &parsed, nil
+}

--- a/internal/cli/audit_findings_test.go
+++ b/internal/cli/audit_findings_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/defenseclaw/defenseclaw/internal/audit"
+	"github.com/defenseclaw/defenseclaw/internal/scanner"
+)
+
+func TestRunAuditFindingsReportsDistinctCurrentAndNewSince(t *testing.T) {
+	store, err := audit.NewStore(t.TempDir() + "/audit.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Init(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	base := time.Date(2026, 8, 15, 10, 0, 0, 0, time.UTC)
+	finding := func(rule, evidence string) scanner.Finding {
+		line := 3
+		return scanner.Finding{
+			Scanner: "codeguard", RuleID: rule, Severity: scanner.SeverityHigh,
+			Title: rule, EvidenceSummary: evidence, Location: "/repo/main.go:3", LineNumber: &line,
+		}
+	}
+	emit := func(at time.Time, findings ...scanner.Finding) {
+		t.Helper()
+		result := &scanner.ScanResult{
+			Scanner: "codeguard", Target: "/repo", TargetType: "code",
+			Timestamp: at, Findings: findings,
+		}
+		if _, emitErr := scanner.EmitScanResult(context.Background(), store, result, scanner.AgentIdentity{}); emitErr != nil {
+			t.Fatalf("emit scan: %v", emitErr)
+		}
+	}
+	emit(base, finding("CG-OLD", "old bytes"))
+	emit(base.Add(time.Hour), finding("CG-NEW", "new bytes"))
+
+	previousStore := auditStore
+	previousScanner, previousTarget := auditFindingsScanner, auditFindingsTarget
+	previousSince, previousNewOnly := auditFindingsSince, auditFindingsNewOnly
+	previousResolved, previousLimit := auditFindingsIncludeResolved, auditFindingsLimit
+	t.Cleanup(func() {
+		auditStore = previousStore
+		auditFindingsScanner, auditFindingsTarget = previousScanner, previousTarget
+		auditFindingsSince, auditFindingsNewOnly = previousSince, previousNewOnly
+		auditFindingsIncludeResolved, auditFindingsLimit = previousResolved, previousLimit
+	})
+	auditStore = store
+	auditFindingsScanner = "codeguard"
+	auditFindingsTarget = "/repo"
+	auditFindingsSince = ""
+	auditFindingsNewOnly = false
+	auditFindingsIncludeResolved = false
+	auditFindingsLimit = 100
+
+	run := func() auditFindingsReport {
+		t.Helper()
+		var output bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&output)
+		if runErr := runAuditFindings(cmd, nil); runErr != nil {
+			t.Fatalf("run audit findings: %v", runErr)
+		}
+		var report auditFindingsReport
+		if decodeErr := json.Unmarshal(output.Bytes(), &report); decodeErr != nil {
+			t.Fatalf("decode report: %v\n%s", decodeErr, output.String())
+		}
+		return report
+	}
+
+	current := run()
+	if !current.CurrentOnly || current.Count != 1 || len(current.DistinctFindings) != 1 ||
+		current.DistinctFindings[0].RuleID != "CG-NEW" || current.DistinctFindings[0].State != "active" {
+		t.Fatalf("default current report=%+v", current)
+	}
+
+	auditFindingsSince = base.Add(30 * time.Minute).Format(time.RFC3339Nano)
+	auditFindingsNewOnly = true
+	newOnly := run()
+	if newOnly.Count != 1 || newOnly.DistinctFindings[0].RuleID != "CG-NEW" || newOnly.Since == "" {
+		t.Fatalf("new-only report=%+v", newOnly)
+	}
+
+	auditFindingsNewOnly = false
+	auditFindingsIncludeResolved = true
+	changed := run()
+	if changed.CurrentOnly || changed.Count != 2 {
+		t.Fatalf("include-resolved since report=%+v", changed)
+	}
+}
+
+func TestRunAuditFindingsValidatesDeltaFlags(t *testing.T) {
+	previousStore := auditStore
+	previousTarget := auditFindingsTarget
+	previousSince, previousNewOnly, previousLimit := auditFindingsSince, auditFindingsNewOnly, auditFindingsLimit
+	t.Cleanup(func() {
+		auditStore = previousStore
+		auditFindingsTarget = previousTarget
+		auditFindingsSince, auditFindingsNewOnly, auditFindingsLimit = previousSince, previousNewOnly, previousLimit
+	})
+	auditStore = &audit.Store{}
+	auditFindingsTarget = ""
+	auditFindingsLimit = 100
+	auditFindingsSince = ""
+	auditFindingsNewOnly = true
+	if err := runAuditFindings(&cobra.Command{}, nil); err == nil || !strings.Contains(err.Error(), "requires --since") {
+		t.Fatalf("new-only without since error=%v", err)
+	}
+	auditFindingsNewOnly = false
+	auditFindingsSince = "yesterday"
+	if err := runAuditFindings(&cobra.Command{}, nil); err == nil || !strings.Contains(err.Error(), "invalid --since") {
+		t.Fatalf("invalid since error=%v", err)
+	}
+
+	auditFindingsSince = ""
+	for _, limit := range []int{0, 10_001} {
+		auditFindingsLimit = limit
+		if err := runAuditFindings(&cobra.Command{}, nil); err == nil ||
+			!strings.Contains(err.Error(), "limit must be between 1 and 10000") {
+			t.Fatalf("limit %d error=%v", limit, err)
+		}
+	}
+
+	auditFindingsLimit = 100
+	auditFindingsTarget = "   "
+	if err := runAuditFindings(&cobra.Command{}, nil); err == nil ||
+		!strings.Contains(err.Error(), "usable scan target") {
+		t.Fatalf("blank target error=%v", err)
+	}
+}

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -73,7 +74,10 @@ func runScanCode(_ *cobra.Command, args []string) error {
 		return nil
 	}
 
-	target := args[0]
+	target, err := filepath.Abs(args[0])
+	if err != nil {
+		return fmt.Errorf("resolve scan target: %w", err)
+	}
 
 	if _, err := os.Stat(target); err != nil {
 		return fmt.Errorf("target not found: %w", err)
@@ -90,7 +94,7 @@ func runScanCode(_ *cobra.Command, args []string) error {
 	}
 
 	var redactor *scanoutput.Redactor
-	if scanNeedsRedactor(false) {
+	if scanNeedsRedactor(auditLog != nil) {
 		dataDir := ""
 		if cfg != nil {
 			dataDir = strings.TrimSpace(cfg.DataDir)
@@ -106,7 +110,14 @@ func runScanCode(_ *cobra.Command, args []string) error {
 	}
 
 	if auditLog != nil {
-		_ = auditLog.LogScan(result)
+		// Persistence sanitizes sensitive findings in place. Commit a detached
+		// copy so --no-redact remains an explicit local-output choice while the
+		// forensic database always receives the protected projection.
+		persisted := scanoutput.Clone(result)
+		if err := auditLog.PersistStandaloneScan(persisted, redactor); err != nil {
+			return fmt.Errorf("persist code scan: %w", err)
+		}
+		result.ScanID = persisted.ScanID
 	}
 
 	if scanOutputJSON {

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -5,6 +5,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -12,6 +13,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
+
+	"github.com/defenseclaw/defenseclaw/internal/audit"
+	"github.com/defenseclaw/defenseclaw/internal/config"
 	"github.com/defenseclaw/defenseclaw/internal/scanner"
 	"github.com/defenseclaw/defenseclaw/internal/scanoutput"
 	"github.com/defenseclaw/defenseclaw/internal/version"
@@ -362,5 +367,120 @@ func TestScanResultV7PreservesFindingScanner(t *testing.T) {
 	}
 	if !strings.HasPrefix(top.Findings[0].RuleID, "clawshield-malware.") {
 		t.Fatalf("rule_id = %q, want clawshield-malware prefix", top.Findings[0].RuleID)
+	}
+}
+
+func TestRunScanCodePersistsStandaloneFindingLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "exec.py")
+	if err := os.WriteFile(target, []byte("os.system(cmd)\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dataDir := filepath.Join(dir, "state")
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	store, err := audit.NewStore(filepath.Join(dataDir, "audit.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	previousConfig, previousStore, previousLog := cfg, auditStore, auditLog
+	previousJSON, previousRaw, previousSchema := scanOutputJSON, scanNoRedact, scanPrintSchema
+	previousFindingScanner, previousFindingTarget := auditFindingsScanner, auditFindingsTarget
+	previousFindingSince, previousFindingNewOnly := auditFindingsSince, auditFindingsNewOnly
+	previousFindingResolved, previousFindingLimit := auditFindingsIncludeResolved, auditFindingsLimit
+	t.Cleanup(func() {
+		cfg, auditStore, auditLog = previousConfig, previousStore, previousLog
+		scanOutputJSON, scanNoRedact, scanPrintSchema = previousJSON, previousRaw, previousSchema
+		auditFindingsScanner, auditFindingsTarget = previousFindingScanner, previousFindingTarget
+		auditFindingsSince, auditFindingsNewOnly = previousFindingSince, previousFindingNewOnly
+		auditFindingsIncludeResolved, auditFindingsLimit = previousFindingResolved, previousFindingLimit
+		_ = store.Close()
+	})
+
+	localConfig := config.DefaultConfig()
+	localConfig.DataDir = dataDir
+	localConfig.AuditDB = filepath.Join(dataDir, "audit.db")
+	localConfig.Scanners.CodeGuard = ""
+	cfg, auditStore, auditLog = localConfig, store, audit.NewLogger(store)
+	scanOutputJSON, scanNoRedact, scanPrintSchema = false, false, false
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	scanArgument := target
+	if relativeTarget, relativeErr := filepath.Rel(workingDir, target); relativeErr == nil &&
+		!filepath.IsAbs(relativeTarget) {
+		scanArgument = relativeTarget
+	}
+
+	for run := 1; run <= 2; run++ {
+		if err := runScanCode(nil, []string{scanArgument}); err != nil {
+			t.Fatalf("standalone scan %d: %v", run, err)
+		}
+	}
+	counts, err := store.GetCounts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counts.TotalScans != 2 {
+		t.Fatalf("scan_results count = %d, want 2", counts.TotalScans)
+	}
+	states, err := store.ListFindingStates("codeguard", target, false, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) == 0 {
+		t.Fatal("standalone scan left finding_states empty")
+	}
+	for _, state := range states {
+		if state.OccurrenceCount != 2 || state.State != "active" || state.Target != target ||
+			!filepath.IsAbs(state.FilePath) {
+			t.Fatalf("finding state was not deduplicated across scans: %+v", state)
+		}
+	}
+
+	auditFindingsScanner = "codeguard"
+	auditFindingsTarget = target
+	auditFindingsSince = ""
+	auditFindingsNewOnly = false
+	auditFindingsIncludeResolved = false
+	auditFindingsLimit = 100
+	var output bytes.Buffer
+	command := &cobra.Command{}
+	command.SetOut(&output)
+	if err := runAuditFindings(command, nil); err != nil {
+		t.Fatalf("audit findings after standalone scan: %v", err)
+	}
+	var report auditFindingsReport
+	if err := json.Unmarshal(output.Bytes(), &report); err != nil {
+		t.Fatalf("decode audit findings report: %v\n%s", err, output.String())
+	}
+	if report.Count != int64(len(states)) || report.Returned != len(states) {
+		t.Fatalf("audit findings report count/returned = %d/%d, want %d: %s",
+			report.Count, report.Returned, len(states), output.String())
+	}
+}
+
+func TestMarshalScanResultV7PreservesPersistedScanID(t *testing.T) {
+	const scanID = "f24a58bd-e929-4cc8-a5c8-9c0399340f5a"
+	result := &scanner.ScanResult{
+		ScanID: scanID, Scanner: "codeguard", Target: "/repo/main.py",
+		Timestamp: time.Now().UTC(),
+	}
+	body, err := marshalScanResultV7WithOptions(result, "test", scanResultV7Options{Raw: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output scanResultV7
+	if err := json.Unmarshal(body, &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.ScanID == nil || *output.ScanID != scanID {
+		t.Fatalf("machine output scan_id = %v, want persisted %q", output.ScanID, scanID)
 	}
 }

--- a/internal/cli/scan_v7.go
+++ b/internal/cli/scan_v7.go
@@ -106,7 +106,10 @@ func marshalScanResultV7WithOptions(
 		bv = binaryVer
 	}
 
-	sid := uuid.New().String()
+	sid := strings.TrimSpace(projected.ScanID)
+	if _, err := uuid.Parse(sid); err != nil {
+		sid = uuid.NewString()
+	}
 	dur := r.Duration.String()
 	agentID := getenvOrNil("DEFENSECLAW_AGENT_ID")
 	agentInst := getenvOrNil("DEFENSECLAW_AGENT_INSTANCE_ID")

--- a/internal/scanner/finding_identity.go
+++ b/internal/scanner/finding_identity.go
@@ -1,0 +1,227 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"path"
+	"strconv"
+	"strings"
+)
+
+const findingStateFingerprintDomain = "defenseclaw-finding-state-v1"
+
+// FindingStateIdentity is the stable, content-addressed identity of one
+// scanner finding. It is deliberately separate from FindingOccurrenceID:
+// occurrences remain immutable forensic facts while this identity drives the
+// compact current-state projection across successful rescans.
+type FindingStateIdentity struct {
+	Fingerprint        string
+	NormalizedTarget   string
+	FilePath           string
+	NormalizedFilePath string
+	LineNumber         int
+	ContentDigest      string
+}
+
+// StableFindingStateIdentity derives a scope-safe finding identity from the
+// fields that define the source fact: scanner, target, rule, normalized file,
+// line, and matched content. The content itself is never retained by this
+// helper; only its SHA-256 digest contributes to the final domain-separated
+// fingerprint.
+//
+// The audit boundary's installation-keyed content token is preferred when
+// present so sensitive redaction does not collapse different matched values.
+// EvidenceSummary is otherwise used because that boundary has made it
+// deterministic and sanitized sensitive findings before persistence. Direct
+// scanner callers that have populated neither fall back to Description.
+func StableFindingStateIdentity(scannerName, targetType, target string, finding Finding) FindingStateIdentity {
+	normalizedScanner := strings.ToLower(strings.TrimSpace(scannerName))
+	normalizedTargetType := NormalizeFindingStateTargetType(targetType)
+	findingScanner := strings.ToLower(strings.TrimSpace(finding.Scanner))
+	if findingScanner == "" {
+		findingScanner = normalizedScanner
+	}
+	normalizedTarget := normalizeFindingIdentityPath(target)
+	filePath, lineNumber := findingIdentityLocation(finding)
+	if filePath == "" {
+		filePath = strings.TrimSpace(target)
+	}
+	normalizedFilePath := normalizeFindingIdentityPath(filePath)
+
+	content := finding.EvidenceSummary
+	if isPersistedFindingContentFingerprint(finding.ContentFingerprint) {
+		// The logger replaces producer values with its installation-keyed
+		// evidence token before sensitive evidence is redacted. Prefer that
+		// token so two same-length redacted secrets at one location remain
+		// distinct without putting an offline-enumerable content hash here.
+		content = "keyed-evidence:" + finding.ContentFingerprint + "\x00" + content
+	} else if content == "" {
+		content = finding.Description
+	}
+	contentSum := sha256.Sum256([]byte(content))
+	contentDigest := hex.EncodeToString(contentSum[:])
+
+	parts := []string{
+		findingStateFingerprintDomain,
+		normalizedScanner,
+		normalizedTargetType,
+		normalizedTarget,
+		findingScanner,
+		strings.ToLower(strings.TrimSpace(finding.RuleID)),
+		normalizedFilePath,
+		strconv.Itoa(lineNumber),
+		contentDigest,
+	}
+	h := sha256.New()
+	var length [8]byte
+	for _, part := range parts {
+		binary.BigEndian.PutUint64(length[:], uint64(len(part)))
+		_, _ = h.Write(length[:])
+		_, _ = h.Write([]byte(part))
+	}
+
+	return FindingStateIdentity{
+		Fingerprint:        hex.EncodeToString(h.Sum(nil)),
+		NormalizedTarget:   normalizedTarget,
+		FilePath:           filePath,
+		NormalizedFilePath: normalizedFilePath,
+		LineNumber:         lineNumber,
+		ContentDigest:      contentDigest,
+	}
+}
+
+func isPersistedFindingContentFingerprint(value string) bool {
+	if len(value) != 8 {
+		return false
+	}
+	for _, char := range value {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// NormalizeFindingStateTarget exposes the exact scope normalization used by
+// StableFindingStateIdentity so persistence queries cannot drift from writes.
+func NormalizeFindingStateTarget(target string) string {
+	return normalizeFindingIdentityPath(target)
+}
+
+// NormalizeFindingStateTargetType folds compatibility aliases that identify
+// the same complete asset scope without coercing unknown/runtime types into a
+// lifecycle-eligible value.
+func NormalizeFindingStateTargetType(targetType string) string {
+	switch targetType = strings.ToLower(strings.TrimSpace(targetType)); targetType {
+	case "code":
+		return "file"
+	case "inventory":
+		return "aibom"
+	default:
+		return targetType
+	}
+}
+
+func normalizeFindingIdentityPath(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	// Scanner locations are serialized paths, so canonicalize both separator
+	// forms independent of the host running the database. This keeps an audit
+	// database moved between Windows and Unix from minting a second identity.
+	value = strings.ReplaceAll(value, `\`, "/")
+	unc := strings.HasPrefix(value, "//")
+	value = path.Clean(value)
+	if unc && !strings.HasPrefix(value, "//") {
+		value = "/" + value
+	}
+	if len(value) >= 2 && value[1] == ':' && value[0] >= 'A' && value[0] <= 'Z' {
+		value = strings.ToLower(value[:1]) + value[1:]
+	}
+	return value
+}
+
+func findingIdentityLocation(finding Finding) (string, int) {
+	location := strings.TrimSpace(finding.Location)
+	lineNumber := 0
+	if finding.LineNumber != nil && *finding.LineNumber > 0 {
+		lineNumber = *finding.LineNumber
+	}
+	if location == "" {
+		return "", lineNumber
+	}
+
+	// A final `:<number>` is ambiguous without structured scanner metadata: it
+	// can be a legitimate POSIX filename or Windows drive-relative path. Strip
+	// only the suffix that exactly repeats an explicit positive LineNumber.
+	if lineNumber > 0 {
+		suffix := ":" + strconv.Itoa(lineNumber)
+		if strings.HasSuffix(location, suffix) && len(location) > len(suffix) {
+			location = strings.TrimSuffix(location, suffix)
+		}
+	}
+	return location, lineNumber
+}
+
+// FindingLifecycleStatus describes how one immutable occurrence affected the
+// canonical state projection.
+type FindingLifecycleStatus string
+
+const (
+	FindingLifecycleNew      FindingLifecycleStatus = "new"
+	FindingLifecycleRepeated FindingLifecycleStatus = "repeated"
+	FindingLifecycleReopened FindingLifecycleStatus = "reopened"
+	FindingLifecycleUpdated  FindingLifecycleStatus = "updated"
+)
+
+// FindingLifecycleObservation records one occurrence's canonical transition.
+type FindingLifecycleObservation struct {
+	OccurrenceID      string
+	Fingerprint       string
+	RuleID            string
+	Severity          Severity
+	Status            FindingLifecycleStatus
+	PersistOccurrence bool
+}
+
+// FindingLifecycleResolution records a current finding that disappeared from
+// a newer complete scan of the same scanner/target scope.
+type FindingLifecycleResolution struct {
+	Fingerprint string
+	RuleID      string
+	Severity    Severity
+}
+
+// FindingLifecycleDelta is attached to ScanResult after atomic persistence.
+// Managed is false for runtime/failed/unsupported scans, which retain the
+// historical emit-every-occurrence behavior.
+type FindingLifecycleDelta struct {
+	Managed           bool
+	Observations      []FindingLifecycleObservation
+	Resolved          []FindingLifecycleResolution
+	GaugeDelta        map[Severity]int64
+	CurrentBySeverity map[Severity]int64
+}
+
+// ShouldEmitOccurrence reports whether a finding is a meaningful current-state
+// transition. Repeated static findings update the distinct lifecycle state but
+// do not inflate the transition ledger, default logs, or finding counters.
+func (delta *FindingLifecycleDelta) ShouldEmitOccurrence(occurrenceID string) bool {
+	if delta == nil || !delta.Managed {
+		return true
+	}
+	for index := range delta.Observations {
+		observation := delta.Observations[index]
+		if observation.OccurrenceID != occurrenceID {
+			continue
+		}
+		return observation.Status != FindingLifecycleRepeated
+	}
+	return false
+}

--- a/internal/scanner/finding_identity_test.go
+++ b/internal/scanner/finding_identity_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import "testing"
+
+func TestStableFindingStateIdentityIsScopedAndCrossPlatformStable(t *testing.T) {
+	line := 17
+	base := Finding{
+		Scanner: "CodeGuard", RuleID: "CG-001", Location: `C:\work\repo\main.go:17`,
+		LineNumber: &line, EvidenceSummary: "matched bytes",
+	}
+	windows := StableFindingStateIdentity("CodeGuard", "code", `C:\work\repo`, base)
+	unixFinding := base
+	unixFinding.Location = "C:/work/repo/main.go:17"
+	unix := StableFindingStateIdentity("codeguard", "code", "C:/work/./repo/", unixFinding)
+	fileAlias := StableFindingStateIdentity("codeguard", "file", "C:/work/repo", unixFinding)
+	if windows.Fingerprint != unix.Fingerprint || windows.NormalizedTarget != "c:/work/repo" ||
+		windows.FilePath != `C:\work\repo\main.go` ||
+		windows.NormalizedFilePath != "c:/work/repo/main.go" || windows.LineNumber != line {
+		t.Fatalf("cross-platform identity drifted: windows=%+v unix=%+v", windows, unix)
+	}
+	if fileAlias.Fingerprint != unix.Fingerprint {
+		t.Fatalf("code/file target-type alias drifted: code=%+v file=%+v", unix, fileAlias)
+	}
+	if got := NormalizeFindingStateTarget(`\\server\share\dir`); got != "//server/share/dir" {
+		t.Fatalf("UNC target normalization=%q", got)
+	}
+	if len(windows.Fingerprint) != 64 || len(windows.ContentDigest) != 64 {
+		t.Fatalf("identity digests are not full SHA-256 values: %+v", windows)
+	}
+
+	checks := map[string]FindingStateIdentity{
+		"scope scanner": StableFindingStateIdentity("other", "code", `C:\work\repo`, base),
+		"target type":   StableFindingStateIdentity("CodeGuard", "plugin", `C:\work\repo`, base),
+		"target":        StableFindingStateIdentity("CodeGuard", "code", `C:\work\other`, base),
+	}
+	changed := base
+	changed.RuleID = "CG-002"
+	checks["rule"] = StableFindingStateIdentity("CodeGuard", "code", `C:\work\repo`, changed)
+	changed = base
+	changed.EvidenceSummary = "different matched bytes"
+	checks["content"] = StableFindingStateIdentity("CodeGuard", "code", `C:\work\repo`, changed)
+	changed = base
+	changed.Scanner = "different-detector"
+	checks["finding scanner"] = StableFindingStateIdentity("CodeGuard", "code", `C:\work\repo`, changed)
+	for dimension, identity := range checks {
+		if identity.Fingerprint == windows.Fingerprint {
+			t.Errorf("%s did not scope the finding identity", dimension)
+		}
+	}
+}
+
+func TestStableFindingStateIdentityPrefersEvidenceAndStructuredLine(t *testing.T) {
+	line := 9
+	finding := Finding{
+		RuleID: "rule", Location: "src/file.go:123", LineNumber: &line,
+		EvidenceSummary: "evidence", Description: "description",
+	}
+	first := StableFindingStateIdentity("scanner", "code", "target", finding)
+	finding.Description = "presentation-only change"
+	second := StableFindingStateIdentity("scanner", "code", "target", finding)
+	if first.Fingerprint != second.Fingerprint || first.LineNumber != line || first.FilePath != "src/file.go:123" {
+		t.Fatalf("presentation text or location suffix overrode canonical evidence/line: first=%+v second=%+v", first, second)
+	}
+
+	finding.EvidenceSummary = "<redacted-sensitive len=20>"
+	finding.ContentFingerprint = "0123abcd"
+	first = StableFindingStateIdentity("scanner", "code", "target", finding)
+	finding.ContentFingerprint = "9876fedc"
+	second = StableFindingStateIdentity("scanner", "code", "target", finding)
+	if first.Fingerprint == second.Fingerprint {
+		t.Fatal("keyed content identity did not distinguish equal-shape redacted evidence")
+	}
+}
+
+func TestStableFindingStateIdentityPreservesAmbiguousNumericFilenameSuffix(t *testing.T) {
+	t.Parallel()
+	for _, location := range []string{"/work/payload:17", `C:17`} {
+		identity := StableFindingStateIdentity(
+			"scanner",
+			"code",
+			"target",
+			Finding{RuleID: "rule", Location: location, EvidenceSummary: "evidence"},
+		)
+		if identity.FilePath != location || identity.LineNumber != 0 {
+			t.Errorf("ambiguous location %q was reinterpreted: %+v", location, identity)
+		}
+	}
+
+	line := 17
+	filename := StableFindingStateIdentity(
+		"scanner",
+		"code",
+		"target",
+		Finding{RuleID: "rule", Location: "/work/payload:17", EvidenceSummary: "evidence"},
+	)
+	structured := StableFindingStateIdentity(
+		"scanner",
+		"code",
+		"target",
+		Finding{
+			RuleID: "rule", Location: "/work/payload:17", LineNumber: &line,
+			EvidenceSummary: "evidence",
+		},
+	)
+	if structured.FilePath != "/work/payload" || structured.LineNumber != line {
+		t.Fatalf("explicit line was not normalized: %+v", structured)
+	}
+	if filename.Fingerprint == structured.Fingerprint {
+		t.Fatal("numeric filename and explicit source line collapsed to one identity")
+	}
+}

--- a/internal/scanner/result.go
+++ b/internal/scanner/result.go
@@ -156,6 +156,9 @@ type ScanResult struct {
 	Verdict    string        `json:"verdict,omitempty"`
 	ExitCode   int           `json:"exit_code,omitempty"`
 	ScanError  string        `json:"error,omitempty"`
+	// FindingLifecycle is populated by the canonical audit persistence path.
+	// It is process-local projection metadata, never part of scanner JSON.
+	FindingLifecycle *FindingLifecycleDelta `json:"-"`
 }
 
 // EffectiveTargetType returns TargetType when set, otherwise InferTargetType(Scanner).

--- a/internal/scanner/scan_emitter.go
+++ b/internal/scanner/scan_emitter.go
@@ -35,6 +35,14 @@ type ScanPersistence interface {
 	InsertScanFindings(scanID, target string, findings []Finding, meta ScanFindingMeta) error
 }
 
+// ScanLifecyclePersistence is the atomic current-state extension implemented
+// by the canonical audit Store. Keeping it optional preserves small test and
+// correlator persistence implementations while ensuring ordinary Store-backed
+// scans cannot commit a summary without its occurrences and lifecycle update.
+type ScanLifecyclePersistence interface {
+	PersistScanLifecycle(ScanSummaryParams, []Finding, ScanFindingMeta) (FindingLifecycleDelta, error)
+}
+
 // Correlator runs after findings are persisted to detect multi-step
 // attack flows (lethal trifecta, escalation chains, destructive
 // flows) by reading a session's recent findings and matching them
@@ -110,6 +118,9 @@ type ScanSummaryParams struct {
 	// mid-stream, tool-call-inspect). Empty for classic scanner
 	// invocations.
 	EvaluationID string
+	// TargetType distinguishes complete, rescan-safe asset scans from runtime
+	// message/tool inspection surfaces, whose occurrences must remain distinct.
+	TargetType string
 }
 
 // ScanFindingMeta stamps correlation + provenance on scan_findings rows.
@@ -233,12 +244,21 @@ func EmitScanResult(
 			AgentInstanceID:   agent.AgentInstanceID,
 			SidecarInstanceID: agent.SidecarInstanceID,
 			EvaluationID:      agent.EvaluationID,
+			TargetType:        result.EffectiveTargetType(),
 		}
-		if err := pers.InsertScanSummary(sum); err != nil {
-			return scanID, err
-		}
-		if err := pers.InsertScanFindings(scanID, result.Target, result.Findings, meta); err != nil {
-			return scanID, err
+		if lifecyclePersistence, ok := pers.(ScanLifecyclePersistence); ok {
+			delta, persistErr := lifecyclePersistence.PersistScanLifecycle(sum, result.Findings, meta)
+			if persistErr != nil {
+				return scanID, persistErr
+			}
+			result.FindingLifecycle = &delta
+		} else {
+			if err := pers.InsertScanSummary(sum); err != nil {
+				return scanID, err
+			}
+			if err := pers.InsertScanFindings(scanID, result.Target, result.Findings, meta); err != nil {
+				return scanID, err
+			}
 		}
 
 		// Correlator runs once per scan, after findings are persisted.


### PR DESCRIPTION
## Problem

Repeated scans inserted duplicate finding rows, and standalone CLI scans could complete without persisting a durable finding lifecycle.

## Current Situation

Scan events existed, but there was no canonical durable identity and state record spanning first seen, last seen, occurrence count, active status, and resolution. Standalone persistence also depended too heavily on observability runtime state.

## Solution

Add a durable `finding_states` lifecycle keyed by stable finding identity, upsert occurrences and resolution transitions, expose filtered `audit findings` reporting, and persist standalone forensic scans without requiring an observability runtime. Reuse the persisted scan ID in JSON and always redact stored data even when local stdout uses `--no-redact`.

## Architecture Diagram

N/A — SQLite lifecycle persistence and reporting.

## What Changed (Where & How)

| Area | Change |
| --- | --- |
| Audit migration and store | Added durable finding-state schema, lifecycle upserts, retention, and standalone persistence. |
| Scanner identity/emitter | Added stable identities and lifecycle deltas. |
| Scan CLI | Persists standalone scans and reuses the persisted scan ID. |
| `audit findings` | Added active/resolved, new-only, limit, and filter reporting. |
| Tests and docs | Added lifecycle, deduplication, transition, retention, CLI, and raw-output isolation coverage. |

## Breaking Changes

A new SQLite table and migration are added. Default reporting now represents distinct finding lifecycle state rather than duplicate occurrences.

## Open Issues / Follow-ups

None.

## Test Plan

- `go test ./internal/audit ./internal/scanoutput`
- `TMPDIR=/private/tmp go test ./internal/cli -count=1`
- Manual macOS lifecycle acceptance verified two scans produce two scan results, one finding state, one transition row, and occurrence count two.
- A third scan preserved one state row, raised occurrence count to three, and reused the database scan ID in JSON.
- Live gateway lifecycle acceptance verified active/resolved transitions and all `audit findings` filters.
- Manual `--no-redact` acceptance verified raw local stdout never entered the database.

Fixes #795