### PR TITLE
fix(inventory): 30-min managed_enterprise cadence + fleet-wide publish jitter

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -245,6 +245,12 @@ type AIDiscoveryConfig struct {
 	Mode               string   `mapstructure:"mode"                      yaml:"mode"` // passive | enhanced
 	ScanIntervalMin    int      `mapstructure:"scan_interval_min"         yaml:"scan_interval_min"`
 	ProcessIntervalSec int      `mapstructure:"process_interval_s"        yaml:"process_interval_s"`
+	// PublishJitterMs bounds the fleet-wide startup/tick jitter applied to
+	// the discovery scan schedule when a run publishes to AI Defense
+	// (managed_enterprise). Zero means "use the mode default" — 10 % of
+	// ScanIntervalMin in managed_enterprise, disabled elsewhere. Set
+	// explicitly to override; a negative value falls back to the default.
+	PublishJitterMs int `mapstructure:"publish_jitter_ms" yaml:"publish_jitter_ms,omitempty"`
 	ScanRoots          []string `mapstructure:"scan_roots"                yaml:"scan_roots,omitempty"`
 	// HomeDirs is the list of user home directories the detectors that
 	// walk per-user dotfiles (editor extensions, MCP configs, shell

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -241,17 +241,17 @@ type Config struct {
 // default; LookupModelProvenanceOnline is a separate, explicit opt-in that
 // sends recovered public model repository IDs to the fixed Hugging Face API.
 type AIDiscoveryConfig struct {
-	Enabled            bool     `mapstructure:"enabled"                   yaml:"enabled"`
-	Mode               string   `mapstructure:"mode"                      yaml:"mode"` // passive | enhanced
-	ScanIntervalMin    int      `mapstructure:"scan_interval_min"         yaml:"scan_interval_min"`
-	ProcessIntervalSec int      `mapstructure:"process_interval_s"        yaml:"process_interval_s"`
+	Enabled            bool   `mapstructure:"enabled"                   yaml:"enabled"`
+	Mode               string `mapstructure:"mode"                      yaml:"mode"` // passive | enhanced
+	ScanIntervalMin    int    `mapstructure:"scan_interval_min"         yaml:"scan_interval_min"`
+	ProcessIntervalSec int    `mapstructure:"process_interval_s"        yaml:"process_interval_s"`
 	// PublishJitterMs bounds the fleet-wide startup/tick jitter applied to
 	// the discovery scan schedule when a run publishes to AI Defense
 	// (managed_enterprise). Zero means "use the mode default" — 10 % of
 	// ScanIntervalMin in managed_enterprise, disabled elsewhere. Set
 	// explicitly to override; a negative value falls back to the default.
-	PublishJitterMs int `mapstructure:"publish_jitter_ms" yaml:"publish_jitter_ms,omitempty"`
-	ScanRoots          []string `mapstructure:"scan_roots"                yaml:"scan_roots,omitempty"`
+	PublishJitterMs int      `mapstructure:"publish_jitter_ms" yaml:"publish_jitter_ms,omitempty"`
+	ScanRoots       []string `mapstructure:"scan_roots"                yaml:"scan_roots,omitempty"`
 	// HomeDirs is the list of user home directories the detectors that
 	// walk per-user dotfiles (editor extensions, MCP configs, shell
 	// history, installed applications) should inspect. Empty means

--- a/internal/inventory/ai_discovery.go
+++ b/internal/inventory/ai_discovery.go
@@ -683,6 +683,7 @@ func AIDiscoveryOptionsFromConfig(cfg *config.Config) AIDiscoveryOptions {
 		Mode:                        ad.Mode,
 		ScanInterval:                time.Duration(ad.ScanIntervalMin) * time.Minute,
 		ProcessInterval:             time.Duration(ad.ProcessIntervalSec) * time.Second,
+		PublishJitter:               time.Duration(ad.PublishJitterMs) * time.Millisecond,
 		ScanRoots:                   append([]string{}, ad.ScanRoots...),
 		SignaturePacks:              append([]string{}, ad.SignaturePacks...),
 		AllowWorkspaceSignatures:    ad.AllowWorkspaceSignatures,
@@ -967,11 +968,16 @@ func (s *ContinuousDiscoveryService) runClaimed(ctx context.Context) (runErr err
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-fullTimer.C:
-			_, _ = s.runScan(ctx, true, "scheduled")
+			// Reset BEFORE runScan so the next interval is measured
+			// from scan start, not scan end — long scans do not stretch
+			// the effective cadence. runScan is serialized by scanMu so
+			// a Reset-then-scan that outlasts the interval simply queues
+			// the next fire; the timer channel remains a single slot.
 			fullTimer.Reset(s.nextScheduledDelay(s.opts.ScanInterval))
+			_, _ = s.runScan(ctx, true, "scheduled")
 		case <-processTimer.C:
-			_, _ = s.runScan(ctx, false, "process")
 			processTimer.Reset(s.nextScheduledDelay(s.opts.ProcessInterval))
+			_, _ = s.runScan(ctx, false, "process")
 		case resp := <-s.triggers:
 			report, err := s.runScan(ctx, true, "api")
 			resp <- scanResponse{report: report, err: err}

--- a/internal/inventory/ai_discovery.go
+++ b/internal/inventory/ai_discovery.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	mrand "math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -75,6 +76,15 @@ const (
 	maxIndeterminateModelAPIMisses   = 1
 	maxPersistedLocalModelAPISignals = 2 * maxLocalModelAPIItems
 )
+
+// managedEnterpriseScanInterval is the minimum full-scan cadence in
+// managed_enterprise mode. Every full-scan tick fans out through
+// managedInventoryEmit to AI Defense, so this doubles as the AI Defense
+// publish cadence — the ingest cost of a fleet-wide 30-min beat is well
+// below the 5-min baseline while still keeping inventory drift bounded.
+// The value is also the floor applied to ProcessIntervalSec in the same
+// mode so the two tickers never diverge onto a faster wall-clock.
+const managedEnterpriseScanInterval = 30 * time.Minute
 
 // aiDiscoveryStateVersion is the schema version of the on-disk state file
 // (`ai_discovery_state.json`). v2 introduced per-signal `evidence_hash`,
@@ -165,6 +175,18 @@ type AIDiscoveryOptions struct {
 	// scan-trace telemetry (StartScan / detector traces / End) remains owned
 	// by the bound observability runtime and fires on every tick.
 	ManagedEnterprise bool
+	// PublishJitter is the maximum wall-clock perturbation applied to the
+	// startup scan and to each scheduled full/process tick when running in
+	// managed_enterprise mode. Non-managed installs default this to zero and
+	// retain the fixed-cadence ticker behavior. In managed_enterprise the
+	// normalization layer defaults it to ScanInterval / 10 (10 %) so a
+	// fleet-wide reboot, an AI Defense outage, or a co-scheduled config
+	// reload does not cause every endpoint to hit the ingest endpoint at the
+	// same wall-clock second. Retry-backoff jitter in the delivery
+	// dispatcher (full jitter, capped at MaxBackoff) already spreads
+	// post-failure retries; this field spreads the first attempt of each
+	// cycle across the fleet so the initial thundering herd never forms.
+	PublishJitter time.Duration
 }
 
 // AIEvidence is an internal normalized evidence record. RawPath is never
@@ -704,11 +726,33 @@ func normalizeAIDiscoveryOptions(opts AIDiscoveryOptions) AIDiscoveryOptions {
 	// a 60s connector/MCP snapshot push to AI Defense. Push volume, not
 	// process-detection cost, dominates the operational spend on managed
 	// installs — align the process cadence with the full-scan cadence so
-	// the two tickers produce one push per 5 min instead of six. Operators
-	// can still configure a longer interval; the floor only lifts values
-	// below the full-scan default.
-	if opts.ManagedEnterprise && opts.ProcessInterval < 5*time.Minute {
-		opts.ProcessInterval = 5 * time.Minute
+	// the two tickers produce one push per full-scan cycle instead of
+	// several. The full-scan cadence is itself lifted to 30 min in
+	// managed_enterprise; the process-interval floor tracks it so both
+	// tickers fire on the same 30-min beat. Operators can still configure
+	// a longer interval; the floor only lifts values below the managed
+	// default.
+	if opts.ManagedEnterprise && opts.ScanInterval < managedEnterpriseScanInterval {
+		opts.ScanInterval = managedEnterpriseScanInterval
+	}
+	if opts.ManagedEnterprise && opts.ProcessInterval < managedEnterpriseScanInterval {
+		opts.ProcessInterval = managedEnterpriseScanInterval
+	}
+	// Default the fleet-wide publish jitter to 10 % of the full-scan
+	// cadence in managed_enterprise. At the 30-min managed default this
+	// is a 3-min window; each endpoint's startup scan and each scheduled
+	// tick land at a uniformly random offset inside that window, so a
+	// synchronized fleet event (reboot, config reload, AI Defense outage
+	// recovery) does not translate into a synchronized ingest spike.
+	// Non-managed installs keep the historical fixed-cadence tick.
+	// A negative operator override is treated as "invalid, use default"
+	// — clamp to zero first so the managed default branch takes over,
+	// then the final clamp handles a non-managed negative.
+	if opts.PublishJitter < 0 {
+		opts.PublishJitter = 0
+	}
+	if opts.ManagedEnterprise && opts.PublishJitter <= 0 {
+		opts.PublishJitter = opts.ScanInterval / 10
 	}
 	if opts.MaxFilesPerScan <= 0 {
 		opts.MaxFilesPerScan = 1000
@@ -896,25 +940,78 @@ func (s *ContinuousDiscoveryService) runClaimed(ctx context.Context) (runErr err
 			}
 		}
 	}()
+	// Startup jitter — sleep for a uniformly random offset in
+	// [0, PublishJitter) before the first scan so a fleet-wide reboot
+	// does not translate into a fleet-wide first-tick spike against
+	// AI Defense. Zero in non-managed installs, so the loop still fires
+	// immediately outside managed_enterprise.
+	if !s.sleepWithJitter(ctx, 0, s.opts.PublishJitter) {
+		return ctx.Err()
+	}
 	_, _ = s.runScan(ctx, true, "startup")
 
-	fullTicker := time.NewTicker(s.opts.ScanInterval)
-	defer fullTicker.Stop()
-	processTicker := time.NewTicker(s.opts.ProcessInterval)
-	defer processTicker.Stop()
+	// Use one-shot timers instead of fixed tickers so each scheduled
+	// interval carries its own jitter draw. The full and process schedules
+	// are independent — a jittered full tick does not delay the next
+	// process tick and vice versa. In non-managed installs PublishJitter
+	// is zero, so nextScheduledDelay collapses to the configured interval
+	// and the two timers behave identically to the previous ticker-based
+	// loop.
+	fullTimer := time.NewTimer(s.nextScheduledDelay(s.opts.ScanInterval))
+	defer fullTimer.Stop()
+	processTimer := time.NewTimer(s.nextScheduledDelay(s.opts.ProcessInterval))
+	defer processTimer.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-fullTicker.C:
+		case <-fullTimer.C:
 			_, _ = s.runScan(ctx, true, "scheduled")
-		case <-processTicker.C:
+			fullTimer.Reset(s.nextScheduledDelay(s.opts.ScanInterval))
+		case <-processTimer.C:
 			_, _ = s.runScan(ctx, false, "process")
+			processTimer.Reset(s.nextScheduledDelay(s.opts.ProcessInterval))
 		case resp := <-s.triggers:
 			report, err := s.runScan(ctx, true, "api")
 			resp <- scanResponse{report: report, err: err}
 		}
+	}
+}
+
+// nextScheduledDelay returns interval + a uniformly random offset in
+// [0, PublishJitter). A non-positive PublishJitter returns the raw interval,
+// preserving the legacy fixed-cadence behavior for non-managed installs.
+func (s *ContinuousDiscoveryService) nextScheduledDelay(interval time.Duration) time.Duration {
+	if interval <= 0 {
+		return 0
+	}
+	jitter := s.opts.PublishJitter
+	if jitter <= 0 {
+		return interval
+	}
+	return interval + time.Duration(mrand.Int64N(int64(jitter)))
+}
+
+// sleepWithJitter blocks for base + a uniformly random offset in
+// [0, jitter). Returns false only when ctx is cancelled during the sleep;
+// callers should treat that as a shutdown signal. A zero total delay
+// returns immediately with ctx.Err() == nil.
+func (s *ContinuousDiscoveryService) sleepWithJitter(ctx context.Context, base, jitter time.Duration) bool {
+	delay := base
+	if jitter > 0 {
+		delay += time.Duration(mrand.Int64N(int64(jitter)))
+	}
+	if delay <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
 	}
 }
 

--- a/internal/inventory/ai_discovery_test.go
+++ b/internal/inventory/ai_discovery_test.go
@@ -2748,3 +2748,142 @@ func TestSleepWithJitterCancellation(t *testing.T) {
 		}
 	})
 }
+
+// TestAIDiscoveryOptionsFromConfigPublishJitter pins the config → options
+// bridge for the new PublishJitter field. An operator override
+// (`ai_discovery.publish_jitter_ms: 45000`) must survive normalization
+// verbatim in managed_enterprise; a zero value must still fall back to the
+// 10 % managed default.
+func TestAIDiscoveryOptionsFromConfigPublishJitter(t *testing.T) {
+	cases := []struct {
+		name     string
+		mode     string
+		scanMin  int
+		jitterMs int
+		want     time.Duration
+	}{
+		{"managed_default_zero_uses_ten_percent", "managed_enterprise", 30, 0, 3 * time.Minute},
+		{"managed_operator_override_preserved", "managed_enterprise", 30, 45_000, 45 * time.Second},
+		{"managed_operator_override_below_normalize_floor_preserved", "managed_enterprise", 30, 500, 500 * time.Millisecond},
+		{"unmanaged_default_zero_stays_zero", "", 5, 0, 0},
+		{"unmanaged_operator_override_preserved", "", 5, 15_000, 15 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{
+				DataDir:        t.TempDir(),
+				DeploymentMode: tc.mode,
+				AIDiscovery: config.AIDiscoveryConfig{
+					Enabled:         true,
+					ScanIntervalMin: tc.scanMin,
+					PublishJitterMs: tc.jitterMs,
+				},
+			}
+			opts := AIDiscoveryOptionsFromConfig(cfg)
+			if opts.PublishJitter != tc.want {
+				t.Fatalf("PublishJitter = %s, want %s (mode=%q, scan_min=%d, jitter_ms=%d)",
+					opts.PublishJitter, tc.want, tc.mode, tc.scanMin, tc.jitterMs)
+			}
+		})
+	}
+}
+
+// TestRunClaimedResetsTimerBeforeScan is a regression guard for the
+// CodeRabbit finding on PR #820 — the scheduled/process timers must be
+// Reset BEFORE the synchronous runScan call so the next interval is
+// measured from scan START, not from scan END. A slow scan therefore
+// does not stretch the effective cadence.
+//
+// The test drives one full-scan tick with an artificially slow scan
+// (a report observer that sleeps for a substantial fraction of the
+// scan interval) and verifies the NEXT scheduled tick still fires
+// within a window measured from the FIRST tick's start, not its end.
+func TestRunClaimedResetsTimerBeforeScan(t *testing.T) {
+	dataDir := t.TempDir()
+	homeDir := t.TempDir()
+
+	// 200 ms base interval, 0 jitter — tight window so a stretched
+	// cadence is obviously outside it. Scan duration is 120 ms —
+	// >50 % of the interval, so the "reset after" bug (period ≈ 320 ms)
+	// is clearly separable from the "reset before" contract (period
+	// ≈ 200 ms).
+	scanInterval := 200 * time.Millisecond
+	scanDuration := 120 * time.Millisecond
+
+	svc := NewContinuousDiscoveryServiceWithOptions(AIDiscoveryOptions{
+		DataDir:         dataDir,
+		HomeDir:         homeDir,
+		ScanRoots:       []string{homeDir},
+		ScanInterval:    scanInterval,
+		ProcessInterval: 10 * time.Second, // silence the process timer for this test
+		PublishJitter:   0,
+	}, nil)
+	t.Cleanup(func() {
+		if svc.InventoryStore() != nil {
+			_ = svc.InventoryStore().Close()
+		}
+	})
+
+	// Observer records the wall-clock arrival of each scan report and
+	// sleeps to make the scan slow. Only slow the SCHEDULED ticks —
+	// let the startup scan return promptly so we're measuring the
+	// tick-to-tick period, not startup + tick.
+	var (
+		mu       sync.Mutex
+		arrivals []time.Time
+	)
+	svc.AddReportObserver(func(_ context.Context, _ AIDiscoveryReport) {
+		mu.Lock()
+		arrivals = append(arrivals, time.Now())
+		count := len(arrivals)
+		mu.Unlock()
+		if count >= 2 { // slow only scheduled ticks, not the initial startup scan
+			time.Sleep(scanDuration)
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() { runDone <- svc.Run(ctx) }()
+
+	// Wait for the startup scan + at least three scheduled ticks so the
+	// tick-to-tick period is measured on scans #2 → #3 (both were slow).
+	deadline := time.After(3 * time.Second)
+	for {
+		mu.Lock()
+		got := len(arrivals)
+		mu.Unlock()
+		if got >= 4 {
+			break
+		}
+		select {
+		case <-deadline:
+			cancel()
+			<-runDone
+			t.Fatalf("only observed %d scan(s) in 3 s; want ≥ 4", got)
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+	cancel()
+	if err := <-runDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run error = %v, want context.Canceled", err)
+	}
+
+	// arrivals[0] = startup, arrivals[1..] = scheduled. Measure
+	// scan #2 start → scan #3 start (both are slow scheduled ticks).
+	mu.Lock()
+	defer mu.Unlock()
+	if len(arrivals) < 4 {
+		t.Fatalf("arrivals = %d, want ≥ 4", len(arrivals))
+	}
+	period := arrivals[3].Sub(arrivals[2])
+	// Reset-before contract: period ≈ scanInterval (200 ms).
+	// Reset-after bug: period ≈ scanDuration + scanInterval (320 ms).
+	// Fail with generous margin either way — 250 ms is above the
+	// contract but below the bug regime.
+	if period > scanInterval+50*time.Millisecond {
+		t.Fatalf("period between slow ticks = %s, want ≤ %s "+
+			"(reset-after regression — cadence is stretching with scan duration; arrivals=%v)",
+			period, scanInterval+50*time.Millisecond, arrivals)
+	}
+}

--- a/internal/inventory/ai_discovery_test.go
+++ b/internal/inventory/ai_discovery_test.go
@@ -2575,11 +2575,12 @@ func TestNormalizeAIDiscoveryOptionsProcessIntervalManagedFloor(t *testing.T) {
 	}{
 		{"unmanaged_default_stays_60s", false, 60 * time.Second, 60 * time.Second},
 		{"unmanaged_zero_falls_back_to_60s", false, 0, 60 * time.Second},
-		{"managed_default_60s_promoted_to_5m", true, 60 * time.Second, 5 * time.Minute},
-		{"managed_zero_promoted_to_5m", true, 0, 5 * time.Minute},
-		{"managed_below_floor_promoted", true, 90 * time.Second, 5 * time.Minute},
-		{"managed_at_floor_preserved", true, 5 * time.Minute, 5 * time.Minute},
-		{"managed_above_floor_preserved", true, 10 * time.Minute, 10 * time.Minute},
+		{"managed_default_60s_promoted_to_30m", true, 60 * time.Second, 30 * time.Minute},
+		{"managed_zero_promoted_to_30m", true, 0, 30 * time.Minute},
+		{"managed_below_floor_promoted", true, 90 * time.Second, 30 * time.Minute},
+		{"managed_previous_5m_floor_promoted", true, 5 * time.Minute, 30 * time.Minute},
+		{"managed_at_floor_preserved", true, 30 * time.Minute, 30 * time.Minute},
+		{"managed_above_floor_preserved", true, 45 * time.Minute, 45 * time.Minute},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2595,4 +2596,155 @@ func TestNormalizeAIDiscoveryOptionsProcessIntervalManagedFloor(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestNormalizeAIDiscoveryOptionsScanIntervalManagedFloor pins the 30 min
+// managed_enterprise floor on the FULL-scan cadence — the field that
+// gates every AI Defense publish through fanoutReport. Non-managed
+// installs preserve the historical 5-min default so local dev / OSS
+// behavior does not shift.
+func TestNormalizeAIDiscoveryOptionsScanIntervalManagedFloor(t *testing.T) {
+	cases := []struct {
+		name    string
+		managed bool
+		input   time.Duration
+		want    time.Duration
+	}{
+		{"unmanaged_default_zero_falls_back_to_5m", false, 0, 5 * time.Minute},
+		{"unmanaged_configured_preserved", false, 5 * time.Minute, 5 * time.Minute},
+		{"managed_zero_promoted_to_30m", true, 0, 30 * time.Minute},
+		{"managed_previous_5m_default_promoted", true, 5 * time.Minute, 30 * time.Minute},
+		{"managed_below_floor_promoted", true, 15 * time.Minute, 30 * time.Minute},
+		{"managed_at_floor_preserved", true, 30 * time.Minute, 30 * time.Minute},
+		{"managed_above_floor_preserved", true, 60 * time.Minute, 60 * time.Minute},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := normalizeAIDiscoveryOptions(AIDiscoveryOptions{
+				DataDir:           t.TempDir(),
+				HomeDir:           t.TempDir(),
+				ScanInterval:      tc.input,
+				ManagedEnterprise: tc.managed,
+			})
+			if opts.ScanInterval != tc.want {
+				t.Fatalf("ScanInterval = %s, want %s (managed=%t, input=%s)",
+					opts.ScanInterval, tc.want, tc.managed, tc.input)
+			}
+		})
+	}
+}
+
+// TestNormalizeAIDiscoveryOptionsPublishJitter pins the fleet-wide jitter
+// default and the non-managed opt-out. In managed_enterprise the jitter
+// defaults to 10 % of ScanInterval so a fleet-wide reboot or AI Defense
+// outage recovery never translates into a synchronized ingest spike.
+// Non-managed installs get zero jitter and keep the fixed-cadence tick.
+func TestNormalizeAIDiscoveryOptionsPublishJitter(t *testing.T) {
+	cases := []struct {
+		name    string
+		managed bool
+		scan    time.Duration
+		input   time.Duration
+		want    time.Duration
+	}{
+		{"unmanaged_default_zero", false, 5 * time.Minute, 0, 0},
+		{"unmanaged_configured_preserved", false, 5 * time.Minute, 15 * time.Second, 15 * time.Second},
+		{"unmanaged_negative_clamped_to_zero", false, 5 * time.Minute, -1 * time.Second, 0},
+		{"managed_default_ten_percent_of_scan", true, 30 * time.Minute, 0, 3 * time.Minute},
+		{"managed_default_tracks_promoted_scan", true, 5 * time.Minute, 0, 3 * time.Minute},
+		{"managed_configured_preserved", true, 30 * time.Minute, 45 * time.Second, 45 * time.Second},
+		{"managed_negative_falls_back_to_default", true, 30 * time.Minute, -5 * time.Second, 3 * time.Minute},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := normalizeAIDiscoveryOptions(AIDiscoveryOptions{
+				DataDir:           t.TempDir(),
+				HomeDir:           t.TempDir(),
+				ScanInterval:      tc.scan,
+				PublishJitter:     tc.input,
+				ManagedEnterprise: tc.managed,
+			})
+			if opts.PublishJitter != tc.want {
+				t.Fatalf("PublishJitter = %s, want %s (managed=%t, scan=%s, input=%s)",
+					opts.PublishJitter, tc.want, tc.managed, tc.scan, tc.input)
+			}
+		})
+	}
+}
+
+// TestNextScheduledDelayJitterBounds pins the [interval, interval+jitter)
+// range on the timer-reset helper. Verifies the non-managed path (zero
+// jitter) collapses to the configured interval — that is the "legacy
+// fixed-cadence ticker behavior" contract non-managed installs rely on.
+func TestNextScheduledDelayJitterBounds(t *testing.T) {
+	base := 30 * time.Minute
+	t.Run("no_jitter_collapses_to_interval", func(t *testing.T) {
+		svc := &ContinuousDiscoveryService{opts: AIDiscoveryOptions{PublishJitter: 0}}
+		for i := 0; i < 200; i++ {
+			if got := svc.nextScheduledDelay(base); got != base {
+				t.Fatalf("nextScheduledDelay = %s, want exact %s (i=%d)", got, base, i)
+			}
+		}
+	})
+	t.Run("nonpositive_interval_returns_zero", func(t *testing.T) {
+		svc := &ContinuousDiscoveryService{opts: AIDiscoveryOptions{PublishJitter: 3 * time.Minute}}
+		if got := svc.nextScheduledDelay(0); got != 0 {
+			t.Fatalf("nextScheduledDelay(0) = %s, want 0", got)
+		}
+	})
+	jitterCases := []struct {
+		name   string
+		jitter time.Duration
+	}{
+		{"managed_default_ten_percent_bounded", 3 * time.Minute},
+		{"tight_jitter_bounded", 1 * time.Second},
+	}
+	for _, tc := range jitterCases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &ContinuousDiscoveryService{opts: AIDiscoveryOptions{PublishJitter: tc.jitter}}
+			min, max := base, base+tc.jitter
+			for i := 0; i < 500; i++ {
+				got := svc.nextScheduledDelay(base)
+				if got < min || got >= max {
+					t.Fatalf("nextScheduledDelay = %s, want [%s, %s) (i=%d)", got, min, max, i)
+				}
+			}
+		})
+	}
+}
+
+// TestSleepWithJitterCancellation pins the two shutdown-facing contracts on
+// the startup-jitter helper: a cancelled context short-circuits the sleep
+// (returns false), and a zero total delay never touches the timer path
+// (returns true immediately even with a live ctx). Regression guard for
+// runClaimed's `if !s.sleepWithJitter(ctx, 0, PublishJitter) { return }`
+// early-return — a false result from a live ctx would swallow the startup
+// scan across every managed_enterprise sidecar.
+func TestSleepWithJitterCancellation(t *testing.T) {
+	svc := &ContinuousDiscoveryService{}
+	t.Run("zero_delay_returns_true_without_blocking", func(t *testing.T) {
+		start := time.Now()
+		if !svc.sleepWithJitter(context.Background(), 0, 0) {
+			t.Fatalf("sleepWithJitter(0,0) = false, want true")
+		}
+		if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
+			t.Fatalf("sleepWithJitter(0,0) blocked for %s, want ~0", elapsed)
+		}
+	})
+	t.Run("cancelled_ctx_short_circuits", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		start := time.Now()
+		if svc.sleepWithJitter(ctx, 500*time.Millisecond, 500*time.Millisecond) {
+			t.Fatalf("sleepWithJitter with cancelled ctx = true, want false")
+		}
+		if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
+			t.Fatalf("sleepWithJitter with cancelled ctx blocked %s, want ~0", elapsed)
+		}
+	})
+	t.Run("live_ctx_returns_true_after_sleep", func(t *testing.T) {
+		if !svc.sleepWithJitter(context.Background(), 5*time.Millisecond, 0) {
+			t.Fatalf("sleepWithJitter with live ctx = false, want true")
+		}
+	})
 }

--- a/internal/observability/destinations/managedaid/adapter.go
+++ b/internal/observability/destinations/managedaid/adapter.go
@@ -358,7 +358,8 @@ func (adapter *Adapter) post(ctx context.Context, body []byte, token string) (in
 		// Transport-level failure info line so an operator tailing
 		// gateway.err.log / gateway.log can see when the AI Defense POST
 		// couldn't complete at all (DNS, TCP, TLS, cancel, deadline).
-		// One line per attempt; low-frequency at the 5 min publish cadence.
+		// One line per attempt; low-frequency at the managed_enterprise
+		// 30-min publish cadence.
 		// The endpoint URL is deliberately redacted to "AI DEFENSE" — the
 		// configured host is release-owned and static across a deployment
 		// so operators don't need it in every log line, and omitting it


### PR DESCRIPTION
## Summary

Two changes rolled together because they solve the same operational problem — AI Defense ingest cost from a synchronized `managed_enterprise` fleet.

- **Cadence** — lift the `managed_enterprise` full-scan / publish cadence from **5 min → 30 min**. Every full-scan tick fans out through `managedInventoryEmit` to AI Defense, so this is also the AI Defense publish cadence. The `ProcessInterval` floor tracks the new `ScanInterval` floor so the two tickers still fire on the same beat. **Only the managed floor moves** — non-managed installs keep the 5-min `ScanIntervalMin` default so local dev / OSS behavior is unchanged.
- **Jitter** — introduce `AIDiscoveryOptions.PublishJitter`, defaulted to **10 % of `ScanInterval`** in `managed_enterprise` (zero elsewhere). Applied to the startup scan and to each scheduled full/process tick.
  - Startup jitter: `sleepWithJitter` delays the first "startup" scan by a uniformly random offset in `[0, PublishJitter)` — a fleet-wide reboot no longer translates into a fleet-wide first-tick spike.
  - Per-tick jitter: fixed `time.Ticker` replaced with self-resetting `time.Timer`s using `nextScheduledDelay(interval + [0, PublishJitter))`. Independent draws for the full and process schedules.

Retry-backoff jitter in the delivery dispatcher (`boundedBackoff` in [internal/observability/delivery/dispatcher.go](internal/observability/delivery/dispatcher.go)) already spreads *post-failure* retries; this change spreads the **first attempt of each cycle** across the fleet so the initial thundering herd never forms during an AI Defense outage or recovery.

## Files touched

- [internal/inventory/ai_discovery.go](internal/inventory/ai_discovery.go) — new `managedEnterpriseScanInterval` const, `PublishJitter` option, `nextScheduledDelay` / `sleepWithJitter` helpers, and the ticker → timer rework in `runClaimed`.
- [internal/inventory/ai_discovery_test.go](internal/inventory/ai_discovery_test.go) — 5 new / updated tests pinning the floor, the jitter default, the timer-reset bounds, and the ctx-cancel short-circuit.
- [internal/observability/destinations/managedaid/adapter.go](internal/observability/destinations/managedaid/adapter.go) — comment refresh (5-min → 30-min cadence).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/inventory/... ./internal/gateway/... ./internal/observability/... ./internal/config/...` — all pass
- [x] `TestNormalizeAIDiscoveryOptionsScanIntervalManagedFloor` — new, pins the 30-min managed floor and non-managed 5-min default
- [x] `TestNormalizeAIDiscoveryOptionsProcessIntervalManagedFloor` — updated to the 30-min floor (was 5 min)
- [x] `TestNormalizeAIDiscoveryOptionsPublishJitter` — pins 10 % managed default, non-managed opt-out, negative clamping
- [x] `TestNextScheduledDelayJitterBounds` — 500-iter uniform-range check for jittered case, exact-value check for the zero-jitter (non-managed) collapse
- [x] `TestSleepWithJitterCancellation` — pins ctx-cancel short-circuit and zero-delay non-blocking path

🤖 Generated with [Claude Code](https://claude.com/claude-code)