### PR TITLE
docs(policies): document atomic invalid-regex rejection

### DIFF
--- a/cli/tests/test_install_docs_static.py
+++ b/cli/tests/test_install_docs_static.py
@@ -2247,3 +2247,14 @@ def test_readme_delegates_observability_operations_to_the_website() -> None:
     assert "make telemetry-generate" in implementation
     assert "make telemetry-check" in implementation
     assert "defenseclaw-gateway restart" not in readme
+
+
+def test_policy_overview_matches_atomic_invalid_regex_rejection() -> None:
+    overview = (ROOT / "docs-site/content/docs/policies/index.mdx").read_text()
+    validation = (ROOT / "docs-site/content/docs/policies/rulepack-validation.mdx").read_text()
+
+    assert "logged and dropped" not in overview
+    assert "rejects the complete candidate" in overview
+    assert "/docs/policies/rulepack-validation" in overview
+    assert "invalid Go regular expression" in validation
+    assert "silently discard the bad file" in validation

--- a/cli/tests/test_install_docs_static.py
+++ b/cli/tests/test_install_docs_static.py
@@ -2255,6 +2255,7 @@ def test_policy_overview_matches_atomic_invalid_regex_rejection() -> None:
 
     assert "logged and dropped" not in overview
     assert "rejects the complete candidate" in overview
+    assert "Regexes compile during [rule-pack validation]" in overview
     assert "/docs/policies/rulepack-validation" in overview
     assert "invalid Go regular expression" in validation
     assert "silently discard the bad file" in validation

--- a/cli/tests/test_install_docs_static.py
+++ b/cli/tests/test_install_docs_static.py
@@ -2258,4 +2258,4 @@ def test_policy_overview_matches_atomic_invalid_regex_rejection() -> None:
     assert "Regexes compile during [rule-pack validation]" in overview
     assert "/docs/policies/rulepack-validation" in overview
     assert "invalid Go regular expression" in validation
-    assert "silently discard the bad file" in validation
+    assert "does not silently discard the bad file" in " ".join(validation.split())

--- a/docs-site/content/docs/policies/index.mdx
+++ b/docs-site/content/docs/policies/index.mdx
@@ -212,8 +212,9 @@ injection:
   - "ignore all instructions"
   - "jailbreak"
 
-# Regex matches. Compiled at load time; bad regexes are logged and
-# dropped (the rest of the file still applies).
+# Regex matches. Compiled during candidate validation; any invalid
+# expression rejects the complete candidate. See
+# docs/policies/rulepack-validation.
 injection_regexes:
   - 'ignore\s+(?:all\s+)?(?:previous|prior|above|your)\s+(?:instructions|rules|directives|guidelines)'
 
@@ -237,6 +238,8 @@ exfiltration:
   - "/etc/passwd"
   - "exfiltrate"
 ```
+
+Regexes compile during [rule-pack validation](/docs/policies/rulepack-validation). Any invalid expression rejects the complete candidate; DefenseClaw does not log-and-drop a bad pattern while applying the rest of the file.
 
 Three-state semantics for each top-level key:
 


### PR DESCRIPTION
> Stacked on #826. Review/merge that PR first; this PR's base is the stack parent, not `main`.

## Problem

The policy overview said invalid local-pattern regexes were logged and dropped while the rest of the file still applied.

## Current Situation

Runtime and `rulepack-validation.mdx` reject the complete candidate atomically. Only the overview wording was stale.

## Solution

Update the overview comment and add a static docs test so the two pages cannot silently drift.

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `docs-site/content/docs/policies/index.mdx` | Atomic rejection wording + validation link |
| `cli/tests/test_install_docs_static.py` | Drift guard |

## Breaking Changes

None

## Open Issues / Follow-ups

None

## Test Plan

```
pytest cli/tests/test_install_docs_static.py::test_policy_overview_matches_atomic_invalid_regex_rejection -q
```

Observed: pass.

Fixes #776