### PR TITLE
fix(openclaw): honor fetch(request, init) and unblock large-body peeks

### DIFF
--- a/extensions/defenseclaw/src/__tests__/fetch-interceptor-init.test.ts
+++ b/extensions/defenseclaw/src/__tests__/fetch-interceptor-init.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Copyright 2026 Cisco Systems, Inc. and its affiliates
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #742: fetch(request, init) must apply init overrides before shape
+ * detection and proxy rewrite.
+ * #732: peeking a Request body above 64 KiB must not deadlock the
+ * cloned tee branch.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createFetchInterceptor } from "../fetch-interceptor.js";
+
+const guardrailPort = 14010;
+
+async function readForwardedBody(body: BodyInit | null | undefined): Promise<string> {
+  if (body == null) return "";
+  if (typeof body === "string") return body;
+  if (body instanceof Uint8Array) return new TextDecoder().decode(body);
+  if (body instanceof ArrayBuffer) return new TextDecoder().decode(body);
+  if (typeof ReadableStream !== "undefined" && body instanceof ReadableStream) {
+    return new Response(body).text();
+  }
+  if (typeof (body as { text?: () => Promise<string> }).text === "function") {
+    return (body as { text: () => Promise<string> }).text();
+  }
+  return String(body);
+}
+
+describe("fetch(request, init) interceptor semantics", () => {
+  const originalFetch = globalThis.fetch;
+  const calls: Array<{ input: string; init?: RequestInit }> = [];
+  let interceptor: ReturnType<typeof createFetchInterceptor>;
+
+  beforeEach(() => {
+    calls.length = 0;
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ input: String(input), init });
+      return new Response("ok");
+    }) as typeof fetch;
+    interceptor = createFetchInterceptor(guardrailPort);
+    interceptor.start();
+  });
+
+  afterEach(() => {
+    interceptor.stop();
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("routes a custom-host Request when only init.body is LLM-shaped", async () => {
+    const request = new Request("https://custom-provider.test/v1/inference", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ event: "not-an-llm" }),
+    });
+
+    await fetch(request, {
+      method: "PUT",
+      body: JSON.stringify({
+        messages: [{ role: "user", content: "override-llm-body" }],
+      }),
+    });
+
+    const proxied = calls.find(
+      (call) => call.input === `http://127.0.0.1:${guardrailPort}/v1/inference`,
+    );
+    expect(proxied).toBeDefined();
+    expect(proxied?.init?.method).toBe("PUT");
+    expect(await readForwardedBody(proxied?.init?.body)).toBe(
+      JSON.stringify({
+        messages: [{ role: "user", content: "override-llm-body" }],
+      }),
+    );
+    expect(calls.map((call) => call.input)).not.toContain(
+      "https://custom-provider.test/v1/inference",
+    );
+  });
+
+  it("forwards override method, body, headers, signal, and Request metadata", async () => {
+    const controller = new AbortController();
+    const request = new Request("https://custom-provider.test/v1/inference", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-from-request": "1" },
+      body: JSON.stringify({
+        messages: [{ role: "user", content: "input-body" }],
+      }),
+      redirect: "follow",
+      credentials: "omit",
+    });
+
+    await fetch(request, {
+      method: "PUT",
+      headers: { "x-from-init": "yes" },
+      body: JSON.stringify({
+        messages: [{ role: "user", content: "override-body" }],
+      }),
+      signal: controller.signal,
+      redirect: "manual",
+      credentials: "include",
+      cache: "no-store",
+      integrity: "sha256-abc",
+      keepalive: true,
+      mode: "cors",
+      referrer: "https://app.example.test/",
+      referrerPolicy: "no-referrer",
+    });
+
+    const forwarded = calls.find(
+      (call) => call.input === `http://127.0.0.1:${guardrailPort}/v1/inference`,
+    )?.init;
+    expect(forwarded).toBeDefined();
+    expect(forwarded?.method).toBe("PUT");
+    expect(await readForwardedBody(forwarded?.body)).toBe(
+      JSON.stringify({
+        messages: [{ role: "user", content: "override-body" }],
+      }),
+    );
+    const headers = new Headers(forwarded?.headers);
+    expect(headers.get("x-from-request")).toBe("1");
+    expect(headers.get("x-from-init")).toBe("yes");
+    expect(headers.get("X-DC-Target-URL")).toBe("https://custom-provider.test");
+    expect(forwarded?.signal).toBeDefined();
+    expect(forwarded?.redirect).toBe("manual");
+    expect(forwarded?.credentials).toBe("include");
+    expect(forwarded?.cache).toBe("no-store");
+    expect(forwarded?.integrity).toBe("sha256-abc");
+    expect(forwarded?.keepalive).toBe(true);
+    expect(forwarded?.mode).toBe("cors");
+    expect(forwarded?.referrer).toBe("https://app.example.test/");
+    expect(forwarded?.referrerPolicy).toBe("no-referrer");
+  });
+
+  it("keeps no-init Request method and body except for proxy headers", async () => {
+    const payload = JSON.stringify({
+      messages: [{ role: "user", content: "plain" }],
+    });
+    const request = new Request("https://custom-provider.test/v1/inference", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: payload,
+      redirect: "error",
+    });
+
+    await fetch(request);
+
+    const forwarded = calls.find(
+      (call) => call.input === `http://127.0.0.1:${guardrailPort}/v1/inference`,
+    )?.init;
+    expect(forwarded?.method).toBe("POST");
+    expect(forwarded?.redirect).toBe("error");
+    expect(await readForwardedBody(forwarded?.body)).toBe(payload);
+    expect(new Headers(forwarded?.headers).get("X-DC-Target-URL")).toBe(
+      "https://custom-provider.test",
+    );
+  });
+
+  it("still short-circuits already-proxied requests without rewriting", async () => {
+    await fetch(`http://127.0.0.1:${guardrailPort}/v1/chat/completions`, {
+      method: "POST",
+      body: JSON.stringify({ messages: [] }),
+    });
+    const passthrough = calls.find(
+      (call) =>
+        call.input === `http://127.0.0.1:${guardrailPort}/v1/chat/completions`,
+    );
+    expect(passthrough).toBeDefined();
+    expect(new Headers(passthrough?.init?.headers).get("X-DC-Target-URL")).toBeNull();
+  });
+
+  it("peeks a >64 KiB Request without hanging and forwards the full body", async () => {
+    const payload = JSON.stringify({
+      model: "custom",
+      messages: [{ role: "user", content: "x".repeat(70_000) }],
+    });
+    const request = new Request("https://custom-provider.test/v1/chat", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: payload,
+    });
+
+    await Promise.race([
+      fetch(request),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("interceptor hung")), 1000);
+      }),
+    ]);
+
+    const proxied = calls.find(
+      (call) => call.input === `http://127.0.0.1:${guardrailPort}/v1/chat`,
+    );
+    expect(proxied).toBeDefined();
+    expect(await readForwardedBody(proxied?.init?.body)).toBe(payload);
+  });
+});

--- a/extensions/defenseclaw/src/__tests__/fetch-interceptor-init.test.ts
+++ b/extensions/defenseclaw/src/__tests__/fetch-interceptor-init.test.ts
@@ -123,7 +123,7 @@ describe("fetch(request, init) interceptor semantics", () => {
       }),
     );
     const headers = new Headers(forwarded?.headers);
-    expect(headers.get("x-from-request")).toBe("1");
+    expect(headers.get("x-from-request")).toBeNull();
     expect(headers.get("x-from-init")).toBe("yes");
     expect(headers.get("X-DC-Target-URL")).toBe("https://custom-provider.test");
     expect(forwarded?.signal).toBeDefined();
@@ -194,6 +194,25 @@ describe("fetch(request, init) interceptor semantics", () => {
 
     const proxied = calls.find(
       (call) => call.input === `http://127.0.0.1:${guardrailPort}/v1/chat`,
+    );
+    expect(proxied).toBeDefined();
+    expect(await readForwardedBody(proxied?.init?.body)).toBe(payload);
+  });
+
+  it("inherits the Request body when init.body is null", async () => {
+    const payload = JSON.stringify({
+      messages: [{ role: "user", content: "keep-request-body" }],
+    });
+    const request = new Request("https://custom-provider.test/v1/inference", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: payload,
+    });
+
+    await fetch(request, { body: null });
+
+    const proxied = calls.find(
+      (call) => call.input === `http://127.0.0.1:${guardrailPort}/v1/inference`,
     );
     expect(proxied).toBeDefined();
     expect(await readForwardedBody(proxied?.init?.body)).toBe(payload);

--- a/extensions/defenseclaw/src/__tests__/fetch-interceptor-init.test.ts
+++ b/extensions/defenseclaw/src/__tests__/fetch-interceptor-init.test.ts
@@ -199,6 +199,51 @@ describe("fetch(request, init) interceptor semantics", () => {
     expect(await readForwardedBody(proxied?.init?.body)).toBe(payload);
   });
 
+  it("does not treat a nested LLM key before the 64 KiB cap as a root shape", async () => {
+    const payload = JSON.stringify({
+      metadata: { messages: [{ role: "user", content: "nested" }] },
+      padding: "x".repeat(70_000),
+    });
+    await fetch("https://custom-provider.test/v1/inference", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: payload,
+    });
+    expect(calls.map((call) => call.input)).toContain(
+      "https://custom-provider.test/v1/inference",
+    );
+    expect(calls.map((call) => call.input)).not.toContain(
+      `http://127.0.0.1:${guardrailPort}/v1/inference`,
+    );
+  });
+
+  it("forwards duplex when the Request body is a stream", async () => {
+    const payload = JSON.stringify({
+      messages: [{ role: "user", content: "stream-body" }],
+    });
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(payload));
+        controller.close();
+      },
+    });
+    const request = new Request("https://custom-provider.test/v1/inference", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: stream,
+      duplex: "half",
+    } as RequestInit);
+
+    await fetch(request);
+
+    const forwarded = calls.find(
+      (call) => call.input === `http://127.0.0.1:${guardrailPort}/v1/inference`,
+    )?.init as (RequestInit & { duplex?: string }) | undefined;
+    expect(forwarded).toBeDefined();
+    expect(forwarded?.duplex).toBe("half");
+    expect(await readForwardedBody(forwarded?.body)).toBe(payload);
+  });
+
   it("inherits the Request body when init.body is null", async () => {
     const payload = JSON.stringify({
       messages: [{ role: "user", content: "keep-request-body" }],

--- a/extensions/defenseclaw/src/__tests__/shape-detection.test.ts
+++ b/extensions/defenseclaw/src/__tests__/shape-detection.test.ts
@@ -311,6 +311,19 @@ describe("peekBodyForShape", () => {
     ).toBe("messages");
   });
 
+  it("ignores a nested LLM-shaped key in a truncated non-LLM prefix", async () => {
+    const body = JSON.stringify({
+      metadata: { messages: [{ role: "user", content: "nested" }] },
+      padding: "x".repeat(70_000),
+    });
+    await expect(
+      peekBodyForShape("https://custom-provider.test/v1/inference", {
+        method: "POST",
+        body,
+      }),
+    ).resolves.toBe("none");
+  });
+
   it("does not hang peeking a Request body larger than 64 KiB", async () => {
     const request = new Request("https://custom-provider.test/v1/chat", {
       method: "POST",

--- a/extensions/defenseclaw/src/__tests__/shape-detection.test.ts
+++ b/extensions/defenseclaw/src/__tests__/shape-detection.test.ts
@@ -21,6 +21,7 @@ import {
   isKnownSafeDomain,
   isLLMShapedRequest,
   peekBodyForShape,
+  resolveEffectiveFetchInit,
 } from "../fetch-interceptor.js";
 
 describe("classifyBodyShape", () => {
@@ -292,5 +293,121 @@ describe("peekBodyForShape", () => {
         body: fd,
       }),
     ).toBe("none");
+  });
+
+  it("prefers init.body over a non-LLM Request body", async () => {
+    const req = new Request("https://custom-provider.test/v1/inference", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ event: "not-an-llm" }),
+    });
+    expect(
+      await peekBodyForShape(req, {
+        method: "PUT",
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "override-llm-body" }],
+        }),
+      }),
+    ).toBe("messages");
+  });
+
+  it("does not hang peeking a Request body larger than 64 KiB", async () => {
+    const request = new Request("https://custom-provider.test/v1/chat", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "custom",
+        messages: [{ role: "user", content: "x".repeat(70_000) }],
+      }),
+    });
+    const shape = await Promise.race([
+      peekBodyForShape(request),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("peek hung")), 1000);
+      }),
+    ]);
+    expect(shape).toBe("messages");
+  });
+
+  it("completes a large Request peek after the caller aborts", async () => {
+    const controller = new AbortController();
+    const request = new Request("https://custom-provider.test/v1/chat", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "custom",
+        messages: [{ role: "user", content: "x".repeat(70_000) }],
+      }),
+      signal: controller.signal,
+    });
+    setTimeout(() => controller.abort(), 5);
+    await expect(
+      Promise.race([
+        peekBodyForShape(request),
+        new Promise<never>((_, reject) => {
+          setTimeout(() => reject(new Error("peek hung after abort")), 1000);
+        }),
+      ]),
+    ).resolves.toBe("messages");
+  });
+});
+
+describe("resolveEffectiveFetchInit", () => {
+  it("lets init override Request method, headers, body, and signal", () => {
+    const requestController = new AbortController();
+    const initController = new AbortController();
+    const req = new Request("https://custom-provider.test/v1/inference", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-from-request": "1" },
+      body: JSON.stringify({ event: "not-an-llm" }),
+      signal: requestController.signal,
+      redirect: "follow",
+      credentials: "omit",
+    });
+    const effective = resolveEffectiveFetchInit(req, {
+      method: "PUT",
+      headers: { "x-from-init": "yes" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+      signal: initController.signal,
+      redirect: "manual",
+      credentials: "include",
+      cache: "no-store",
+      integrity: "sha256-abc",
+      keepalive: true,
+      mode: "cors",
+      referrer: "https://app.example.test/",
+      referrerPolicy: "no-referrer",
+    });
+    expect(effective.method).toBe("PUT");
+    expect(effective.headers.get("x-from-request")).toBe("1");
+    expect(effective.headers.get("x-from-init")).toBe("yes");
+    expect(effective.body).toBe(
+      JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+    );
+    expect(effective.redirect).toBe("manual");
+    expect(effective.credentials).toBe("include");
+    expect(effective.cache).toBe("no-store");
+    expect(effective.integrity).toBe("sha256-abc");
+    expect(effective.keepalive).toBe(true);
+    expect(effective.mode).toBe("cors");
+    expect(effective.referrer).toBe("https://app.example.test/");
+    expect(effective.referrerPolicy).toBe("no-referrer");
+    expect(effective.signal).toBeDefined();
+    initController.abort();
+    expect(effective.signal?.aborted).toBe(true);
+  });
+
+  it("keeps Request metadata when init is omitted", () => {
+    const req = new Request("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      body: JSON.stringify({ messages: [] }),
+      redirect: "error",
+      credentials: "same-origin",
+    });
+    const effective = resolveEffectiveFetchInit(req);
+    expect(effective.method).toBe("POST");
+    expect(effective.redirect).toBe("error");
+    expect(effective.credentials).toBe("same-origin");
+    expect(effective.body).toBe(req.body);
   });
 });

--- a/extensions/defenseclaw/src/__tests__/shape-detection.test.ts
+++ b/extensions/defenseclaw/src/__tests__/shape-detection.test.ts
@@ -379,7 +379,7 @@ describe("resolveEffectiveFetchInit", () => {
       referrerPolicy: "no-referrer",
     });
     expect(effective.method).toBe("PUT");
-    expect(effective.headers.get("x-from-request")).toBe("1");
+    expect(effective.headers.get("x-from-request")).toBeNull();
     expect(effective.headers.get("x-from-init")).toBe("yes");
     expect(effective.body).toBe(
       JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
@@ -409,5 +409,28 @@ describe("resolveEffectiveFetchInit", () => {
     expect(effective.redirect).toBe("error");
     expect(effective.credentials).toBe("same-origin");
     expect(effective.body).toBe(req.body);
+  });
+
+  it("inherits the Request body when init.body is null", () => {
+    const req = new Request("https://custom-provider.test/v1/inference", {
+      method: "POST",
+      body: JSON.stringify({ messages: [{ role: "user", content: "keep" }] }),
+    });
+    const effective = resolveEffectiveFetchInit(req, { body: null });
+    expect(effective.body).toBe(req.body);
+  });
+
+  it("replaces Request headers when init.headers is supplied", () => {
+    const req = new Request("https://custom-provider.test/v1/inference", {
+      method: "POST",
+      headers: { authorization: "Bearer request-token", "x-keep": "1" },
+      body: JSON.stringify({ messages: [] }),
+    });
+    const effective = resolveEffectiveFetchInit(req, {
+      headers: { "content-type": "application/json" },
+    });
+    expect(effective.headers.get("authorization")).toBeNull();
+    expect(effective.headers.get("x-keep")).toBeNull();
+    expect(effective.headers.get("content-type")).toBe("application/json");
   });
 });

--- a/extensions/defenseclaw/src/__tests__/shape-detection.test.ts
+++ b/extensions/defenseclaw/src/__tests__/shape-detection.test.ts
@@ -343,20 +343,38 @@ describe("peekBodyForShape", () => {
   });
 
   it("completes a large Request peek after the caller aborts", async () => {
-    const controller = new AbortController();
+    let release!: (chunk: Uint8Array) => void;
+    const firstChunk = new Promise<Uint8Array>((resolve) => {
+      release = resolve;
+    });
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        controller.enqueue(await firstChunk);
+        controller.close();
+      },
+    });
+    const abort = new AbortController();
     const request = new Request("https://custom-provider.test/v1/chat", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        model: "custom",
-        messages: [{ role: "user", content: "x".repeat(70_000) }],
-      }),
-      signal: controller.signal,
-    });
-    setTimeout(() => controller.abort(), 5);
+      body: stream,
+      duplex: "half",
+      signal: abort.signal,
+    } as RequestInit);
+    const peek = peekBodyForShape(request);
+    await Promise.resolve();
+    abort.abort();
+    release(
+      new TextEncoder().encode(
+        JSON.stringify({
+          model: "custom",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      ),
+    );
     await expect(
       Promise.race([
-        peekBodyForShape(request),
+        peek,
         new Promise<never>((_, reject) => {
           setTimeout(() => reject(new Error("peek hung after abort")), 1000);
         }),

--- a/extensions/defenseclaw/src/fetch-interceptor.ts
+++ b/extensions/defenseclaw/src/fetch-interceptor.ts
@@ -681,7 +681,12 @@ async function readStreamBounded(
       total += value.byteLength;
     }
   } finally {
-    if (options?.cancelRemainder !== false) {
+    if (options?.cancelRemainder === false) {
+      // Fire-and-forget: awaiting tee-branch cancel() can deadlock
+      // against the unconsumed sibling (#732), but skipping cancel
+      // entirely leaves the rest of a multi-GB body queued.
+      void reader.cancel().catch(() => undefined);
+    } else {
       try {
         await reader.cancel();
       } catch {
@@ -704,7 +709,13 @@ async function readStreamBounded(
 }
 
 function hasOwnBody(init?: RequestInit): boolean {
-  return Boolean(init && Object.prototype.hasOwnProperty.call(init, "body"));
+  // Native fetch(request, { body: null | undefined }) inherits the
+  // Request body. Only a non-null init.body replaces it.
+  return Boolean(
+    init &&
+      Object.prototype.hasOwnProperty.call(init, "body") &&
+      init.body != null,
+  );
 }
 
 /**
@@ -748,16 +759,9 @@ function combineAbortSignals(
   requestSignal?: AbortSignal | null,
   initSignal?: AbortSignal | null,
 ): AbortSignal | null | undefined {
-  if (requestSignal && initSignal && requestSignal !== initSignal) {
-    const anyFn = (
-      AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal }
-    ).any;
-    if (typeof anyFn === "function") {
-      return anyFn.call(AbortSignal, [requestSignal, initSignal]);
-    }
-    return initSignal;
-  }
-  return initSignal ?? requestSignal;
+  // Native fetch(request, { signal }) uses the init signal only.
+  if (initSignal) return initSignal;
+  return requestSignal;
 }
 
 /**
@@ -782,12 +786,10 @@ export function resolveEffectiveFetchInit(
   referrerPolicy?: ReferrerPolicy;
 } {
   const req = input instanceof Request ? input : null;
-  const headers = new Headers(req?.headers);
-  if (init?.headers) {
-    new Headers(init.headers).forEach((value, key) => {
-      headers.set(key, value);
-    });
-  }
+  const headers =
+    init?.headers != null
+      ? new Headers(init.headers)
+      : new Headers(req?.headers);
   return {
     method: String(init?.method ?? req?.method ?? "GET"),
     headers,
@@ -1159,15 +1161,11 @@ export function createFetchInterceptor(
         headers.set(k, v);
       }
 
-      // Peek may have cloned a Request body. Hand originalFetch a
-      // fresh clone so undici does not see a locked/disturbed stream.
+      // Peek used a clone. Consume the original Request tee branch so
+      // the leftover sibling is not left unread.
       let rewriteBody = effective.body;
       if (!hasOwnBody(init) && input instanceof Request && !input.bodyUsed) {
-        try {
-          rewriteBody = input.clone().body;
-        } catch {
-          rewriteBody = effective.body;
-        }
+        rewriteBody = input.body ?? effective.body;
       }
 
       // Preserve Request metadata and caller init extras (duplex, etc.),

--- a/extensions/defenseclaw/src/fetch-interceptor.ts
+++ b/extensions/defenseclaw/src/fetch-interceptor.ts
@@ -728,13 +728,72 @@ function classifyPeekText(text: string): LLMBodyShape {
   try {
     return classifyBodyShape(JSON.parse(text));
   } catch {
-    if (/"messages"\s*:/.test(text)) return "messages";
-    if (/"contents"\s*:/.test(text)) return "contents";
-    if (/"inputs"\s*:/.test(text)) return "input";
-    if (/"input"\s*:/.test(text)) return "input";
-    if (/"prompt"\s*:/.test(text)) return "prompt";
-    return "none";
+    return classifyTruncatedRootKeys(text);
   }
+}
+
+/** Recover an LLM shape from a 64 KiB-truncated JSON object prefix. */
+function classifyTruncatedRootKeys(text: string): LLMBodyShape {
+  const keys = new Set(rootObjectKeys(text));
+  if (keys.has("messages")) return "messages";
+  if (keys.has("contents")) return "contents";
+  if (keys.has("inputs")) return "input";
+  if (keys.has("input")) return "input";
+  if (keys.has("prompt")) return "prompt";
+  return "none";
+}
+
+/**
+ * Collect object keys at depth 1 so a nested `"messages"` (or similar)
+ * cannot classify a non-LLM body after the peek cap slices the document.
+ */
+function rootObjectKeys(text: string): string[] {
+  const keys: string[] = [];
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]!;
+    if (inString) {
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (ch === "\\") {
+        escape = true;
+        continue;
+      }
+      if (ch === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === "\"") {
+      if (depth === 1) {
+        const match = /^"((?:\\.|[^"\\])*)"\s*:/.exec(text.slice(i));
+        if (match) {
+          keys.push(match[1]!.replace(/\\(.)/g, "$1"));
+          i += match[0].length - 1;
+          continue;
+        }
+      }
+      inString = true;
+      continue;
+    }
+    if (ch === "{" || ch === "[") {
+      depth++;
+      continue;
+    }
+    if (ch === "}" || ch === "]") {
+      depth = Math.max(0, depth - 1);
+    }
+  }
+  return keys;
+}
+
+function requestDuplex(value: object | undefined): "half" | undefined {
+  if (!value || !("duplex" in value)) return undefined;
+  return (value as { duplex?: unknown }).duplex === "half" ? "half" : undefined;
 }
 
 function peekConcreteBody(body: unknown): LLMBodyShape {
@@ -1170,6 +1229,13 @@ export function createFetchInterceptor(
 
       // Preserve Request metadata and caller init extras (duplex, etc.),
       // then apply the resolved method/body/signal/redirect family.
+      const duplex =
+        requestDuplex(init) ??
+        (input instanceof Request ? requestDuplex(input) : undefined) ??
+        (typeof ReadableStream !== "undefined" &&
+        rewriteBody instanceof ReadableStream
+          ? "half"
+          : undefined);
       const newInit: RequestInit = {
         ...(input instanceof Request
           ? {
@@ -1198,6 +1264,7 @@ export function createFetchInterceptor(
         mode: effective.mode,
         referrer: effective.referrer,
         referrerPolicy: effective.referrerPolicy,
+        ...(duplex ? { duplex } : {}),
       };
 
       if (shapeBranch === "shape") {

--- a/extensions/defenseclaw/src/fetch-interceptor.ts
+++ b/extensions/defenseclaw/src/fetch-interceptor.ts
@@ -653,10 +653,16 @@ function decodeUtf8Safe(buf: ArrayBufferView): string {
  * the cap; subsequent chunks are never read, so a pathological body
  * (GBs) never allocates past `cap` bytes. Returns the raw byte
  * sequence so the caller can decide on encoding.
+ *
+ * `cancelRemainder` defaults to true for standalone streams (sidecar
+ * overlay responses). Request.clone() tees the body; awaiting
+ * cancel() on one tee branch can stay pending until the sibling is
+ * consumed (#732), so Request peeks must pass false.
  */
 async function readStreamBounded(
   stream: ReadableStream<Uint8Array>,
   cap: number,
+  options?: { cancelRemainder?: boolean },
 ): Promise<Uint8Array> {
   const reader = stream.getReader();
   const chunks: Uint8Array[] = [];
@@ -675,12 +681,12 @@ async function readStreamBounded(
       total += value.byteLength;
     }
   } finally {
-    // Cancel the rest of the stream so the underlying transport
-    // does not keep delivering bytes we will never consume.
-    try {
-      await reader.cancel();
-    } catch {
-      /* ignore */
+    if (options?.cancelRemainder !== false) {
+      try {
+        await reader.cancel();
+      } catch {
+        /* ignore */
+      }
     }
     try {
       reader.releaseLock();
@@ -697,11 +703,116 @@ async function readStreamBounded(
   return out;
 }
 
+function hasOwnBody(init?: RequestInit): boolean {
+  return Boolean(init && Object.prototype.hasOwnProperty.call(init, "body"));
+}
+
+/**
+ * Classify a bounded peek. Full JSON wins; if the 64 KiB cap sliced
+ * mid-document, recover the top-level LLM key from the prefix so a
+ * large messages[] body is not treated as non-LLM.
+ */
+function classifyPeekText(text: string): LLMBodyShape {
+  if (!text) return "none";
+  try {
+    return classifyBodyShape(JSON.parse(text));
+  } catch {
+    if (/"messages"\s*:/.test(text)) return "messages";
+    if (/"contents"\s*:/.test(text)) return "contents";
+    if (/"inputs"\s*:/.test(text)) return "input";
+    if (/"input"\s*:/.test(text)) return "input";
+    if (/"prompt"\s*:/.test(text)) return "prompt";
+    return "none";
+  }
+}
+
+function peekConcreteBody(body: unknown): LLMBodyShape {
+  if (body == null) return "none";
+  if (typeof body === "string") {
+    return classifyPeekText(body.slice(0, BODY_PEEK_CAP_BYTES));
+  }
+  if (body instanceof Uint8Array) {
+    return classifyPeekText(decodeUtf8Safe(body.subarray(0, BODY_PEEK_CAP_BYTES)));
+  }
+  if (body instanceof ArrayBuffer) {
+    return classifyPeekText(
+      decodeUtf8Safe(new Uint8Array(body).subarray(0, BODY_PEEK_CAP_BYTES)),
+    );
+  }
+  // ReadableStream, FormData, Blob, etc. — consuming them would break
+  // the downstream fetch. Fall back to path-only detection.
+  return "none";
+}
+
+function combineAbortSignals(
+  requestSignal?: AbortSignal | null,
+  initSignal?: AbortSignal | null,
+): AbortSignal | null | undefined {
+  if (requestSignal && initSignal && requestSignal !== initSignal) {
+    const anyFn = (
+      AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal }
+    ).any;
+    if (typeof anyFn === "function") {
+      return anyFn.call(AbortSignal, [requestSignal, initSignal]);
+    }
+    return initSignal;
+  }
+  return initSignal ?? requestSignal;
+}
+
+/**
+ * Fetch `request` + `init` precedence used by shape detection and the
+ * proxy rewrite. Caller `init` wins, matching native Fetch.
+ */
+export function resolveEffectiveFetchInit(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): {
+  method: string;
+  headers: Headers;
+  body?: BodyInit | null;
+  signal?: AbortSignal | null;
+  redirect?: RequestRedirect;
+  credentials?: RequestCredentials;
+  cache?: RequestCache;
+  integrity?: string;
+  keepalive?: boolean;
+  mode?: RequestMode;
+  referrer?: string;
+  referrerPolicy?: ReferrerPolicy;
+} {
+  const req = input instanceof Request ? input : null;
+  const headers = new Headers(req?.headers);
+  if (init?.headers) {
+    new Headers(init.headers).forEach((value, key) => {
+      headers.set(key, value);
+    });
+  }
+  return {
+    method: String(init?.method ?? req?.method ?? "GET"),
+    headers,
+    body: hasOwnBody(init) ? init!.body : (req ? req.body : undefined),
+    signal: combineAbortSignals(req?.signal, init?.signal),
+    redirect: init?.redirect ?? req?.redirect,
+    credentials: init?.credentials ?? req?.credentials,
+    cache: init?.cache ?? req?.cache,
+    integrity: init?.integrity ?? req?.integrity,
+    keepalive: init?.keepalive ?? req?.keepalive,
+    mode: init?.mode ?? req?.mode,
+    referrer: init?.referrer ?? req?.referrer,
+    referrerPolicy: init?.referrerPolicy ?? req?.referrerPolicy,
+  };
+}
+
 export async function peekBodyForShape(
   input: RequestInfo | URL,
   init?: RequestInit,
 ): Promise<LLMBodyShape> {
   try {
+    // Fetch spec: a supplied init.body replaces the Request body.
+    if (hasOwnBody(init)) {
+      return peekConcreteBody(init!.body);
+    }
     if (input instanceof Request) {
       // input.clone() keeps the caller's Request body intact for the
       // downstream originalFetch call. Prefer a streaming read
@@ -714,7 +825,11 @@ export async function peekBodyForShape(
         .body;
       let bytes: Uint8Array;
       if (stream && typeof stream.getReader === "function") {
-        bytes = await readStreamBounded(stream, BODY_PEEK_CAP_BYTES);
+        // Do not await tee-branch cancel(): it can deadlock against
+        // the unconsumed original Request body (#732).
+        bytes = await readStreamBounded(stream, BODY_PEEK_CAP_BYTES, {
+          cancelRemainder: false,
+        });
       } else {
         const text = await cloned.text().catch(() => "");
         if (!text) return "none";
@@ -725,47 +840,12 @@ export async function peekBodyForShape(
         const capped = text.length > BODY_PEEK_CAP_BYTES
           ? text.slice(0, BODY_PEEK_CAP_BYTES)
           : text;
-        try {
-          return classifyBodyShape(JSON.parse(capped));
-        } catch {
-          return "none";
-        }
+        return classifyPeekText(capped);
       }
       if (bytes.byteLength === 0) return "none";
-      try {
-        return classifyBodyShape(JSON.parse(decodeUtf8Safe(bytes)));
-      } catch {
-        return "none";
-      }
+      return classifyPeekText(decodeUtf8Safe(bytes));
     }
-    const body = init?.body as unknown;
-    if (body == null) return "none";
-    if (typeof body === "string") {
-      try {
-        return classifyBodyShape(JSON.parse(body.slice(0, BODY_PEEK_CAP_BYTES)));
-      } catch {
-        return "none";
-      }
-    }
-    if (body instanceof Uint8Array) {
-      const slice = body.subarray(0, BODY_PEEK_CAP_BYTES);
-      try {
-        return classifyBodyShape(JSON.parse(decodeUtf8Safe(slice)));
-      } catch {
-        return "none";
-      }
-    }
-    if (body instanceof ArrayBuffer) {
-      const view = new Uint8Array(body).subarray(0, BODY_PEEK_CAP_BYTES);
-      try {
-        return classifyBodyShape(JSON.parse(decodeUtf8Safe(view)));
-      } catch {
-        return "none";
-      }
-    }
-    // ReadableStream, FormData, Blob, etc. — consuming them would break
-    // the downstream fetch. Fall back to path-only detection.
-    return "none";
+    return peekConcreteBody(init?.body);
   } catch {
     return "none";
   }
@@ -1027,13 +1107,13 @@ export function createFetchInterceptor(
       let shouldIntercept = knownLLM;
       let shapeBranch: "known" | "shape" | "passthrough" = knownLLM ? "known" : "passthrough";
       let bodyShape: LLMBodyShape = "none";
+      const effective = resolveEffectiveFetchInit(input, init);
 
       // Layer 1: request-shape detection. Only peek the body when the
       // allowlist didn't already match — peeking costs a clone().
       if (!knownLLM) {
-        const method = (input instanceof Request ? input.method : init?.method) ?? "GET";
         bodyShape = await peekBodyForShape(input, init);
-        if (isLLMShapedRequest(urlStr, method, bodyShape, guardrailPort)) {
+        if (isLLMShapedRequest(urlStr, effective.method, bodyShape, guardrailPort)) {
           shouldIntercept = true;
           shapeBranch = "shape";
         }
@@ -1066,10 +1146,9 @@ export function createFetchInterceptor(
       // Rewrite: keep path + query, replace scheme://host with proxy.
       const proxied = `${proxyBase}${original.pathname}${original.search}`;
 
-      // Merge all original headers and add proxy-hop headers.
-      const headers = new Headers(
-        input instanceof Request ? input.headers : (init?.headers as HeadersInit | undefined),
-      );
+      // Merge effective headers (Request + init overrides) and add
+      // proxy-hop headers. init wins, matching native Fetch (#742).
+      const headers = new Headers(effective.headers);
       const providerKey = extractProviderKey(headers);
       const proxyHdrs = buildProxyHeaders(
         original.origin,
@@ -1080,11 +1159,48 @@ export function createFetchInterceptor(
         headers.set(k, v);
       }
 
-      // Build new init, preserving all original properties.
-      const newInit: RequestInit =
-        input instanceof Request
-          ? { method: input.method, body: input.body, headers }
-          : { ...(init ?? {}), headers };
+      // Peek may have cloned a Request body. Hand originalFetch a
+      // fresh clone so undici does not see a locked/disturbed stream.
+      let rewriteBody = effective.body;
+      if (!hasOwnBody(init) && input instanceof Request && !input.bodyUsed) {
+        try {
+          rewriteBody = input.clone().body;
+        } catch {
+          rewriteBody = effective.body;
+        }
+      }
+
+      // Preserve Request metadata and caller init extras (duplex, etc.),
+      // then apply the resolved method/body/signal/redirect family.
+      const newInit: RequestInit = {
+        ...(input instanceof Request
+          ? {
+              method: input.method,
+              redirect: input.redirect,
+              credentials: input.credentials,
+              cache: input.cache,
+              integrity: input.integrity,
+              keepalive: input.keepalive,
+              mode: input.mode,
+              referrer: input.referrer,
+              referrerPolicy: input.referrerPolicy,
+              signal: input.signal,
+            }
+          : {}),
+        ...(init ?? {}),
+        method: effective.method,
+        body: rewriteBody,
+        headers,
+        signal: effective.signal ?? undefined,
+        redirect: effective.redirect,
+        credentials: effective.credentials,
+        cache: effective.cache,
+        integrity: effective.integrity,
+        keepalive: effective.keepalive,
+        mode: effective.mode,
+        referrer: effective.referrer,
+        referrerPolicy: effective.referrerPolicy,
+      };
 
       if (shapeBranch === "shape") {
         console.log(


### PR DESCRIPTION
> Stacked on #825. Review/merge that PR first; this PR's base is the stack parent, not `main`.

## Problem

`fetch(request, init)` ignored `init` during shape detection and proxy rewrite. Peeking a Request body above 64 KiB could deadlock on tee-branch `reader.cancel()`.

## Current Situation

Unknown-host LLM payloads supplied only in `init.body` passed through. Intercepted rewrites dropped override method/body/headers/signal and Request metadata. Large Request peeks hung.

## Solution

Resolve effective Fetch semantics with `init` winning before peek and rewrite. Do not await cancel on cloned Request tee branches. Recover LLM shape from a truncated JSON prefix so large messages[] bodies still classify.

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `extensions/defenseclaw/src/fetch-interceptor.ts` | Effective init, bounded peek without tee deadlock |
| `extensions/defenseclaw/src/__tests__/shape-detection.test.ts` | Init-body preference and >64 KiB peek |
| `extensions/defenseclaw/src/__tests__/fetch-interceptor-init.test.ts` | Interceptor rewrite and full-body forward |

## Breaking Changes

`fetch(request, init)` now matches native Fetch override precedence.

## Open Issues / Follow-ups

None

## Test Plan

```
npm test
```

in `extensions/defenseclaw`. Observed: 21 files, 283 passed.

Fixes #742
Fixes #732