### PR TITLE
feat(runtime): add deployment_mode=container for Kubernetes environments

### DIFF
--- a/internal/audit/audit_db_path_unix.go
+++ b/internal/audit/audit_db_path_unix.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 )
 
@@ -52,6 +53,13 @@ func validateAuditDBPlatformTrust(_ string, info os.FileInfo, directory, _ bool)
 		if directory && owner == 0 && info.Mode()&os.ModeSticky != 0 {
 			return nil
 		}
+		// In container environments, Kubernetes fsGroup makes emptyDir
+		// volumes group-writable. Accept group-writable directories
+		// when deployment_mode=container. Mount points are root-owned
+		// (owner==0) while user-created subdirs are user-owned.
+		if directory && isContainerDeploymentMode() {
+			return nil
+		}
 		kind := "file"
 		if directory {
 			kind = "directory"
@@ -59,6 +67,10 @@ func validateAuditDBPlatformTrust(_ string, info os.FileInfo, directory, _ bool)
 		return fmt.Errorf("audit: database %s is group- or other-writable", kind)
 	}
 	return nil
+}
+
+func isContainerDeploymentMode() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("DEFENSECLAW_DEPLOYMENT_MODE")), "container")
 }
 
 // macOS and some Unix installations expose a root-level system directory as a
@@ -89,5 +101,8 @@ func auditDBModeMatches(info os.FileInfo, want os.FileMode) bool {
 }
 
 func auditDBImmediateDirectoryModeTrusted(info os.FileInfo) bool {
-	return info.Mode().Perm()&0o022 == 0
+	if info.Mode().Perm()&0o022 == 0 {
+		return true
+	}
+	return isContainerDeploymentMode()
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -44,6 +44,7 @@ const (
 	DeploymentModeSandboxed         DeploymentMode = "sandboxed"
 	DeploymentModeServer            DeploymentMode = "server"
 	DeploymentModeSaaS              DeploymentMode = "saas"
+	DeploymentModeContainer         DeploymentMode = "container"
 )
 
 var validDeploymentModes = map[string]struct{}{
@@ -53,6 +54,7 @@ var validDeploymentModes = map[string]struct{}{
 	string(DeploymentModeSandboxed):         {},
 	string(DeploymentModeServer):            {},
 	string(DeploymentModeSaaS):              {},
+	string(DeploymentModeContainer):         {},
 }
 
 const (

--- a/internal/gateway/device_identity_directory_other.go
+++ b/internal/gateway/device_identity_directory_other.go
@@ -7,6 +7,7 @@ package gateway
 
 import (
 	"fmt"
+	"strings"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -16,7 +17,10 @@ func validateDeviceIdentityPathSyntax(_, _ string) error { return nil }
 
 func validateFreshIdentityDirectoryPlatform(path string, info os.FileInfo) error {
 	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok || stat.Uid != uint32(os.Geteuid()) {
+	if !ok {
+		return fmt.Errorf("gateway: device identity directory ownership unavailable: %s", path)
+	}
+	if stat.Uid != uint32(os.Geteuid()) && !isContainerDeploymentMode() {
 		return fmt.Errorf("gateway: device identity directory is not owned by the current user: %s", path)
 	}
 	resolved, err := filepath.EvalSymlinks(path)
@@ -47,4 +51,8 @@ func syncFreshIdentityDirectory(path string) error {
 		return fmt.Errorf("gateway: close device identity directory %s after sync: %w", path, closeErr)
 	}
 	return nil
+}
+
+func isContainerDeploymentMode() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("DEFENSECLAW_DEPLOYMENT_MODE")), "container")
 }

--- a/internal/managed/managed.go
+++ b/internal/managed/managed.go
@@ -41,6 +41,10 @@ func IsManagedEnterprise(mode string) bool {
 	return strings.EqualFold(strings.TrimSpace(mode), DeploymentModeManagedEnterprise)
 }
 
+func IsContainer(mode string) bool {
+	return strings.EqualFold(strings.TrimSpace(mode), "container")
+}
+
 func HookGuardianAuthorizationDir(dataDir string) string {
 	if configured := strings.TrimSpace(os.Getenv(HookGuardianAuthorizationDirEnv)); configured != "" {
 		return filepath.Clean(configured)

--- a/internal/managed/runtime_dir.go
+++ b/internal/managed/runtime_dir.go
@@ -25,6 +25,9 @@ func PinnedDeploymentMode() string {
 // the transient case where mkdir succeeds and the subsequent validation
 // then fails. The leaf itself is validated after Mkdir completes.
 func PrepareServiceRuntimeDir(deploymentMode, path, label string) error {
+	if IsContainer(deploymentMode) {
+		return os.MkdirAll(path, 0o700)
+	}
 	if !IsManagedEnterprise(deploymentMode) {
 		return safefile.ProtectDirectory(path)
 	}

--- a/internal/safefile/protect_other.go
+++ b/internal/safefile/protect_other.go
@@ -8,9 +8,14 @@ package safefile
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 func protectFile(_ string, file *os.File) error { return file.Chmod(0o600) }
+
+func isContainerMode() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("DEFENSECLAW_DEPLOYMENT_MODE")), "container")
+}
 
 func protectDirectory(path string) error {
 	info, err := os.Stat(path)
@@ -31,6 +36,9 @@ func validatePrivateProtection(path string, wantDirectory bool) error {
 	if info.Mode()&os.ModeSymlink != 0 || (wantDirectory && !info.IsDir()) ||
 		(!wantDirectory && !info.Mode().IsRegular()) {
 		return fmt.Errorf("safefile: private path has an unexpected type: %s", path)
+	}
+	if isContainerMode() {
+		return nil
 	}
 	if wantDirectory && info.Mode().Perm()&0o077 != 0 {
 		return fmt.Errorf("safefile: private directory permissions are too broad: %s", path)

--- a/schemas/config/v8/defenseclaw-config.schema.json
+++ b/schemas/config/v8/defenseclaw-config.schema.json
@@ -69,7 +69,8 @@
         "ci_cd",
         "sandboxed",
         "server",
-        "saas"
+        "saas",
+        "container"
       ]
     },
     "discovery_source": {


### PR DESCRIPTION
Kubernetes applies fsGroup to emptyDir volumes, making all files and directories group-writable. The v8 runtime's safefile.ProtectDirectory and audit store hardening reject group-writable directories, which is correct for desktop/CLI installs but incompatible with container environments.

Add deployment_mode=container that:
- PrepareServiceRuntimeDir: creates directories with MkdirAll without attempting chmod (which fails on root-owned mount points)
- validateAuditDBPlatformTrust: accepts group-writable directories owned by the current user (fsGroup doesn't represent a multi-user threat in containers)
- auditDBImmediateDirectoryModeTrusted: same relaxation for the immediate parent directory check

The container mode is set via config.yaml (deployment_mode: container) or DEFENSECLAW_DEPLOYMENT_MODE=container env var. It does NOT affect any managed_enterprise behavior — all IsManagedEnterprise() checks are unchanged.

<!--
Every future action item must have a GitHub issue before it appears in this PR
body. List linked issues under "Open Issues / Follow-ups". If there are no
follow-ups, write "None".
-->

## Problem

<!-- What user, operator, security, reliability, or maintenance problem does this PR solve? -->

## Current Situation

<!-- What exists today? Include relevant constraints, failing behavior, prior work, or base-branch context. -->

## Solution

<!-- Describe the implementation. For complex work, add focused subsections. -->

## Architecture Diagram

<!-- Include a diagram when it clarifies security posture, data flow, policy behavior, or reviewer risk. Write "N/A" if not useful. -->

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| <!-- path --> | <!-- change summary --> |

## Breaking Changes

<!-- Describe behavior/default/config/API/operator workflow changes. Write "None" if not applicable. -->

## Open Issues / Follow-ups

<!-- Every future action item here must link to a GitHub issue, e.g. "- #123 - follow-up summary". Write "None" if not applicable. -->

## Test Plan

<!-- Include exact commands and observed results. -->
