### PR TITLE
feat(cel): add portable ActionFacts document form

### DIFF
--- a/docs-site/content/docs/policies/cel/authoring.mdx
+++ b/docs-site/content/docs/policies/cel/authoring.mdx
@@ -282,6 +282,8 @@ expression. Repository contributors should add focused Go fixtures and run
 The shipped-rule matrix also compiles the checked-AST document form and compares
 its result and error classification with native typed evaluation for every
 authoritative, projectable ActionFacts case.
+Set `AGENTCEL_BIN` when running the opt-in AgentCEL E2E test to repeat the
+complete 147-rule by 180-case matrix through AgentCEL's bare-document CLI.
 When the compiled default catalog changes, also run `make generate-guardrail-catalog` and
 `make check-guardrail-catalog`.
 </Callout>

--- a/docs-site/content/docs/policies/cel/authoring.mdx
+++ b/docs-site/content/docs/policies/cel/authoring.mdx
@@ -197,6 +197,39 @@ defenseclaw.guardrail.semantic.v1.PathAccess.PATH_ACCESS_DELETE
 The authoritative schema is
 [`internal/guardrail/semanticpb/facts.proto`](https://github.com/cisco-ai-defense/defenseclaw/blob/main/internal/guardrail/semanticpb/facts.proto).
 
+## Stock document-CEL form
+
+Rule authors continue to write the typed `f` form above. DefenseClaw also has
+an internal portability compiler for checking the shipped rules with a stock
+CEL implementation that knows only one declaration, `input: dyn`. It operates
+on the resolved, type-checked AST after normal admission; it never replaces
+identifiers or enum names in source text.
+
+The canonical document contract is:
+
+| Typed source | Stock document form |
+| --- | --- |
+| Root `f` | Root `input` |
+| Protobuf snake-case selections | The same snake-case object keys |
+| Fully qualified enum constant | Canonical enum-name string such as `"PATH_ACCESS_DELETE"` |
+| Protobuf enum value | The same canonical enum-name string |
+| CEL/protobuf `int64` | Canonical decimal string, including `"0"` and values above JavaScript's `2^53` exact-integer boundary |
+| Empty repeated field | `[]` |
+| Unpopulated scalar | Its protobuf default |
+
+The data document is produced with protobuf JSON using proto field names and
+unpopulated values. An absent `parse` message is materialized as its default
+object so typed and document field selection agree. Unknown enum values and
+any checked node, operator, type, or comprehension shape outside the closed
+portable allowlist fail closed. Comprehension variables are alpha-renamed to
+prevent a source variable from shadowing the document root. Canonical source
+also receives a versioned SHA-256 identity.
+
+This is a compatibility and regression boundary, not a second public policy
+ingress. The gateway still compiles and executes the authored typed rule in
+production. The portable Facts document is private, ephemeral policy material
+and must not be logged, persisted, audited, or exposed through an API.
+
 ## Validate what you author
 
 <Steps>
@@ -246,6 +279,9 @@ before enabling action mode.
 There is no public CLI that injects synthetic `ActionFacts` into one CEL
 expression. Repository contributors should add focused Go fixtures and run
 `go test ./internal/guardrail/semantic ./internal/guardrail ./internal/gateway`.
+The shipped-rule matrix also compiles the checked-AST document form and compares
+its result and error classification with native typed evaluation for every
+authoritative, projectable ActionFacts case.
 When the compiled default catalog changes, also run `make generate-guardrail-catalog` and
 `make check-guardrail-catalog`.
 </Callout>

--- a/docs-site/content/docs/policies/cel/engine.mdx
+++ b/docs-site/content/docs/policies/cel/engine.mdx
@@ -125,6 +125,12 @@ cross-engine document contract executable and regression-testable without
 importing another policy engine. Its activation remains subject to the same
 privacy boundary as typed `ActionFacts`.
 
+An opt-in process test accepts an `AGENTCEL_BIN`, loads every translated rule
+instance as its own bare `.cel` file, and checks all 26,460 rule-by-case
+outcomes through AgentCEL's public document CLI against native typed results.
+DefenseClaw does not import AgentCEL, and the binary identity remains the
+caller's responsibility for each run.
+
 ## Resource limits
 
 | Limit | Maximum |

--- a/docs-site/content/docs/policies/cel/engine.mdx
+++ b/docs-site/content/docs/policies/cel/engine.mdx
@@ -94,6 +94,37 @@ and list equality are rejected. DefenseClaw adds no custom CEL helper
 functions. `matches` must use a literal Go/RE2 pattern of at most 512 bytes;
 dynamic regexes and global-form `matches(value, pattern)` are rejected.
 
+## Native and portable equivalence
+
+Production evaluates the admitted typed program against
+`f: defenseclaw.guardrail.semantic.v1.Facts`. The repository also compiles each
+shipped expression into canonical stock document CEL with `input: dyn` and
+checks both programs over the same authoritative projections.
+
+The translation boundary is checked-AST-only and fail-closed:
+
+- only the resolved root `f` becomes `input`; local variables are
+  alpha-renamed, so shadowing cannot redirect a field selection;
+- resolved protobuf enum constants become their canonical enum-name strings;
+- every CEL/protobuf `int64` literal becomes a canonical decimal string to
+  match protobuf JSON's lossless `int64` representation;
+- only the admitted Boolean calls, scalar/list literals, typed schema selects,
+  and the exact standard `exists` expansion can be emitted; and
+- the result is canonically unparsed, checked again in the schema-free stock
+  environment, and assigned a versioned SHA-256 identity.
+
+Facts are serialized with protobuf JSON `UseProtoNames` and
+`EmitUnpopulated`. This yields snake-case keys, canonical enum strings,
+lossless decimal strings for `int64`, and explicit empty lists/default
+scalars. The internal adapter materializes the default `parse` object and
+rejects unknown enum values before evaluation.
+
+The portability evaluator does not replace the production engine, expose a
+new public input endpoint, or relax rule admission. It exists to make the
+cross-engine document contract executable and regression-testable without
+importing another policy engine. Its activation remains subject to the same
+privacy boundary as typed `ActionFacts`.
+
 ## Resource limits
 
 | Limit | Maximum |
@@ -203,7 +234,12 @@ pending-to-success contract and connector matrix.
 `defenseclaw guardrail validate-pack` is the public authority for schema,
 regex, CEL typing and admission, and aggregate-cost checks. It does not inject
 synthetic facts or prove that a connector projects the fields an expression
-expects.
+expects. The repository matrix separately compiles both typed and portable
+forms of all 147 shipped rule instances (31 unique expressions) and compares
+26,460 native/document result-and-error pairs across 180 authoritative,
+projectable tool-call cases. Text-only regex, judge, live-eval, and HTTP rows
+are explicitly non-applicable because they cannot construct authenticated
+ActionFacts.
 
 Repository contributors should add focused Go fixtures and run:
 

--- a/docs/SECURITY-TEST-SUITE.md
+++ b/docs/SECURITY-TEST-SUITE.md
@@ -8,6 +8,7 @@ in
 | Target | Scope |
 | --- | --- |
 | `make security-suite-test` | Deterministic trusted-tool-call, regex/rule, stubbed-judge, and severity benchmark tests |
+| `go test ./internal/gateway -run '^TestGuardrailProfilesCELActionFactsCorpusMatrix$' -v` | Every shipped profile's exact typed `f` CEL expressions against every authoritative, projectable CEL-targeted tool-call case |
 | `make security-suite-eval` | Opt-in live-model evaluation; requires `DEFENSECLAW_LLM_KEY` |
 | `go test ./internal/gateway/ -run TestSecuritySuiteE2E -v` | In-process HTTP inspect and audit path; `DEFENSECLAW_GATEWAY_URL` selects an external gateway |
 
@@ -26,3 +27,12 @@ by `make test`.
 The compact `toolcall/corpus.jsonl` is the TP/FP acceptance set for structured
 tool actions. It contains inert payloads only and asserts canonical owner
 routing without duplicating low-level parser grammar tests.
+
+`TestGuardrailProfilesCELActionFactsCorpusMatrix` discovers every shipped
+profile, compiles each embedded expression without rewriting the typed `f`
+activation, and evaluates the complete rule-by-case matrix through
+`actionfacts.Analyze`, `semantic.Project`, and the bounded CEL evaluator.
+Non-authoritative structured rows remain legacy-fallback cases, as they do in
+production. Regex, judge, live-eval, and HTTP corpus rows carry text rather
+than authenticated ActionFacts; the test inventories and reports them as
+inapplicable instead of counting them as CEL coverage.

--- a/docs/SECURITY-TEST-SUITE.md
+++ b/docs/SECURITY-TEST-SUITE.md
@@ -9,7 +9,7 @@ in
 | --- | --- |
 | `make security-suite-test` | Deterministic trusted-tool-call, regex/rule, stubbed-judge, and severity benchmark tests |
 | `go test ./internal/gateway -run '^TestGuardrailProfilesCELActionFactsCorpusMatrix$' -v` | Every shipped profile's exact typed `f` CEL and checked-AST-translated stock `input` CEL against every authoritative, projectable CEL-targeted tool-call case, with equivalent results and error classifications |
-| `AGENTCEL_BIN=/path/to/agentcel go test ./internal/gateway -run '^TestGuardrailPortableCELAgentCELE2E$' -v` | Optional process-boundary proof through AgentCEL's public bare-document CEL CLI; DefenseClaw does not import AgentCEL |
+| `AGENTCEL_BIN=/path/to/agentcel go test ./internal/gateway -run '^TestGuardrailPortableCELAgentCELE2E$' -v` | Optional exhaustive process-boundary proof: AgentCEL loads all 147 translated `.cel` rule instances and reproduces their native results over all 180 applicable cases (26,460 evaluations); DefenseClaw does not import AgentCEL |
 | `make security-suite-eval` | Opt-in live-model evaluation; requires `DEFENSECLAW_LLM_KEY` |
 | `go test ./internal/gateway/ -run TestSecuritySuiteE2E -v` | In-process HTTP inspect and audit path; `DEFENSECLAW_GATEWAY_URL` selects an external gateway |
 

--- a/docs/SECURITY-TEST-SUITE.md
+++ b/docs/SECURITY-TEST-SUITE.md
@@ -8,7 +8,8 @@ in
 | Target | Scope |
 | --- | --- |
 | `make security-suite-test` | Deterministic trusted-tool-call, regex/rule, stubbed-judge, and severity benchmark tests |
-| `go test ./internal/gateway -run '^TestGuardrailProfilesCELActionFactsCorpusMatrix$' -v` | Every shipped profile's exact typed `f` CEL expressions against every authoritative, projectable CEL-targeted tool-call case |
+| `go test ./internal/gateway -run '^TestGuardrailProfilesCELActionFactsCorpusMatrix$' -v` | Every shipped profile's exact typed `f` CEL and checked-AST-translated stock `input` CEL against every authoritative, projectable CEL-targeted tool-call case, with equivalent results and error classifications |
+| `AGENTCEL_BIN=/path/to/agentcel go test ./internal/gateway -run '^TestGuardrailPortableCELAgentCELE2E$' -v` | Optional process-boundary proof through AgentCEL's public bare-document CEL CLI; DefenseClaw does not import AgentCEL |
 | `make security-suite-eval` | Opt-in live-model evaluation; requires `DEFENSECLAW_LLM_KEY` |
 | `go test ./internal/gateway/ -run TestSecuritySuiteE2E -v` | In-process HTTP inspect and audit path; `DEFENSECLAW_GATEWAY_URL` selects an external gateway |
 
@@ -29,9 +30,14 @@ tool actions. It contains inert payloads only and asserts canonical owner
 routing without duplicating low-level parser grammar tests.
 
 `TestGuardrailProfilesCELActionFactsCorpusMatrix` discovers every shipped
-profile, compiles each embedded expression without rewriting the typed `f`
-activation, and evaluates the complete rule-by-case matrix through
-`actionfacts.Analyze`, `semantic.Project`, and the bounded CEL evaluator.
+profile, compiles each embedded expression as its native typed `f` activation,
+translates the admitted checked AST to canonical stock document CEL with
+`input: dyn`, and evaluates both forms through `actionfacts.Analyze`,
+`semantic.Project`, and their bounded CEL evaluators. The current gate covers
+147 rule instances, 31 unique expressions, and 26,460 native/document
+equivalence pairs over 180 authoritative, projectable cases. Its protobuf JSON
+document uses snake-case names, emitted defaults and empty lists, canonical
+enum strings, and lossless decimal strings for `int64`.
 Non-authoritative structured rows remain legacy-fallback cases, as they do in
 production. Regex, judge, live-eval, and HTTP corpus rows carry text rather
 than authenticated ActionFacts; the test inventories and reports them as

--- a/internal/gateway/guardrail_cel_agentcel_e2e_test.go
+++ b/internal/gateway/guardrail_cel_agentcel_e2e_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/guardrail/semantic"
+	"github.com/defenseclaw/defenseclaw/internal/guardrail/semanticpb"
+)
+
+// TestGuardrailPortableCELAgentCELE2E is an opt-in process-boundary check. It
+// intentionally consumes only an AgentCEL binary and its public bare-document
+// CEL CLI; DefenseClaw does not import the AgentCEL module.
+func TestGuardrailPortableCELAgentCELE2E(t *testing.T) {
+	agentCEL := os.Getenv("AGENTCEL_BIN")
+	if agentCEL == "" {
+		t.Skip("set AGENTCEL_BIN to an AgentCEL binary with bare document CEL support")
+	}
+	if info, err := os.Stat(agentCEL); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("AGENTCEL_BIN is not a regular file: %v", err)
+	}
+
+	compiler, err := semantic.NewCompiler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expression := `f.commands.exists(c, c.id == 9007199254740993 && ` +
+		`defenseclaw.guardrail.semantic.v1.OperationKind.OPERATION_KIND_DELETE in c.operations)`
+	portable, code := compiler.CompilePortable(expression)
+	if code != semantic.CompileOK || portable == nil {
+		t.Fatalf("CompilePortable() = (%v, %q)", portable, code)
+	}
+	document, err := semantic.PortableDocument(&semanticpb.Facts{
+		Commands: []*semanticpb.CommandFact{{
+			Id:         9007199254740993,
+			Operations: []semanticpb.OperationKind{semanticpb.OperationKind_OPERATION_KIND_DELETE},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	documentJSON, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	directory := t.TempDir()
+	rulePath := filepath.Join(directory, "defenseclaw_actionfacts.cel")
+	if err := os.WriteFile(rulePath, []byte(portable.Expression()+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(directory, "agentcel.yaml")
+	configuration := fmt.Sprintf(
+		"version: v1\nrequire_certified: false\nrules:\n  paths:\n    - %q\n  required: true\n",
+		rulePath,
+	)
+	if err := os.WriteFile(configPath, []byte(configuration), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.CommandContext(
+		t.Context(),
+		agentCEL,
+		"scan",
+		"--config", configPath,
+		"--format", "json",
+		"--input-kind", "document",
+		"--rule", "defenseclaw_actionfacts",
+		"-",
+	)
+	command.Stdin = bytes.NewReader(documentJSON)
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	runErr := command.Run()
+	var exitErr *exec.ExitError
+	if runErr == nil || !errors.As(runErr, &exitErr) || exitErr.ExitCode() != 1 {
+		t.Fatalf("AgentCEL exit err=%v stdout=%s stderr=%s", runErr, stdout.String(), stderr.String())
+	}
+	var result struct {
+		Matched       bool `json:"matched"`
+		Authoritative bool `json:"authoritative"`
+		Matches       []struct {
+			RuleID string `json:"rule_id"`
+		} `json:"matches"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode AgentCEL output: %v; stdout=%s stderr=%s", err, stdout.String(), stderr.String())
+	}
+	if !result.Matched || !result.Authoritative || len(result.Matches) != 1 ||
+		result.Matches[0].RuleID != "defenseclaw_actionfacts" {
+		t.Fatalf("unexpected AgentCEL result: %#v; stderr=%s", result, stderr.String())
+	}
+}

--- a/internal/gateway/guardrail_cel_agentcel_e2e_test.go
+++ b/internal/gateway/guardrail_cel_agentcel_e2e_test.go
@@ -26,13 +26,16 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/defenseclaw/defenseclaw/internal/actionfacts"
 	"github.com/defenseclaw/defenseclaw/internal/guardrail/semantic"
-	"github.com/defenseclaw/defenseclaw/internal/guardrail/semanticpb"
 )
 
-// TestGuardrailPortableCELAgentCELE2E is an opt-in process-boundary check. It
-// intentionally consumes only an AgentCEL binary and its public bare-document
-// CEL CLI; DefenseClaw does not import the AgentCEL module.
+// TestGuardrailPortableCELAgentCELE2E is an opt-in exhaustive process-boundary
+// check. It consumes only an AgentCEL binary and its public bare-document CEL
+// CLI; DefenseClaw does not import the AgentCEL module. Every shipped rule
+// instance is loaded as a separate .cel file, and every authoritative,
+// projectable CEL-targeted corpus case is compared with native typed
+// evaluation.
 func TestGuardrailPortableCELAgentCELE2E(t *testing.T) {
 	agentCEL := os.Getenv("AGENTCEL_BIN")
 	if agentCEL == "" {
@@ -42,44 +45,147 @@ func TestGuardrailPortableCELAgentCELE2E(t *testing.T) {
 		t.Fatalf("AGENTCEL_BIN is not a regular file: %v", err)
 	}
 
-	compiler, err := semantic.NewCompiler()
-	if err != nil {
-		t.Fatal(err)
-	}
-	expression := `f.commands.exists(c, c.id == 9007199254740993 && ` +
-		`defenseclaw.guardrail.semantic.v1.OperationKind.OPERATION_KIND_DELETE in c.operations)`
-	portable, code := compiler.CompilePortable(expression)
-	if code != semantic.CompileOK || portable == nil {
-		t.Fatalf("CompilePortable() = (%v, %q)", portable, code)
-	}
-	document, err := semantic.PortableDocument(&semanticpb.Facts{
-		Commands: []*semanticpb.CommandFact{{
-			Id:         9007199254740993,
-			Operations: []semanticpb.OperationKind{semanticpb.OperationKind_OPERATION_KIND_DELETE},
-		}},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	documentJSON, err := json.Marshal(document)
-	if err != nil {
-		t.Fatal(err)
+	_, rules := loadShippedGuardrailCELRules(t)
+	if len(rules) == 0 {
+		t.Fatal("shipped guardrail CEL inventory is empty")
 	}
 
 	directory := t.TempDir()
-	rulePath := filepath.Join(directory, "defenseclaw_actionfacts.cel")
-	if err := os.WriteFile(rulePath, []byte(portable.Expression()+"\n"), 0o600); err != nil {
+	rulesDirectory := filepath.Join(directory, "rules")
+	if err := os.Mkdir(rulesDirectory, 0o700); err != nil {
 		t.Fatal(err)
+	}
+	syntheticIDs := make([]string, len(rules))
+	for index, rule := range rules {
+		syntheticIDs[index] = fmt.Sprintf("defenseclaw_%03d", index)
+		rulePath := filepath.Join(rulesDirectory, syntheticIDs[index]+".cel")
+		if err := os.WriteFile(rulePath, []byte(rule.portable.Expression()+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
 	}
 	configPath := filepath.Join(directory, "agentcel.yaml")
 	configuration := fmt.Sprintf(
 		"version: v1\nrequire_certified: false\nrules:\n  paths:\n    - %q\n  required: true\n",
-		rulePath,
+		rulesDirectory,
 	)
 	if err := os.WriteFile(configPath, []byte(configuration), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
+	validate := exec.CommandContext(
+		t.Context(), agentCEL, "validate", "--config", configPath, "--format", "json",
+	)
+	validationJSON, err := validate.Output()
+	if err != nil {
+		t.Fatalf("AgentCEL validate: %v", err)
+	}
+	var validation struct {
+		Valid     bool `json:"valid"`
+		RuleCount int  `json:"rule_count"`
+	}
+	if err := json.Unmarshal(validationJSON, &validation); err != nil {
+		t.Fatalf("decode AgentCEL validation: %v; output=%s", err, validationJSON)
+	}
+	if !validation.Valid || validation.RuleCount != len(rules) {
+		t.Fatalf("AgentCEL validation = %#v, want %d valid rules", validation, len(rules))
+	}
+
+	shippedRuleIDs := make(map[string]struct{}, len(rules))
+	for _, rule := range rules {
+		shippedRuleIDs[rule.id] = struct{}{}
+	}
+
+	corpus := readSecurityCorpus[toolCallCorpusCase](t, actionFactsSecurityCorpus)
+	applicableCases := 0
+	evaluations := 0
+	for _, corpusCase := range corpus {
+		if _, targeted := shippedRuleIDs[corpusCase.RuleID]; !targeted {
+			continue
+		}
+		facts := actionfacts.Analyze(toolCallCorpusActionFactsInput(corpusCase))
+		if !facts.Authoritative() {
+			continue
+		}
+		projection, projectionCode := semantic.Project(facts)
+		if projectionCode != semantic.ProjectionOK {
+			continue
+		}
+		document, err := semantic.PortableDocument(projection)
+		if err != nil {
+			t.Fatalf("portable document case=%q: %v", corpusCase.ID, err)
+		}
+		documentJSON, err := json.Marshal(document)
+		if err != nil {
+			t.Fatalf("marshal portable document case=%q: %v", corpusCase.ID, err)
+		}
+
+		expected := make(map[string]struct{})
+		for index, rule := range rules {
+			result, code := rule.program.EvalBool(t.Context(), projection)
+			if code != semantic.EvalOK {
+				t.Fatalf("native evaluation profile=%q rule=%q case=%q: %s", rule.profile, rule.id, corpusCase.ID, code)
+			}
+			if result.Matched {
+				expected[syntheticIDs[index]] = struct{}{}
+			}
+		}
+
+		result, exitCode, stderr := scanAgentCELDocument(t, agentCEL, configPath, documentJSON)
+		wantExitCode := 0
+		if len(expected) != 0 {
+			wantExitCode = 1
+		}
+		if exitCode != wantExitCode || !result.Authoritative || result.Matched != (len(expected) != 0) {
+			t.Fatalf(
+				"AgentCEL case=%q exit=%d result=%#v stderr=%s; want exit=%d matches=%d",
+				corpusCase.ID, exitCode, result, stderr, wantExitCode, len(expected),
+			)
+		}
+		actual := make(map[string]struct{}, len(result.Matches))
+		for _, match := range result.Matches {
+			if _, duplicate := actual[match.RuleID]; duplicate {
+				t.Fatalf("AgentCEL case=%q repeated match %q", corpusCase.ID, match.RuleID)
+			}
+			actual[match.RuleID] = struct{}{}
+		}
+		if len(actual) != len(expected) {
+			t.Fatalf("AgentCEL case=%q returned %d matches, want %d", corpusCase.ID, len(actual), len(expected))
+		}
+		for id := range expected {
+			if _, ok := actual[id]; !ok {
+				t.Fatalf("AgentCEL case=%q omitted expected match %q", corpusCase.ID, id)
+			}
+		}
+		applicableCases++
+		evaluations += len(rules)
+	}
+	if applicableCases != 180 || evaluations != len(rules)*applicableCases {
+		t.Fatalf(
+			"AgentCEL corpus coverage cases=%d evaluations=%d, want cases=180 evaluations=%d",
+			applicableCases, evaluations, len(rules)*180,
+		)
+	}
+	t.Logf(
+		"AgentCEL bare-document process matrix: rule_instances=%d applicable_cases=%d evaluations=%d",
+		len(rules), applicableCases, evaluations,
+	)
+}
+
+type agentCELScanResult struct {
+	Matched       bool `json:"matched"`
+	Authoritative bool `json:"authoritative"`
+	Matches       []struct {
+		RuleID string `json:"rule_id"`
+	} `json:"matches"`
+}
+
+func scanAgentCELDocument(
+	t *testing.T,
+	agentCEL string,
+	configPath string,
+	documentJSON []byte,
+) (agentCELScanResult, int, string) {
+	t.Helper()
 	command := exec.CommandContext(
 		t.Context(),
 		agentCEL,
@@ -87,7 +193,6 @@ func TestGuardrailPortableCELAgentCELE2E(t *testing.T) {
 		"--config", configPath,
 		"--format", "json",
 		"--input-kind", "document",
-		"--rule", "defenseclaw_actionfacts",
 		"-",
 	)
 	command.Stdin = bytes.NewReader(documentJSON)
@@ -95,22 +200,17 @@ func TestGuardrailPortableCELAgentCELE2E(t *testing.T) {
 	command.Stdout = &stdout
 	command.Stderr = &stderr
 	runErr := command.Run()
-	var exitErr *exec.ExitError
-	if runErr == nil || !errors.As(runErr, &exitErr) || exitErr.ExitCode() != 1 {
-		t.Fatalf("AgentCEL exit err=%v stdout=%s stderr=%s", runErr, stdout.String(), stderr.String())
+	exitCode := 0
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(runErr, &exitErr) {
+			t.Fatalf("run AgentCEL: %v", runErr)
+		}
+		exitCode = exitErr.ExitCode()
 	}
-	var result struct {
-		Matched       bool `json:"matched"`
-		Authoritative bool `json:"authoritative"`
-		Matches       []struct {
-			RuleID string `json:"rule_id"`
-		} `json:"matches"`
-	}
+	var result agentCELScanResult
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
 		t.Fatalf("decode AgentCEL output: %v; stdout=%s stderr=%s", err, stdout.String(), stderr.String())
 	}
-	if !result.Matched || !result.Authoritative || len(result.Matches) != 1 ||
-		result.Matches[0].RuleID != "defenseclaw_actionfacts" {
-		t.Fatalf("unexpected AgentCEL result: %#v; stderr=%s", result, stderr.String())
-	}
+	return result, exitCode, stderr.String()
 }

--- a/internal/gateway/guardrail_cel_corpus_test.go
+++ b/internal/gateway/guardrail_cel_corpus_test.go
@@ -1,0 +1,321 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/actionfacts"
+	"github.com/defenseclaw/defenseclaw/internal/guardrail/semantic"
+)
+
+const actionFactsSecurityCorpus = "toolcall/corpus.jsonl"
+
+var textOnlySecurityCorpora = []string{
+	"e2e/corpus.jsonl",
+	"eval_corpus/exfil/corpus.jsonl",
+	"eval_corpus/injection/corpus.jsonl",
+	"eval_corpus/pii/corpus.jsonl",
+	"eval_corpus/tool_injection/corpus.jsonl",
+	"judge/corpus.jsonl",
+	"regex/corpus.jsonl",
+}
+
+type guardrailCELRule struct {
+	profile    string
+	category   string
+	id         string
+	expression string
+	program    *semantic.Program
+}
+
+type securityCorpusIdentity struct {
+	ID string `json:"id"`
+}
+
+// TestGuardrailProfilesCELActionFactsCorpusMatrix is the exhaustive native
+// compatibility gate for shipped CEL. Every profile is loaded, every embedded
+// typed-f expression is compiled as authored, and every compiled program is
+// evaluated against every CEL-targeted tool-call case whose ActionFacts are
+// authoritative and project successfully, matching the production boundary.
+//
+// The other security-suite corpora carry text for regex, judge, or HTTP
+// surfaces. They cannot construct the authenticated ActionFacts input that
+// owns this CEL surface, so the test inventories and reports them separately
+// instead of treating them as semantic-rule coverage.
+func TestGuardrailProfilesCELActionFactsCorpusMatrix(t *testing.T) {
+	profiles, rules := loadShippedGuardrailCELRules(t)
+	if len(profiles) == 0 || len(rules) == 0 {
+		t.Fatal("shipped guardrail CEL inventory is empty")
+	}
+
+	wantCorpora := append([]string{actionFactsSecurityCorpus}, textOnlySecurityCorpora...)
+	sort.Strings(wantCorpora)
+	if got := discoverSecuritySuiteCorpora(t); !slices.Equal(got, wantCorpora) {
+		t.Fatalf("security corpus classification changed: got %v, want %v", got, wantCorpora)
+	}
+
+	textOnlyCases := 0
+	for _, relative := range textOnlySecurityCorpora {
+		rows := readSecurityCorpus[securityCorpusIdentity](t, relative)
+		if len(rows) == 0 {
+			t.Fatalf("text-only corpus %q is empty", relative)
+		}
+		requireUniqueCorpusIDs(t, relative, rows)
+		textOnlyCases += len(rows)
+		t.Logf("text-only corpus %s: %d cases (not ActionFacts-applicable)", relative, len(rows))
+	}
+
+	allToolCallCases := readSecurityCorpus[toolCallCorpusCase](t, actionFactsSecurityCorpus)
+	if len(allToolCallCases) == 0 {
+		t.Fatal("tool-call corpus is empty")
+	}
+
+	ruleIDs := make(map[string]struct{})
+	uniqueExpressions := make(map[string]struct{})
+	expressionsByRuleID := make(map[string]map[string]struct{})
+	profileRuleCounts := make(map[string]int, len(profiles))
+	for _, rule := range rules {
+		ruleIDs[rule.id] = struct{}{}
+		uniqueExpressions[rule.expression] = struct{}{}
+		profileRuleCounts[rule.profile]++
+		if expressionsByRuleID[rule.id] == nil {
+			expressionsByRuleID[rule.id] = make(map[string]struct{})
+		}
+		expressionsByRuleID[rule.id][rule.expression] = struct{}{}
+	}
+
+	seenToolCallIDs := make(map[string]struct{}, len(allToolCallCases))
+	celTargeted := make([]toolCallCorpusCase, 0, len(allToolCallCases))
+	for _, corpusCase := range allToolCallCases {
+		if strings.TrimSpace(corpusCase.ID) == "" || strings.TrimSpace(corpusCase.RuleID) == "" {
+			t.Fatal("tool-call corpus id and rule_id are required")
+		}
+		if _, duplicate := seenToolCallIDs[corpusCase.ID]; duplicate {
+			t.Fatalf("tool-call corpus repeats id %q", corpusCase.ID)
+		}
+		seenToolCallIDs[corpusCase.ID] = struct{}{}
+		if _, hasCEL := ruleIDs[corpusCase.RuleID]; !hasCEL {
+			continue
+		}
+		celTargeted = append(celTargeted, corpusCase)
+	}
+	if len(celTargeted) == 0 {
+		t.Fatal("tool-call corpus has no CEL-targeted ActionFacts cases")
+	}
+
+	evaluations := 0
+	applicableCases := 0
+	nonAuthoritativeCases := 0
+	projectionRejectedCases := 0
+	coveredRuleIDs := make(map[string]struct{})
+	coveredExpressions := make(map[string]struct{})
+	for _, corpusCase := range celTargeted {
+		facts := actionfacts.Analyze(toolCallCorpusActionFactsInput(corpusCase))
+		if !facts.Authoritative() {
+			nonAuthoritativeCases++
+			continue
+		}
+		projection, projectionCode := semantic.Project(facts)
+		if projectionCode != semantic.ProjectionOK {
+			projectionRejectedCases++
+			continue
+		}
+		applicableCases++
+		coveredRuleIDs[corpusCase.RuleID] = struct{}{}
+		for expression := range expressionsByRuleID[corpusCase.RuleID] {
+			coveredExpressions[expression] = struct{}{}
+		}
+		for _, rule := range rules {
+			_, evalCode := rule.program.EvalBool(t.Context(), projection)
+			if evalCode != semantic.EvalOK {
+				t.Fatalf(
+					"evaluate profile=%q category=%q rule=%q case=%q: %s",
+					rule.profile,
+					rule.category,
+					rule.id,
+					corpusCase.ID,
+					evalCode,
+				)
+			}
+			evaluations++
+		}
+	}
+	if applicableCases == 0 {
+		t.Fatal("tool-call corpus has no authoritative, projectable CEL cases")
+	}
+	if len(coveredExpressions) != len(uniqueExpressions) {
+		t.Fatalf(
+			"authoritative tool-call corpus targets %d/%d shipped CEL expressions",
+			len(coveredExpressions),
+			len(uniqueExpressions),
+		)
+	}
+
+	wantEvaluations := len(rules) * applicableCases
+	if evaluations != wantEvaluations {
+		t.Fatalf("CEL evaluations=%d, want complete matrix of %d", evaluations, wantEvaluations)
+	}
+	for _, profile := range profiles {
+		t.Logf("profile %s: %d CEL rule instances", profile, profileRuleCounts[profile])
+	}
+	t.Logf(
+		"guardrail CEL corpus matrix: profiles=%d rule_instances=%d rule_ids=%d unique_expressions=%d toolcall_cases=%d cel_targeted_cases=%d applicable_cases=%d non_authoritative_cel_targets=%d projection_rejected_cel_targets=%d structured_non_cel_targets=%d text_only_cases=%d evaluations=%d",
+		len(profiles),
+		len(rules),
+		len(ruleIDs),
+		len(uniqueExpressions),
+		len(allToolCallCases),
+		len(celTargeted),
+		applicableCases,
+		nonAuthoritativeCases,
+		projectionRejectedCases,
+		len(allToolCallCases)-len(celTargeted),
+		textOnlyCases,
+		evaluations,
+	)
+	if len(coveredRuleIDs) != len(ruleIDs) {
+		t.Logf(
+			"targeted-rule coverage: %d/%d CEL rule IDs; every rule still runs over every applicable case and all %d unique expressions are targeted",
+			len(coveredRuleIDs),
+			len(ruleIDs),
+			len(uniqueExpressions),
+		)
+	}
+}
+
+func loadShippedGuardrailCELRules(t *testing.T) ([]string, []guardrailCELRule) {
+	t.Helper()
+	root := guardrailPoliciesRoot(t)
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read shipped guardrail profiles: %v", err)
+	}
+	profiles := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			profiles = append(profiles, entry.Name())
+		}
+	}
+	sort.Strings(profiles)
+
+	rules := make([]guardrailCELRule, 0)
+	for _, profile := range profiles {
+		pack := mustLoadRulePack(t, filepath.Join(root, profile))
+		if pack == nil {
+			t.Fatalf("profile %q returned a nil rule pack", profile)
+		}
+		if err := pack.Validate(); err != nil {
+			t.Fatalf("validate shipped profile %q: %v", profile, err)
+		}
+		compiler, err := semantic.NewCompiler()
+		if err != nil {
+			t.Fatalf("construct CEL compiler for profile %q: %v", profile, err)
+		}
+		profileRules := 0
+		for _, ruleFile := range pack.RuleFiles {
+			for _, rule := range ruleFile.Rules {
+				if rule.Expression == "" {
+					continue
+				}
+				if strings.TrimSpace(rule.Expression) != rule.Expression {
+					t.Fatalf("profile %q rule %q CEL has outer whitespace", profile, rule.ID)
+				}
+				program, compileCode := compiler.Compile(rule.Expression)
+				if compileCode != semantic.CompileOK {
+					t.Fatalf(
+						"compile profile=%q category=%q rule=%q: %s",
+						profile,
+						ruleFile.Category,
+						rule.ID,
+						compileCode,
+					)
+				}
+				rules = append(rules, guardrailCELRule{
+					profile:    profile,
+					category:   ruleFile.Category,
+					id:         rule.ID,
+					expression: rule.Expression,
+					program:    program,
+				})
+				profileRules++
+			}
+		}
+		if profileRules == 0 {
+			t.Fatalf("shipped profile %q has no CEL expressions", profile)
+		}
+	}
+	sort.Slice(rules, func(left, right int) bool {
+		if rules[left].profile != rules[right].profile {
+			return rules[left].profile < rules[right].profile
+		}
+		if rules[left].category != rules[right].category {
+			return rules[left].category < rules[right].category
+		}
+		return rules[left].id < rules[right].id
+	})
+	return profiles, rules
+}
+
+func discoverSecuritySuiteCorpora(t *testing.T) []string {
+	t.Helper()
+	root := filepath.Join("testdata", "security_suite")
+	corpora := make([]string, 0, 1+len(textOnlySecurityCorpora))
+	if err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || entry.Name() != "corpus.jsonl" {
+			return nil
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		corpora = append(corpora, filepath.ToSlash(relative))
+		return nil
+	}); err != nil {
+		t.Fatalf("discover security-suite corpora: %v", err)
+	}
+	sort.Strings(corpora)
+	return corpora
+}
+
+func readSecurityCorpus[T any](t *testing.T, relative string) []T {
+	t.Helper()
+	return readJSONL[T](t, strings.Split(filepath.ToSlash(relative), "/")...)
+}
+
+func requireUniqueCorpusIDs(t *testing.T, relative string, rows []securityCorpusIdentity) {
+	t.Helper()
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if strings.TrimSpace(row.ID) == "" {
+			t.Fatalf("corpus %q contains a blank id", relative)
+		}
+		if _, duplicate := seen[row.ID]; duplicate {
+			t.Fatalf("corpus %q repeats id %q", relative, row.ID)
+		}
+		seen[row.ID] = struct{}{}
+	}
+}

--- a/internal/gateway/guardrail_cel_corpus_test.go
+++ b/internal/gateway/guardrail_cel_corpus_test.go
@@ -47,15 +47,17 @@ type guardrailCELRule struct {
 	id         string
 	expression string
 	program    *semantic.Program
+	portable   *semantic.PortableProgram
 }
 
 type securityCorpusIdentity struct {
 	ID string `json:"id"`
 }
 
-// TestGuardrailProfilesCELActionFactsCorpusMatrix is the exhaustive native
-// compatibility gate for shipped CEL. Every profile is loaded, every embedded
-// typed-f expression is compiled as authored, and every compiled program is
+// TestGuardrailProfilesCELActionFactsCorpusMatrix is the exhaustive native and
+// stock-document compatibility gate for shipped CEL. Every profile is loaded,
+// every embedded typed-f expression is compiled as authored and translated
+// from its checked AST to canonical input-dyn CEL, and both programs are
 // evaluated against every CEL-targeted tool-call case whose ActionFacts are
 // authoritative and project successfully, matching the production boundary.
 //
@@ -93,11 +95,20 @@ func TestGuardrailProfilesCELActionFactsCorpusMatrix(t *testing.T) {
 
 	ruleIDs := make(map[string]struct{})
 	uniqueExpressions := make(map[string]struct{})
+	portableIdentities := make(map[string]struct{})
+	portableByExpression := make(map[string]string)
 	expressionsByRuleID := make(map[string]map[string]struct{})
 	profileRuleCounts := make(map[string]int, len(profiles))
 	for _, rule := range rules {
 		ruleIDs[rule.id] = struct{}{}
 		uniqueExpressions[rule.expression] = struct{}{}
+		portableIdentities[rule.portable.Identity()] = struct{}{}
+		if previous, ok := portableByExpression[rule.expression]; ok &&
+			previous != rule.portable.Identity() {
+			t.Fatalf("expression %q has nondeterministic portable identities %q and %q",
+				rule.expression, previous, rule.portable.Identity())
+		}
+		portableByExpression[rule.expression] = rule.portable.Identity()
 		profileRuleCounts[rule.profile]++
 		if expressionsByRuleID[rule.id] == nil {
 			expressionsByRuleID[rule.id] = make(map[string]struct{})
@@ -124,7 +135,7 @@ func TestGuardrailProfilesCELActionFactsCorpusMatrix(t *testing.T) {
 		t.Fatal("tool-call corpus has no CEL-targeted ActionFacts cases")
 	}
 
-	evaluations := 0
+	equivalencePairs := 0
 	applicableCases := 0
 	nonAuthoritativeCases := 0
 	projectionRejectedCases := 0
@@ -147,18 +158,33 @@ func TestGuardrailProfilesCELActionFactsCorpusMatrix(t *testing.T) {
 			coveredExpressions[expression] = struct{}{}
 		}
 		for _, rule := range rules {
-			_, evalCode := rule.program.EvalBool(t.Context(), projection)
-			if evalCode != semantic.EvalOK {
+			nativeResult, nativeCode := rule.program.EvalBool(t.Context(), projection)
+			portableResult, portableCode := rule.portable.EvalBool(t.Context(), projection)
+			if nativeCode != portableCode || nativeResult.Matched != portableResult.Matched {
+				t.Fatalf(
+					"portable mismatch profile=%q category=%q rule=%q case=%q: native=(matched=%t code=%s) portable=(matched=%t code=%s) portable_identity=%q",
+					rule.profile,
+					rule.category,
+					rule.id,
+					corpusCase.ID,
+					nativeResult.Matched,
+					nativeCode,
+					portableResult.Matched,
+					portableCode,
+					rule.portable.Identity(),
+				)
+			}
+			if nativeCode != semantic.EvalOK {
 				t.Fatalf(
 					"evaluate profile=%q category=%q rule=%q case=%q: %s",
 					rule.profile,
 					rule.category,
 					rule.id,
 					corpusCase.ID,
-					evalCode,
+					nativeCode,
 				)
 			}
-			evaluations++
+			equivalencePairs++
 		}
 	}
 	if applicableCases == 0 {
@@ -173,18 +199,19 @@ func TestGuardrailProfilesCELActionFactsCorpusMatrix(t *testing.T) {
 	}
 
 	wantEvaluations := len(rules) * applicableCases
-	if evaluations != wantEvaluations {
-		t.Fatalf("CEL evaluations=%d, want complete matrix of %d", evaluations, wantEvaluations)
+	if equivalencePairs != wantEvaluations {
+		t.Fatalf("CEL equivalence pairs=%d, want complete matrix of %d", equivalencePairs, wantEvaluations)
 	}
 	for _, profile := range profiles {
 		t.Logf("profile %s: %d CEL rule instances", profile, profileRuleCounts[profile])
 	}
 	t.Logf(
-		"guardrail CEL corpus matrix: profiles=%d rule_instances=%d rule_ids=%d unique_expressions=%d toolcall_cases=%d cel_targeted_cases=%d applicable_cases=%d non_authoritative_cel_targets=%d projection_rejected_cel_targets=%d structured_non_cel_targets=%d text_only_cases=%d evaluations=%d",
+		"guardrail CEL corpus matrix: profiles=%d rule_instances=%d rule_ids=%d unique_expressions=%d portable_identities=%d toolcall_cases=%d cel_targeted_cases=%d applicable_cases=%d non_authoritative_cel_targets=%d projection_rejected_cel_targets=%d structured_non_cel_targets=%d text_only_cases=%d equivalence_pairs=%d native_evaluations=%d portable_evaluations=%d",
 		len(profiles),
 		len(rules),
 		len(ruleIDs),
 		len(uniqueExpressions),
+		len(portableIdentities),
 		len(allToolCallCases),
 		len(celTargeted),
 		applicableCases,
@@ -192,7 +219,9 @@ func TestGuardrailProfilesCELActionFactsCorpusMatrix(t *testing.T) {
 		projectionRejectedCases,
 		len(allToolCallCases)-len(celTargeted),
 		textOnlyCases,
-		evaluations,
+		equivalencePairs,
+		equivalencePairs,
+		equivalencePairs,
 	)
 	if len(coveredRuleIDs) != len(ruleIDs) {
 		t.Logf(
@@ -251,12 +280,23 @@ func loadShippedGuardrailCELRules(t *testing.T) ([]string, []guardrailCELRule) {
 						compileCode,
 					)
 				}
+				portable, portableCode := compiler.CompilePortable(rule.Expression)
+				if portableCode != semantic.CompileOK {
+					t.Fatalf(
+						"compile portable profile=%q category=%q rule=%q: %s",
+						profile,
+						ruleFile.Category,
+						rule.ID,
+						portableCode,
+					)
+				}
 				rules = append(rules, guardrailCELRule{
 					profile:    profile,
 					category:   ruleFile.Category,
 					id:         rule.ID,
 					expression: rule.Expression,
 					program:    program,
+					portable:   portable,
 				})
 				profileRules++
 			}

--- a/internal/gateway/security_toolcall_corpus_test.go
+++ b/internal/gateway/security_toolcall_corpus_test.go
@@ -43,6 +43,35 @@ type toolCallCorpusCase struct {
 	NoOtherFinding   bool                `json:"no_other_finding,omitempty"`
 }
 
+func toolCallCorpusActionFactsInput(test toolCallCorpusCase) actionfacts.Input {
+	tool := strings.TrimSpace(test.Tool)
+	if tool == "" {
+		tool = "shell"
+	}
+	cwd := test.CWD
+	if cwd == "" {
+		cwd = "/repo"
+	}
+	activeHome := test.ActiveHome
+	if activeHome == "" {
+		activeHome = "/home/alice"
+	}
+	input := actionfacts.Input{
+		Tool:             tool,
+		Args:             append(json.RawMessage(nil), test.Args...),
+		Command:          test.Command,
+		Argv:             append([]string(nil), test.Argv...),
+		CWD:              cwd,
+		ActiveHome:       activeHome,
+		ActiveAgentFiles: append([]string(nil), test.ActiveAgentFiles...),
+		DialectHint:      test.Dialect,
+	}
+	if test.ArgsRaw != "" {
+		input.Args = json.RawMessage(test.ArgsRaw)
+	}
+	return input
+}
+
 // TestSecuritySuiteToolCall is the compact TP/FP corpus for the trusted
 // structured-action lane. Parser grammar edge cases stay with ActionFacts;
 // focused dispatcher tests keep special fallback and mixed-action invariants.
@@ -95,35 +124,11 @@ func TestSecuritySuiteToolCall(t *testing.T) {
 				t.Fatalf("unsupported expect_route %q", test.ExpectRoute)
 			}
 
-			tool := strings.TrimSpace(test.Tool)
-			if tool == "" {
-				tool = "shell"
-			}
-			cwd := test.CWD
-			if cwd == "" {
-				cwd = "/repo"
-			}
-			activeHome := test.ActiveHome
-			if activeHome == "" {
-				activeHome = "/home/alice"
-			}
 			legacyText := test.LegacyText
 			if legacyText == "" {
 				legacyText = test.Command
 			}
-			input := actionfacts.Input{
-				Tool:             tool,
-				Args:             append(json.RawMessage(nil), test.Args...),
-				Command:          test.Command,
-				Argv:             append([]string(nil), test.Argv...),
-				CWD:              cwd,
-				ActiveHome:       activeHome,
-				ActiveAgentFiles: append([]string(nil), test.ActiveAgentFiles...),
-				DialectHint:      test.Dialect,
-			}
-			if test.ArgsRaw != "" {
-				input.Args = json.RawMessage(test.ArgsRaw)
-			}
+			input := toolCallCorpusActionFactsInput(test)
 			findings := dispatchTrustedAction(t.Context(), trustedActionRequest{
 				Input:              input,
 				LegacyText:         legacyText,

--- a/internal/gateway/testdata/security_suite/README.md
+++ b/internal/gateway/testdata/security_suite/README.md
@@ -22,6 +22,9 @@ surface.
 # deterministic tiers (tool-call semantics + regex + stubbed judge), no secrets:
 go test ./internal/gateway/ -run 'TestSecuritySuite(ToolCall|Regex|Judge)' -v
 
+# exact typed-CEL matrix for every shipped profile and applicable ActionFacts case:
+go test ./internal/gateway/ -run '^TestGuardrailProfilesCELActionFactsCorpusMatrix$' -v
+
 # live judge scoring against a real model:
 GUARDRAIL_BENCHMARK_LLM=1 DEFENSECLAW_LLM_KEY=... \
   go test ./internal/gateway/ -run TestSecuritySuiteJudge -v
@@ -52,6 +55,12 @@ neighbors, the canonical owner ID, semantic-versus-fallback routing, duplicate
 suppression, and whether a finding can contribute to enforcement. Payloads are
 parsed but never executed. Parser grammar edge cases remain in the focused
 ActionFacts tests instead of being duplicated here.
+
+The typed-CEL matrix treats a row as evaluable only when its target rule owns a
+CEL expression and `ActionFacts` is authoritative and projects successfully.
+CEL-targeted rows with partial or unsupported facts remain fallback-only.
+Every other corpus tier is text-only and is explicitly reported as
+non-applicable to the ActionFacts CEL activation.
 
 - `rule_id` — canonical owner expected to match or remain absent.
 - `command`, `argv`, `args`, `dialect`, `cwd`, and `active_home` — structured

--- a/internal/gateway/testdata/security_suite/README.md
+++ b/internal/gateway/testdata/security_suite/README.md
@@ -22,8 +22,13 @@ surface.
 # deterministic tiers (tool-call semantics + regex + stubbed judge), no secrets:
 go test ./internal/gateway/ -run 'TestSecuritySuite(ToolCall|Regex|Judge)' -v
 
-# exact typed-CEL matrix for every shipped profile and applicable ActionFacts case:
+# exact typed/native-versus-stock-document CEL matrix for every shipped profile
+# and applicable ActionFacts case:
 go test ./internal/gateway/ -run '^TestGuardrailProfilesCELActionFactsCorpusMatrix$' -v
+
+# optional external proof through AgentCEL's bare-document CEL CLI:
+AGENTCEL_BIN=/path/to/agentcel \
+  go test ./internal/gateway/ -run '^TestGuardrailPortableCELAgentCELE2E$' -v
 
 # live judge scoring against a real model:
 GUARDRAIL_BENCHMARK_LLM=1 DEFENSECLAW_LLM_KEY=... \
@@ -58,7 +63,10 @@ ActionFacts tests instead of being duplicated here.
 
 The typed-CEL matrix treats a row as evaluable only when its target rule owns a
 CEL expression and `ActionFacts` is authoritative and projects successfully.
-CEL-targeted rows with partial or unsupported facts remain fallback-only.
+For every such row it compares the native typed result/error with the
+checked-AST-translated `input: dyn` result/error over the canonical protobuf
+JSON document. CEL-targeted rows with partial or unsupported facts remain
+fallback-only.
 Every other corpus tier is text-only and is explicitly reported as
 non-applicable to the ActionFacts CEL activation.
 

--- a/internal/gateway/testdata/security_suite/README.md
+++ b/internal/gateway/testdata/security_suite/README.md
@@ -26,7 +26,8 @@ go test ./internal/gateway/ -run 'TestSecuritySuite(ToolCall|Regex|Judge)' -v
 # and applicable ActionFacts case:
 go test ./internal/gateway/ -run '^TestGuardrailProfilesCELActionFactsCorpusMatrix$' -v
 
-# optional external proof through AgentCEL's bare-document CEL CLI:
+# optional exhaustive 147-rule x 180-case proof through AgentCEL's
+# bare-document CEL CLI (26,460 cross-process evaluations):
 AGENTCEL_BIN=/path/to/agentcel \
   go test ./internal/gateway/ -run '^TestGuardrailPortableCELAgentCELE2E$' -v
 

--- a/internal/guardrail/semantic/compile.go
+++ b/internal/guardrail/semantic/compile.go
@@ -30,12 +30,20 @@ type cachedCompile struct {
 	code    CompileCode
 }
 
-// Compiler owns one candidate-local expression cache. Compile is safe for
-// concurrent use so callers may validate independent rules in parallel.
+type cachedPortableCompile struct {
+	program *PortableProgram
+	code    CompileCode
+}
+
+// Compiler owns candidate-local native and portable expression caches.
+// Compile and CompilePortable are safe for concurrent use so callers may
+// validate independent rules in parallel.
 type Compiler struct {
-	mu    sync.Mutex
-	env   *cel.Env
-	cache map[string]cachedCompile
+	mu            sync.Mutex
+	env           *cel.Env
+	portableEnv   *cel.Env
+	cache         map[string]cachedCompile
+	portableCache map[string]cachedPortableCompile
 }
 
 // Program is an immutable, reusable checked CEL program.
@@ -51,8 +59,9 @@ func NewCompiler() (*Compiler, error) {
 		return nil, err
 	}
 	return &Compiler{
-		env:   env,
-		cache: make(map[string]cachedCompile),
+		env:           env,
+		cache:         make(map[string]cachedCompile),
+		portableCache: make(map[string]cachedPortableCompile),
 	}, nil
 }
 
@@ -75,61 +84,9 @@ func (c *Compiler) Compile(expression string) (*Program, CompileCode) {
 }
 
 func (c *Compiler) compile(expression string) (*Program, CompileCode) {
-	if !utf8.ValidString(expression) {
-		return nil, CompileExpressionEncoding
-	}
-	if len(expression) > maxExpressionBytes ||
-		utf8.RuneCountInString(expression) > maxExpressionRunes {
-		return nil, CompileExpressionSize
-	}
-	parsed, issues := c.env.Parse(expression)
-	if issues != nil && issues.Err() != nil {
-		return nil, CompileSyntax
-	}
-	if parsed == nil || parsed.NativeRep() == nil {
-		return nil, CompileSyntax
-	}
-	if celast.NodeCount(parsed.NativeRep()) > maxExpressionNodes {
-		return nil, CompileASTNodes
-	}
-	if celast.ExceedsDepth(parsed.NativeRep(), maxExpressionDepth+1) {
-		return nil, CompileASTDepth
-	}
-
-	checked, issues := c.env.Check(parsed)
-	if issues != nil && issues.Err() != nil {
-		return nil, CompileType
-	}
-	if checked == nil || checked.NativeRep() == nil {
-		return nil, CompileType
-	}
-	if celast.NodeCount(checked.NativeRep()) > maxExpressionNodes {
-		return nil, CompileASTNodes
-	}
-	if celast.ExceedsDepth(checked.NativeRep(), maxExpressionDepth+1) {
-		return nil, CompileASTDepth
-	}
-	if !checked.OutputType().IsExactType(cel.BoolType) {
-		return nil, CompileResultType
-	}
-	if !validateSurface(checked) {
-		return nil, CompileSurface
-	}
-	if !validateEnumDomains(checked) {
-		return nil, CompileEnumDomain
-	}
-	if !validateComprehensionDepth(checked) {
-		return nil, CompileComprehensionDepth
-	}
-	if code := validateRegexes(checked); code != CompileOK {
+	checked, staticCost, code := c.check(expression)
+	if code != CompileOK {
 		return nil, code
-	}
-	estimate, err := c.env.EstimateCost(checked, boundedCostEstimator{})
-	if err != nil || estimate.Max == math.MaxUint64 {
-		return nil, CompileStaticCostUnbounded
-	}
-	if estimate.Max > maxRuleStaticCost {
-		return nil, CompileStaticCost
 	}
 	evaluable, err := c.env.Program(
 		checked,
@@ -142,8 +99,68 @@ func (c *Compiler) compile(expression string) (*Program, CompileCode) {
 	}
 	return &Program{
 		program:    evaluable,
-		staticCost: estimate.Max,
+		staticCost: staticCost,
 	}, CompileOK
+}
+
+func (c *Compiler) check(expression string) (*cel.Ast, uint64, CompileCode) {
+	if !utf8.ValidString(expression) {
+		return nil, 0, CompileExpressionEncoding
+	}
+	if len(expression) > maxExpressionBytes ||
+		utf8.RuneCountInString(expression) > maxExpressionRunes {
+		return nil, 0, CompileExpressionSize
+	}
+	parsed, issues := c.env.Parse(expression)
+	if issues != nil && issues.Err() != nil {
+		return nil, 0, CompileSyntax
+	}
+	if parsed == nil || parsed.NativeRep() == nil {
+		return nil, 0, CompileSyntax
+	}
+	if celast.NodeCount(parsed.NativeRep()) > maxExpressionNodes {
+		return nil, 0, CompileASTNodes
+	}
+	if celast.ExceedsDepth(parsed.NativeRep(), maxExpressionDepth+1) {
+		return nil, 0, CompileASTDepth
+	}
+
+	checked, issues := c.env.Check(parsed)
+	if issues != nil && issues.Err() != nil {
+		return nil, 0, CompileType
+	}
+	if checked == nil || checked.NativeRep() == nil {
+		return nil, 0, CompileType
+	}
+	if celast.NodeCount(checked.NativeRep()) > maxExpressionNodes {
+		return nil, 0, CompileASTNodes
+	}
+	if celast.ExceedsDepth(checked.NativeRep(), maxExpressionDepth+1) {
+		return nil, 0, CompileASTDepth
+	}
+	if !checked.OutputType().IsExactType(cel.BoolType) {
+		return nil, 0, CompileResultType
+	}
+	if !validateSurface(checked) {
+		return nil, 0, CompileSurface
+	}
+	if !validateEnumDomains(checked) {
+		return nil, 0, CompileEnumDomain
+	}
+	if !validateComprehensionDepth(checked) {
+		return nil, 0, CompileComprehensionDepth
+	}
+	if code := validateRegexes(checked); code != CompileOK {
+		return nil, 0, code
+	}
+	estimate, err := c.env.EstimateCost(checked, boundedCostEstimator{})
+	if err != nil || estimate.Max == math.MaxUint64 {
+		return nil, 0, CompileStaticCostUnbounded
+	}
+	if estimate.Max > maxRuleStaticCost {
+		return nil, 0, CompileStaticCost
+	}
+	return checked, estimate.Max, CompileOK
 }
 
 // StaticCost returns the admitted checked-expression maximum.

--- a/internal/guardrail/semantic/environment.go
+++ b/internal/guardrail/semantic/environment.go
@@ -36,3 +36,16 @@ func newEnvironment() (*cel.Env, error) {
 		cel.ExpressionNodeLimit(maxParserNodes),
 	)
 }
+
+// newPortableEnvironment is deliberately schema-free. Portable expressions
+// are rechecked against the same stock document declaration available in CEL
+// implementations that do not know DefenseClaw's private protobuf schema.
+func newPortableEnvironment() (*cel.Env, error) {
+	return cel.NewEnv(
+		cel.Variable("input", cel.DynType),
+		cel.ParserExpressionSizeLimit(maxExpressionRunes),
+		cel.ParserRecursionLimit(maxParserRecursion),
+		cel.ParserErrorRecoveryLimit(maxParserRecoveries),
+		cel.ExpressionNodeLimit(maxParserNodes),
+	)
+}

--- a/internal/guardrail/semantic/evaluate.go
+++ b/internal/guardrail/semantic/evaluate.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 
 	"github.com/defenseclaw/defenseclaw/internal/guardrail/semanticpb"
+	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/interpreter"
 )
@@ -42,10 +43,15 @@ func (p *Program) EvalBool(
 	if ctx == nil || facts == nil {
 		return Result{}, EvalProjectionInvalid
 	}
-	value, details, err := p.program.ContextEval(
-		ctx,
-		map[string]any{"f": facts},
-	)
+	return evalBoolProgram(ctx, p.program, map[string]any{"f": facts})
+}
+
+func evalBoolProgram(
+	ctx context.Context,
+	program cel.Program,
+	activation map[string]any,
+) (Result, EvalCode) {
+	value, details, err := program.ContextEval(ctx, activation)
 	result := Result{}
 	if details != nil && details.ActualCost() != nil {
 		result.Cost = *details.ActualCost()

--- a/internal/guardrail/semantic/portable.go
+++ b/internal/guardrail/semantic/portable.go
@@ -1,0 +1,570 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package semantic
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"unicode/utf8"
+
+	"github.com/defenseclaw/defenseclaw/internal/guardrail/semanticpb"
+	"github.com/google/cel-go/cel"
+	celast "github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/operators"
+	"github.com/google/cel-go/common/overloads"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/parser"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+const portableIdentityDomain = "defenseclaw.guardrail.semantic.portable-cel.v1\x00"
+
+// PortableProgram is the stock document-CEL form of one admitted typed Facts
+// expression. Its source expression is canonical and evaluates against a
+// single dyn variable named input.
+type PortableProgram struct {
+	program          cel.Program
+	expression       string
+	identity         string
+	sourceStaticCost uint64
+}
+
+// Expression returns the canonical stock CEL source.
+func (p *PortableProgram) Expression() string {
+	if p == nil {
+		return ""
+	}
+	return p.expression
+}
+
+// Identity returns the versioned SHA-256 identity of Expression.
+func (p *PortableProgram) Identity() string {
+	if p == nil {
+		return ""
+	}
+	return p.identity
+}
+
+// SourceStaticCost returns the admitted maximum for the typed source rule.
+// The document form is executed with the runtime cost limit; its dyn input
+// does not provide enough static size information for the typed estimator.
+func (p *PortableProgram) SourceStaticCost() uint64 {
+	if p == nil {
+		return 0
+	}
+	return p.sourceStaticCost
+}
+
+// CompilePortable admits a typed Facts expression, translates only its
+// resolved checked AST, canonically unparses it, and checks the result in a
+// schema-free stock CEL environment.
+func (c *Compiler) CompilePortable(expression string) (*PortableProgram, CompileCode) {
+	if c == nil {
+		return nil, CompileProgram
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.env == nil {
+		return nil, CompileProgram
+	}
+	if c.portableEnv == nil {
+		portableEnv, err := newPortableEnvironment()
+		if err != nil {
+			return nil, CompileProgram
+		}
+		c.portableEnv = portableEnv
+	}
+	if c.portableCache == nil {
+		c.portableCache = make(map[string]cachedPortableCompile)
+	}
+	if cached, ok := c.portableCache[expression]; ok {
+		return cached.program, cached.code
+	}
+	program, code := c.compilePortable(expression)
+	c.portableCache[expression] = cachedPortableCompile{program: program, code: code}
+	return program, code
+}
+
+func (c *Compiler) compilePortable(expression string) (*PortableProgram, CompileCode) {
+	checked, sourceStaticCost, code := c.check(expression)
+	if code != CompileOK {
+		return nil, code
+	}
+	canonical, ok := translatePortableCheckedAST(checked)
+	if !ok {
+		return nil, CompileSurface
+	}
+	if !utf8.ValidString(canonical) ||
+		len(canonical) > maxExpressionBytes ||
+		utf8.RuneCountInString(canonical) > maxExpressionRunes {
+		return nil, CompileExpressionSize
+	}
+	parsed, issues := c.portableEnv.Parse(canonical)
+	if issues != nil && issues.Err() != nil {
+		return nil, CompileProgram
+	}
+	if parsed == nil || parsed.NativeRep() == nil ||
+		celast.NodeCount(parsed.NativeRep()) > maxExpressionNodes ||
+		celast.ExceedsDepth(parsed.NativeRep(), maxExpressionDepth+1) {
+		return nil, CompileProgram
+	}
+	portableChecked, issues := c.portableEnv.Check(parsed)
+	if issues != nil && issues.Err() != nil {
+		return nil, CompileProgram
+	}
+	if portableChecked == nil || portableChecked.NativeRep() == nil ||
+		!portableChecked.OutputType().IsExactType(cel.BoolType) {
+		return nil, CompileProgram
+	}
+	evaluable, err := c.portableEnv.Program(
+		portableChecked,
+		cel.EvalOptions(cel.OptOptimize),
+		cel.InterruptCheckFrequency(interruptFrequency),
+		cel.CostLimit(maxRuleRuntimeCost),
+	)
+	if err != nil {
+		return nil, CompileProgram
+	}
+	digest := sha256.Sum256([]byte(portableIdentityDomain + canonical))
+	return &PortableProgram{
+		program:          evaluable,
+		expression:       canonical,
+		identity:         "sha256:" + hex.EncodeToString(digest[:]),
+		sourceStaticCost: sourceStaticCost,
+	}, CompileOK
+}
+
+// EvalBool evaluates the portable expression against the canonical document
+// projection of facts. The document is ephemeral policy material and must not
+// be logged, persisted, audited, or exposed through an API.
+func (p *PortableProgram) EvalBool(
+	ctx context.Context,
+	facts *semanticpb.Facts,
+) (Result, EvalCode) {
+	if p == nil || p.program == nil {
+		return Result{}, EvalError
+	}
+	if ctx == nil || facts == nil {
+		return Result{}, EvalProjectionInvalid
+	}
+	document, err := PortableDocument(facts)
+	if err != nil {
+		return Result{}, EvalProjectionInvalid
+	}
+	return evalBoolProgram(ctx, p.program, map[string]any{"input": document})
+}
+
+// PortableDocument converts Facts to the exact stock-CEL activation contract.
+// Proto field names and unpopulated values are emitted, enums use canonical
+// proto names, and every int64 is a canonical decimal string as required by
+// protojson. Invalid enum values fail closed instead of changing the document
+// type from string to number.
+func PortableDocument(facts *semanticpb.Facts) (map[string]any, error) {
+	if facts == nil {
+		return nil, errors.New("portable Facts document is nil")
+	}
+	cloned, ok := proto.Clone(facts).(*semanticpb.Facts)
+	if !ok || cloned == nil {
+		return nil, errors.New("clone portable Facts document")
+	}
+	// Typed CEL reads an absent proto3 message as its default message. Ensure
+	// the stock document has the same selectable object rather than JSON null.
+	if cloned.Parse == nil {
+		cloned.Parse = &semanticpb.ParseResult{}
+	}
+	if err := validatePortableProto(cloned.ProtoReflect()); err != nil {
+		return nil, err
+	}
+	encoded, err := (protojson.MarshalOptions{
+		UseProtoNames:   true,
+		EmitUnpopulated: true,
+	}).Marshal(cloned)
+	if err != nil {
+		return nil, fmt.Errorf("marshal portable Facts document: %w", err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(encoded, &document); err != nil {
+		return nil, fmt.Errorf("decode portable Facts document: %w", err)
+	}
+	if document == nil {
+		return nil, errors.New("portable Facts document is not an object")
+	}
+	return document, nil
+}
+
+func validatePortableProto(message protoreflect.Message) error {
+	if !message.IsValid() {
+		return errors.New("portable Facts document contains an invalid message")
+	}
+	fields := message.Descriptor().Fields()
+	for index := 0; index < fields.Len(); index++ {
+		field := fields.Get(index)
+		value := message.Get(field)
+		if field.IsList() {
+			list := value.List()
+			for item := 0; item < list.Len(); item++ {
+				switch field.Kind() {
+				case protoreflect.EnumKind:
+					if field.Enum().Values().ByNumber(list.Get(item).Enum()) == nil {
+						return fmt.Errorf("portable Facts field %s has an unknown enum value", field.FullName())
+					}
+				case protoreflect.MessageKind:
+					if err := validatePortableProto(list.Get(item).Message()); err != nil {
+						return err
+					}
+				}
+			}
+			continue
+		}
+		switch field.Kind() {
+		case protoreflect.EnumKind:
+			if field.Enum().Values().ByNumber(value.Enum()) == nil {
+				return fmt.Errorf("portable Facts field %s has an unknown enum value", field.FullName())
+			}
+		case protoreflect.MessageKind:
+			if message.Has(field) {
+				if err := validatePortableProto(value.Message()); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type portableTranslator struct {
+	checked       *cel.Ast
+	factory       celast.ExprFactory
+	messages      map[string]protoreflect.MessageDescriptor
+	enumConstants map[string]protoreflect.EnumValueDescriptor
+	nextIter      int
+}
+
+func translatePortableCheckedAST(checked *cel.Ast) (string, bool) {
+	if checked == nil || checked.NativeRep() == nil || !checked.IsChecked() {
+		return "", false
+	}
+	translator := &portableTranslator{
+		checked:       checked,
+		factory:       celast.NewExprFactory(),
+		messages:      make(map[string]protoreflect.MessageDescriptor),
+		enumConstants: make(map[string]protoreflect.EnumValueDescriptor),
+	}
+	translator.addFile(semanticpb.File_facts_proto)
+	rewritten, ok := translator.rewrite(checked.NativeRep().Expr(), nil)
+	if !ok {
+		return "", false
+	}
+	canonical, err := parser.Unparse(rewritten, celast.NewSourceInfo(nil))
+	if err != nil {
+		return "", false
+	}
+	return canonical, true
+}
+
+func (t *portableTranslator) addFile(file protoreflect.FileDescriptor) {
+	var addEnums func(protoreflect.EnumDescriptors)
+	addEnums = func(enums protoreflect.EnumDescriptors) {
+		for index := 0; index < enums.Len(); index++ {
+			enum := enums.Get(index)
+			for valueIndex := 0; valueIndex < enum.Values().Len(); valueIndex++ {
+				value := enum.Values().Get(valueIndex)
+				name := string(enum.FullName()) + "." + string(value.Name())
+				t.enumConstants[name] = value
+			}
+		}
+	}
+	var addMessages func(protoreflect.MessageDescriptors)
+	addMessages = func(messages protoreflect.MessageDescriptors) {
+		for index := 0; index < messages.Len(); index++ {
+			message := messages.Get(index)
+			t.messages[string(message.FullName())] = message
+			addEnums(message.Enums())
+			addMessages(message.Messages())
+		}
+	}
+	addEnums(file.Enums())
+	addMessages(file.Messages())
+}
+
+func (t *portableTranslator) rewrite(
+	expr celast.Expr,
+	scope map[string]string,
+) (celast.Expr, bool) {
+	if expr == nil || !t.allowedType(t.checked.NativeRep().GetType(expr.ID())) {
+		return nil, false
+	}
+	if reference, ok := t.checked.NativeRep().ReferenceMap()[expr.ID()]; ok &&
+		reference.Value != nil {
+		value := t.enumConstants[reference.Name]
+		if value == nil {
+			return nil, false
+		}
+		return t.factory.NewLiteral(expr.ID(), types.String(value.Name())), true
+	}
+
+	switch expr.Kind() {
+	case celast.CallKind:
+		call := expr.AsCall()
+		if !t.allowedCall(call) {
+			return nil, false
+		}
+		arguments := make([]celast.Expr, 0, len(call.Args()))
+		for _, argument := range call.Args() {
+			rewritten, ok := t.rewrite(argument, scope)
+			if !ok {
+				return nil, false
+			}
+			arguments = append(arguments, rewritten)
+		}
+		if call.IsMemberFunction() {
+			target, ok := t.rewrite(call.Target(), scope)
+			if !ok {
+				return nil, false
+			}
+			return t.factory.NewMemberCall(expr.ID(), call.FunctionName(), target, arguments...), true
+		}
+		return t.factory.NewCall(expr.ID(), call.FunctionName(), arguments...), true
+
+	case celast.ComprehensionKind:
+		return t.rewriteExists(expr, scope)
+
+	case celast.IdentKind:
+		name := expr.AsIdent()
+		if translated, ok := scope[name]; ok {
+			return t.factory.NewIdent(expr.ID(), translated), true
+		}
+		reference := t.checked.NativeRep().ReferenceMap()[expr.ID()]
+		factsName := string((&semanticpb.Facts{}).ProtoReflect().Descriptor().FullName())
+		if name == "f" && reference != nil && reference.Name == "f" &&
+			t.checked.NativeRep().GetType(expr.ID()).TypeName() == factsName {
+			return t.factory.NewIdent(expr.ID(), "input"), true
+		}
+		return nil, false
+
+	case celast.ListKind:
+		list := expr.AsList()
+		if len(list.OptionalIndices()) != 0 {
+			return nil, false
+		}
+		elements := make([]celast.Expr, 0, list.Size())
+		for _, element := range list.Elements() {
+			rewritten, ok := t.rewrite(element, scope)
+			if !ok {
+				return nil, false
+			}
+			elements = append(elements, rewritten)
+		}
+		return t.factory.NewList(expr.ID(), elements, nil), true
+
+	case celast.LiteralKind:
+		switch value := expr.AsLiteral().(type) {
+		case types.Bool, types.String:
+			return t.factory.NewLiteral(expr.ID(), value), true
+		case types.Int:
+			return t.factory.NewLiteral(
+				expr.ID(),
+				types.String(strconv.FormatInt(int64(value), 10)),
+			), true
+		default:
+			return nil, false
+		}
+
+	case celast.SelectKind:
+		selection := expr.AsSelect()
+		if selection.IsTestOnly() {
+			return nil, false
+		}
+		operandType := t.checked.NativeRep().GetType(selection.Operand().ID())
+		message := t.messages[operandType.TypeName()]
+		if message == nil ||
+			message.Fields().ByName(protoreflect.Name(selection.FieldName())) == nil {
+			return nil, false
+		}
+		operand, ok := t.rewrite(selection.Operand(), scope)
+		if !ok {
+			return nil, false
+		}
+		return t.factory.NewSelect(expr.ID(), operand, selection.FieldName()), true
+
+	default:
+		return nil, false
+	}
+}
+
+func (t *portableTranslator) rewriteExists(
+	expr celast.Expr,
+	scope map[string]string,
+) (celast.Expr, bool) {
+	comprehension := expr.AsComprehension()
+	if comprehension.HasIterVar2() ||
+		comprehension.IterVar() == "" ||
+		comprehension.AccuVar() == "" ||
+		!isBoolLiteral(comprehension.AccuInit(), false) ||
+		!isAccumulatorIdent(comprehension.Result(), comprehension.AccuVar()) ||
+		!isExistsCondition(comprehension.LoopCondition(), comprehension.AccuVar()) {
+		return nil, false
+	}
+	step := comprehension.LoopStep()
+	if step.Kind() != celast.CallKind {
+		return nil, false
+	}
+	stepCall := step.AsCall()
+	if stepCall.IsMemberFunction() ||
+		stepCall.FunctionName() != operators.LogicalOr ||
+		len(stepCall.Args()) != 2 ||
+		!isAccumulatorIdent(stepCall.Args()[0], comprehension.AccuVar()) {
+		return nil, false
+	}
+	iterType := t.checked.NativeRep().GetType(comprehension.IterRange().ID())
+	if iterType.Kind() != types.ListKind ||
+		!t.checked.NativeRep().GetType(stepCall.Args()[1].ID()).IsExactType(types.BoolType) {
+		return nil, false
+	}
+	rangeExpr, ok := t.rewrite(comprehension.IterRange(), scope)
+	if !ok {
+		return nil, false
+	}
+	iterName := "item" + strconv.Itoa(t.nextIter)
+	t.nextIter++
+	nested := clonePortableScope(scope)
+	nested[comprehension.IterVar()] = iterName
+	predicate, ok := t.rewrite(stepCall.Args()[1], nested)
+	if !ok {
+		return nil, false
+	}
+	return t.factory.NewMemberCall(
+		expr.ID(),
+		operators.Exists,
+		rangeExpr,
+		t.factory.NewIdent(expr.ID(), iterName),
+		predicate,
+	), true
+}
+
+func (t *portableTranslator) allowedType(valueType *types.Type) bool {
+	if valueType == nil {
+		return false
+	}
+	switch valueType.Kind() {
+	case types.BoolKind, types.IntKind, types.StringKind:
+		return true
+	case types.ListKind:
+		parameters := valueType.Parameters()
+		return len(parameters) == 1 && t.allowedType(parameters[0])
+	case types.StructKind:
+		_, ok := t.messages[valueType.TypeName()]
+		return ok
+	default:
+		return false
+	}
+}
+
+func (t *portableTranslator) allowedCall(call celast.CallExpr) bool {
+	operands := call.Args()
+	if call.IsMemberFunction() {
+		operands = append([]celast.Expr{call.Target()}, operands...)
+	}
+	allExact := func(kind types.Kind) bool {
+		for _, operand := range operands {
+			if t.checked.NativeRep().GetType(operand.ID()).Kind() != kind {
+				return false
+			}
+		}
+		return true
+	}
+	switch call.FunctionName() {
+	case operators.LogicalAnd, operators.LogicalOr:
+		return !call.IsMemberFunction() && len(operands) == 2 && allExact(types.BoolKind)
+	case operators.LogicalNot:
+		return !call.IsMemberFunction() && len(operands) == 1 && allExact(types.BoolKind)
+	case operators.Equals, operators.NotEquals:
+		if call.IsMemberFunction() || len(operands) != 2 {
+			return false
+		}
+		leftType := t.checked.NativeRep().GetType(operands[0].ID())
+		rightType := t.checked.NativeRep().GetType(operands[1].ID())
+		return isPortableScalar(leftType) && isPortableScalar(rightType) &&
+			leftType.Kind() == rightType.Kind()
+	case operators.In, operators.OldIn:
+		if call.IsMemberFunction() || len(operands) != 2 ||
+			!isPortableScalar(t.checked.NativeRep().GetType(operands[0].ID())) {
+			return false
+		}
+		listType := t.checked.NativeRep().GetType(operands[1].ID())
+		return listType.Kind() == types.ListKind && len(listType.Parameters()) == 1 &&
+			isPortableScalar(listType.Parameters()[0]) &&
+			t.checked.NativeRep().GetType(operands[0].ID()).Kind() == listType.Parameters()[0].Kind()
+	case overloads.StartsWith, overloads.EndsWith, overloads.Contains, overloads.Matches:
+		return call.IsMemberFunction() && len(operands) == 2 && allExact(types.StringKind)
+	default:
+		return false
+	}
+}
+
+func isPortableScalar(valueType *types.Type) bool {
+	if valueType == nil {
+		return false
+	}
+	switch valueType.Kind() {
+	case types.BoolKind, types.IntKind, types.StringKind:
+		return true
+	default:
+		return false
+	}
+}
+
+func isBoolLiteral(expr celast.Expr, want bool) bool {
+	if expr == nil || expr.Kind() != celast.LiteralKind {
+		return false
+	}
+	value, ok := expr.AsLiteral().(types.Bool)
+	return ok && bool(value) == want
+}
+
+func isAccumulatorIdent(expr celast.Expr, name string) bool {
+	return expr != nil && expr.Kind() == celast.IdentKind && expr.AsIdent() == name
+}
+
+func isExistsCondition(expr celast.Expr, accumulator string) bool {
+	if expr == nil || expr.Kind() != celast.CallKind {
+		return false
+	}
+	outer := expr.AsCall()
+	if outer.IsMemberFunction() || outer.FunctionName() != operators.NotStrictlyFalse ||
+		len(outer.Args()) != 1 || outer.Args()[0].Kind() != celast.CallKind {
+		return false
+	}
+	inner := outer.Args()[0].AsCall()
+	return !inner.IsMemberFunction() && inner.FunctionName() == operators.LogicalNot &&
+		len(inner.Args()) == 1 && isAccumulatorIdent(inner.Args()[0], accumulator)
+}
+
+func clonePortableScope(scope map[string]string) map[string]string {
+	cloned := make(map[string]string, len(scope)+1)
+	for name, translated := range scope {
+		cloned[name] = translated
+	}
+	return cloned
+}

--- a/internal/guardrail/semantic/portable_test.go
+++ b/internal/guardrail/semantic/portable_test.go
@@ -1,0 +1,293 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package semantic
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/guardrail/semanticpb"
+)
+
+const (
+	parseUnspecified = "defenseclaw.guardrail.semantic.v1." +
+		"ParseStatus.PARSE_STATUS_UNSPECIFIED"
+	pathAccessRead = "defenseclaw.guardrail.semantic.v1." +
+		"PathAccess.PATH_ACCESS_READ"
+)
+
+func TestCompilePortableCanonicalIdentityAndCache(t *testing.T) {
+	compiler, err := NewCompiler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sources := []string{
+		`f.commands.exists(c, c.id == 9007199254740993 && ` +
+			`c.pipeline_id == 9223372036854775807 && ` +
+			operationDelete + ` in c.operations)`,
+		`f.commands.exists(command, command.id==9007199254740993 && ` +
+			`command.pipeline_id==9223372036854775807 && ` +
+			operationDelete + ` in command.operations)`,
+	}
+	first, code := compiler.CompilePortable(sources[0])
+	if code != CompileOK || first == nil {
+		t.Fatalf("CompilePortable(first) = (%v, %q)", first, code)
+	}
+	second, code := compiler.CompilePortable(sources[1])
+	if code != CompileOK || second == nil {
+		t.Fatalf("CompilePortable(second) = (%v, %q)", second, code)
+	}
+	if first.Expression() != second.Expression() || first.Identity() != second.Identity() {
+		t.Fatalf(
+			"alpha/whitespace-equivalent translation changed identity:\nfirst:  %s %s\nsecond: %s %s",
+			first.Identity(), first.Expression(), second.Identity(), second.Expression(),
+		)
+	}
+	if first.Expression() == "" ||
+		!strings.Contains(first.Expression(), `input.commands.exists(item0`) ||
+		!strings.Contains(first.Expression(), `"9007199254740993"`) ||
+		!strings.Contains(first.Expression(), `"9223372036854775807"`) ||
+		!strings.Contains(first.Expression(), `"OPERATION_KIND_DELETE"`) ||
+		strings.Contains(first.Expression(), "defenseclaw.guardrail.semantic.v1") {
+		t.Fatalf("unexpected portable expression: %s", first.Expression())
+	}
+	if !strings.HasPrefix(first.Identity(), "sha256:") || len(first.Identity()) != len("sha256:")+64 {
+		t.Fatalf("portable identity = %q", first.Identity())
+	}
+	if first.SourceStaticCost() == 0 {
+		t.Fatal("portable program lost typed source cost")
+	}
+	cached, code := compiler.CompilePortable(sources[0])
+	if code != CompileOK || cached != first {
+		t.Fatalf("cached CompilePortable() = (%v, %q)", cached, code)
+	}
+
+	facts := &semanticpb.Facts{
+		Commands: []*semanticpb.CommandFact{{
+			Id:         9007199254740993,
+			PipelineId: 9223372036854775807,
+			Operations: []semanticpb.OperationKind{semanticpb.OperationKind_OPERATION_KIND_DELETE},
+		}},
+	}
+	assertPortableEquivalent(t, compiler, sources[0], facts, true)
+}
+
+func TestPortableEvaluationDefaultsEmptyListsAndPipelineIDs(t *testing.T) {
+	compiler, err := NewCompiler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defaultExpression := `f.tool == "" && f.cwd == "" && f.active_home == "" && ` +
+		`f.parse.status == ` + parseUnspecified +
+		` && !f.commands.exists(c, c.argv_complete)`
+	assertPortableEquivalent(t, compiler, defaultExpression, &semanticpb.Facts{}, true)
+	commandDefaults := `f.commands.exists(c, c.id == 0 && c.program == "" && ` +
+		`!c.argv_complete && !c.operations.exists(o, o == ` + operationDelete + `))`
+	assertPortableEquivalent(t, compiler, commandDefaults, &semanticpb.Facts{
+		Commands: []*semanticpb.CommandFact{{}},
+	}, true)
+
+	pipelineExpression := `f.commands.exists(src, f.commands.exists(dst, ` +
+		`src.id != dst.id && src.pipeline_id != 0 && ` +
+		`src.pipeline_id == dst.pipeline_id))`
+	assertPortableEquivalent(t, compiler, pipelineExpression, &semanticpb.Facts{}, false)
+	assertPortableEquivalent(t, compiler, pipelineExpression, &semanticpb.Facts{
+		Commands: []*semanticpb.CommandFact{
+			{Id: 1, PipelineId: 0},
+			{Id: 2, PipelineId: 0},
+		},
+	}, false)
+	assertPortableEquivalent(t, compiler, pipelineExpression, &semanticpb.Facts{
+		Commands: []*semanticpb.CommandFact{
+			{Id: 9007199254740993, PipelineId: 9223372036854775807},
+			{Id: 9007199254740994, PipelineId: 9223372036854775807},
+		},
+	}, true)
+}
+
+func TestPortableTranslationResolvesRootAndShadowedVariables(t *testing.T) {
+	compiler, err := NewCompiler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expression := `f.commands.exists(input, input.id == 7 && ` +
+		`f.paths.exists(f, f.command_id == input.id && ` +
+		`f.access == ` + pathAccessRead + `))`
+	facts := &semanticpb.Facts{
+		Commands: []*semanticpb.CommandFact{{Id: 7}},
+		Paths: []*semanticpb.PathFact{{
+			CommandId: 7,
+			Access:    semanticpb.PathAccess_PATH_ACCESS_READ,
+		}},
+	}
+	portable, code := compiler.CompilePortable(expression)
+	if code != CompileOK || portable == nil {
+		t.Fatalf("CompilePortable() = (%v, %q)", portable, code)
+	}
+	if !strings.Contains(portable.Expression(), "input.commands.exists(item0") ||
+		!strings.Contains(portable.Expression(), "input.paths.exists(item1") {
+		t.Fatalf("root/local resolution was not canonical: %s", portable.Expression())
+	}
+	assertPortableEquivalent(t, compiler, expression, facts, true)
+}
+
+func TestPortableDocumentProtoJSONContract(t *testing.T) {
+	document, err := PortableDocument(&semanticpb.Facts{
+		Commands: []*semanticpb.CommandFact{{
+			Id:         9007199254740993,
+			PipelineId: 9223372036854775807,
+			Operations: []semanticpb.OperationKind{semanticpb.OperationKind_OPERATION_KIND_DELETE},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parse, ok := document["parse"].(map[string]any)
+	if !ok {
+		t.Fatalf("default parse document = %#v", document["parse"])
+	}
+	if parse["status"] != "PARSE_STATUS_UNSPECIFIED" ||
+		parse["dialect"] != "DIALECT_UNSPECIFIED" ||
+		len(parse["issues"].([]any)) != 0 {
+		t.Fatalf("default parse document = %#v", parse)
+	}
+	commands := document["commands"].([]any)
+	command := commands[0].(map[string]any)
+	if command["id"] != "9007199254740993" ||
+		command["parent_command_id"] != "0" ||
+		command["pipeline_id"] != "9223372036854775807" {
+		t.Fatalf("int64 document contract = %#v", command)
+	}
+	operations := command["operations"].([]any)
+	if len(operations) != 1 || operations[0] != "OPERATION_KIND_DELETE" {
+		t.Fatalf("enum document contract = %#v", operations)
+	}
+	if command["argv_complete"] != false || len(command["argv"].([]any)) != 0 {
+		t.Fatalf("unpopulated document contract = %#v", command)
+	}
+	if _, err := PortableDocument(nil); err == nil {
+		t.Fatal("nil Facts document was accepted")
+	}
+	if _, err := PortableDocument(&semanticpb.Facts{
+		Parse: &semanticpb.ParseResult{Status: semanticpb.ParseStatus(999)},
+	}); err == nil {
+		t.Fatal("unknown enum value was accepted")
+	}
+}
+
+func TestCompilePortableEnumDomainsFailClosed(t *testing.T) {
+	compiler, err := NewCompiler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name       string
+		expression string
+		want       CompileCode
+	}{
+		{
+			name:       "numeric enum",
+			expression: `f.parse.status == 0`,
+			want:       CompileEnumDomain,
+		},
+		{
+			name: "cross-domain enum",
+			expression: `f.parse.status == defenseclaw.guardrail.semantic.v1.` +
+				`Dialect.DIALECT_UNSPECIFIED`,
+			want: CompileEnumDomain,
+		},
+		{
+			name: "mixed enum list",
+			expression: `f.commands.exists(c, c.operations.exists(o, ` +
+				`o in [` + operationDelete + `, 5]))`,
+			want: CompileEnumDomain,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			program, code := compiler.CompilePortable(test.expression)
+			if code != test.want || program != nil {
+				t.Fatalf("CompilePortable() = (%v, %q), want (nil, %q)", program, code, test.want)
+			}
+		})
+	}
+}
+
+func TestPortableCheckedASTRejectsUnsupportedNodes(t *testing.T) {
+	environment, err := newEnvironment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := map[string]string{
+		"all comprehension": `f.commands.all(c, c.argv_complete)`,
+		"arithmetic":        `1 + 1 == 2`,
+		"conditional":       `true ? f.tool == "exec" : false`,
+		"index":             `[f.tool][0] == "exec"`,
+		"map":               `{"tool": f.tool}["tool"] == "exec"`,
+		"presence":          `has(f.parse.status)`,
+	}
+	for name, expression := range tests {
+		t.Run(name, func(t *testing.T) {
+			parsed, issues := environment.Parse(expression)
+			if issues != nil && issues.Err() != nil {
+				t.Fatalf("parse unsupported checked form: %v", issues.Err())
+			}
+			checked, issues := environment.Check(parsed)
+			if issues != nil && issues.Err() != nil {
+				t.Fatalf("check unsupported checked form: %v", issues.Err())
+			}
+			if translated, ok := translatePortableCheckedAST(checked); ok {
+				t.Fatalf("unsupported checked AST translated to %q", translated)
+			}
+		})
+	}
+}
+
+func assertPortableEquivalent(
+	t *testing.T,
+	compiler *Compiler,
+	expression string,
+	facts *semanticpb.Facts,
+	want bool,
+) {
+	t.Helper()
+	native, code := compiler.Compile(expression)
+	if code != CompileOK || native == nil {
+		t.Fatalf("Compile(%q) = (%v, %q)", expression, native, code)
+	}
+	portable, code := compiler.CompilePortable(expression)
+	if code != CompileOK || portable == nil {
+		t.Fatalf("CompilePortable(%q) = (%v, %q)", expression, portable, code)
+	}
+	nativeResult, nativeCode := native.EvalBool(t.Context(), facts)
+	portableResult, portableCode := portable.EvalBool(t.Context(), facts)
+	if nativeCode != portableCode || nativeResult.Matched != portableResult.Matched {
+		t.Fatalf(
+			"native=(matched=%t code=%s) portable=(matched=%t code=%s) expression=%q portable_expression=%q",
+			nativeResult.Matched,
+			nativeCode,
+			portableResult.Matched,
+			portableCode,
+			expression,
+			portable.Expression(),
+		)
+	}
+	if nativeCode != EvalOK || nativeResult.Matched != want {
+		t.Fatalf("evaluation = (matched=%t code=%s), want (matched=%t code=%s)",
+			nativeResult.Matched, nativeCode, want, EvalOK)
+	}
+}


### PR DESCRIPTION
DefenseClaw CEL validation stack 2 of 2, on top of #814.

This adds a fail-closed portability compiler for admitted typed ActionFacts CEL. It translates only the resolved checked AST from f: defenseclaw.guardrail.semantic.v1.Facts to canonical stock document CEL over input: dyn; it does not perform source-text replacement. Resolved enum constants become canonical enum-name strings, protobuf int64 values and literals become lossless decimal strings, comprehension variables are alpha-renamed, and a closed node/operator/type allowlist rejects unsupported forms. The canonical source receives a versioned SHA-256 identity and is rechecked in a schema-free stock cel-go environment.

Facts are projected through protojson with UseProtoNames and EmitUnpopulated. Missing parse defaults are materialized, unknown enum values fail closed, and the document remains private ephemeral policy material. Production continues to execute the authored typed f program; this portable form is an interoperability and regression boundary, not a new public DefenseClaw ingress.

Exhaustive corpus result:
- 3 profiles, 147 rule instances, 49 IDs, 31 unique expressions and portable identities
- 279 structured tool-call rows; 226 CEL-targeted
- 180 authoritative/projectable rows; 46 fallback-only rows; 53 structured non-CEL rows
- 26,460 native/portable equivalence pairs, or 52,920 in-process evaluations, with equivalent match and error classification
- 1,276 text-only regex/judge/e2e/eval rows inventoried as non-applicable because they cannot produce authenticated ActionFacts

AgentCEL process boundary:
- an opt-in AGENTCEL_BIN test writes all 147 translated rule instances as separate bare .cel files
- AgentCEL validates all 147 files, then scans all 180 applicable documents
- all 26,460 AgentCEL rule-by-case outcomes match native typed DefenseClaw evaluation
- the verified local run used AgentCEL bare-document commit 4400a816; DefenseClaw imports no AgentCEL module

Validation:
- go test ./internal/guardrail/semantic ./internal/guardrail ./internal/gateway -count=1
- go test -race ./internal/guardrail/semantic -count=1
- go vet ./internal/guardrail/semantic ./internal/guardrail ./internal/gateway
- AGENTCEL_BIN=/private/tmp/agentcel-defenseclaw-exhaustive go test ./internal/gateway -run TestGuardrailPortableCELAgentCELE2E -count=1 -v