### PR TITLE
fix(ci): authorize radar issues from live job result only

### DIFF
--- a/.github/workflows/connector-version-radar.yml
+++ b/.github/workflows/connector-version-radar.yml
@@ -333,6 +333,10 @@ jobs:
       actions: read
       contents: read
       issues: write
+    # Issue mutation is authorized only by GitHub's recorded live-job
+    # conclusion (needs.live.result). Candidate-writable artifacts such as
+    # classification.json may shape the issue body after reporter checks,
+    # but they must never enable --open-issue.
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -366,12 +370,11 @@ jobs:
           set -euo pipefail
           mkdir -p radar-results
           open_flag=()
-          while IFS= read -r -d '' classification; do
-            if jq -e '.classification == "candidate_regression"' "${classification}" >/dev/null; then
-              open_flag+=(--open-issue)
-              break
-            fi
-          done < <(find radar-results -name classification.json -type f -print0)
+          # Trusted authorization: the live job's GitHub-recorded conclusion.
+          # A forged but coherent classification.json cannot set this flag.
+          if [ "${{ needs.live.result }}" = "failure" ]; then
+            open_flag+=(--open-issue)
+          fi
           python3 scripts/live-connector-e2e/report.py \
             --results-dir radar-results \
             "${open_flag[@]}" \

--- a/cli/tests/test_live_connector_upgrade_harness.py
+++ b/cli/tests/test_live_connector_upgrade_harness.py
@@ -8,6 +8,7 @@ import runpy
 import shutil
 import stat
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -339,3 +340,61 @@ def test_report_issue_rows_only_include_candidate_regressions(tmp_path: Path) ->
     assert failures == [
         ("codex", "macos", "candidate-upgrade:tool-block:enforced", "block verdict missing")
     ]
+
+
+def test_radar_workflow_does_not_authorize_issues_from_classification_artifacts() -> None:
+    workflow = Path(__file__).resolve().parents[2] / ".github/workflows/connector-version-radar.yml"
+    text = workflow.read_text(encoding="utf-8")
+    live_section = text.split("\n  live:", 1)[1].split("\n  report:", 1)[0]
+    report_section = text.split("\n  report:", 1)[1]
+
+    assert "issues: write" not in live_section
+    assert "contents: read" in live_section
+    assert "issues: write" in report_section
+    assert 'needs.live.result }}" = "failure"' in report_section
+    assert "--open-issue" in report_section
+    assert "find radar-results -name classification.json" not in report_section
+    assert "jq -e '.classification" not in report_section
+
+
+def test_report_without_open_issue_flag_does_not_mutate_issues(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    report_module = runpy.run_path(str(REPORT))
+    candidate = tmp_path / "connector-version-radar-codex-0.144.1"
+    candidate.mkdir()
+    (candidate / "classification.json").write_text(
+        json.dumps({"classification": "candidate_regression"}),
+        encoding="utf-8",
+    )
+    (candidate / "results.jsonl").write_text(
+        json.dumps(
+            {
+                "connector": "codex",
+                "os": "macos",
+                "event": "candidate-upgrade:tool-block:enforced",
+                "status": "fail",
+                "version": "0.144.1",
+                "detail": "forged coherent regression",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    def _forbidden(*_args, **_kwargs):
+        raise AssertionError("forged classification.json must not mutate issues without --open-issue")
+
+    report_module["open_or_update_issue"] = _forbidden
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "report.py",
+            "--results-dir",
+            str(tmp_path),
+            "--run-url",
+            "https://example.invalid/run",
+        ],
+    )
+    assert report_module["main"]() == 1

--- a/scripts/live-connector-e2e/report.py
+++ b/scripts/live-connector-e2e/report.py
@@ -21,7 +21,10 @@
 #   2. Records the resolved upstream version per connector x os.
 #   3. On candidate-regression classified failures, builds a regression issue
 #      body and (when --open-issue is passed and gh is authenticated) opens or
-#      updates a GitHub issue labeled `connector-regression`.
+#      updates a GitHub issue labeled `connector-regression`. Callers must
+#      derive --open-issue from trusted workflow state (for example a GitHub
+#      job conclusion). classification.json is defense-in-depth for the issue
+#      body only and must not authorize the write.
 #   4. Exits non-zero when failures exist so the report job is red — but it
 #      NEVER edits validated_versions.json or hook_contracts.json. Bumping a
 #      validated/approved version is a deliberate human action.


### PR DESCRIPTION
> Stacked on #827. Review/merge that PR first; this PR's base is the stack parent, not `main`.

## Problem

The radar report job treated candidate-writable `classification.json` as the authority to pass `--open-issue`.

## Current Situation

The live job runs untrusted candidate connector software and uploads artifacts. A later token-bearing job read those files to decide whether to create or update GitHub issues.

## Solution

Authorize `--open-issue` only from GitHub's recorded `needs.live.result == failure`. Keep reporter classification checks for issue-body filtering. Prove a forged coherent `classification.json` does not mutate issues without the trusted flag.

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `.github/workflows/connector-version-radar.yml` | Trusted job-result gate |
| `scripts/live-connector-e2e/report.py` | Document authorization vs body filtering |
| `cli/tests/test_live_connector_upgrade_harness.py` | Forged-artifact and workflow contract tests |

## Breaking Changes

A successful live job that only forges `classification.json` no longer opens an issue. Real regressions still fail the live job, which remains the write signal.

## Open Issues / Follow-ups

None

## Test Plan

```
pytest cli/tests/test_live_connector_upgrade_harness.py::test_radar_workflow_does_not_authorize_issues_from_classification_artifacts cli/tests/test_live_connector_upgrade_harness.py::test_report_without_open_issue_flag_does_not_mutate_issues -q
```

Observed: pass.

Fixes #741