### PR TITLE
fix(macos): import standalone app v1.1.19

### DIFF
--- a/macos/DefenseClawMac/.gitignore
+++ b/macos/DefenseClawMac/.gitignore
@@ -19,3 +19,5 @@ xcuserdata/
 *.xcuserstate
 DerivedData/
 .DS_Store
+__pycache__/
+*.pyc

--- a/macos/DefenseClawMac/DefenseClawMac.xcodeproj/project.pbxproj
+++ b/macos/DefenseClawMac/DefenseClawMac.xcodeproj/project.pbxproj
@@ -236,7 +236,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 0.8.10;
-				OTHER_CODE_SIGN_FLAGS = "";
+				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cisco.defenseclaw.macos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/macos/DefenseClawMac/DefenseClawMac/App/AppState.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/App/AppState.swift
@@ -1125,7 +1125,7 @@ final class AppState {
         // binary — never present overlapping runtime actions.
         guard !runtimeInstallState.isRunning else { return false }
         guard let runtimeUpdate = availableRuntimeUpdate else { return true }
-        guard let resolverCommand = RuntimeUpgradeResolverCommand.authenticated(
+        guard let resolverCommand = Self.authenticatedRuntimeUpgradeResolverCommand(
             releaseTag: runtimeUpdate.tag
         ) else {
             let failure = """

--- a/macos/DefenseClawMac/DefenseClawMac/App/AppState.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/App/AppState.swift
@@ -71,6 +71,13 @@ enum PanelID: String, CaseIterable, Identifiable {
     }
 }
 
+enum AppSettingsTab: Hashable {
+    case general
+    case monitoring
+    case notifications
+    case connection
+}
+
 enum AlertPanelRequest: Equatable {
     case all
     case blocks
@@ -138,6 +145,7 @@ final class AppState {
 
     // DefenseClaw runtime (CLI + gateway) update state
     var installedRuntimeVersion: String?
+    var runtimeSetupCommands: Set<String>?
     var runtimeVersionCheckInProgress = false
     var runtimeVersionError: String?
     var runtimeReleaseChecked = false
@@ -223,6 +231,7 @@ final class AppState {
     var overviewEnforcementMetrics = OverviewEnforcementMetrics()
     /// Last `alerts acknowledge` failure, surfaced in the popover/panel.
     var ackError: String?
+    var ackInProgress = false
     var scanInFlight = false
 
     // UI state
@@ -250,6 +259,7 @@ final class AppState {
     var auditPresetRequest: String?
     var logPanelRequest: LogPanelRequest?
     var commandPalettePresented = false
+    var selectedSettingsTab: AppSettingsTab = .general
 
     // Settings (mirrored via @AppStorage in views; defaults here)
     @ObservationIgnored @AppStorage(SettingsKeys.pulseInterval) var pulseInterval: Double = 5
@@ -426,6 +436,7 @@ final class AppState {
     /// intentionally remain process-wide.
     private func resetInstallationScopedState() {
         installedRuntimeVersion = nil
+        runtimeSetupCommands = nil
         runtimeVersionError = nil
         runtimeReleaseChecked = false
         availableRuntimeUpdate = nil
@@ -811,49 +822,65 @@ final class AppState {
         connectorSetupInFlight.contains(ConnectorOnboarding.normalizedConnector(name))
     }
 
-    /// Mirrors the TUI exactly: `defenseclaw alerts acknowledge --severity <S>`
-    /// downgrades that whole severity class to ACK in the audit DB. Audit rows
-    /// then drop out of the queue on refresh by themselves. Scan blocks and
-    /// egress rows are NOT suppressed — they come from the immutable
-    /// gateway.jsonl and the TUI re-shows them on every reload; hiding them
-    /// locally made Findings drift to zero against the TUI. Use Dismiss for a
-    /// view-local hide (also TUI parity: cleared on next app launch).
+    /// Runtime 0.8.9 keeps severity selectors and confirms broad mutations
+    /// interactively. The invocation helper supplies that confirmation over
+    /// stdin while remaining compatible with older runtimes that ignore it.
+    /// Audit rows drop from the queue via the acknowledgement projection;
+    /// synthetic stream rows remain a local hide because they have no protected
+    /// audit disposition.
     func acknowledge(_ rows: [AlertRow]) async {
+        guard !rows.isEmpty, !ackInProgress else { return }
+        ackInProgress = true
+        defer { ackInProgress = false }
+
         ackError = nil
         var severities = Set<Severity>()
+        var localRows: [AlertRow] = []
         for row in rows {
             if case .audit = row {
                 severities.insert(row.severity)
             } else {
-                // Scan blocks / egress rows have no DB-side ack (they live in
-                // gateway.jsonl). An explicit Ack is still a user request to
-                // clear them, so hide them view-locally — the TUI's
-                // "Dismiss all" does the same local clear. Passive refreshes
-                // never suppress them (Findings parity).
-                dismissedIDs.insert(row.id)
+                localRows.append(row)
             }
         }
-        for severity in severities {
+        var failures: [String] = []
+        for severity in severities.sorted(by: >) {
+            let invocation = AlertDispositionCommand.acknowledge(severity: severity.rawValue)
             let result = await runCommand(
                 title: "Acknowledge \(severity.rawValue) alerts",
-                arguments: ["alerts", "acknowledge", "--severity", severity.rawValue],
+                arguments: invocation.arguments,
+                standardInput: invocation.standardInput,
                 category: "alerts",
                 origin: "Alerts",
                 successEffects: ["\(severity.rawValue) alerts acknowledged"]
             )
             if !result.succeeded {
-                ackError = "alerts acknowledge \(severity.rawValue) failed (exit \(result.exitCode))"
+                let detail = result.output
+                    .split(separator: "\n")
+                    .last(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty })
+                    .map { String($0.prefix(120)) }
+                failures.append(
+                    "\(severity.rawValue) failed (exit \(result.exitCode))"
+                        + (detail.map { ": \($0)" } ?? "")
+                )
             }
+        }
+        if failures.isEmpty {
+            for row in localRows { dismissedIDs.insert(row.id) }
+        } else {
+            ackError = "alerts acknowledge " + failures.joined(separator: "; ")
         }
         await refreshAlerts()
     }
 
-    /// `defenseclaw alerts dismiss --severity <S|all>` — same DB semantics as the TUI.
+    /// Severity-wide dismissal with the same cross-runtime confirmation bridge.
     func dismissViaCLI(severity: Severity?) async {
         ackError = nil
+        let invocation = AlertDispositionCommand.dismiss(severity: severity?.rawValue)
         let result = await runCommand(
             title: "Dismiss alerts",
-            arguments: ["alerts", "dismiss", "--severity", severity?.rawValue ?? "all"],
+            arguments: invocation.arguments,
+            standardInput: invocation.standardInput,
             category: "alerts",
             origin: "Alerts",
             successEffects: ["Alert queue updated"]
@@ -978,6 +1005,7 @@ final class AppState {
         guard installationSnapshotIsCurrent(generation) else { return }
         guard locatedBinary != nil else {
             installedRuntimeVersion = nil
+            runtimeSetupCommands = nil
             runtimeVersionError = "DefenseClaw CLI not found. Set its path in Connection."
             return
         }
@@ -986,6 +1014,11 @@ final class AppState {
         guard installationSnapshotIsCurrent(generation) else { return }
         if let version = UpdateChecker.parseVersion(result.output) {
             installedRuntimeVersion = version
+            let setupHelp = await cli.run(arguments: ["setup", "--help"], mutation: false)
+            guard installationSnapshotIsCurrent(generation) else { return }
+            runtimeSetupCommands = setupHelp.succeeded
+                ? CommandRegistry.setupCommands(from: setupHelp.output)
+                : nil
             runtimeVersionError = nil
             // A detected, working CLI supersedes an earlier bundled-install
             // failure (e.g. the user installed via the shell script instead);
@@ -994,6 +1027,7 @@ final class AppState {
             if case .failed = runtimeInstallState { runtimeInstallState = .idle }
         } else {
             installedRuntimeVersion = nil
+            runtimeSetupCommands = nil
             runtimeVersionError = result.succeeded
                 ? "Could not read the installed runtime version."
                 : "Runtime version check failed (exit \(result.exitCode))."
@@ -1091,7 +1125,7 @@ final class AppState {
         // binary — never present overlapping runtime actions.
         guard !runtimeInstallState.isRunning else { return false }
         guard let runtimeUpdate = availableRuntimeUpdate else { return true }
-        guard let resolverCommand = Self.authenticatedRuntimeUpgradeResolverCommand(
+        guard let resolverCommand = RuntimeUpgradeResolverCommand.authenticated(
             releaseTag: runtimeUpdate.tag
         ) else {
             let failure = """
@@ -1109,6 +1143,37 @@ final class AppState {
         runtimeUpgradeLog = guidance
         runtimeUpgradeState = .actionRequired(guidance: guidance, command: resolverCommand)
         return false
+    }
+
+    /// Targets the installation that produced the warning. The installed CLI
+    /// authenticates the release-owned resolver before replacing any audit
+    /// files; the app only prepares the explicit operator command.
+    func auditStoreRecoveryCommand(
+        expectedGeneration: Int,
+        expectedBinaryPath: String?
+    ) async -> String? {
+        guard installationSnapshotIsCurrent(expectedGeneration) else { return nil }
+        guard let expectedBinaryPath,
+              await cli.locateBinary() == expectedBinaryPath else { return nil }
+        let versionResult = await cli.run(
+            binary: expectedBinaryPath,
+            arguments: ["--version"],
+            mutation: false
+        )
+        guard installationSnapshotIsCurrent(expectedGeneration),
+              await cli.locateBinary() == expectedBinaryPath,
+              versionResult.succeeded,
+              let installedVersion = UpdateChecker.parseVersion(versionResult.output) else {
+            return nil
+        }
+        return RuntimeAuditRecoveryCommand.command(for: RuntimeAuditRecoveryTarget(
+            homeRoot: installationContext.homeRoot,
+            configURL: installationContext.configURL,
+            venvURL: installationContext.venvURL,
+            runtimeCLIURL: URL(fileURLWithPath: expectedBinaryPath, isDirectory: false),
+            installedVersion: installedVersion,
+            permitsMutation: installationContext.permitsMutation
+        ))
     }
 
     /// Download, install over the current bundle, and restart the app.

--- a/macos/DefenseClawMac/DefenseClawMac/App/DefenseClawApp.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/App/DefenseClawApp.swift
@@ -24,10 +24,15 @@ import ServiceManagement
 @main
 struct DefenseClawApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
-    @State private var appState = AppState()
+    @State private var appState: AppState
+
+    init() {
+        CLIProcessGroupLauncher.execIfRequested()
+        _appState = State(initialValue: AppState())
+    }
 
     var body: some Scene {
-        WindowGroup("DefenseClaw", id: "main") {
+        Window("DefenseClaw", id: "main") {
             MainWindow()
                 .environment(appState)
                 .frame(minWidth: 980, minHeight: 640)
@@ -35,8 +40,8 @@ struct DefenseClawApp: App {
         }
         .defaultSize(width: 1180, height: 760)
         .commands {
-            // DefenseClaw has one primary dashboard; WindowGroup gives the menu
-            // bar a reliable recreation target without exposing duplicate windows.
+            // DefenseClaw has one primary dashboard. The singleton Window scene
+            // lets the menu bar restore it without creating duplicate dashboards.
             CommandGroup(replacing: .newItem) { }
             CommandGroup(after: .appSettings) {
                 Button("Check for Updates…") {
@@ -186,6 +191,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         applyActivationPolicy()
+        DCToolbarQuickHelpMonitor.shared.start()
 
         // Optional hide-instead-of-minimize behavior. Standard macOS minimize is
         // the default; people can opt into a menu-bar-only transition in Settings.
@@ -231,18 +237,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     static func openMainWindow() {
-        NSApp.setActivationPolicy(
-            (UserDefaults.standard.object(forKey: "showDockIcon") as? Bool ?? true) ? .regular : .accessory
-        )
-        NSApp.activate(ignoringOtherApps: true)
+        prepareForMainWindowPresentation()
         for window in NSApp.windows where window.identifier?.rawValue.contains("main") == true {
             if window.isMiniaturized { window.deminiaturize(nil) }
             window.makeKeyAndOrderFront(nil)
             return
         }
         // A non-main utility window must never be promoted as the dashboard.
-        // Ask SwiftUI to recreate the released WindowGroup instead.
+        // Ask SwiftUI to recreate the released singleton window instead.
         recreateMainWindow?()
+    }
+
+    static func prepareForMainWindowPresentation() {
+        NSApp.setActivationPolicy(
+            (UserDefaults.standard.object(forKey: "showDockIcon") as? Bool ?? true) ? .regular : .accessory
+        )
+        NSApp.activate(ignoringOtherApps: true)
     }
 }
 

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/AIDiscoveryActionPolicy.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/AIDiscoveryActionPolicy.swift
@@ -1,0 +1,79 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+enum AIDiscoveryPrimaryAction: Equatable, Sendable {
+    case enable
+    case scan
+
+    static func resolve(enabled: Bool) -> Self {
+        enabled ? .scan : .enable
+    }
+
+    var title: String {
+        switch self {
+        case .enable: "Enable AI Discovery"
+        case .scan: "Scan AI Discovery"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .enable: "Enable AI Discovery"
+        case .scan: "Scan Now"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .enable: "power"
+        case .scan: "wand.and.rays"
+        }
+    }
+
+    var arguments: [String] {
+        switch self {
+        case .enable: ["agent", "discovery", "enable", "--yes"]
+        case .scan: ["agent", "discovery", "scan"]
+        }
+    }
+
+    var category: String {
+        switch self {
+        case .enable: "setup"
+        case .scan: "scan"
+        }
+    }
+
+    var successEffects: [String] {
+        switch self {
+        case .enable: ["AI Discovery enabled", "Initial AI usage scan completed"]
+        case .scan: ["AI Discovery snapshot refreshed"]
+        }
+    }
+}
+
+enum AIDiscoveryScanRequestStep: Equatable, Sendable {
+    case loadStatus
+    case showDisabled
+    case scan
+
+    static func resolve(statusLoaded: Bool, enabled: Bool) -> Self {
+        guard statusLoaded else { return .loadStatus }
+        return enabled ? .scan : .showDisabled
+    }
+}

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/AlertDispositionCommand.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/AlertDispositionCommand.swift
@@ -1,0 +1,49 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+struct AlertDispositionInvocation: Equatable, Sendable {
+    let arguments: [String]
+    let standardInput: String
+}
+
+enum AlertDispositionCommand {
+    /// Runtime 0.8.9 keeps severity selectors and asks for confirmation before
+    /// applying a broad mutation. Supplying the answer on stdin also remains
+    /// compatible with older tagged runtimes that ignore it.
+    static let confirmationInput = "y"
+
+    static func acknowledge(severity: String) -> AlertDispositionInvocation {
+        invocation(action: "acknowledge", severity: severity)
+    }
+
+    static func dismiss(severity: String?) -> AlertDispositionInvocation {
+        invocation(action: "dismiss", severity: severity ?? "all")
+    }
+
+    static func suppliesConfirmation(for arguments: [String]) -> Bool {
+        arguments.starts(with: ["alerts", "acknowledge"])
+            || arguments.starts(with: ["alerts", "dismiss"])
+    }
+
+    private static func invocation(action: String, severity: String) -> AlertDispositionInvocation {
+        AlertDispositionInvocation(
+            arguments: ["alerts", action, "--severity", severity],
+            standardInput: confirmationInput
+        )
+    }
+}

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/AuditStore.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/AuditStore.swift
@@ -24,7 +24,19 @@ import SQLite3
 private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
 actor AuditStore {
+    private struct FileIdentity: Equatable {
+        let device: UInt64
+        let inode: UInt64
+    }
+
+    private struct DatabaseFamilyIdentity: Equatable {
+        let database: FileIdentity
+        let wal: FileIdentity?
+        let sharedMemory: FileIdentity?
+    }
+
     private var db: OpaquePointer?
+    private var openedIdentity: DatabaseFamilyIdentity?
     private let path: String
 
     init(url: URL) {
@@ -39,22 +51,55 @@ actor AuditStore {
     /// Release the path-bound SQLite handle before AppState swaps to another
     /// installation. Actor serialization waits for any in-flight query first.
     func close() {
-        guard let db else { return }
-        sqlite3_close_v2(db)
+        if let db { sqlite3_close_v2(db) }
         self.db = nil
+        openedIdentity = nil
     }
 
     private func ensureOpen() {
-        guard db == nil else { return }
-        guard FileManager.default.fileExists(atPath: path) else { return }
-        var handle: OpaquePointer?
-        // Read-only; gateway writes via WAL so allow shared access.
-        if sqlite3_open_v2(path, &handle, SQLITE_OPEN_READONLY, nil) == SQLITE_OK {
-            db = handle
-            sqlite3_busy_timeout(db, 500)
-        } else {
-            sqlite3_close(handle)
+        let currentIdentity = databaseFamilyIdentity()
+        if db != nil, currentIdentity != openedIdentity {
+            close()
         }
+        guard db == nil, var expectedIdentity = currentIdentity else { return }
+
+        // A runtime recovery replaces audit.db at the same path. Capture the
+        // identity on both sides of open so this actor never retains a handle
+        // to the retired database family or races a replacement in progress.
+        for _ in 0..<2 {
+            var handle: OpaquePointer?
+            if sqlite3_open_v2(path, &handle, SQLITE_OPEN_READONLY, nil) == SQLITE_OK,
+               let afterOpenIdentity = databaseFamilyIdentity(),
+               afterOpenIdentity == expectedIdentity {
+                db = handle
+                openedIdentity = afterOpenIdentity
+                sqlite3_busy_timeout(db, 500)
+                return
+            }
+            sqlite3_close(handle)
+            guard let retryIdentity = databaseFamilyIdentity(), retryIdentity != expectedIdentity else {
+                return
+            }
+            expectedIdentity = retryIdentity
+        }
+    }
+
+    private func databaseFamilyIdentity() -> DatabaseFamilyIdentity? {
+        guard let database = fileIdentity(atPath: path) else { return nil }
+        return DatabaseFamilyIdentity(
+            database: database,
+            wal: fileIdentity(atPath: path + "-wal"),
+            sharedMemory: fileIdentity(atPath: path + "-shm")
+        )
+    }
+
+    private func fileIdentity(atPath candidatePath: String) -> FileIdentity? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: candidatePath),
+              let device = attributes[.systemNumber] as? NSNumber,
+              let inode = attributes[.systemFileNumber] as? NSNumber else {
+            return nil
+        }
+        return FileIdentity(device: device.uint64Value, inode: inode.uint64Value)
     }
 
     private func tableExists(_ name: String) -> Bool {
@@ -62,6 +107,13 @@ actor AuditStore {
         guard db != nil else { return false }
         let rows = query("SELECT name FROM sqlite_master WHERE type='table' AND name=?", binds: [name])
         return !rows.isEmpty
+    }
+
+    private func columnNames(in table: String) -> Set<String> {
+        guard table.range(of: "^[A-Za-z0-9_]+$", options: .regularExpression) != nil else {
+            return []
+        }
+        return Set(query("PRAGMA table_info(\(table))").compactMap { $0["name"] as? String })
     }
 
     /// Runs a query, returning rows as [column: value] dictionaries.
@@ -189,6 +241,16 @@ actor AuditStore {
         ).map(decodeAuditEvent)
     }
 
+    /// Loads the complete record for an inspector selection. Alert list rows
+    /// intentionally carry only a bounded details preview.
+    func event(id: String) -> AuditEvent? {
+        guard tableExists("audit_events"), !id.isEmpty else { return nil }
+        return query(
+            "SELECT * FROM audit_events WHERE id = ? LIMIT 1",
+            binds: [id]
+        ).first.map(decodeAuditEvent)
+    }
+
     func scanFindings(runID: String? = nil, target: String? = nil, limit: Int = 20) -> [ScanFindingEvent] {
         guard tableExists("scan_results") else { return [] }
         var conditions = ["raw_json IS NOT NULL", "raw_json != ''"]
@@ -234,21 +296,37 @@ actor AuditStore {
         }
     }
 
-    /// The TUI's alert queue: db.py::list_alerts(500) loads the last 500
-    /// non-ACK rows of ANY listed severity, and the panel then counts only
-    /// the CRITICAL/HIGH/MEDIUM/LOW buckets in memory. Older severity-bearing
-    /// rows that scrolled out of the 500-row window do NOT count — replicate
-    /// that exactly: window first, filter second.
+    /// The TUI's alert queue: db.py::list_alert_summaries(500) excludes rows
+    /// hidden by the v8 acknowledgement projection and non-finding telemetry
+    /// buckets before applying the bounded window. Older schemas omit those
+    /// surfaces, so add each condition only when its table/columns exist.
     func alertQueueEvents(limit: Int = 500) -> [AuditEvent] {
         guard tableExists("audit_events") else { return [] }
+        let columns = columnNames(in: "audit_events")
+        var conditions = [
+            "UPPER(severity) IN ('CRITICAL','HIGH','MEDIUM','LOW','ERROR','INFO')",
+            "action NOT LIKE 'dismiss%'",
+        ]
+        if columns.contains("bucket"), columns.contains("event_name") {
+            conditions.append("(bucket IS NULL OR (bucket = 'security.finding' AND event_name = 'finding.observed'))")
+        }
+        if tableExists("alert_acknowledgement_projection"),
+           columnNames(in: "alert_acknowledgement_projection").contains("alert_id") {
+            conditions.append("""
+                NOT EXISTS (
+                    SELECT 1 FROM alert_acknowledgement_projection AS projection
+                    WHERE projection.alert_id = audit_events.id
+                )
+                """)
+        }
         let rows = query("""
-            SELECT * FROM audit_events
-            WHERE UPPER(severity) IN ('CRITICAL','HIGH','MEDIUM','LOW','WARNING','ERROR','INFO')
-              AND action NOT LIKE 'dismiss%'
-            ORDER BY timestamp DESC LIMIT ?
-            """, binds: [limit])
+            SELECT *, substr(COALESCE(details, ''), 1, 4096) AS details
+            FROM audit_events
+            WHERE \(conditions.joined(separator: " AND "))
+            ORDER BY timestamp DESC, rowid DESC LIMIT ?
+            """, binds: [max(limit, 1)])
         return rows.map(decodeAuditEvent)
-            .filter { $0.severity != .info } // bucket filter: C/H/M/L only (WARNING→MEDIUM)
+            .filter { $0.severity != .info }
     }
 
     /// db.py::get_counts — Overview ENFORCEMENT summary.

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/CLIRunner.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/CLIRunner.swift
@@ -29,11 +29,272 @@ struct CLIResult: Sendable {
     var succeeded: Bool { exitCode == 0 && !cancelled && !outputTruncated }
 }
 
+struct CatalogListCLIResult: Sendable {
+    var result: CLIResult
+    var usedIsolatedAuditStore: Bool
+    var selectedBinaryPath: String?
+}
+
 enum CLICancellationDisposition: Sendable, Equatable {
     case requested
     case alreadyRequested
     case finishing
     case notFound
+}
+
+/// Re-enters the signed app executable as a tiny process launcher. Establishing
+/// a process group before `execv` makes every descendant independently
+/// reachable even if an intermediate process forks and exits during
+/// cancellation. The same entry point is used by standalone runner tests.
+enum CLIProcessGroupLauncher {
+    private static let marker = "--defenseclaw-internal-command-launcher-v1"
+
+    static func execIfRequested(arguments: [String] = CommandLine.arguments) {
+        guard arguments.count >= 3, arguments[1] == marker else { return }
+        let target = arguments[2]
+        guard target.hasPrefix("/"),
+              wasInvokedBySameExecutableParent(),
+              setpgid(0, 0) == 0 else {
+            failAndExit()
+        }
+
+        var pointers: [UnsafeMutablePointer<CChar>?] = ([target] + arguments.dropFirst(3)).map {
+            strdup(String($0))
+        }
+        pointers.append(nil)
+        defer {
+            for pointer in pointers.compactMap({ $0 }) { free(pointer) }
+        }
+        execv(target, &pointers)
+        failAndExit()
+    }
+
+    static func configure(
+        _ process: Process,
+        target: String,
+        arguments: [String]
+    ) -> Bool {
+        guard let executableURL = Bundle.main.executableURL else { return false }
+        process.executableURL = executableURL
+        process.arguments = [marker, target] + arguments
+        return true
+    }
+
+    /// The marker is an internal protocol, not a public command-execution
+    /// surface. Only a running copy of this exact executable may create the
+    /// launcher child; direct invocations from a shell or another local process
+    /// fail before the target is executed.
+    private static func wasInvokedBySameExecutableParent() -> Bool {
+        guard let executableURL = Bundle.main.executableURL else { return false }
+        let canonicalExecutable = executableURL.resolvingSymlinksInPath()
+
+        var parentPathBuffer = [CChar](
+            repeating: 0,
+            count: 4_096
+        )
+        let parentPathLength = parentPathBuffer.withUnsafeMutableBytes { buffer in
+            proc_pidpath(getppid(), buffer.baseAddress, UInt32(buffer.count))
+        }
+        guard parentPathLength > 0 else { return false }
+
+        let parentPath = parentPathBuffer.withUnsafeBufferPointer { buffer in
+            String(cString: buffer.baseAddress!)
+        }
+        let canonicalParent = URL(fileURLWithPath: parentPath).resolvingSymlinksInPath()
+        guard canonicalParent.path == canonicalExecutable.path else { return false }
+
+        guard let parentAttributes = try? FileManager.default.attributesOfItem(
+                  atPath: canonicalParent.path
+              ),
+              let executableAttributes = try? FileManager.default.attributesOfItem(
+                  atPath: canonicalExecutable.path
+              ),
+              let parentDevice = parentAttributes[.systemNumber] as? NSNumber,
+              let parentFile = parentAttributes[.systemFileNumber] as? NSNumber,
+              let executableDevice = executableAttributes[.systemNumber] as? NSNumber,
+              let executableFile = executableAttributes[.systemFileNumber] as? NSNumber else {
+            return false
+        }
+        return parentDevice == executableDevice && parentFile == executableFile
+    }
+
+    private static func failAndExit() -> Never {
+        let message = "DefenseClaw internal command launcher failed.\n"
+        message.withCString { pointer in
+            _ = Darwin.write(STDERR_FILENO, pointer, strlen(pointer))
+        }
+        Darwin._exit(126)
+    }
+}
+
+/// Coordinates direct-process termination with the detached pipe reader.
+/// Descendants may inherit stdout/stderr and keep the pipe open after the
+/// command exits, so EOF alone is not a reliable completion signal.
+private final class CLIOutputReadControl: @unchecked Sendable {
+    private let lock = NSLock()
+    private var parentExited = false
+
+    func markParentExited() {
+        lock.lock()
+        parentExited = true
+        lock.unlock()
+    }
+
+    var hasParentExited: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return parentExited
+    }
+}
+
+private struct CLIProcessIdentity: Hashable, Sendable {
+    let pid: pid_t
+    let startSeconds: UInt64
+    let startMicroseconds: UInt64
+}
+
+/// Signals the command's dedicated process group. PID/start-time descendant
+/// tracking remains a fallback for environments that cannot establish the
+/// group, and prevents signaling an unrelated process after PID reuse.
+private final class CLIProcessTree: @unchecked Sendable {
+    private let rootPID: pid_t
+    private let lock = NSLock()
+    private var processGroupID: pid_t?
+    private var identities: [pid_t: CLIProcessIdentity] = [:]
+
+    init(rootPID: pid_t) {
+        self.rootPID = rootPID
+        self.processGroupID = nil
+        refreshProcessGroup()
+        if let identity = Self.identity(for: rootPID) {
+            identities[rootPID] = identity
+        }
+    }
+
+    /// Waits until the signed launcher has established the dedicated group.
+    /// A command that already exited needs no cancellation tracking; a live
+    /// command that never establishes its group is rejected fail-closed.
+    func waitUntilReady(process: Process) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        for _ in 0..<1_000 {
+            refreshProcessGroup()
+            if processGroupID != nil { return true }
+            if !process.isRunning { return true }
+            usleep(1_000)
+        }
+        refreshProcessGroup()
+        return processGroupID != nil || !process.isRunning
+    }
+
+    @discardableResult
+    func send(_ signal: Int32) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        // Process.run() returns after the signed launcher starts, so the
+        // launcher may establish its group just after this tracker is created.
+        refreshProcessGroup()
+        if let processGroupID {
+            // A negative PID addresses the process group, including children
+            // reparented after an earlier cancellation signal.
+            errno = 0
+            if Darwin.kill(-processGroupID, signal) == 0 || errno == EPERM {
+                return true
+            }
+            return false
+        }
+
+        discoverDescendants()
+        var signalledProcess = false
+
+        // Signal descendants before the direct child so they cannot disappear
+        // from the ancestry graph before being captured.
+        let descendants = identities.values
+            .filter { $0.pid != rootPID }
+            .sorted { $0.pid < $1.pid }
+        for identity in descendants where Self.matches(identity) {
+            errno = 0
+            if Darwin.kill(identity.pid, signal) == 0 || errno == EPERM {
+                signalledProcess = true
+            }
+        }
+        if let root = identities[rootPID], Self.matches(root) {
+            errno = 0
+            if Darwin.kill(root.pid, signal) == 0 || errno == EPERM {
+                signalledProcess = true
+            }
+        }
+        return signalledProcess
+    }
+
+    private func refreshProcessGroup() {
+        guard processGroupID == nil else { return }
+        if getpgid(rootPID) == rootPID {
+            processGroupID = rootPID
+            return
+        }
+        errno = 0
+        if Darwin.kill(-rootPID, 0) == 0 || errno == EPERM {
+            // The leader may have exited quickly while descendants retain the
+            // intended group. A signal-0 probe proves the group still exists.
+            processGroupID = rootPID
+        }
+    }
+
+    private func discoverDescendants() {
+        if identities[rootPID] == nil, let root = Self.identity(for: rootPID) {
+            identities[rootPID] = root
+        }
+        var queue = Array(identities.values)
+        var visited: Set<CLIProcessIdentity> = []
+        while let parent = queue.popLast() {
+            guard visited.insert(parent).inserted, Self.matches(parent) else { continue }
+            for pid in Self.childPIDs(of: parent.pid) {
+                guard let child = Self.identity(for: pid) else { continue }
+                let isNew = identities[pid] != child
+                identities[pid] = child
+                if isNew { queue.append(child) }
+            }
+        }
+    }
+
+    private static func childPIDs(of parent: pid_t) -> [pid_t] {
+        let requiredBytes = proc_listchildpids(parent, nil, 0)
+        guard requiredBytes > 0 else { return [] }
+        let stride = MemoryLayout<pid_t>.stride
+        let capacity = min(max(Int(requiredBytes) / stride + 16, 16), 32_768)
+        var pids = [pid_t](repeating: 0, count: capacity)
+        let count = pids.withUnsafeMutableBytes { buffer in
+            proc_listchildpids(parent, buffer.baseAddress, Int32(buffer.count))
+        }
+        guard count > 0 else { return [] }
+        return Array(pids.prefix(min(Int(count), pids.count))).filter { $0 > 0 }
+    }
+
+    private static func identity(for pid: pid_t) -> CLIProcessIdentity? {
+        guard pid > 0 else { return nil }
+        var info = proc_bsdinfo()
+        let count = withUnsafeMutablePointer(to: &info) { pointer in
+            proc_pidinfo(
+                pid,
+                PROC_PIDTBSDINFO,
+                0,
+                pointer,
+                Int32(MemoryLayout<proc_bsdinfo>.size)
+            )
+        }
+        guard count == MemoryLayout<proc_bsdinfo>.size else { return nil }
+        return CLIProcessIdentity(
+            pid: pid,
+            startSeconds: info.pbi_start_tvsec,
+            startMicroseconds: info.pbi_start_tvusec
+        )
+    }
+
+    private static func matches(_ identity: CLIProcessIdentity) -> Bool {
+        Self.identity(for: identity.pid) == identity
+    }
 }
 
 enum CLIOutputLimits {
@@ -51,195 +312,6 @@ enum CLIOutputLimits {
 private struct CapturedCLIOutput: Sendable {
     var output: String
     var truncated: Bool
-}
-
-/// Coordinates the detached pipe reader with direct-process termination.
-/// A descendant can inherit stdout/stderr and keep the pipe open after the
-/// command itself exits, so EOF alone is not a reliable completion signal.
-private final class CLIOutputReadControl: @unchecked Sendable {
-    private let lock = NSLock()
-    private var parentExited = false
-
-    deinit {}
-
-    func markParentExited() {
-        lock.lock()
-        parentExited = true
-        lock.unlock()
-    }
-
-    var hasParentExited: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return parentExited
-    }
-}
-
-/// A directly spawned command that is also the leader of its own process
-/// group. Group isolation must be established by `posix_spawn`; trying to call
-/// `setpgid` after `Process.run()` races the child reaching `exec`.
-private final class CLIProcess: @unchecked Sendable {
-    let processIdentifier: pid_t
-    let processGroupIdentifier: pid_t
-
-    private init(processIdentifier: pid_t) {
-        self.processIdentifier = processIdentifier
-        self.processGroupIdentifier = processIdentifier
-    }
-
-    deinit {}
-
-    static func spawn(
-        executable: String,
-        arguments: [String],
-        environment: [String: String],
-        outputPipe: Pipe,
-        inputPipe: Pipe?
-    ) throws -> CLIProcess {
-        guard !executable.utf8.contains(0),
-              arguments.allSatisfy({ !$0.utf8.contains(0) }),
-              environment.allSatisfy({
-                  !$0.key.isEmpty
-                      && !$0.key.contains("=")
-                      && !$0.key.utf8.contains(0)
-                      && !$0.value.utf8.contains(0)
-              }) else {
-            throw posixError(EINVAL)
-        }
-
-        var fileActions: posix_spawn_file_actions_t?
-        try check(posix_spawn_file_actions_init(&fileActions))
-        defer { _ = posix_spawn_file_actions_destroy(&fileActions) }
-
-        let outputReadDescriptor = outputPipe.fileHandleForReading.fileDescriptor
-        let outputWriteDescriptor = outputPipe.fileHandleForWriting.fileDescriptor
-        try check(posix_spawn_file_actions_addclose(&fileActions, outputReadDescriptor))
-        try check(posix_spawn_file_actions_adddup2(
-            &fileActions,
-            outputWriteDescriptor,
-            STDOUT_FILENO
-        ))
-        try check(posix_spawn_file_actions_adddup2(
-            &fileActions,
-            outputWriteDescriptor,
-            STDERR_FILENO
-        ))
-        try check(posix_spawn_file_actions_addclose(&fileActions, outputWriteDescriptor))
-
-        if let inputPipe {
-            let inputReadDescriptor = inputPipe.fileHandleForReading.fileDescriptor
-            let inputWriteDescriptor = inputPipe.fileHandleForWriting.fileDescriptor
-            try check(posix_spawn_file_actions_adddup2(
-                &fileActions,
-                inputReadDescriptor,
-                STDIN_FILENO
-            ))
-            try check(posix_spawn_file_actions_addclose(&fileActions, inputReadDescriptor))
-            try check(posix_spawn_file_actions_addclose(&fileActions, inputWriteDescriptor))
-        }
-
-        var attributes: posix_spawnattr_t?
-        try check(posix_spawnattr_init(&attributes))
-        defer { _ = posix_spawnattr_destroy(&attributes) }
-
-        var defaultSignals = sigset_t()
-        sigemptyset(&defaultSignals)
-        sigaddset(&defaultSignals, SIGINT)
-        sigaddset(&defaultSignals, SIGTERM)
-        try check(posix_spawnattr_setsigdefault(&attributes, &defaultSignals))
-
-        var signalMask = sigset_t()
-        sigemptyset(&signalMask)
-        try check(posix_spawnattr_setsigmask(&attributes, &signalMask))
-
-        let flags = Int16(POSIX_SPAWN_SETPGROUP)
-            | Int16(POSIX_SPAWN_SETSIGDEF)
-            | Int16(POSIX_SPAWN_SETSIGMASK)
-            | Int16(POSIX_SPAWN_CLOEXEC_DEFAULT)
-        try check(posix_spawnattr_setflags(&attributes, flags))
-        // A zero pgroup value makes the child a process-group leader whose
-        // group identifier is its own PID.
-        try check(posix_spawnattr_setpgroup(&attributes, 0))
-
-        let argumentStrings = [executable] + arguments
-        let environmentStrings = environment
-            .map { "\($0.key)=\($0.value)" }
-            .sorted()
-        var childPID: pid_t = 0
-        let spawnStatus = try withCStringArray(argumentStrings) { argumentVector in
-            try withCStringArray(environmentStrings) { environmentVector in
-                executable.withCString { executablePointer in
-                    posix_spawn(
-                        &childPID,
-                        executablePointer,
-                        &fileActions,
-                        &attributes,
-                        argumentVector,
-                        environmentVector
-                    )
-                }
-            }
-        }
-        try check(spawnStatus)
-        return CLIProcess(processIdentifier: childPID)
-    }
-
-    var isProcessGroupRunning: Bool {
-        if Darwin.kill(-processGroupIdentifier, 0) == 0 { return true }
-        return errno == EPERM
-    }
-
-    @discardableResult
-    func signalProcessGroup(_ signal: Int32) -> Bool {
-        if Darwin.kill(-processGroupIdentifier, signal) == 0 { return true }
-        return errno == EPERM
-    }
-
-    func waitUntilExit() -> Int32 {
-        var status: Int32 = 0
-        var waitResult: pid_t
-        repeat {
-            waitResult = Darwin.waitpid(processIdentifier, &status, 0)
-        } while waitResult == -1 && errno == EINTR
-
-        guard waitResult == processIdentifier else { return 126 }
-        let terminationSignal = status & 0x7f
-        if terminationSignal == 0 {
-            return (status >> 8) & 0xff
-        }
-        if terminationSignal != 0x7f {
-            return terminationSignal
-        }
-        return 126
-    }
-
-    private static func check(_ status: Int32) throws {
-        guard status == 0 else { throw posixError(status) }
-    }
-
-    private static func posixError(_ code: Int32) -> NSError {
-        NSError(domain: NSPOSIXErrorDomain, code: Int(code))
-    }
-
-    private static func withCStringArray<Result>(
-        _ strings: [String],
-        body: (UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>) throws -> Result
-    ) throws -> Result {
-        var pointers: [UnsafeMutablePointer<CChar>?] = []
-        pointers.reserveCapacity(strings.count + 1)
-        for string in strings {
-            guard let pointer = strdup(string) else {
-                pointers.forEach { free($0) }
-                throw posixError(ENOMEM)
-            }
-            pointers.append(pointer)
-        }
-        pointers.append(nil)
-        defer { pointers.dropLast().forEach { free($0) } }
-        return try pointers.withUnsafeMutableBufferPointer { buffer in
-            try body(buffer.baseAddress!)
-        }
-    }
 }
 
 private enum CLIUTF8 {
@@ -418,14 +490,19 @@ private struct BoundedCLILineStreamer: Sendable {
 }
 
 actor CLIRunner {
+    private static let isolatedCatalogResources = Set(["skill", "mcp", "plugin"])
+    private static let isolatedCatalogDirectoryPrefix = "DefenseClaw-catalog-read-only-"
+    private static let auditStoreMalformedLine =
+        "Failed to open audit store: database disk image is malformed"
     /// User override (App Settings ▸ Connection) wins; otherwise search standard locations.
     static let pathOverrideKey = "defenseclawBinaryPath"
 
     private struct ActiveRun {
         let token: UUID
-        let process: CLIProcess
+        let process: Process
+        let processTree: CLIProcessTree
+        let mutation: Bool
         var cancellationRequested: Bool
-        var cancellationTask: Task<Void, Never>?
     }
 
     private enum RunState {
@@ -444,21 +521,20 @@ actor CLIRunner {
     func rebind(to context: InstallationContext) {
         guard installationContext != context else { return }
         if installationContext.permitsMutation, !context.permitsMutation {
-            let activeRuns = runStates.compactMap { executionID, state -> (UUID, ActiveRun)? in
-                guard case .running(let active) = state,
-                      active.process.isProcessGroupRunning else { return nil }
-                return (executionID, active)
+            let activeMutations = runStates.compactMap { runID, state -> (UUID, UUID)? in
+                guard case .running(let active) = state, active.mutation else { return nil }
+                return (runID, active.token)
             }
-            for (executionID, active) in activeRuns {
-                _ = requestCancellation(executionID: executionID, token: active.token)
+            for (runID, token) in activeMutations {
+                _ = requestCancellation(executionID: runID, token: token)
             }
         }
         installationContext = context
         cachedPaths.removeAll()
     }
 
-    /// Reserve an Activity run before its visible row is published. This makes
-    /// a cancellation click racing process launch durable instead of a no-op.
+    /// Reserve an Activity run before its visible row is published so a
+    /// cancellation racing process launch is retained instead of discarded.
     func reserve(runID: UUID) -> Bool {
         guard runStates[runID] == nil else { return false }
         runStates[runID] = .reserved(cancelRequested: false)
@@ -467,6 +543,35 @@ actor CLIRunner {
 
     func locateBinary() -> String? {
         locateBinary(named: "defenseclaw")
+    }
+
+    /// Prefer the selected installation's interpreter, then the interpreter
+    /// adjacent to the resolved CLI. The second path covers source and PATH
+    /// installs whose venv does not live below DEFENSECLAW_HOME.
+    func locateRuntimePython() -> String? {
+        Self.runtimePythonCandidates(
+            contextPythonPath: installationContext.runtimePythonURL.path,
+            selectedCLIPath: locateBinary()
+        ).first(where: FileManager.default.isExecutableFile(atPath:))
+    }
+
+    nonisolated static func runtimePythonCandidates(
+        contextPythonPath: String,
+        selectedCLIPath: String?
+    ) -> [String] {
+        var candidates = [contextPythonPath]
+        if let selectedCLIPath, !selectedCLIPath.isEmpty {
+            let resolvedCLI = URL(fileURLWithPath: selectedCLIPath)
+                .resolvingSymlinksInPath()
+            let siblingPython = resolvedCLI
+                .deletingLastPathComponent()
+                .appendingPathComponent("python", isDirectory: false)
+                .path
+            if !candidates.contains(siblingPython) {
+                candidates.append(siblingPython)
+            }
+        }
+        return candidates
     }
 
     func locateBinary(named name: String) -> String? {
@@ -511,6 +616,200 @@ actor CLIRunner {
     /// Subprocess-backed — callers cache the result; never run on the pulse.
     func locateTool(_ name: String) -> String? {
         which(name)
+    }
+
+    /// Catalog list commands currently initialize the runtime's writable audit
+    /// store before dispatch. If that store is corrupt, preserve catalog
+    /// availability by re-running only the allowlisted read-only list command
+    /// with a private, ephemeral DefenseClaw home. The real config and venv
+    /// remain pinned, while audit-backed status/history is intentionally absent.
+    func runReadOnlyCatalogList(resource: String) async -> CatalogListCLIResult {
+        guard Self.isolatedCatalogResources.contains(resource) else {
+            return CatalogListCLIResult(
+                result: CLIResult(exitCode: 64, output: "Unsupported isolated catalog resource."),
+                usedIsolatedAuditStore: false,
+                selectedBinaryPath: nil
+            )
+        }
+
+        let sourceContext = installationContext
+        guard let selectedBinary = locateBinary() else {
+            return CatalogListCLIResult(
+                result: CLIResult(
+                    exitCode: 127,
+                    output: "defenseclaw binary not found. Set its path in Settings ▸ Connection."
+                ),
+                usedIsolatedAuditStore: false,
+                selectedBinaryPath: nil
+            )
+        }
+        let arguments = [resource, "list", "--json"]
+        let primary = await run(binary: selectedBinary, arguments: arguments, mutation: false)
+        guard installationContext == sourceContext else {
+            return CatalogListCLIResult(
+                result: CLIResult(
+                    exitCode: 75,
+                    output: "DefenseClaw installation changed while loading the catalog. Refresh to retry."
+                ),
+                usedIsolatedAuditStore: false,
+                selectedBinaryPath: selectedBinary
+            )
+        }
+        guard !primary.succeeded, Self.isAuditStoreCorruption(primary.output) else {
+            return CatalogListCLIResult(
+                result: primary,
+                usedIsolatedAuditStore: false,
+                selectedBinaryPath: selectedBinary
+            )
+        }
+
+        let sourceConfig = await run(
+            binary: selectedBinary,
+            arguments: ["config", "show", "--source", "--format", "json"],
+            mutation: false
+        )
+        guard installationContext == sourceContext, sourceConfig.succeeded else {
+            return CatalogListCLIResult(
+                result: primary,
+                usedIsolatedAuditStore: false,
+                selectedBinaryPath: selectedBinary
+            )
+        }
+
+        let fileManager = FileManager.default
+        let temporaryHome = fileManager.temporaryDirectory.appendingPathComponent(
+            Self.isolatedCatalogDirectoryPrefix + UUID().uuidString,
+            isDirectory: true
+        )
+        do {
+            try fileManager.createDirectory(
+                at: temporaryHome,
+                withIntermediateDirectories: false,
+                attributes: [.posixPermissions: NSNumber(value: Int16(0o700))]
+            )
+        } catch {
+            return CatalogListCLIResult(
+                result: CLIResult(
+                    exitCode: 73,
+                    output: "Could not create a private read-only catalog workspace: \(error.localizedDescription)"
+                ),
+                usedIsolatedAuditStore: false,
+                selectedBinaryPath: selectedBinary
+            )
+        }
+        defer { try? fileManager.removeItem(at: temporaryHome) }
+
+        let isolatedConfigURL = temporaryHome.appendingPathComponent("config.json", isDirectory: false)
+        guard let isolatedConfig = Self.isolatedCatalogConfig(
+            sourceJSON: sourceConfig.output,
+            temporaryHome: temporaryHome,
+            pluginDirectory: sourceContext.dataDirectory.appendingPathComponent(
+                "plugins",
+                isDirectory: true
+            )
+        ), fileManager.createFile(
+            atPath: isolatedConfigURL.path,
+            contents: isolatedConfig,
+            attributes: [.posixPermissions: NSNumber(value: Int16(0o600))]
+        ) else {
+            return CatalogListCLIResult(
+                result: primary,
+                usedIsolatedAuditStore: false,
+                selectedBinaryPath: selectedBinary
+            )
+        }
+
+        let isolatedContext = InstallationContext(
+            source: .environmentHome,
+            accessMode: .invalidReadOnly("Isolated read-only catalog view."),
+            homeRoot: temporaryHome,
+            configURL: isolatedConfigURL,
+            dataDirectory: temporaryHome,
+            auditDBURL: temporaryHome.appendingPathComponent("audit.db", isDirectory: false),
+            environmentURL: temporaryHome.appendingPathComponent(".env", isDirectory: false),
+            gatewayJSONLURL: temporaryHome.appendingPathComponent("gateway.jsonl", isDirectory: false),
+            gatewayLogURL: temporaryHome.appendingPathComponent("gateway.log", isDirectory: false),
+            gatewayErrorLogURL: nil,
+            watchdogLogURL: temporaryHome.appendingPathComponent("watchdog.log", isDirectory: false),
+            venvURL: sourceContext.venvURL
+        )
+        let isolatedRunner = CLIRunner(context: isolatedContext)
+        let fallback = await isolatedRunner.run(
+            binary: selectedBinary,
+            arguments: arguments,
+            mutation: false
+        )
+        guard installationContext == sourceContext else {
+            return CatalogListCLIResult(
+                result: CLIResult(
+                    exitCode: 75,
+                    output: "DefenseClaw installation changed while loading the catalog. Refresh to retry."
+                ),
+                usedIsolatedAuditStore: false,
+                selectedBinaryPath: selectedBinary
+            )
+        }
+        return CatalogListCLIResult(
+            result: fallback,
+            usedIsolatedAuditStore: fallback.succeeded,
+            selectedBinaryPath: selectedBinary
+        )
+    }
+
+    nonisolated static func isAuditStoreCorruption(_ output: String) -> Bool {
+        output.components(separatedBy: .newlines).contains {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines) == auditStoreMalformedLine
+        }
+    }
+
+    private nonisolated static func isolatedCatalogConfig(
+        sourceJSON: String,
+        temporaryHome: URL,
+        pluginDirectory: URL
+    ) -> Data? {
+        guard sourceJSON.utf8.count <= CLIOutputLimits.maximumOutputBytes,
+              let sourceData = sourceJSON
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .data(using: .utf8),
+              var config = try? JSONSerialization.jsonObject(with: sourceData) as? [String: Any],
+              (config["config_version"] as? NSNumber)?.intValue == 8 else {
+            return nil
+        }
+
+        config = removingInlineSecrets(from: config)
+        config["data_dir"] = temporaryHome.path
+        config["quarantine_dir"] = temporaryHome.appendingPathComponent("quarantine").path
+        config["policy_dir"] = temporaryHome.appendingPathComponent("policies").path
+        if config["plugin_dir"] == nil {
+            config["plugin_dir"] = pluginDirectory.path
+        }
+        // Catalog inventory needs no telemetry sink. Keeping an operator's
+        // destinations here could emit from the isolated helper or reach a
+        // path outside its private workspace.
+        config["observability"] = [String: Any]()
+
+        return try? JSONSerialization.data(withJSONObject: config, options: [.sortedKeys])
+    }
+
+    private nonisolated static func removingInlineSecrets(
+        from dictionary: [String: Any]
+    ) -> [String: Any] {
+        dictionary.reduce(into: [String: Any]()) { result, entry in
+            let lowerKey = entry.key.lowercased()
+            let namesEnvironmentVariable = lowerKey.hasSuffix("_env")
+            let namesInlineSecret = !namesEnvironmentVariable && [
+                "api_key", "token", "password", "secret", "credential",
+            ].contains { lowerKey == $0 || lowerKey.hasSuffix("_\($0)") }
+            guard !namesInlineSecret else { return }
+
+            if let nested = entry.value as? [String: Any] {
+                result[entry.key] = removingInlineSecrets(from: nested)
+            } else if let array = entry.value as? [[String: Any]] {
+                result[entry.key] = array.map(removingInlineSecrets(from:))
+            } else {
+                result[entry.key] = entry.value
+            }
+        }
     }
 
     private func which(_ name: String) -> String? {
@@ -621,7 +920,6 @@ actor CLIRunner {
                 break
             }
         }
-
         if mutation, !installationContext.permitsMutation {
             let reason = installationContext.accessMode.reason ?? "This installation is read only."
             return CLIResult(exitCode: 77, output: "Operation refused by the Mac app: \(reason)")
@@ -629,6 +927,10 @@ actor CLIRunner {
         guard let binary = locateBinary(named: binaryName) else {
             let setting = binaryName == "defenseclaw" ? " Set its path in Settings ▸ Connection." : ""
             return CLIResult(exitCode: 127, output: "\(binaryName) binary not found.\(setting)")
+        }
+        let proc = Process()
+        guard CLIProcessGroupLauncher.configure(proc, target: binary, arguments: arguments) else {
+            return CLIResult(exitCode: 126, output: "Internal command launcher is unavailable.")
         }
         var env = Self.subprocessEnvironment()
         env["NO_COLOR"] = "1"
@@ -640,30 +942,37 @@ actor CLIRunner {
         for (key, value) in installationContext.protectedSubprocessEnvironment {
             env[key] = value
         }
+        proc.environment = env
 
         let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = pipe
         let inputPipe = standardInput == nil ? nil : Pipe()
+        proc.standardInput = inputPipe
 
-        let proc: CLIProcess
         do {
-            proc = try CLIProcess.spawn(
-                executable: binary,
-                arguments: arguments,
-                environment: env,
-                outputPipe: pipe,
-                inputPipe: inputPipe
-            )
-            try? pipe.fileHandleForWriting.close()
-            try? inputPipe?.fileHandleForReading.close()
+            try proc.run()
         } catch {
             return CLIResult(exitCode: 126, output: "Failed to launch \(binary): \(error.localizedDescription)")
         }
         let runToken = UUID()
+        let processTree = CLIProcessTree(rootPID: proc.processIdentifier)
+        guard processTree.waitUntilReady(process: proc) else {
+            processTree.send(SIGKILL)
+            proc.waitUntilExit()
+            try? pipe.fileHandleForReading.close()
+            try? inputPipe?.fileHandleForWriting.close()
+            return CLIResult(
+                exitCode: 126,
+                output: "Internal command launcher did not establish an isolated process group."
+            )
+        }
         runStates[executionID] = .running(ActiveRun(
             token: runToken,
             process: proc,
-            cancellationRequested: false,
-            cancellationTask: nil
+            processTree: processTree,
+            mutation: mutation,
+            cancellationRequested: false
         ))
 
         if let standardInput, let inputPipe {
@@ -672,20 +981,15 @@ actor CLIRunner {
         }
 
         let readControl = CLIOutputReadControl()
-
-        // A detached waiter keeps the actor available for cancellation while a
-        // command is alive. It also tells the reader when the direct process has
-        // exited, even if a descendant still owns the pipe's write end.
         let terminationTask = Task.detached(priority: .utility) {
-            let exitCode = proc.waitUntilExit()
+            proc.waitUntilExit()
             readControl.markParentExited()
-            return exitCode
+            return proc.terminationStatus
         }
 
-        // A detached reader keeps draining the pipe even if the calling Task is
-        // cancelled. poll(2) bounds each wait, and the post-exit drain has a
-        // hard ceiling, so a descendant-held pipe cannot leave an Activity row
-        // running forever after the direct process exits.
+        // Keep process waiting and pipe reads off the actor so Cancel remains
+        // responsive. poll(2) also bounds a descendant-held output pipe after
+        // the direct command has exited.
         let outputTask = Task.detached(priority: .utility) {
             var collector = BoundedCLIOutputCollector()
             var streamer = BoundedCLILineStreamer()
@@ -709,6 +1013,7 @@ actor CLIRunner {
                     }
                     if parentExitObservedAt == nil { parentExitObservedAt = now }
                 }
+
                 var descriptor = pollfd(
                     fd: pipe.fileHandleForReading.fileDescriptor,
                     events: Int16(POLLIN | POLLHUP | POLLERR),
@@ -730,6 +1035,7 @@ actor CLIRunner {
                     }
                     break readLoop
                 }
+
                 let byteCount = readBuffer.withUnsafeMutableBytes { buffer in
                     Darwin.read(
                         pipe.fileHandleForReading.fileDescriptor,
@@ -789,37 +1095,23 @@ actor CLIRunner {
                 await self.requestCancellation(executionID: executionID, token: runToken)
             }
         }
-
         let explicitlyCancelled: Bool
-        let cancellationTask: Task<Void, Never>?
         if case .running(let active) = runStates[executionID], active.token == runToken {
             explicitlyCancelled = active.cancellationRequested
-            cancellationTask = active.cancellationTask
+            runStates[executionID] = nil
         } else {
             explicitlyCancelled = false
-            cancellationTask = nil
         }
-        // Keep the token-guarded state registered until an accepted
-        // cancellation finishes its bounded group escalation. Otherwise a
-        // direct parent that exits on SIGINT could let an ignoring descendant
-        // outlive both the run result and the later SIGTERM/SIGKILL steps.
-        if let cancellationTask {
-            await cancellationTask.value
-        }
-        if case .running(let active) = runStates[executionID], active.token == runToken {
-            runStates[executionID] = nil
-        }
-        let cancelled = Task.isCancelled || explicitlyCancelled
         return CLIResult(
             exitCode: completion.1,
             output: completion.0.output,
-            cancelled: cancelled,
+            cancelled: Task.isCancelled || explicitlyCancelled,
             outputTruncated: completion.0.truncated
         )
     }
 
     /// Request bounded cancellation of an Activity-owned process. Repeated
-    /// requests share one escalation ladder and never target a later run that
+    /// requests share one escalation ladder and cannot target a later run that
     /// happens to reuse the same public identifier.
     @discardableResult
     func cancel(runID: UUID) -> CLICancellationDisposition {
@@ -839,51 +1131,25 @@ actor CLIRunner {
         case .running(var active):
             if let expectedToken, active.token != expectedToken { return .notFound }
             guard !active.cancellationRequested else { return .alreadyRequested }
-            guard active.process.isProcessGroupRunning else { return .finishing }
+            guard active.process.isRunning else { return .finishing }
             active.cancellationRequested = true
             runStates[executionID] = .running(active)
-            guard active.process.signalProcessGroup(SIGINT) else {
-                active.cancellationRequested = false
-                runStates[executionID] = .running(active)
-                return .finishing
-            }
-            active.cancellationTask = scheduleCancellationEscalation(
-                executionID: executionID,
-                token: active.token
-            )
-            runStates[executionID] = .running(active)
+            active.processTree.send(SIGINT)
+            scheduleCancellationEscalation(processTree: active.processTree)
             return .requested
         }
     }
 
-    private func scheduleCancellationEscalation(
-        executionID: UUID,
-        token: UUID
-    ) -> Task<Void, Never> {
-        Task.detached { [weak self] in
+    private func scheduleCancellationEscalation(processTree: CLIProcessTree) {
+        Task.detached {
             try? await Task.sleep(for: .milliseconds(500))
-            guard await self?.terminateIfNeeded(executionID: executionID, token: token) == true else {
-                return
-            }
+            // If the group is already gone, stop here. In particular, do not
+            // retain its numeric PGID long enough for a later SIGKILL to reach
+            // an unrelated process group that reuses the identifier.
+            guard processTree.send(SIGTERM) else { return }
             try? await Task.sleep(for: .seconds(1))
-            await self?.killIfNeeded(executionID: executionID, token: token)
+            processTree.send(SIGKILL)
         }
-    }
-
-    private func terminateIfNeeded(executionID: UUID, token: UUID) -> Bool {
-        guard case .running(let active) = runStates[executionID],
-              active.token == token,
-              active.cancellationRequested,
-              active.process.isProcessGroupRunning else { return false }
-        return active.process.signalProcessGroup(SIGTERM)
-    }
-
-    private func killIfNeeded(executionID: UUID, token: UUID) {
-        guard case .running(let active) = runStates[executionID],
-              active.token == token,
-              active.cancellationRequested,
-              active.process.isProcessGroupRunning else { return }
-        _ = active.process.signalProcessGroup(SIGKILL)
     }
 
     /// Lightweight doctor probe (TUI Shift+D) — parsed into check rows.

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/CatalogCLI.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/CatalogCLI.swift
@@ -28,10 +28,24 @@ enum CatalogCLIError: LocalizedError {
     }
 }
 
+struct CatalogListing<Item: Sendable>: Sendable {
+    var items: [Item]
+    var auditHistoryUnavailable: Bool
+    var selectedBinaryPath: String?
+}
+
+private struct CatalogRows {
+    var values: [(String, [String: Any])]
+    var auditHistoryUnavailable: Bool
+    var selectedBinaryPath: String?
+}
+
 enum CatalogCLI {
-    static func skills(using cli: CLIRunner) async throws -> [SkillItem] {
+    static let auditHistoryUnavailableMessage = "Audit history is unavailable. Showing a read-only host catalog; repair the DefenseClaw audit store before running catalog actions."
+
+    static func skills(using cli: CLIRunner) async throws -> CatalogListing<SkillItem> {
         let groups = try await rows(resource: "skill", collection: "skills", using: cli)
-        return groups.map { group, row in
+        let items = groups.values.map { group, row in
             let connector = string(row["connector"]).nonEmpty ?? group
             let name = string(row["name"])
             let status = effectiveStatus(
@@ -52,11 +66,16 @@ enum CatalogCLI {
                 scan: scan(row["scan"])
             )
         }
+        return CatalogListing(
+            items: items,
+            auditHistoryUnavailable: groups.auditHistoryUnavailable,
+            selectedBinaryPath: groups.selectedBinaryPath
+        )
     }
 
-    static func mcps(using cli: CLIRunner) async throws -> [MCPItem] {
+    static func mcps(using cli: CLIRunner) async throws -> CatalogListing<MCPItem> {
         let groups = try await rows(resource: "mcp", collection: "mcp_servers", using: cli)
-        return groups.map { group, row in
+        let items = groups.values.map { group, row in
             let connector = string(row["connector"]).nonEmpty ?? group
             let endpoint = string(row["server_url"]).nonEmpty
                 ?? string(row["url"]).nonEmpty
@@ -81,11 +100,16 @@ enum CatalogCLI {
                 scan: scan(row["scan"])
             )
         }
+        return CatalogListing(
+            items: items,
+            auditHistoryUnavailable: groups.auditHistoryUnavailable,
+            selectedBinaryPath: groups.selectedBinaryPath
+        )
     }
 
-    static func plugins(using cli: CLIRunner) async throws -> [PluginItem] {
+    static func plugins(using cli: CLIRunner) async throws -> CatalogListing<PluginItem> {
         let groups = try await rows(resource: "plugin", collection: "plugins", using: cli)
-        return groups.map { group, row in
+        let items = groups.values.map { group, row in
             let connector = string(row["connector"]).nonEmpty ?? group
             let commandID = string(row["id"]).nonEmpty ?? string(row["name"])
             return PluginItem(
@@ -101,11 +125,21 @@ enum CatalogCLI {
                 scan: scan(row["scan"])
             )
         }
+        return CatalogListing(
+            items: items,
+            auditHistoryUnavailable: groups.auditHistoryUnavailable,
+            selectedBinaryPath: groups.selectedBinaryPath
+        )
     }
 
     static func tools(using cli: CLIRunner) async throws -> [ToolItem] {
-        let groups = try await rows(resource: "tool", collection: "tools", using: cli)
-        return groups.map { group, row in
+        let groups = try await rows(
+            resource: "tool",
+            collection: "tools",
+            permitIsolatedAuditFallback: false,
+            using: cli
+        )
+        return groups.values.map { group, row in
             let connector = string(row["connector"]).nonEmpty ?? group
             let status = string(row["status"]).nonEmpty ?? "active"
             let name = string(row["name"]).nonEmpty ?? string(row["target_name"])
@@ -125,9 +159,17 @@ enum CatalogCLI {
     private static func rows(
         resource: String,
         collection: String,
+        permitIsolatedAuditFallback: Bool = true,
         using cli: CLIRunner
-    ) async throws -> [(String, [String: Any])] {
-        let result = await cli.run(arguments: [resource, "list", "--json"], mutation: false)
+    ) async throws -> CatalogRows {
+        let command = permitIsolatedAuditFallback
+            ? await cli.runReadOnlyCatalogList(resource: resource)
+            : CatalogListCLIResult(
+                result: await cli.run(arguments: [resource, "list", "--json"], mutation: false),
+                usedIsolatedAuditStore: false,
+                selectedBinaryPath: nil
+            )
+        let result = command.result
         guard result.succeeded else {
             throw CatalogCLIError.commandFailed(result.output.trimmingCharacters(in: .whitespacesAndNewlines))
         }
@@ -145,7 +187,11 @@ enum CatalogCLI {
                 flattened.append((connector, group))
             }
         }
-        return flattened
+        return CatalogRows(
+            values: flattened,
+            auditHistoryUnavailable: command.usedIsolatedAuditStore,
+            selectedBinaryPath: command.selectedBinaryPath
+        )
     }
 
     private static func jsonData(from output: String) throws -> Data {
@@ -223,6 +269,10 @@ struct CatalogResourceAction: Identifiable, Hashable {
     var detail: String
     var systemImage: String
     var readOnly: Bool = false
+    /// Whether running this action can change installation-owned state. This
+    /// is intentionally independent from confirmation: scans are one-click
+    /// operations, but they still refresh on-disk catalog caches.
+    var changesState: Bool = true
     var destructive: Bool = false
     var id: String { verb }
 }
@@ -233,6 +283,7 @@ struct CatalogInvocation: Identifiable {
     var arguments: [String]
     var detail: String
     var requiresConfirmation: Bool
+    var changesState: Bool = true
     var destructive: Bool
 
     var displayCommand: String {
@@ -248,7 +299,7 @@ enum CatalogActions {
             ]
         }
         var actions = [
-            action("scan", "Scan", "Run the skill security scan", "shield.lefthalf.filled", readOnly: true),
+            action("scan", "Scan", "Run the skill security scan", "shield.lefthalf.filled", readOnly: true, changesState: true),
             action("info", "Info", "Show full skill details", "info.circle", readOnly: true),
         ]
         switch item.status.lowercased() {
@@ -282,7 +333,7 @@ enum CatalogActions {
             ]
         }
         var actions = [
-            action("scan", "Scan", "Run the MCP security scan", "shield.lefthalf.filled", readOnly: true),
+            action("scan", "Scan", "Run the MCP security scan", "shield.lefthalf.filled", readOnly: true, changesState: true),
             action("info", "Info", "Show MCP list details", "info.circle", readOnly: true),
         ]
         switch item.status.lowercased() {
@@ -301,7 +352,7 @@ enum CatalogActions {
 
     static func plugins(_ item: PluginItem) -> [CatalogResourceAction] {
         var actions = [
-            action("scan", "Scan", "Run the plugin security scan", "shield.lefthalf.filled", readOnly: true),
+            action("scan", "Scan", "Run the plugin security scan", "shield.lefthalf.filled", readOnly: true, changesState: true),
             action("info", "Info", "Show full plugin details", "info.circle", readOnly: true),
         ]
         if item.verdict.lowercased() == "blocked" {
@@ -390,6 +441,7 @@ enum CatalogActions {
             arguments: arguments,
             detail: action.detail,
             requiresConfirmation: !action.readOnly,
+            changesState: action.changesState,
             destructive: action.destructive
         )
     }
@@ -400,9 +452,11 @@ enum CatalogActions {
         _ detail: String,
         _ image: String,
         readOnly: Bool = false,
+        changesState: Bool? = nil,
         destructive: Bool = false
     ) -> CatalogResourceAction {
         CatalogResourceAction(verb: verb, label: label, detail: detail, systemImage: image,
-                              readOnly: readOnly, destructive: destructive)
+                              readOnly: readOnly, changesState: changesState ?? !readOnly,
+                              destructive: destructive)
     }
 }

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/CommandActivityStore.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/CommandActivityStore.swift
@@ -54,8 +54,8 @@ struct CommandActivityEntry: Identifiable, Sendable {
     var statusLabel: String {
         switch status {
         case .running: "Running"
-        case .cancelling: "Cancelling…"
-        case .finishing: "Finishing…"
+        case .cancelling: "Cancelling..."
+        case .finishing: "Finishing..."
         case .succeeded: "Exit 0"
         case .failed: "Exit \(exitCode ?? -1)"
         case .cancelled: "Cancelled"
@@ -119,7 +119,7 @@ final class CommandActivityStore {
         )
         selectedID = id
         while entries.count > Self.maximumEntries,
-              let removable = entries.lastIndex(where: { !$0.status.isActive }) {
+              let removable = entries.lastIndex(where: { $0.status != .running }) {
             entries.remove(at: removable)
         }
 
@@ -154,21 +154,21 @@ final class CommandActivityStore {
         entries[index].status = .cancelling
         Task {
             let disposition = await runner.cancel(runID: id)
-            applyCancellationDisposition(disposition, to: id)
-        }
-    }
-
-    func applyCancellationDisposition(_ disposition: CLICancellationDisposition, to id: UUID) {
-        guard let index = entries.firstIndex(where: { $0.id == id }),
-              entries[index].status == .cancelling else { return }
-        switch disposition {
-        case .requested, .alreadyRequested:
-            break
-        case .finishing, .notFound:
-            // `.notFound` can race the runner removing its state immediately
-            // before the actual result resumes here. Keep the row active so
-            // clearCompleted() cannot remove it before run() finalizes it.
-            entries[index].status = .finishing
+            guard let index = entries.firstIndex(where: { $0.id == id }),
+                  entries[index].status == .cancelling else { return }
+            switch disposition {
+            case .requested, .alreadyRequested:
+                break
+            case .finishing:
+                entries[index].status = .finishing
+            case .notFound:
+                entries[index].finishedAt = Date()
+                entries[index].status = .cancelled
+                if entries[index].output.isEmpty {
+                    entries[index].output = "Cancellation requested after the command process was no longer active.\n"
+                }
+                entries[index].suggestedNextAction = "Refresh the affected view to verify its final state."
+            }
         }
     }
 

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/CommandRegistry.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/CommandRegistry.swift
@@ -196,7 +196,7 @@ enum CommandInvocationError: LocalizedError, Equatable {
 }
 
 enum CommandRegistry {
-    static let sourceCount = 232
+    static let sourceCount = 231
     static let all: [CommandDefinition] = [
         CommandDefinition(id: 0, title: "init", binary: "defenseclaw", arguments: ["init"], summary: "Initialize DefenseClaw", category: "setup", requiresInput: false, usage: ""),
         CommandDefinition(id: 1, title: "init first-run", binary: "defenseclaw", arguments: ["init", "--non-interactive", "--yes", "--verify"], summary: "Run guided first-run backend with defaults", category: "setup", requiresInput: false, usage: ""),

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/CommandRegistry.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/CommandRegistry.swift
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Synchronized with DefenseClaw mainline cli/defenseclaw/tui/registry_data.py.
-// Keep these 227 entries aligned when the TUI command palette changes.
+// Keep these entries aligned when the TUI command palette changes.
 
 import Foundation
 
@@ -82,6 +82,37 @@ struct CommandDefinition: Identifiable, Hashable, Sendable {
     var requiresTerminal: Bool {
         summary.localizedCaseInsensitiveContains("interactive")
             || arguments.last == "shell"
+            || title == "setup galileo"
+    }
+
+    var acceptsSecretInput: Bool {
+        title == "keys set"
+    }
+
+    func invocation(extraArguments: [String], secretInput: String) throws -> CommandInvocation {
+        guard acceptsSecretInput else {
+            let invocationArguments = arguments + extraArguments
+            let suppliesAlertConfirmation = invocationArguments.starts(with: ["alerts", "acknowledge"])
+                || invocationArguments.starts(with: ["alerts", "dismiss"])
+            return CommandInvocation(
+                arguments: invocationArguments,
+                standardInput: suppliesAlertConfirmation ? "y" : nil
+            )
+        }
+        guard extraArguments.count == 1,
+              extraArguments[0].range(
+                  of: "^[A-Za-z_][A-Za-z0-9_]*$",
+                  options: .regularExpression
+              ) != nil else {
+            throw CommandInvocationError.invalidCredentialName
+        }
+        guard !secretInput.isEmpty else {
+            throw CommandInvocationError.missingCredentialValue
+        }
+        return CommandInvocation(
+            arguments: arguments + extraArguments,
+            standardInput: secretInput
+        )
     }
 
     /// `keys set` must receive its credential over stdin. Keeping this
@@ -145,8 +176,46 @@ struct CommandExecutionPlan: Equatable, Sendable {
     let standardInput: String?
 }
 
+struct CommandInvocation: Equatable, Sendable {
+    let arguments: [String]
+    let standardInput: String?
+}
+
+enum CommandInvocationError: LocalizedError, Equatable {
+    case invalidCredentialName
+    case missingCredentialValue
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidCredentialName:
+            return "Enter one credential environment name."
+        case .missingCredentialValue:
+            return "Enter the credential value."
+        }
+    }
+}
+
+struct CommandExecutionPlan: Equatable, Sendable {
+    enum Error: LocalizedError {
+        case invalidCredentialName
+        case missingSecret
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidCredentialName:
+                "Enter one environment name using letters, digits, and underscores."
+            case .missingSecret:
+                "Enter the secret value."
+            }
+        }
+    }
+
+    let arguments: [String]
+    let standardInput: String?
+}
+
 enum CommandRegistry {
-    static let sourceCount = 227
+    static let sourceCount = 232
     static let all: [CommandDefinition] = [
         CommandDefinition(id: 0, title: "init", binary: "defenseclaw", arguments: ["init"], summary: "Initialize DefenseClaw", category: "setup", requiresInput: false, usage: ""),
         CommandDefinition(id: 1, title: "init first-run", binary: "defenseclaw", arguments: ["init", "--non-interactive", "--yes", "--verify"], summary: "Run guided first-run backend with defaults", category: "setup", requiresInput: false, usage: ""),
@@ -167,215 +236,305 @@ enum CommandRegistry {
         CommandDefinition(id: 17, title: "setup openhands", binary: "defenseclaw", arguments: ["setup", "openhands", "--yes"], summary: "Configure OpenHands observability hooks", category: "setup", requiresInput: false, usage: ""),
         CommandDefinition(id: 18, title: "setup antigravity", binary: "defenseclaw", arguments: ["setup", "antigravity", "--yes"], summary: "Configure Antigravity observability hooks", category: "setup", requiresInput: false, usage: ""),
         CommandDefinition(id: 19, title: "setup opencode", binary: "defenseclaw", arguments: ["setup", "opencode", "--yes"], summary: "Configure OpenCode observability hooks", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 226, title: "setup amp", binary: "defenseclaw", arguments: ["setup", "amp", "--yes"], summary: "Configure Amp synchronous policy plugin", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 227, title: "setup omnigent", binary: "defenseclaw", arguments: ["setup", "omnigent", "--yes"], summary: "Configure OmniGent ALLOW/ASK/DENY policy bridge", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 20, title: "setup rotate-token", binary: "defenseclaw", arguments: ["setup", "rotate-token", "--yes"], summary: "Rotate the gateway token", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 21, title: "setup gateway", binary: "defenseclaw", arguments: ["setup", "gateway"], summary: "Configure gateway connection (interactive)", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 22, title: "setup guardrail", binary: "defenseclaw", arguments: ["setup", "guardrail"], summary: "Configure LLM guardrail", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 23, title: "setup redaction", binary: "defenseclaw", arguments: ["setup", "redaction"], summary: "Configure v8 redaction policy", category: "setup", requiresInput: true, usage: "[status|remove-all|apply|defaults|bucket|profile|destination|route] [flags]"),
-        CommandDefinition(id: 24, title: "setup notifications", binary: "defenseclaw", arguments: ["setup", "notifications"], summary: "Show/toggle desktop notifications", category: "setup", requiresInput: true, usage: "<status|on|off> [--yes]"),
-        CommandDefinition(id: 25, title: "setup splunk", binary: "defenseclaw", arguments: ["setup", "splunk"], summary: "Configure Splunk / O11y", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 26, title: "setup local-observability up", binary: "defenseclaw", arguments: ["setup", "local-observability", "up"], summary: "Start local Prom/Loki/Tempo/Grafana stack", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 27, title: "setup local-observability down", binary: "defenseclaw", arguments: ["setup", "local-observability", "down"], summary: "Stop local observability stack", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 28, title: "setup local-observability reset", binary: "defenseclaw", arguments: ["setup", "local-observability", "reset", "--yes"], summary: "Stop local observability and wipe stored event volumes", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 29, title: "setup local-observability status", binary: "defenseclaw", arguments: ["setup", "local-observability", "status"], summary: "Show local observability stack status", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 30, title: "setup local-observability url", binary: "defenseclaw", arguments: ["setup", "local-observability", "url"], summary: "Show local observability URLs", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 31, title: "setup local-observability logs", binary: "defenseclaw", arguments: ["setup", "local-observability", "logs"], summary: "Tail local observability logs", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 32, title: "setup observability add", binary: "defenseclaw", arguments: ["setup", "observability", "add"], summary: "Add an observability/audit destination preset", category: "setup", requiresInput: true, usage: "<preset> [flags]"),
-        CommandDefinition(id: 33, title: "setup observability list", binary: "defenseclaw", arguments: ["setup", "observability", "list"], summary: "List configured observability destinations", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 34, title: "setup observability enable", binary: "defenseclaw", arguments: ["setup", "observability", "enable"], summary: "Enable an observability destination", category: "setup", requiresInput: true, usage: "<name>"),
-        CommandDefinition(id: 35, title: "setup observability disable", binary: "defenseclaw", arguments: ["setup", "observability", "disable"], summary: "Disable an observability destination", category: "setup", requiresInput: true, usage: "<name>"),
-        CommandDefinition(id: 36, title: "setup observability remove", binary: "defenseclaw", arguments: ["setup", "observability", "remove", "--yes"], summary: "Remove an observability destination", category: "setup", requiresInput: true, usage: "<name>"),
-        CommandDefinition(id: 37, title: "setup observability test", binary: "defenseclaw", arguments: ["setup", "observability", "test"], summary: "Probe an observability destination", category: "setup", requiresInput: true, usage: "<name>"),
-        CommandDefinition(id: 38, title: "setup observability migrate-splunk", binary: "defenseclaw", arguments: ["setup", "observability", "migrate-splunk", "--apply"], summary: "Migrate legacy splunk: block into audit_sinks[]", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 39, title: "setup webhook add", binary: "defenseclaw", arguments: ["setup", "webhook", "add"], summary: "Add a notifier webhook", category: "setup", requiresInput: true, usage: "<name> --type <slack|pagerduty|webex|generic>"),
-        CommandDefinition(id: 40, title: "setup webhook list", binary: "defenseclaw", arguments: ["setup", "webhook", "list"], summary: "List notifier webhooks", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 41, title: "setup webhook show", binary: "defenseclaw", arguments: ["setup", "webhook", "show"], summary: "Show a notifier webhook", category: "setup", requiresInput: true, usage: "<name>"),
-        CommandDefinition(id: 42, title: "setup webhook enable", binary: "defenseclaw", arguments: ["setup", "webhook", "enable"], summary: "Enable a notifier webhook", category: "setup", requiresInput: true, usage: "<name>"),
-        CommandDefinition(id: 43, title: "setup webhook disable", binary: "defenseclaw", arguments: ["setup", "webhook", "disable"], summary: "Disable a notifier webhook", category: "setup", requiresInput: true, usage: "<name>"),
-        CommandDefinition(id: 44, title: "setup webhook remove", binary: "defenseclaw", arguments: ["setup", "webhook", "remove", "--yes"], summary: "Remove a notifier webhook", category: "setup", requiresInput: true, usage: "<name>"),
-        CommandDefinition(id: 45, title: "setup webhook test", binary: "defenseclaw", arguments: ["setup", "webhook", "test"], summary: "Send/probe a notifier webhook", category: "setup", requiresInput: true, usage: "<name>"),
-        CommandDefinition(id: 46, title: "setup provider add", binary: "defenseclaw", arguments: ["setup", "provider", "add"], summary: "Add a custom LLM provider to the overlay", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 47, title: "setup provider remove", binary: "defenseclaw", arguments: ["setup", "provider", "remove"], summary: "Remove a custom LLM provider from the overlay", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 48, title: "setup provider list", binary: "defenseclaw", arguments: ["setup", "provider", "list"], summary: "List overlay provider entries", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 49, title: "setup provider show", binary: "defenseclaw", arguments: ["setup", "provider", "show"], summary: "Show merged provider registry", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 50, title: "agent discover", binary: "defenseclaw", arguments: ["agent", "discover"], summary: "Discover installed agents and emit sanitized telemetry", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 51, title: "agent usage", binary: "defenseclaw", arguments: ["agent", "usage"], summary: "Show continuous AI visibility from the sidecar", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 52, title: "agent usage --refresh", binary: "defenseclaw", arguments: ["agent", "usage", "--refresh"], summary: "Trigger an AI-usage scan and render results", category: "scan", requiresInput: false, usage: ""),
-        CommandDefinition(id: 53, title: "agent discovery setup", binary: "defenseclaw", arguments: ["agent", "discovery", "setup"], summary: "Interactive AI discovery wizard (mode, intervals, sources)", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 54, title: "agent discovery enable", binary: "defenseclaw", arguments: ["agent", "discovery", "enable", "--yes"], summary: "Enable AI discovery, save config, restart, and scan", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 55, title: "agent discovery disable", binary: "defenseclaw", arguments: ["agent", "discovery", "disable", "--yes"], summary: "Disable AI discovery and restart the gateway", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 56, title: "agent discovery status", binary: "defenseclaw", arguments: ["agent", "discovery", "status"], summary: "Show on-disk vs live AI discovery state", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 57, title: "agent discovery scan", binary: "defenseclaw", arguments: ["agent", "discovery", "scan"], summary: "Trigger one immediate AI discovery scan", category: "scan", requiresInput: false, usage: ""),
-        CommandDefinition(id: 58, title: "agent signatures list", binary: "defenseclaw", arguments: ["agent", "signatures", "list"], summary: "List the merged AI discovery signature catalog", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 59, title: "scan skill", binary: "defenseclaw", arguments: ["skill", "scan"], summary: "Scan a skill", category: "scan", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 60, title: "scan skill --all", binary: "defenseclaw", arguments: ["skill", "scan", "--all"], summary: "Scan all skills", category: "scan", requiresInput: false, usage: ""),
-        CommandDefinition(id: 61, title: "scan mcp", binary: "defenseclaw", arguments: ["mcp", "scan"], summary: "Scan an MCP server", category: "scan", requiresInput: true, usage: "<url>"),
-        CommandDefinition(id: 62, title: "scan mcp --all", binary: "defenseclaw", arguments: ["mcp", "scan", "--all"], summary: "Scan all MCP servers", category: "scan", requiresInput: false, usage: ""),
-        CommandDefinition(id: 63, title: "scan plugin", binary: "defenseclaw", arguments: ["plugin", "scan"], summary: "Scan a plugin", category: "scan", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 64, title: "scan aibom", binary: "defenseclaw", arguments: ["aibom", "scan"], summary: "Generate AIBOM inventory", category: "scan", requiresInput: false, usage: ""),
-        CommandDefinition(id: 65, title: "scan code", binary: "defenseclaw-gateway", arguments: ["scan", "code"], summary: "CodeGuard scan", category: "scan", requiresInput: true, usage: "<path>"),
-        CommandDefinition(id: 66, title: "block skill", binary: "defenseclaw", arguments: ["skill", "block"], summary: "Block a skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 67, title: "allow skill", binary: "defenseclaw", arguments: ["skill", "allow"], summary: "Allow-list a skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 68, title: "unblock skill", binary: "defenseclaw", arguments: ["skill", "unblock"], summary: "Unblock a skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 69, title: "disable skill", binary: "defenseclaw", arguments: ["skill", "disable"], summary: "Disable a skill at runtime", category: "enforce", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 70, title: "enable skill", binary: "defenseclaw", arguments: ["skill", "enable"], summary: "Enable a skill at runtime", category: "enforce", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 71, title: "quarantine skill", binary: "defenseclaw", arguments: ["skill", "quarantine"], summary: "Quarantine a skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 72, title: "restore skill", binary: "defenseclaw", arguments: ["skill", "restore"], summary: "Restore a quarantined skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 73, title: "block mcp", binary: "defenseclaw", arguments: ["mcp", "block"], summary: "Block an MCP server", category: "enforce", requiresInput: true, usage: "<url>"),
-        CommandDefinition(id: 74, title: "allow mcp", binary: "defenseclaw", arguments: ["mcp", "allow"], summary: "Allow-list an MCP server", category: "enforce", requiresInput: true, usage: "<url>"),
-        CommandDefinition(id: 75, title: "unblock mcp", binary: "defenseclaw", arguments: ["mcp", "unblock"], summary: "Unblock an MCP server", category: "enforce", requiresInput: true, usage: "<url>"),
-        CommandDefinition(id: 76, title: "set mcp", binary: "defenseclaw", arguments: ["mcp", "set"], summary: "Scan + set MCP server in the active connector's config", category: "enforce", requiresInput: true, usage: "<url>"),
-        CommandDefinition(id: 77, title: "unset mcp", binary: "defenseclaw", arguments: ["mcp", "unset"], summary: "Unset MCP server from the active connector's config", category: "enforce", requiresInput: true, usage: "<url>"),
-        CommandDefinition(id: 78, title: "block plugin", binary: "defenseclaw", arguments: ["plugin", "block"], summary: "Block a plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 79, title: "allow plugin", binary: "defenseclaw", arguments: ["plugin", "allow"], summary: "Allow-list a plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 80, title: "disable plugin", binary: "defenseclaw", arguments: ["plugin", "disable"], summary: "Disable a plugin at runtime", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 81, title: "enable plugin", binary: "defenseclaw", arguments: ["plugin", "enable"], summary: "Enable a plugin at runtime", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 82, title: "quarantine plugin", binary: "defenseclaw", arguments: ["plugin", "quarantine"], summary: "Quarantine a plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 83, title: "restore plugin", binary: "defenseclaw", arguments: ["plugin", "restore"], summary: "Restore a quarantined plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 84, title: "remove plugin", binary: "defenseclaw", arguments: ["plugin", "remove"], summary: "Remove a plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 85, title: "block tool", binary: "defenseclaw", arguments: ["tool", "block"], summary: "Block a tool", category: "enforce", requiresInput: true, usage: "<tool-name>"),
-        CommandDefinition(id: 86, title: "allow tool", binary: "defenseclaw", arguments: ["tool", "allow"], summary: "Allow-list a tool", category: "enforce", requiresInput: true, usage: "<tool-name>"),
-        CommandDefinition(id: 87, title: "unblock tool", binary: "defenseclaw", arguments: ["tool", "unblock"], summary: "Unblock a tool", category: "enforce", requiresInput: true, usage: "<tool-name>"),
-        CommandDefinition(id: 88, title: "install skill", binary: "defenseclaw", arguments: ["skill", "install"], summary: "Install a skill from ClawHub", category: "install", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 89, title: "install plugin", binary: "defenseclaw", arguments: ["plugin", "install"], summary: "Install a plugin", category: "install", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 90, title: "install codeguard", binary: "defenseclaw", arguments: ["codeguard", "install-skill"], summary: "Install CodeGuard skill", category: "install", requiresInput: false, usage: ""),
-        CommandDefinition(id: 91, title: "policy list", binary: "defenseclaw", arguments: ["policy", "list"], summary: "List policies", category: "policy", requiresInput: false, usage: ""),
-        CommandDefinition(id: 92, title: "policy show", binary: "defenseclaw", arguments: ["policy", "show"], summary: "Show policy details", category: "policy", requiresInput: true, usage: "<policy-name>"),
-        CommandDefinition(id: 93, title: "policy create", binary: "defenseclaw", arguments: ["policy", "create"], summary: "Create a new policy", category: "policy", requiresInput: true, usage: "<policy-name>"),
-        CommandDefinition(id: 94, title: "policy activate", binary: "defenseclaw", arguments: ["policy", "activate"], summary: "Activate a policy", category: "policy", requiresInput: true, usage: "<policy-name>"),
-        CommandDefinition(id: 95, title: "policy delete", binary: "defenseclaw", arguments: ["policy", "delete"], summary: "Delete a user policy", category: "policy", requiresInput: true, usage: "<policy-name>"),
-        CommandDefinition(id: 96, title: "policy validate", binary: "defenseclaw", arguments: ["policy", "validate"], summary: "Validate policy data + Rego", category: "policy", requiresInput: false, usage: ""),
-        CommandDefinition(id: 97, title: "policy test", binary: "defenseclaw", arguments: ["policy", "test"], summary: "Run OPA policy tests", category: "policy", requiresInput: false, usage: ""),
-        CommandDefinition(id: 98, title: "policy edit actions", binary: "defenseclaw", arguments: ["policy", "edit", "actions"], summary: "Edit severity action rules", category: "policy", requiresInput: false, usage: ""),
-        CommandDefinition(id: 99, title: "policy edit scanner", binary: "defenseclaw", arguments: ["policy", "edit", "scanner"], summary: "Edit scanner overrides", category: "policy", requiresInput: false, usage: ""),
-        CommandDefinition(id: 100, title: "policy edit guardrail", binary: "defenseclaw", arguments: ["policy", "edit", "guardrail"], summary: "Edit guardrail policy", category: "policy", requiresInput: false, usage: ""),
-        CommandDefinition(id: 101, title: "policy edit firewall", binary: "defenseclaw", arguments: ["policy", "edit", "firewall"], summary: "Edit firewall policy", category: "policy", requiresInput: false, usage: ""),
-        CommandDefinition(id: 102, title: "policy evaluate", binary: "defenseclaw-gateway", arguments: ["policy", "evaluate"], summary: "Dry-run admission evaluation", category: "policy", requiresInput: false, usage: ""),
-        CommandDefinition(id: 103, title: "policy evaluate-firewall", binary: "defenseclaw-gateway", arguments: ["policy", "evaluate-firewall"], summary: "Dry-run firewall evaluation", category: "policy", requiresInput: false, usage: ""),
-        CommandDefinition(id: 104, title: "policy reload", binary: "defenseclaw-gateway", arguments: ["policy", "reload"], summary: "Reload policy in running sidecar", category: "policy", requiresInput: false, usage: ""),
-        CommandDefinition(id: 105, title: "policy domains", binary: "defenseclaw-gateway", arguments: ["policy", "domains"], summary: "Show firewall domain lists", category: "policy", requiresInput: false, usage: ""),
-        CommandDefinition(id: 106, title: "list skills", binary: "defenseclaw", arguments: ["skill", "list"], summary: "List skills with scan status", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 107, title: "list mcps", binary: "defenseclaw", arguments: ["mcp", "list"], summary: "List MCP servers with status", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 108, title: "list plugins", binary: "defenseclaw", arguments: ["plugin", "list"], summary: "List installed plugins", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 109, title: "list tools", binary: "defenseclaw", arguments: ["tool", "list"], summary: "List tool rules", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 110, title: "info skill", binary: "defenseclaw", arguments: ["skill", "info"], summary: "Show skill details", category: "info", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 111, title: "info plugin", binary: "defenseclaw", arguments: ["plugin", "info"], summary: "Show plugin details", category: "info", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 112, title: "tool status", binary: "defenseclaw", arguments: ["tool", "status"], summary: "Show tool block/allow status", category: "info", requiresInput: true, usage: "<tool-name>"),
-        CommandDefinition(id: 113, title: "status", binary: "defenseclaw", arguments: ["status"], summary: "Show DefenseClaw status", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 114, title: "doctor", binary: "defenseclaw", arguments: ["doctor"], summary: "Run health checks", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 115, title: "doctor run", binary: "defenseclaw", arguments: ["doctor"], summary: "Run health checks", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 116, title: "doctor --fix", binary: "defenseclaw", arguments: ["doctor", "--fix", "--yes"], summary: "Auto-repair safe health issues", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 117, title: "config validate", binary: "defenseclaw", arguments: ["config", "validate"], summary: "Validate config.yaml", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 118, title: "config show", binary: "defenseclaw", arguments: ["config", "show"], summary: "Show resolved config with secrets masked", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 119, title: "config path", binary: "defenseclaw", arguments: ["config", "path"], summary: "Show DefenseClaw filesystem paths", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 120, title: "keys list", binary: "defenseclaw", arguments: ["keys", "list"], summary: "List configured and missing credentials", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 121, title: "keys list --json", binary: "defenseclaw", arguments: ["keys", "list", "--json"], summary: "List credentials as JSON for setup parity", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 122, title: "keys check", binary: "defenseclaw", arguments: ["keys", "check"], summary: "Fail if required credentials are missing", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 123, title: "keys set", binary: "defenseclaw", arguments: ["keys", "set"], summary: "Persist a credential to the DefenseClaw .env", category: "setup", requiresInput: true, usage: "<ENV_NAME>"),
-        CommandDefinition(id: 124, title: "keys fill-missing", binary: "defenseclaw", arguments: ["keys", "fill-missing", "--yes"], summary: "List missing required credentials", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 125, title: "settings save", binary: "defenseclaw", arguments: ["settings", "save"], summary: "Persist current settings/config", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 126, title: "guardrail status", binary: "defenseclaw", arguments: ["guardrail", "status"], summary: "Show guardrail status", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 127, title: "guardrail enable", binary: "defenseclaw", arguments: ["guardrail", "enable", "--yes"], summary: "Enable guardrail", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 128, title: "guardrail disable", binary: "defenseclaw", arguments: ["guardrail", "disable", "--yes"], summary: "Disable guardrail", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 129, title: "version", binary: "defenseclaw", arguments: ["version"], summary: "Show DefenseClaw version information", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 130, title: "start", binary: "defenseclaw-gateway", arguments: ["start"], summary: "Start gateway sidecar", category: "daemon", requiresInput: false, usage: ""),
-        CommandDefinition(id: 131, title: "stop", binary: "defenseclaw-gateway", arguments: ["stop"], summary: "Stop gateway sidecar", category: "daemon", requiresInput: false, usage: ""),
-        CommandDefinition(id: 132, title: "restart", binary: "defenseclaw-gateway", arguments: ["restart"], summary: "Restart gateway sidecar", category: "daemon", requiresInput: false, usage: ""),
-        CommandDefinition(id: 133, title: "gateway status", binary: "defenseclaw-gateway", arguments: ["status"], summary: "Show gateway health", category: "daemon", requiresInput: false, usage: ""),
-        CommandDefinition(id: 134, title: "watchdog start", binary: "defenseclaw-gateway", arguments: ["watchdog", "start"], summary: "Start health watchdog", category: "daemon", requiresInput: false, usage: ""),
-        CommandDefinition(id: 135, title: "watchdog stop", binary: "defenseclaw-gateway", arguments: ["watchdog", "stop"], summary: "Stop health watchdog", category: "daemon", requiresInput: false, usage: ""),
-        CommandDefinition(id: 136, title: "watchdog status", binary: "defenseclaw-gateway", arguments: ["watchdog", "status"], summary: "Show watchdog status", category: "daemon", requiresInput: false, usage: ""),
-        CommandDefinition(id: 137, title: "connector verify", binary: "defenseclaw-gateway", arguments: ["connector", "verify"], summary: "Verify connector config is clean/current", category: "daemon", requiresInput: false, usage: ""),
-        CommandDefinition(id: 138, title: "connector teardown", binary: "defenseclaw-gateway", arguments: ["connector", "teardown"], summary: "Remove active connector config patches", category: "daemon", requiresInput: false, usage: ""),
-        CommandDefinition(id: 139, title: "connector list-backups", binary: "defenseclaw-gateway", arguments: ["connector", "list-backups"], summary: "List connector backup files", category: "daemon", requiresInput: false, usage: ""),
-        CommandDefinition(id: 140, title: "gateway audit export", binary: "defenseclaw-gateway", arguments: ["audit", "export"], summary: "Export gateway audit log", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 141, title: "gateway provenance show", binary: "defenseclaw-gateway", arguments: ["provenance", "show"], summary: "Show gateway binary/config provenance", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 142, title: "sandbox init", binary: "defenseclaw", arguments: ["sandbox", "init"], summary: "Initialize sandbox environment", category: "sandbox", requiresInput: false, usage: ""),
-        CommandDefinition(id: 143, title: "sandbox setup", binary: "defenseclaw", arguments: ["sandbox", "setup"], summary: "Configure sandbox networking", category: "sandbox", requiresInput: false, usage: ""),
-        CommandDefinition(id: 144, title: "sandbox start", binary: "defenseclaw-gateway", arguments: ["sandbox", "start"], summary: "Start sandbox services", category: "sandbox", requiresInput: false, usage: ""),
-        CommandDefinition(id: 145, title: "sandbox stop", binary: "defenseclaw-gateway", arguments: ["sandbox", "stop"], summary: "Stop sandbox services", category: "sandbox", requiresInput: false, usage: ""),
-        CommandDefinition(id: 146, title: "sandbox restart", binary: "defenseclaw-gateway", arguments: ["sandbox", "restart"], summary: "Restart sandbox services", category: "sandbox", requiresInput: false, usage: ""),
-        CommandDefinition(id: 147, title: "sandbox status", binary: "defenseclaw-gateway", arguments: ["sandbox", "status"], summary: "Show sandbox status", category: "sandbox", requiresInput: false, usage: ""),
-        CommandDefinition(id: 148, title: "sandbox exec", binary: "defenseclaw-gateway", arguments: ["sandbox", "exec"], summary: "Run command in sandbox", category: "sandbox", requiresInput: true, usage: "<command>"),
-        CommandDefinition(id: 149, title: "sandbox shell", binary: "defenseclaw-gateway", arguments: ["sandbox", "shell"], summary: "Open sandbox shell", category: "sandbox", requiresInput: false, usage: ""),
-        CommandDefinition(id: 150, title: "sandbox policy diff", binary: "defenseclaw-gateway", arguments: ["sandbox", "policy", "diff"], summary: "Compare policy vs endpoints", category: "sandbox", requiresInput: false, usage: ""),
-        CommandDefinition(id: 151, title: "upgrade", binary: "defenseclaw", arguments: ["upgrade", "--yes"], summary: "Run CLI upgrade preflight; hard cuts require the release-owned resolver", category: "other", requiresInput: false, usage: ""),
-        CommandDefinition(id: 152, title: "uninstall dry-run", binary: "defenseclaw", arguments: ["uninstall", "--dry-run"], summary: "Preview uninstall changes without modifying the system", category: "other", requiresInput: false, usage: ""),
-        CommandDefinition(id: 153, title: "uninstall --yes", binary: "defenseclaw", arguments: ["uninstall", "--yes"], summary: "Uninstall DefenseClaw after showing the plan", category: "other", requiresInput: false, usage: ""),
-        CommandDefinition(id: 154, title: "uninstall --all --yes", binary: "defenseclaw", arguments: ["uninstall", "--all", "--yes"], summary: "Uninstall DefenseClaw and wipe local data", category: "other", requiresInput: false, usage: ""),
-        CommandDefinition(id: 155, title: "reset --yes", binary: "defenseclaw", arguments: ["reset", "--yes"], summary: "Wipe DefenseClaw local data and keep binaries", category: "other", requiresInput: false, usage: ""),
-        CommandDefinition(id: 156, title: "setup", binary: "defenseclaw", arguments: ["setup"], summary: "Show setup command help", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 157, title: "setup local-observability", binary: "defenseclaw", arguments: ["setup", "local-observability"], summary: "Show local observability commands", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 158, title: "setup observability", binary: "defenseclaw", arguments: ["setup", "observability"], summary: "Show observability sink commands", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 159, title: "setup provider", binary: "defenseclaw", arguments: ["setup", "provider"], summary: "Show provider registry commands", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 160, title: "setup webhook", binary: "defenseclaw", arguments: ["setup", "webhook"], summary: "Show webhook commands", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 161, title: "skill", binary: "defenseclaw", arguments: ["skill"], summary: "Show skill commands", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 162, title: "skill list", binary: "defenseclaw", arguments: ["skill", "list"], summary: "List skills with scan status", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 163, title: "skill search", binary: "defenseclaw", arguments: ["skill", "search"], summary: "Search available skills", category: "info", requiresInput: true, usage: "<query>"),
-        CommandDefinition(id: 164, title: "skill scan", binary: "defenseclaw", arguments: ["skill", "scan"], summary: "Scan a skill", category: "scan", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 165, title: "skill info", binary: "defenseclaw", arguments: ["skill", "info"], summary: "Show skill details", category: "info", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 166, title: "skill allow", binary: "defenseclaw", arguments: ["skill", "allow"], summary: "Allow-list a skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 167, title: "skill block", binary: "defenseclaw", arguments: ["skill", "block"], summary: "Block a skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 168, title: "skill disable", binary: "defenseclaw", arguments: ["skill", "disable"], summary: "Disable a skill at runtime", category: "enforce", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 169, title: "skill enable", binary: "defenseclaw", arguments: ["skill", "enable"], summary: "Enable a skill at runtime", category: "enforce", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 170, title: "skill install", binary: "defenseclaw", arguments: ["skill", "install"], summary: "Install a skill from ClawHub", category: "install", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 171, title: "skill quarantine", binary: "defenseclaw", arguments: ["skill", "quarantine"], summary: "Quarantine a skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 172, title: "skill restore", binary: "defenseclaw", arguments: ["skill", "restore"], summary: "Restore a quarantined skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 173, title: "skill unblock", binary: "defenseclaw", arguments: ["skill", "unblock"], summary: "Unblock a skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
-        CommandDefinition(id: 174, title: "mcp", binary: "defenseclaw", arguments: ["mcp"], summary: "Show MCP commands", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 175, title: "mcp list", binary: "defenseclaw", arguments: ["mcp", "list"], summary: "List MCP servers with status", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 176, title: "mcp scan", binary: "defenseclaw", arguments: ["mcp", "scan"], summary: "Scan an MCP server", category: "scan", requiresInput: true, usage: "<url>"),
-        CommandDefinition(id: 177, title: "mcp allow", binary: "defenseclaw", arguments: ["mcp", "allow"], summary: "Allow-list an MCP server", category: "enforce", requiresInput: true, usage: "<url>"),
-        CommandDefinition(id: 178, title: "mcp block", binary: "defenseclaw", arguments: ["mcp", "block"], summary: "Block an MCP server", category: "enforce", requiresInput: true, usage: "<url>"),
-        CommandDefinition(id: 179, title: "mcp set", binary: "defenseclaw", arguments: ["mcp", "set"], summary: "Scan + set MCP server in the active connector's config", category: "enforce", requiresInput: true, usage: "<name> [--url <url>]"),
-        CommandDefinition(id: 180, title: "mcp unblock", binary: "defenseclaw", arguments: ["mcp", "unblock"], summary: "Unblock an MCP server", category: "enforce", requiresInput: true, usage: "<url>"),
-        CommandDefinition(id: 181, title: "mcp unset", binary: "defenseclaw", arguments: ["mcp", "unset"], summary: "Unset MCP server from the active connector's config", category: "enforce", requiresInput: true, usage: "<name-or-url>"),
-        CommandDefinition(id: 182, title: "plugin", binary: "defenseclaw", arguments: ["plugin"], summary: "Show plugin commands", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 183, title: "plugin list", binary: "defenseclaw", arguments: ["plugin", "list"], summary: "List installed plugins", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 184, title: "plugin scan", binary: "defenseclaw", arguments: ["plugin", "scan"], summary: "Scan a plugin", category: "scan", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 185, title: "plugin info", binary: "defenseclaw", arguments: ["plugin", "info"], summary: "Show plugin details", category: "info", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 186, title: "plugin allow", binary: "defenseclaw", arguments: ["plugin", "allow"], summary: "Allow-list a plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 187, title: "plugin block", binary: "defenseclaw", arguments: ["plugin", "block"], summary: "Block a plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 188, title: "plugin disable", binary: "defenseclaw", arguments: ["plugin", "disable"], summary: "Disable a plugin at runtime", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 189, title: "plugin enable", binary: "defenseclaw", arguments: ["plugin", "enable"], summary: "Enable a plugin at runtime", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 190, title: "plugin install", binary: "defenseclaw", arguments: ["plugin", "install"], summary: "Install a plugin", category: "install", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 191, title: "plugin quarantine", binary: "defenseclaw", arguments: ["plugin", "quarantine"], summary: "Quarantine a plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 192, title: "plugin remove", binary: "defenseclaw", arguments: ["plugin", "remove"], summary: "Remove a plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 193, title: "plugin restore", binary: "defenseclaw", arguments: ["plugin", "restore"], summary: "Restore a quarantined plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
-        CommandDefinition(id: 194, title: "tool", binary: "defenseclaw", arguments: ["tool"], summary: "Show tool commands", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 195, title: "tool list", binary: "defenseclaw", arguments: ["tool", "list"], summary: "List tool rules", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 196, title: "tool allow", binary: "defenseclaw", arguments: ["tool", "allow"], summary: "Allow-list a tool", category: "enforce", requiresInput: true, usage: "<tool-name>"),
-        CommandDefinition(id: 197, title: "tool block", binary: "defenseclaw", arguments: ["tool", "block"], summary: "Block a tool", category: "enforce", requiresInput: true, usage: "<tool-name>"),
-        CommandDefinition(id: 198, title: "tool unblock", binary: "defenseclaw", arguments: ["tool", "unblock"], summary: "Unblock a tool", category: "enforce", requiresInput: true, usage: "<tool-name>"),
-        CommandDefinition(id: 199, title: "policy", binary: "defenseclaw", arguments: ["policy"], summary: "Show policy commands", category: "policy", requiresInput: false, usage: ""),
-        CommandDefinition(id: 200, title: "policy edit", binary: "defenseclaw", arguments: ["policy", "edit"], summary: "Show policy edit commands", category: "policy", requiresInput: false, usage: ""),
-        CommandDefinition(id: 201, title: "keys", binary: "defenseclaw", arguments: ["keys"], summary: "Show credential commands", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 202, title: "config", binary: "defenseclaw", arguments: ["config"], summary: "Show config commands", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 203, title: "guardrail", binary: "defenseclaw", arguments: ["guardrail"], summary: "Show guardrail commands", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 204, title: "settings", binary: "defenseclaw", arguments: ["settings"], summary: "Show settings commands", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 205, title: "audit", binary: "defenseclaw", arguments: ["audit"], summary: "Show audit commands", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 206, title: "codeguard", binary: "defenseclaw", arguments: ["codeguard"], summary: "Show CodeGuard commands", category: "install", requiresInput: false, usage: ""),
-        CommandDefinition(id: 207, title: "codeguard install-skill", binary: "defenseclaw", arguments: ["codeguard", "install-skill"], summary: "Install CodeGuard skill", category: "install", requiresInput: false, usage: ""),
-        CommandDefinition(id: 208, title: "aibom", binary: "defenseclaw", arguments: ["aibom"], summary: "Show AIBOM commands", category: "scan", requiresInput: false, usage: ""),
-        CommandDefinition(id: 209, title: "sandbox", binary: "defenseclaw", arguments: ["sandbox"], summary: "Show sandbox commands", category: "sandbox", requiresInput: false, usage: ""),
-        CommandDefinition(id: 210, title: "reset", binary: "defenseclaw", arguments: ["reset"], summary: "Run interactive local data reset", category: "other", requiresInput: false, usage: ""),
-        CommandDefinition(id: 211, title: "uninstall", binary: "defenseclaw", arguments: ["uninstall"], summary: "Run interactive uninstall flow", category: "other", requiresInput: false, usage: ""),
-        CommandDefinition(id: 212, title: "skills", binary: "defenseclaw", arguments: ["skill", "list"], summary: "List skills", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 213, title: "mcps", binary: "defenseclaw", arguments: ["mcp", "list"], summary: "List MCP servers", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 214, title: "plugins", binary: "defenseclaw", arguments: ["plugin", "list"], summary: "List plugins", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 215, title: "tools", binary: "defenseclaw", arguments: ["tool", "list"], summary: "List tools", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 216, title: "alerts", binary: "defenseclaw", arguments: ["alerts", "--no-tui"], summary: "List alerts", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 217, title: "alerts acknowledge", binary: "defenseclaw", arguments: ["alerts", "acknowledge"], summary: "Acknowledge alerts by severity", category: "enforce", requiresInput: true, usage: "--severity HIGH"),
-        CommandDefinition(id: 218, title: "alerts dismiss", binary: "defenseclaw", arguments: ["alerts", "dismiss"], summary: "Dismiss alerts by severity", category: "enforce", requiresInput: true, usage: "--severity HIGH"),
-        CommandDefinition(id: 219, title: "audit log-activity", binary: "defenseclaw", arguments: ["audit", "log-activity"], summary: "Log operator activity (payload via --payload-file)", category: "other", requiresInput: true, usage: "--payload-file <path>"),
-        CommandDefinition(id: 220, title: "fix credentials", binary: "defenseclaw", arguments: ["keys", "fill-missing", "--yes"], summary: "List missing required credentials", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 221, title: "setup connector", binary: "defenseclaw", arguments: ["setup"], summary: "Open connector setup choices in the CLI", category: "setup", requiresInput: false, usage: ""),
-        CommandDefinition(id: 222, title: "restart gateway", binary: "defenseclaw-gateway", arguments: ["restart"], summary: "Restart the gateway sidecar", category: "daemon", requiresInput: false, usage: ""),
-        CommandDefinition(id: 223, title: "open setup", binary: "defenseclaw", arguments: ["setup"], summary: "Jump to the TUI Setup panel", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 224, title: "readiness", binary: "defenseclaw", arguments: ["doctor"], summary: "Run health checks that feed Setup Readiness", category: "info", requiresInput: false, usage: ""),
-        CommandDefinition(id: 225, title: "help", binary: "defenseclaw", arguments: ["--help"], summary: "Show CLI help", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 20, title: "setup amp", binary: "defenseclaw", arguments: ["setup", "amp", "--yes"], summary: "Configure Amp synchronous policy plugin", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 21, title: "setup omnigent", binary: "defenseclaw", arguments: ["setup", "omnigent", "--yes"], summary: "Configure OmniGent ALLOW/ASK/DENY policy bridge", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 22, title: "setup rotate-token", binary: "defenseclaw", arguments: ["setup", "rotate-token", "--yes"], summary: "Rotate gateway and scoped hook tokens", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 23, title: "setup gateway", binary: "defenseclaw", arguments: ["setup", "gateway"], summary: "Configure gateway connection (interactive)", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 24, title: "setup guardrail", binary: "defenseclaw", arguments: ["setup", "guardrail"], summary: "Configure LLM guardrail", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 25, title: "setup notifications", binary: "defenseclaw", arguments: ["setup", "notifications"], summary: "Show/toggle desktop notifications", category: "setup", requiresInput: true, usage: "<status|on|off> [--yes]"),
+        CommandDefinition(id: 26, title: "setup splunk", binary: "defenseclaw", arguments: ["setup", "splunk"], summary: "Configure Splunk / O11y", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 27, title: "setup local-observability up", binary: "defenseclaw", arguments: ["setup", "local-observability", "up"], summary: "Start local Prom/Loki/Tempo/Grafana stack", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 28, title: "setup local-observability down", binary: "defenseclaw", arguments: ["setup", "local-observability", "down"], summary: "Stop local observability stack", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 29, title: "setup local-observability reset", binary: "defenseclaw", arguments: ["setup", "local-observability", "reset", "--yes"], summary: "Stop local observability and wipe stored event volumes", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 30, title: "setup local-observability status", binary: "defenseclaw", arguments: ["setup", "local-observability", "status"], summary: "Show local observability stack status", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 31, title: "setup local-observability url", binary: "defenseclaw", arguments: ["setup", "local-observability", "url"], summary: "Show local observability URLs", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 32, title: "setup local-observability logs", binary: "defenseclaw", arguments: ["setup", "local-observability", "logs"], summary: "Tail local observability logs", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 33, title: "setup observability add", binary: "defenseclaw", arguments: ["setup", "observability", "add"], summary: "Add an observability/audit destination preset", category: "setup", requiresInput: true, usage: "<preset> [flags]"),
+        CommandDefinition(id: 34, title: "setup observability list", binary: "defenseclaw", arguments: ["setup", "observability", "list"], summary: "List configured observability destinations", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 35, title: "setup observability enable", binary: "defenseclaw", arguments: ["setup", "observability", "enable"], summary: "Enable an observability destination", category: "setup", requiresInput: true, usage: "<name>"),
+        CommandDefinition(id: 36, title: "setup observability disable", binary: "defenseclaw", arguments: ["setup", "observability", "disable"], summary: "Disable an observability destination", category: "setup", requiresInput: true, usage: "<name>"),
+        CommandDefinition(id: 37, title: "setup observability remove", binary: "defenseclaw", arguments: ["setup", "observability", "remove", "--yes"], summary: "Remove an observability destination", category: "setup", requiresInput: true, usage: "<name>"),
+        CommandDefinition(id: 38, title: "setup observability test", binary: "defenseclaw", arguments: ["setup", "observability", "test"], summary: "Probe an observability destination", category: "setup", requiresInput: true, usage: "<name>"),
+        CommandDefinition(id: 39, title: "setup galileo", binary: "defenseclaw", arguments: ["setup", "galileo"], summary: "Configure Galileo Cloud or self-hosted OTLP traces", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 40, title: "setup galileo status", binary: "defenseclaw", arguments: ["setup", "galileo", "status"], summary: "Show Galileo destination status", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 41, title: "setup galileo test", binary: "defenseclaw", arguments: ["setup", "galileo", "test"], summary: "Send a Galileo OTLP canary trace", category: "scan", requiresInput: false, usage: ""),
+        CommandDefinition(id: 42, title: "setup webhook add", binary: "defenseclaw", arguments: ["setup", "webhook", "add"], summary: "Add a notifier webhook", category: "setup", requiresInput: true, usage: "<slack|pagerduty|webex|generic> [flags]"),
+        CommandDefinition(id: 43, title: "setup webhook list", binary: "defenseclaw", arguments: ["setup", "webhook", "list"], summary: "List notifier webhooks", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 44, title: "setup webhook show", binary: "defenseclaw", arguments: ["setup", "webhook", "show"], summary: "Show a notifier webhook", category: "setup", requiresInput: true, usage: "<name>"),
+        CommandDefinition(id: 45, title: "setup webhook enable", binary: "defenseclaw", arguments: ["setup", "webhook", "enable"], summary: "Enable a notifier webhook", category: "setup", requiresInput: true, usage: "<name>"),
+        CommandDefinition(id: 46, title: "setup webhook disable", binary: "defenseclaw", arguments: ["setup", "webhook", "disable"], summary: "Disable a notifier webhook", category: "setup", requiresInput: true, usage: "<name>"),
+        CommandDefinition(id: 47, title: "setup webhook remove", binary: "defenseclaw", arguments: ["setup", "webhook", "remove", "--yes"], summary: "Remove a notifier webhook", category: "setup", requiresInput: true, usage: "<name>"),
+        CommandDefinition(id: 48, title: "setup webhook test", binary: "defenseclaw", arguments: ["setup", "webhook", "test"], summary: "Send/probe a notifier webhook", category: "setup", requiresInput: true, usage: "<name>"),
+        CommandDefinition(id: 49, title: "setup provider add", binary: "defenseclaw", arguments: ["setup", "provider", "add"], summary: "Add a custom LLM provider to the overlay", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 50, title: "setup provider remove", binary: "defenseclaw", arguments: ["setup", "provider", "remove"], summary: "Remove a custom LLM provider from the overlay", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 51, title: "setup provider list", binary: "defenseclaw", arguments: ["setup", "provider", "list"], summary: "List overlay provider entries", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 52, title: "setup provider show", binary: "defenseclaw", arguments: ["setup", "provider", "show"], summary: "Show merged provider registry", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 53, title: "agent discover", binary: "defenseclaw", arguments: ["agent", "discover"], summary: "Discover installed agents and emit sanitized telemetry", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 54, title: "agent usage", binary: "defenseclaw", arguments: ["agent", "usage"], summary: "Show continuous AI visibility from the sidecar", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 55, title: "agent usage --refresh", binary: "defenseclaw", arguments: ["agent", "usage", "--refresh"], summary: "Trigger an AI-usage scan and render results", category: "scan", requiresInput: false, usage: ""),
+        CommandDefinition(id: 56, title: "agent discovery setup", binary: "defenseclaw", arguments: ["agent", "discovery", "setup"], summary: "Interactive AI discovery wizard (mode, intervals, sources)", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 57, title: "agent discovery enable", binary: "defenseclaw", arguments: ["agent", "discovery", "enable", "--yes"], summary: "Enable AI discovery, save config, restart, and scan", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 58, title: "agent discovery disable", binary: "defenseclaw", arguments: ["agent", "discovery", "disable", "--yes"], summary: "Disable AI discovery and restart the gateway", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 59, title: "agent discovery status", binary: "defenseclaw", arguments: ["agent", "discovery", "status"], summary: "Show on-disk vs live AI discovery state", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 60, title: "agent discovery scan", binary: "defenseclaw", arguments: ["agent", "discovery", "scan"], summary: "Trigger one immediate AI discovery scan", category: "scan", requiresInput: false, usage: ""),
+        CommandDefinition(id: 61, title: "agent signatures list", binary: "defenseclaw", arguments: ["agent", "signatures", "list"], summary: "List the merged AI discovery signature catalog", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 62, title: "scan skill", binary: "defenseclaw", arguments: ["skill", "scan"], summary: "Scan a skill", category: "scan", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 63, title: "scan skill --all", binary: "defenseclaw", arguments: ["skill", "scan", "--all"], summary: "Scan all skills", category: "scan", requiresInput: false, usage: ""),
+        CommandDefinition(id: 64, title: "scan mcp", binary: "defenseclaw", arguments: ["mcp", "scan"], summary: "Scan an MCP server", category: "scan", requiresInput: true, usage: "<url>"),
+        CommandDefinition(id: 65, title: "scan mcp --all", binary: "defenseclaw", arguments: ["mcp", "scan", "--all"], summary: "Scan all MCP servers", category: "scan", requiresInput: false, usage: ""),
+        CommandDefinition(id: 66, title: "scan plugin", binary: "defenseclaw", arguments: ["plugin", "scan"], summary: "Scan a plugin", category: "scan", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 67, title: "scan aibom", binary: "defenseclaw", arguments: ["aibom", "scan"], summary: "Generate AIBOM inventory", category: "scan", requiresInput: false, usage: ""),
+        CommandDefinition(id: 68, title: "scan code", binary: "defenseclaw-gateway", arguments: ["scan", "code"], summary: "CodeGuard scan", category: "scan", requiresInput: true, usage: "<path>"),
+        CommandDefinition(id: 69, title: "block skill", binary: "defenseclaw", arguments: ["skill", "block"], summary: "Block a skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 70, title: "allow skill", binary: "defenseclaw", arguments: ["skill", "allow"], summary: "Allow-list a skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 71, title: "unblock skill", binary: "defenseclaw", arguments: ["skill", "unblock"], summary: "Unblock a skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 72, title: "disable skill", binary: "defenseclaw", arguments: ["skill", "disable"], summary: "Disable a skill at runtime", category: "enforce", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 73, title: "enable skill", binary: "defenseclaw", arguments: ["skill", "enable"], summary: "Enable a skill at runtime", category: "enforce", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 74, title: "quarantine skill", binary: "defenseclaw", arguments: ["skill", "quarantine"], summary: "Quarantine a skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 75, title: "restore skill", binary: "defenseclaw", arguments: ["skill", "restore"], summary: "Restore a quarantined skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 76, title: "block mcp", binary: "defenseclaw", arguments: ["mcp", "block"], summary: "Block an MCP server", category: "enforce", requiresInput: true, usage: "<url>"),
+        CommandDefinition(id: 77, title: "allow mcp", binary: "defenseclaw", arguments: ["mcp", "allow"], summary: "Allow-list an MCP server", category: "enforce", requiresInput: true, usage: "<url>"),
+        CommandDefinition(id: 78, title: "unblock mcp", binary: "defenseclaw", arguments: ["mcp", "unblock"], summary: "Unblock an MCP server", category: "enforce", requiresInput: true, usage: "<url>"),
+        CommandDefinition(id: 79, title: "set mcp", binary: "defenseclaw", arguments: ["mcp", "set"], summary: "Scan + set MCP server in the active connector's config", category: "enforce", requiresInput: true, usage: "<url>"),
+        CommandDefinition(id: 80, title: "unset mcp", binary: "defenseclaw", arguments: ["mcp", "unset"], summary: "Unset MCP server from the active connector's config", category: "enforce", requiresInput: true, usage: "<url>"),
+        CommandDefinition(id: 81, title: "block plugin", binary: "defenseclaw", arguments: ["plugin", "block"], summary: "Block a plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 82, title: "allow plugin", binary: "defenseclaw", arguments: ["plugin", "allow"], summary: "Allow-list a plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 83, title: "disable plugin", binary: "defenseclaw", arguments: ["plugin", "disable"], summary: "Disable a plugin at runtime", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 84, title: "enable plugin", binary: "defenseclaw", arguments: ["plugin", "enable"], summary: "Enable a plugin at runtime", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 85, title: "quarantine plugin", binary: "defenseclaw", arguments: ["plugin", "quarantine"], summary: "Quarantine a plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 86, title: "restore plugin", binary: "defenseclaw", arguments: ["plugin", "restore"], summary: "Restore a quarantined plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 87, title: "remove plugin", binary: "defenseclaw", arguments: ["plugin", "remove"], summary: "Remove a plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 88, title: "block tool", binary: "defenseclaw", arguments: ["tool", "block"], summary: "Block a tool", category: "enforce", requiresInput: true, usage: "<tool-name>"),
+        CommandDefinition(id: 89, title: "allow tool", binary: "defenseclaw", arguments: ["tool", "allow"], summary: "Allow-list a tool", category: "enforce", requiresInput: true, usage: "<tool-name>"),
+        CommandDefinition(id: 90, title: "unblock tool", binary: "defenseclaw", arguments: ["tool", "unblock"], summary: "Unblock a tool", category: "enforce", requiresInput: true, usage: "<tool-name>"),
+        CommandDefinition(id: 91, title: "install skill", binary: "defenseclaw", arguments: ["skill", "install"], summary: "Install a skill from ClawHub", category: "install", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 92, title: "install plugin", binary: "defenseclaw", arguments: ["plugin", "install"], summary: "Install a plugin", category: "install", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 93, title: "install codeguard", binary: "defenseclaw", arguments: ["codeguard", "install-skill"], summary: "Install CodeGuard skill", category: "install", requiresInput: false, usage: ""),
+        CommandDefinition(id: 94, title: "policy list", binary: "defenseclaw", arguments: ["policy", "list"], summary: "List policies", category: "policy", requiresInput: false, usage: ""),
+        CommandDefinition(id: 95, title: "policy show", binary: "defenseclaw", arguments: ["policy", "show"], summary: "Show policy details", category: "policy", requiresInput: true, usage: "<policy-name>"),
+        CommandDefinition(id: 96, title: "policy create", binary: "defenseclaw", arguments: ["policy", "create"], summary: "Create a new policy", category: "policy", requiresInput: true, usage: "<policy-name>"),
+        CommandDefinition(id: 97, title: "policy activate", binary: "defenseclaw", arguments: ["policy", "activate"], summary: "Activate a policy", category: "policy", requiresInput: true, usage: "<policy-name>"),
+        CommandDefinition(id: 98, title: "policy delete", binary: "defenseclaw", arguments: ["policy", "delete"], summary: "Delete a user policy", category: "policy", requiresInput: true, usage: "<policy-name>"),
+        CommandDefinition(id: 99, title: "policy validate", binary: "defenseclaw", arguments: ["policy", "validate"], summary: "Validate policy data + Rego", category: "policy", requiresInput: false, usage: ""),
+        CommandDefinition(id: 100, title: "policy test", binary: "defenseclaw", arguments: ["policy", "test"], summary: "Run OPA policy tests", category: "policy", requiresInput: false, usage: ""),
+        CommandDefinition(id: 101, title: "policy edit actions", binary: "defenseclaw", arguments: ["policy", "edit", "actions"], summary: "Edit severity action rules", category: "policy", requiresInput: false, usage: ""),
+        CommandDefinition(id: 102, title: "policy edit scanner", binary: "defenseclaw", arguments: ["policy", "edit", "scanner"], summary: "Edit scanner overrides", category: "policy", requiresInput: false, usage: ""),
+        CommandDefinition(id: 103, title: "policy edit guardrail", binary: "defenseclaw", arguments: ["policy", "edit", "guardrail"], summary: "Edit guardrail policy", category: "policy", requiresInput: false, usage: ""),
+        CommandDefinition(id: 104, title: "policy edit firewall", binary: "defenseclaw", arguments: ["policy", "edit", "firewall"], summary: "Edit firewall policy", category: "policy", requiresInput: false, usage: ""),
+        CommandDefinition(id: 105, title: "policy evaluate", binary: "defenseclaw-gateway", arguments: ["policy", "evaluate"], summary: "Dry-run admission evaluation", category: "policy", requiresInput: false, usage: ""),
+        CommandDefinition(id: 106, title: "policy evaluate-firewall", binary: "defenseclaw-gateway", arguments: ["policy", "evaluate-firewall"], summary: "Dry-run firewall evaluation", category: "policy", requiresInput: false, usage: ""),
+        CommandDefinition(id: 107, title: "policy reload", binary: "defenseclaw-gateway", arguments: ["policy", "reload"], summary: "Reload policy in running sidecar", category: "policy", requiresInput: false, usage: ""),
+        CommandDefinition(id: 108, title: "policy domains", binary: "defenseclaw-gateway", arguments: ["policy", "domains"], summary: "Show firewall domain lists", category: "policy", requiresInput: false, usage: ""),
+        CommandDefinition(id: 109, title: "list skills", binary: "defenseclaw", arguments: ["skill", "list"], summary: "List skills with scan status", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 110, title: "list mcps", binary: "defenseclaw", arguments: ["mcp", "list"], summary: "List MCP servers with status", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 111, title: "list plugins", binary: "defenseclaw", arguments: ["plugin", "list"], summary: "List installed plugins", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 112, title: "list tools", binary: "defenseclaw", arguments: ["tool", "list"], summary: "List tool rules", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 113, title: "info skill", binary: "defenseclaw", arguments: ["skill", "info"], summary: "Show skill details", category: "info", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 114, title: "info plugin", binary: "defenseclaw", arguments: ["plugin", "info"], summary: "Show plugin details", category: "info", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 115, title: "tool status", binary: "defenseclaw", arguments: ["tool", "status"], summary: "Show tool block/allow status", category: "info", requiresInput: true, usage: "<tool-name>"),
+        CommandDefinition(id: 116, title: "status", binary: "defenseclaw", arguments: ["status"], summary: "Show DefenseClaw status", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 117, title: "doctor", binary: "defenseclaw", arguments: ["doctor"], summary: "Run health checks", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 118, title: "doctor run", binary: "defenseclaw", arguments: ["doctor"], summary: "Run health checks", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 119, title: "doctor --fix", binary: "defenseclaw", arguments: ["doctor", "--fix", "--yes"], summary: "Auto-repair safe health issues", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 120, title: "config validate", binary: "defenseclaw", arguments: ["config", "validate"], summary: "Validate config.yaml", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 121, title: "config show", binary: "defenseclaw", arguments: ["config", "show"], summary: "Show resolved config with secrets masked", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 122, title: "config show effective observability", binary: "defenseclaw", arguments: ["config", "show", "--effective", "--section", "observability"], summary: "Show effective observability policy", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 123, title: "config reference observability", binary: "defenseclaw", arguments: ["config", "reference", "observability"], summary: "Show the complete observability reference", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 124, title: "observability plan", binary: "defenseclaw", arguments: ["observability", "plan"], summary: "Show collection and destination routing plan", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 125, title: "config path", binary: "defenseclaw", arguments: ["config", "path"], summary: "Show DefenseClaw filesystem paths", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 126, title: "keys list", binary: "defenseclaw", arguments: ["keys", "list"], summary: "List configured and missing credentials", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 127, title: "keys list --json", binary: "defenseclaw", arguments: ["keys", "list", "--json"], summary: "List credentials as JSON for setup parity", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 128, title: "keys check", binary: "defenseclaw", arguments: ["keys", "check"], summary: "Fail if required credentials are missing", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 129, title: "keys set", binary: "defenseclaw", arguments: ["keys", "set"], summary: "Persist a credential to the DefenseClaw .env", category: "setup", requiresInput: true, usage: "<ENV_NAME>"),
+        CommandDefinition(id: 130, title: "keys fill-missing", binary: "defenseclaw", arguments: ["keys", "fill-missing", "--yes"], summary: "List missing required credentials", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 131, title: "settings save", binary: "defenseclaw", arguments: ["settings", "save"], summary: "Persist current settings/config", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 132, title: "guardrail status", binary: "defenseclaw", arguments: ["guardrail", "status"], summary: "Show guardrail status", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 133, title: "guardrail enable", binary: "defenseclaw", arguments: ["guardrail", "enable", "--yes"], summary: "Enable guardrail", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 134, title: "guardrail disable", binary: "defenseclaw", arguments: ["guardrail", "disable", "--yes"], summary: "Disable guardrail", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 135, title: "version", binary: "defenseclaw", arguments: ["version"], summary: "Show DefenseClaw version information", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 136, title: "start", binary: "defenseclaw-gateway", arguments: ["start"], summary: "Start gateway sidecar", category: "daemon", requiresInput: false, usage: ""),
+        CommandDefinition(id: 137, title: "stop", binary: "defenseclaw-gateway", arguments: ["stop"], summary: "Stop gateway sidecar", category: "daemon", requiresInput: false, usage: ""),
+        CommandDefinition(id: 138, title: "restart", binary: "defenseclaw-gateway", arguments: ["restart"], summary: "Restart gateway sidecar", category: "daemon", requiresInput: false, usage: ""),
+        CommandDefinition(id: 139, title: "gateway status", binary: "defenseclaw-gateway", arguments: ["status"], summary: "Show gateway health", category: "daemon", requiresInput: false, usage: ""),
+        CommandDefinition(id: 140, title: "watchdog start", binary: "defenseclaw-gateway", arguments: ["watchdog", "start"], summary: "Start health watchdog", category: "daemon", requiresInput: false, usage: ""),
+        CommandDefinition(id: 141, title: "watchdog stop", binary: "defenseclaw-gateway", arguments: ["watchdog", "stop"], summary: "Stop health watchdog", category: "daemon", requiresInput: false, usage: ""),
+        CommandDefinition(id: 142, title: "watchdog status", binary: "defenseclaw-gateway", arguments: ["watchdog", "status"], summary: "Show watchdog status", category: "daemon", requiresInput: false, usage: ""),
+        CommandDefinition(id: 143, title: "connector verify", binary: "defenseclaw-gateway", arguments: ["connector", "verify"], summary: "Verify connector config is clean/current", category: "daemon", requiresInput: false, usage: ""),
+        CommandDefinition(id: 144, title: "connector teardown", binary: "defenseclaw-gateway", arguments: ["connector", "teardown"], summary: "Remove active connector config patches", category: "daemon", requiresInput: false, usage: ""),
+        CommandDefinition(id: 145, title: "connector list-backups", binary: "defenseclaw-gateway", arguments: ["connector", "list-backups"], summary: "List connector backup files", category: "daemon", requiresInput: false, usage: ""),
+        CommandDefinition(id: 146, title: "gateway audit export", binary: "defenseclaw-gateway", arguments: ["audit", "export"], summary: "Export gateway audit log", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 147, title: "gateway provenance show", binary: "defenseclaw-gateway", arguments: ["provenance", "show"], summary: "Show gateway binary/config provenance", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 148, title: "sandbox init", binary: "defenseclaw", arguments: ["sandbox", "init"], summary: "Initialize sandbox environment", category: "sandbox", requiresInput: false, usage: ""),
+        CommandDefinition(id: 149, title: "sandbox setup", binary: "defenseclaw", arguments: ["sandbox", "setup"], summary: "Configure sandbox networking", category: "sandbox", requiresInput: false, usage: ""),
+        CommandDefinition(id: 150, title: "sandbox start", binary: "defenseclaw-gateway", arguments: ["sandbox", "start"], summary: "Start sandbox services", category: "sandbox", requiresInput: false, usage: ""),
+        CommandDefinition(id: 151, title: "sandbox stop", binary: "defenseclaw-gateway", arguments: ["sandbox", "stop"], summary: "Stop sandbox services", category: "sandbox", requiresInput: false, usage: ""),
+        CommandDefinition(id: 152, title: "sandbox restart", binary: "defenseclaw-gateway", arguments: ["sandbox", "restart"], summary: "Restart sandbox services", category: "sandbox", requiresInput: false, usage: ""),
+        CommandDefinition(id: 153, title: "sandbox status", binary: "defenseclaw-gateway", arguments: ["sandbox", "status"], summary: "Show sandbox status", category: "sandbox", requiresInput: false, usage: ""),
+        CommandDefinition(id: 154, title: "sandbox exec", binary: "defenseclaw-gateway", arguments: ["sandbox", "exec"], summary: "Run command in sandbox", category: "sandbox", requiresInput: true, usage: "<command>"),
+        CommandDefinition(id: 155, title: "sandbox shell", binary: "defenseclaw-gateway", arguments: ["sandbox", "shell"], summary: "Open sandbox shell", category: "sandbox", requiresInput: false, usage: ""),
+        CommandDefinition(id: 156, title: "sandbox policy diff", binary: "defenseclaw-gateway", arguments: ["sandbox", "policy", "diff"], summary: "Compare policy vs endpoints", category: "sandbox", requiresInput: false, usage: ""),
+        CommandDefinition(id: 157, title: "upgrade", binary: "defenseclaw", arguments: ["upgrade", "--yes"], summary: "Upgrade DefenseClaw", category: "other", requiresInput: false, usage: ""),
+        CommandDefinition(id: 158, title: "uninstall dry-run", binary: "defenseclaw", arguments: ["uninstall", "--dry-run"], summary: "Preview uninstall changes without modifying the system", category: "other", requiresInput: false, usage: ""),
+        CommandDefinition(id: 159, title: "uninstall --yes", binary: "defenseclaw", arguments: ["uninstall", "--yes"], summary: "Uninstall DefenseClaw after showing the plan", category: "other", requiresInput: false, usage: ""),
+        CommandDefinition(id: 160, title: "uninstall --all --yes", binary: "defenseclaw", arguments: ["uninstall", "--all", "--yes"], summary: "Uninstall DefenseClaw and wipe local data", category: "other", requiresInput: false, usage: ""),
+        CommandDefinition(id: 161, title: "reset --yes", binary: "defenseclaw", arguments: ["reset", "--yes"], summary: "Wipe DefenseClaw local data and keep binaries", category: "other", requiresInput: false, usage: ""),
+        CommandDefinition(id: 162, title: "setup", binary: "defenseclaw", arguments: ["setup"], summary: "Show setup command help", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 163, title: "setup local-observability", binary: "defenseclaw", arguments: ["setup", "local-observability"], summary: "Show local observability commands", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 164, title: "setup observability", binary: "defenseclaw", arguments: ["setup", "observability"], summary: "Show observability sink commands", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 165, title: "setup provider", binary: "defenseclaw", arguments: ["setup", "provider"], summary: "Show provider registry commands", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 166, title: "setup webhook", binary: "defenseclaw", arguments: ["setup", "webhook"], summary: "Show webhook commands", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 167, title: "skill", binary: "defenseclaw", arguments: ["skill"], summary: "Show skill commands", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 168, title: "skill list", binary: "defenseclaw", arguments: ["skill", "list"], summary: "List skills with scan status", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 169, title: "skill search", binary: "defenseclaw", arguments: ["skill", "search"], summary: "Search available skills", category: "info", requiresInput: true, usage: "<query>"),
+        CommandDefinition(id: 170, title: "skill scan", binary: "defenseclaw", arguments: ["skill", "scan"], summary: "Scan a skill", category: "scan", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 171, title: "skill info", binary: "defenseclaw", arguments: ["skill", "info"], summary: "Show skill details", category: "info", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 172, title: "skill allow", binary: "defenseclaw", arguments: ["skill", "allow"], summary: "Allow-list a skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 173, title: "skill block", binary: "defenseclaw", arguments: ["skill", "block"], summary: "Block a skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 174, title: "skill disable", binary: "defenseclaw", arguments: ["skill", "disable"], summary: "Disable a skill at runtime", category: "enforce", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 175, title: "skill enable", binary: "defenseclaw", arguments: ["skill", "enable"], summary: "Enable a skill at runtime", category: "enforce", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 176, title: "skill install", binary: "defenseclaw", arguments: ["skill", "install"], summary: "Install a skill from ClawHub", category: "install", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 177, title: "skill quarantine", binary: "defenseclaw", arguments: ["skill", "quarantine"], summary: "Quarantine a skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 178, title: "skill restore", binary: "defenseclaw", arguments: ["skill", "restore"], summary: "Restore a quarantined skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 179, title: "skill unblock", binary: "defenseclaw", arguments: ["skill", "unblock"], summary: "Unblock a skill", category: "enforce", requiresInput: true, usage: "<skill-name>"),
+        CommandDefinition(id: 180, title: "mcp", binary: "defenseclaw", arguments: ["mcp"], summary: "Show MCP commands", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 181, title: "mcp list", binary: "defenseclaw", arguments: ["mcp", "list"], summary: "List MCP servers with status", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 182, title: "mcp scan", binary: "defenseclaw", arguments: ["mcp", "scan"], summary: "Scan an MCP server", category: "scan", requiresInput: true, usage: "<url>"),
+        CommandDefinition(id: 183, title: "mcp allow", binary: "defenseclaw", arguments: ["mcp", "allow"], summary: "Allow-list an MCP server", category: "enforce", requiresInput: true, usage: "<url>"),
+        CommandDefinition(id: 184, title: "mcp block", binary: "defenseclaw", arguments: ["mcp", "block"], summary: "Block an MCP server", category: "enforce", requiresInput: true, usage: "<url>"),
+        CommandDefinition(id: 185, title: "mcp set", binary: "defenseclaw", arguments: ["mcp", "set"], summary: "Scan + set MCP server in the active connector's config", category: "enforce", requiresInput: true, usage: "<name> [--url <url>]"),
+        CommandDefinition(id: 186, title: "mcp unblock", binary: "defenseclaw", arguments: ["mcp", "unblock"], summary: "Unblock an MCP server", category: "enforce", requiresInput: true, usage: "<url>"),
+        CommandDefinition(id: 187, title: "mcp unset", binary: "defenseclaw", arguments: ["mcp", "unset"], summary: "Unset MCP server from the active connector's config", category: "enforce", requiresInput: true, usage: "<name-or-url>"),
+        CommandDefinition(id: 188, title: "plugin", binary: "defenseclaw", arguments: ["plugin"], summary: "Show plugin commands", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 189, title: "plugin list", binary: "defenseclaw", arguments: ["plugin", "list"], summary: "List installed plugins", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 190, title: "plugin scan", binary: "defenseclaw", arguments: ["plugin", "scan"], summary: "Scan a plugin", category: "scan", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 191, title: "plugin info", binary: "defenseclaw", arguments: ["plugin", "info"], summary: "Show plugin details", category: "info", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 192, title: "plugin allow", binary: "defenseclaw", arguments: ["plugin", "allow"], summary: "Allow-list a plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 193, title: "plugin block", binary: "defenseclaw", arguments: ["plugin", "block"], summary: "Block a plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 194, title: "plugin disable", binary: "defenseclaw", arguments: ["plugin", "disable"], summary: "Disable a plugin at runtime", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 195, title: "plugin enable", binary: "defenseclaw", arguments: ["plugin", "enable"], summary: "Enable a plugin at runtime", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 196, title: "plugin install", binary: "defenseclaw", arguments: ["plugin", "install"], summary: "Install a plugin", category: "install", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 197, title: "plugin quarantine", binary: "defenseclaw", arguments: ["plugin", "quarantine"], summary: "Quarantine a plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 198, title: "plugin remove", binary: "defenseclaw", arguments: ["plugin", "remove"], summary: "Remove a plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 199, title: "plugin restore", binary: "defenseclaw", arguments: ["plugin", "restore"], summary: "Restore a quarantined plugin", category: "enforce", requiresInput: true, usage: "<plugin-name>"),
+        CommandDefinition(id: 200, title: "tool", binary: "defenseclaw", arguments: ["tool"], summary: "Show tool commands", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 201, title: "tool list", binary: "defenseclaw", arguments: ["tool", "list"], summary: "List tool rules", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 202, title: "tool allow", binary: "defenseclaw", arguments: ["tool", "allow"], summary: "Allow-list a tool", category: "enforce", requiresInput: true, usage: "<tool-name>"),
+        CommandDefinition(id: 203, title: "tool block", binary: "defenseclaw", arguments: ["tool", "block"], summary: "Block a tool", category: "enforce", requiresInput: true, usage: "<tool-name>"),
+        CommandDefinition(id: 204, title: "tool unblock", binary: "defenseclaw", arguments: ["tool", "unblock"], summary: "Unblock a tool", category: "enforce", requiresInput: true, usage: "<tool-name>"),
+        CommandDefinition(id: 205, title: "policy", binary: "defenseclaw", arguments: ["policy"], summary: "Show policy commands", category: "policy", requiresInput: false, usage: ""),
+        CommandDefinition(id: 206, title: "policy edit", binary: "defenseclaw", arguments: ["policy", "edit"], summary: "Show policy edit commands", category: "policy", requiresInput: false, usage: ""),
+        CommandDefinition(id: 207, title: "keys", binary: "defenseclaw", arguments: ["keys"], summary: "Show credential commands", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 208, title: "config", binary: "defenseclaw", arguments: ["config"], summary: "Show config commands", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 209, title: "guardrail", binary: "defenseclaw", arguments: ["guardrail"], summary: "Show guardrail commands", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 210, title: "settings", binary: "defenseclaw", arguments: ["settings"], summary: "Show settings commands", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 211, title: "audit", binary: "defenseclaw", arguments: ["audit"], summary: "Show audit commands", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 212, title: "codeguard", binary: "defenseclaw", arguments: ["codeguard"], summary: "Show CodeGuard commands", category: "install", requiresInput: false, usage: ""),
+        CommandDefinition(id: 213, title: "codeguard install-skill", binary: "defenseclaw", arguments: ["codeguard", "install-skill"], summary: "Install CodeGuard skill", category: "install", requiresInput: false, usage: ""),
+        CommandDefinition(id: 214, title: "aibom", binary: "defenseclaw", arguments: ["aibom"], summary: "Show AIBOM commands", category: "scan", requiresInput: false, usage: ""),
+        CommandDefinition(id: 215, title: "sandbox", binary: "defenseclaw", arguments: ["sandbox"], summary: "Show sandbox commands", category: "sandbox", requiresInput: false, usage: ""),
+        CommandDefinition(id: 216, title: "reset", binary: "defenseclaw", arguments: ["reset"], summary: "Run interactive local data reset", category: "other", requiresInput: false, usage: ""),
+        CommandDefinition(id: 217, title: "uninstall", binary: "defenseclaw", arguments: ["uninstall"], summary: "Run interactive uninstall flow", category: "other", requiresInput: false, usage: ""),
+        CommandDefinition(id: 218, title: "skills", binary: "defenseclaw", arguments: ["skill", "list"], summary: "List skills", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 219, title: "mcps", binary: "defenseclaw", arguments: ["mcp", "list"], summary: "List MCP servers", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 220, title: "plugins", binary: "defenseclaw", arguments: ["plugin", "list"], summary: "List plugins", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 221, title: "tools", binary: "defenseclaw", arguments: ["tool", "list"], summary: "List tools", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 222, title: "alerts", binary: "defenseclaw", arguments: ["alerts", "--no-tui"], summary: "List alerts", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 223, title: "alerts acknowledge", binary: "defenseclaw", arguments: ["alerts", "acknowledge"], summary: "Acknowledge alerts by severity", category: "enforce", requiresInput: true, usage: "--severity HIGH"),
+        CommandDefinition(id: 224, title: "alerts dismiss", binary: "defenseclaw", arguments: ["alerts", "dismiss"], summary: "Dismiss alerts by severity", category: "enforce", requiresInput: true, usage: "--severity HIGH"),
+        CommandDefinition(id: 225, title: "audit log-activity", binary: "defenseclaw", arguments: ["audit", "log-activity"], summary: "Log operator activity (payload via --payload-file)", category: "other", requiresInput: true, usage: "--payload-file <path>"),
+        CommandDefinition(id: 226, title: "fix credentials", binary: "defenseclaw", arguments: ["keys", "fill-missing", "--yes"], summary: "List missing required credentials", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 227, title: "setup connector", binary: "defenseclaw", arguments: ["setup"], summary: "Open connector setup choices in the CLI", category: "setup", requiresInput: false, usage: ""),
+        CommandDefinition(id: 228, title: "restart gateway", binary: "defenseclaw-gateway", arguments: ["restart"], summary: "Restart the gateway sidecar", category: "daemon", requiresInput: false, usage: ""),
+        CommandDefinition(id: 229, title: "open setup", binary: "defenseclaw", arguments: ["setup"], summary: "Jump to the TUI Setup panel", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 230, title: "readiness", binary: "defenseclaw", arguments: ["doctor"], summary: "Run health checks that feed Setup Readiness", category: "info", requiresInput: false, usage: ""),
+        CommandDefinition(id: 231, title: "help", binary: "defenseclaw", arguments: ["--help"], summary: "Show CLI help", category: "info", requiresInput: false, usage: ""),
     ]
+
+    /// Keep the generated source table exact while exposing only commands the
+    /// installed runtime reports in its setup catalog.
+    static func paletteCommands(supportedSetupCommands: Set<String>?) -> [CommandDefinition] {
+        all.filter { command in
+            guard command.arguments == ["setup", "amp", "--yes"] else { return true }
+            return supportedSetupCommands?.contains("amp") == true
+        }
+    }
+
+    static func setupCommands(from help: String) -> Set<String> {
+        var insideCommands = false
+        var commands: Set<String> = []
+        for line in help.components(separatedBy: .newlines) {
+            if line.trimmingCharacters(in: .whitespaces) == "Commands:" {
+                insideCommands = true
+                continue
+            }
+            guard insideCommands else { continue }
+            if !line.isEmpty, line.first?.isWhitespace == false { break }
+            guard line.hasPrefix("  "), !line.hasPrefix("    ") else { continue }
+            let command = line.trimmingCharacters(in: .whitespaces)
+                .split(whereSeparator: \.isWhitespace)
+                .first.map(String.init) ?? ""
+            guard !command.isEmpty,
+                  command.range(of: #"^[a-z0-9][a-z0-9-]*$"#, options: .regularExpression) != nil
+            else { continue }
+            commands.insert(command)
+        }
+        return commands
+    }
+}
+
+enum CommandArgumentParser {
+    struct ParseError: LocalizedError {
+        let message: String
+        var errorDescription: String? { message }
+    }
+
+    static func parse(_ input: String) throws -> [String] {
+        var result: [String] = []
+        var current = ""
+        var quote: Character?
+        var escaped = false
+        var tokenStarted = false
+
+        for character in input {
+            if escaped {
+                current.append(character)
+                escaped = false
+                tokenStarted = true
+                continue
+            }
+            if character == "\\" && quote != "'" {
+                escaped = true
+                tokenStarted = true
+                continue
+            }
+            if let activeQuote = quote {
+                if character == activeQuote { quote = nil }
+                else {
+                    current.append(character)
+                    tokenStarted = true
+                }
+                continue
+            }
+            if character == "'" || character == "\"" {
+                quote = character
+                tokenStarted = true
+            } else if character.isWhitespace {
+                if tokenStarted {
+                    result.append(current)
+                    current = ""
+                    tokenStarted = false
+                }
+            } else {
+                current.append(character)
+                tokenStarted = true
+            }
+        }
+
+        if escaped { throw ParseError(message: "The final backslash does not escape a character.") }
+        if quote != nil { throw ParseError(message: "A quoted argument is not closed.") }
+        if tokenStarted { result.append(current) }
+        return result
+    }
 }
 
 enum CommandArgumentParser {

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/CommandRegistry.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/CommandRegistry.swift
@@ -195,25 +195,6 @@ enum CommandInvocationError: LocalizedError, Equatable {
     }
 }
 
-struct CommandExecutionPlan: Equatable, Sendable {
-    enum Error: LocalizedError {
-        case invalidCredentialName
-        case missingSecret
-
-        var errorDescription: String? {
-            switch self {
-            case .invalidCredentialName:
-                "Enter one environment name using letters, digits, and underscores."
-            case .missingSecret:
-                "Enter the secret value."
-            }
-        }
-    }
-
-    let arguments: [String]
-    let standardInput: String?
-}
-
 enum CommandRegistry {
     static let sourceCount = 232
     static let all: [CommandDefinition] = [
@@ -373,7 +354,7 @@ enum CommandRegistry {
         CommandDefinition(id: 154, title: "sandbox exec", binary: "defenseclaw-gateway", arguments: ["sandbox", "exec"], summary: "Run command in sandbox", category: "sandbox", requiresInput: true, usage: "<command>"),
         CommandDefinition(id: 155, title: "sandbox shell", binary: "defenseclaw-gateway", arguments: ["sandbox", "shell"], summary: "Open sandbox shell", category: "sandbox", requiresInput: false, usage: ""),
         CommandDefinition(id: 156, title: "sandbox policy diff", binary: "defenseclaw-gateway", arguments: ["sandbox", "policy", "diff"], summary: "Compare policy vs endpoints", category: "sandbox", requiresInput: false, usage: ""),
-        CommandDefinition(id: 157, title: "upgrade", binary: "defenseclaw", arguments: ["upgrade", "--yes"], summary: "Upgrade DefenseClaw", category: "other", requiresInput: false, usage: ""),
+        CommandDefinition(id: 157, title: "upgrade", binary: "defenseclaw", arguments: ["upgrade", "--yes"], summary: "Run CLI upgrade preflight; hard cuts require the release-owned resolver", category: "other", requiresInput: false, usage: ""),
         CommandDefinition(id: 158, title: "uninstall dry-run", binary: "defenseclaw", arguments: ["uninstall", "--dry-run"], summary: "Preview uninstall changes without modifying the system", category: "other", requiresInput: false, usage: ""),
         CommandDefinition(id: 159, title: "uninstall --yes", binary: "defenseclaw", arguments: ["uninstall", "--yes"], summary: "Uninstall DefenseClaw after showing the plan", category: "other", requiresInput: false, usage: ""),
         CommandDefinition(id: 160, title: "uninstall --all --yes", binary: "defenseclaw", arguments: ["uninstall", "--all", "--yes"], summary: "Uninstall DefenseClaw and wipe local data", category: "other", requiresInput: false, usage: ""),
@@ -479,61 +460,6 @@ enum CommandRegistry {
             commands.insert(command)
         }
         return commands
-    }
-}
-
-enum CommandArgumentParser {
-    struct ParseError: LocalizedError {
-        let message: String
-        var errorDescription: String? { message }
-    }
-
-    static func parse(_ input: String) throws -> [String] {
-        var result: [String] = []
-        var current = ""
-        var quote: Character?
-        var escaped = false
-        var tokenStarted = false
-
-        for character in input {
-            if escaped {
-                current.append(character)
-                escaped = false
-                tokenStarted = true
-                continue
-            }
-            if character == "\\" && quote != "'" {
-                escaped = true
-                tokenStarted = true
-                continue
-            }
-            if let activeQuote = quote {
-                if character == activeQuote { quote = nil }
-                else {
-                    current.append(character)
-                    tokenStarted = true
-                }
-                continue
-            }
-            if character == "'" || character == "\"" {
-                quote = character
-                tokenStarted = true
-            } else if character.isWhitespace {
-                if tokenStarted {
-                    result.append(current)
-                    current = ""
-                    tokenStarted = false
-                }
-            } else {
-                current.append(character)
-                tokenStarted = true
-            }
-        }
-
-        if escaped { throw ParseError(message: "The final backslash does not escape a character.") }
-        if quote != nil { throw ParseError(message: "A quoted argument is not closed.") }
-        if tokenStarted { result.append(current) }
-        return result
     }
 }
 

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/ConfigStore.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/ConfigStore.swift
@@ -127,20 +127,190 @@ indirect enum YAMLNode: Sendable {
 }
 
 enum MiniYAML {
+    private static let maximumSourceBytes = 4 * 1024 * 1024
+    private static let maximumNodes = 65_536
+
     /// Parses block-style YAML mappings/sequences with plain or quoted scalars.
-    /// Ignores comments, documents markers, anchors, and flow collections —
-    /// adequate for defenseclaw's generated config.yaml.
+    /// Supports the nested flow collections emitted by DefenseClaw's
+    /// style-preserving config writer and ignores document markers and anchors.
     static func parse(_ text: String) -> YAMLNode {
+        guard text.utf8.count <= maximumSourceBytes else {
+            return .scalar("")
+        }
+        let lines = logicalLines(from: text)
+        var index = 0
+        let root = parseBlock(lines: lines, index: &index, indent: 0)
+        guard boundedNodeCount(root) != nil else { return .scalar("") }
+        return root
+    }
+
+    private enum FlowLineState {
+        case open
+        case complete
+        case invalid
+    }
+
+    private struct PendingFlowLine {
+        var indent: Int
+        var parts: [String]
+        var balance: FlowBalance
+
+        var content: String { parts.joined() }
+    }
+
+    private struct FlowBalance {
+        private var stack: [Character] = []
+        private var inSingle = false
+        private var inDouble = false
+        private var escaped = false
+        private var invalid = false
+
+        var state: FlowLineState {
+            if invalid { return .invalid }
+            if !stack.isEmpty || inSingle || inDouble { return .open }
+            return .complete
+        }
+
+        var isInsideQuote: Bool { inSingle || inDouble }
+
+        /// YAML folds ordinary quoted line breaks to a space. A trailing
+        /// backslash in a double-quoted scalar escapes the line break instead.
+        mutating func foldedLineBreakEscapesWhitespace() -> Bool {
+            guard inDouble, escaped else { return false }
+            escaped = false
+            return true
+        }
+
+        var quoteState: (inSingle: Bool, inDouble: Bool) {
+            (inSingle, inDouble)
+        }
+
+        mutating func consume(_ value: String) {
+            let characters = Array(value)
+            var index = 0
+            while index < characters.count, !invalid {
+                let character = characters[index]
+                if inDouble {
+                    if escaped {
+                        escaped = false
+                    } else if character == "\\" {
+                        escaped = true
+                    } else if character == "\"" {
+                        inDouble = false
+                    }
+                    index += 1
+                    continue
+                }
+                if inSingle {
+                    if character == "'" {
+                        if index + 1 < characters.count, characters[index + 1] == "'" {
+                            index += 2
+                            continue
+                        }
+                        inSingle = false
+                    }
+                    index += 1
+                    continue
+                }
+
+                switch character {
+                case "\"":
+                    inDouble = true
+                case "'":
+                    inSingle = true
+                case "{":
+                    stack.append("}")
+                case "[":
+                    stack.append("]")
+                case "}", "]":
+                    if stack.last == character {
+                        stack.removeLast()
+                    } else {
+                        invalid = true
+                    }
+                default:
+                    break
+                }
+                index += 1
+            }
+        }
+    }
+
+    /// PyYAML wraps large flow collections at its configured width. Rejoin
+    /// only lines that begin with a mapping/sequence value and have balanced
+    /// flow delimiters; ordinary block YAML retains its physical line shape.
+    private static func logicalLines(from text: String) -> [(indent: Int, content: String)] {
         var lines: [(indent: Int, content: String)] = []
+        var pending: PendingFlowLine?
+
         for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
             let line = String(rawLine)
             let stripped = line.trimmingCharacters(in: .whitespaces)
+
+            if var continuation = pending {
+                if !continuation.balance.isInsideQuote,
+                   stripped.isEmpty || stripped.hasPrefix("#") {
+                    continue
+                }
+                let escapedLineBreak = continuation.balance.foldedLineBreakEscapesWhitespace()
+                if escapedLineBreak {
+                    if let last = continuation.parts.indices.last,
+                       continuation.parts[last].last == "\\" {
+                        continuation.parts[last].removeLast()
+                    }
+                } else {
+                    continuation.parts.append(" ")
+                    continuation.balance.consume(" ")
+                }
+                let quoteState = continuation.balance.quoteState
+                let content = stripInlineComment(
+                    stripped,
+                    startingInSingle: quoteState.inSingle,
+                    startingInDouble: quoteState.inDouble
+                ).trimmingCharacters(in: .whitespaces)
+                continuation.parts.append(content)
+                continuation.balance.consume(content)
+                switch continuation.balance.state {
+                case .open:
+                    pending = continuation
+                case .complete, .invalid:
+                    lines.append((continuation.indent, continuation.content))
+                    pending = nil
+                }
+                continue
+            }
+
             if stripped.isEmpty || stripped.hasPrefix("#") || stripped == "---" { continue }
             let indent = line.prefix { $0 == " " }.count
-            lines.append((indent, stripped))
+            let content = stripInlineComment(stripped).trimmingCharacters(in: .whitespaces)
+            guard !content.isEmpty else { continue }
+
+            guard let candidate = flowCandidate(in: content) else {
+                lines.append((indent, content))
+                continue
+            }
+            var balance = FlowBalance()
+            balance.consume(candidate)
+            if balance.state == .open {
+                pending = PendingFlowLine(indent: indent, parts: [content], balance: balance)
+            } else {
+                lines.append((indent, content))
+            }
         }
-        var index = 0
-        return parseBlock(lines: lines, index: &index, indent: 0)
+        if let pending { lines.append((pending.indent, pending.content)) }
+        return lines
+    }
+
+    private static func flowCandidate(in content: String) -> String? {
+        if content.hasPrefix("- ") {
+            let candidate = String(content.dropFirst(2)).trimmingCharacters(in: .whitespaces)
+            return candidate.first == "{" || candidate.first == "[" ? candidate : nil
+        } else if let colon = findColon(content) {
+            let candidate = String(content[content.index(after: colon)...])
+                .trimmingCharacters(in: .whitespaces)
+            return candidate.first == "{" || candidate.first == "[" ? candidate : nil
+        }
+        return nil
     }
 
     private static func parseBlock(lines: [(indent: Int, content: String)], index: inout Int, indent: Int) -> YAMLNode {
@@ -162,6 +332,8 @@ enum MiniYAML {
                 index += 1
                 if inline.isEmpty {
                     seq.append(parseBlock(lines: lines, index: &index, indent: nextIndent(lines, index, greaterThan: indent)))
+                } else if inline.hasPrefix("{") || inline.hasPrefix("[") {
+                    seq.append(inlineNode(inline))
                 } else if let colon = findColon(inline) {
                     // "- key: value" — sequence of mappings; gather subsequent deeper keys
                     var item: [String: YAMLNode] = [:]
@@ -169,7 +341,7 @@ enum MiniYAML {
                     let value = String(inline[inline.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
                     item[key] = value.isEmpty
                         ? parseBlock(lines: lines, index: &index, indent: nextIndent(lines, index, greaterThan: indent))
-                        : .scalar(unquote(value))
+                        : inlineNode(value)
                     while index < lines.count, lines[index].indent > indent, !lines[index].content.hasPrefix("- ") {
                         let sub = lines[index]
                         if let c = findColon(sub.content) {
@@ -178,12 +350,12 @@ enum MiniYAML {
                             index += 1
                             item[k] = v.isEmpty
                                 ? parseBlock(lines: lines, index: &index, indent: nextIndent(lines, index, greaterThan: sub.indent))
-                                : .scalar(unquote(v))
+                                : inlineNode(v)
                         } else { index += 1 }
                     }
                     seq.append(.mapping(item))
                 } else {
-                    seq.append(.scalar(unquote(inline)))
+                    seq.append(inlineNode(inline))
                 }
             } else if let colon = findColon(content) {
                 if isSequence == true { break }
@@ -194,7 +366,7 @@ enum MiniYAML {
                 if value.isEmpty {
                     map[key] = parseBlock(lines: lines, index: &index, indent: nextIndent(lines, index, greaterThan: indent))
                 } else {
-                    map[key] = .scalar(unquote(value))
+                    map[key] = inlineNode(value)
                 }
             } else {
                 index += 1 // unrecognized line — skip
@@ -202,6 +374,320 @@ enum MiniYAML {
         }
         if isSequence == true { return .sequence(seq) }
         return .mapping(map)
+    }
+
+    /// DefenseClaw preserves compact flow style when it expands seed values
+    /// such as `observability: {}`. Parse those generated collections while
+    /// leaving quoted values such as `"{}"` as ordinary strings.
+    private static func inlineNode(_ raw: String) -> YAMLNode {
+        let value = raw.trimmingCharacters(in: .whitespaces)
+        let syntax = stripInlineComment(value).trimmingCharacters(in: .whitespaces)
+        let isQuoted = (syntax.hasPrefix("\"") && syntax.hasSuffix("\""))
+            || (syntax.hasPrefix("'") && syntax.hasSuffix("'"))
+        if !isQuoted {
+            var parser = FlowParser(syntax)
+            if let node = parser.parse() { return node }
+        }
+        return .scalar(unquote(value))
+    }
+
+    /// Bounded parser for the flow mappings/sequences produced by the runtime.
+    /// A collection is accepted only when the complete value parses, so a
+    /// truncated config remains a scalar and InstallationContext fails closed.
+    private struct FlowParser {
+        private static let maximumDepth = 32
+        private static let maximumSourceBytes = 4 * 1024 * 1024
+        private static let maximumNodes = 65_536
+        private static let maximumMappingEntries = 1_024
+
+        private let characters: [Character]
+        private let sourceByteCount: Int
+        private var index = 0
+        private var nodeCount = 0
+
+        init(_ value: String) {
+            characters = Array(value)
+            sourceByteCount = value.utf8.count
+        }
+
+        mutating func parse() -> YAMLNode? {
+            guard sourceByteCount <= Self.maximumSourceBytes else { return nil }
+            skipWhitespace()
+            guard let first = peek(), first == "{" || first == "[",
+                  let node = parseValue(depth: 0)
+            else { return nil }
+            skipWhitespace()
+            return index == characters.count ? node : nil
+        }
+
+        private mutating func parseValue(depth: Int) -> YAMLNode? {
+            guard depth <= Self.maximumDepth, nodeCount < Self.maximumNodes else { return nil }
+            nodeCount += 1
+            skipWhitespace()
+            guard let character = peek() else { return nil }
+            switch character {
+            case "{":
+                return parseMapping(depth: depth)
+            case "[":
+                return parseSequence(depth: depth)
+            case "\"", "'":
+                return parseQuotedScalar().map(YAMLNode.scalar)
+            default:
+                return parsePlainScalar().map(YAMLNode.scalar)
+            }
+        }
+
+        private mutating func parseMapping(depth: Int) -> YAMLNode? {
+            guard consume("{") else { return nil }
+            skipWhitespace()
+            if consume("}") { return .mapping([:]) }
+
+            var mapping: [String: YAMLNode] = [:]
+            while true {
+                let quotedKey = peek() == "\"" || peek() == "'"
+                guard let key = parseMappingKey() else { return nil }
+                guard key != "<<", nodeCount < Self.maximumNodes else { return nil }
+                nodeCount += 1
+                if !quotedKey, !plainMappingKeyIsString(key) { return nil }
+                skipWhitespace()
+                guard consume(":") else { return nil }
+                if !quotedKey, let next = peek(),
+                   !next.isWhitespace && next != "{" && next != "[" {
+                    return nil
+                }
+                guard let value = parseValue(depth: depth + 1) else { return nil }
+                guard mapping[key] == nil,
+                      mapping.count < Self.maximumMappingEntries
+                else { return nil }
+                mapping[key] = value
+                skipWhitespace()
+                if consume("}") { return .mapping(mapping) }
+                guard consume(",") else { return nil }
+                skipWhitespace()
+                if consume("}") { return .mapping(mapping) }
+            }
+        }
+
+        private mutating func parseSequence(depth: Int) -> YAMLNode? {
+            guard consume("[") else { return nil }
+            skipWhitespace()
+            if consume("]") { return .sequence([]) }
+
+            var sequence: [YAMLNode] = []
+            while true {
+                guard sequence.count < Self.maximumNodes else { return nil }
+                guard let value = parseValue(depth: depth + 1) else { return nil }
+                sequence.append(value)
+                skipWhitespace()
+                if consume("]") { return .sequence(sequence) }
+                guard consume(",") else { return nil }
+                skipWhitespace()
+                if consume("]") { return .sequence(sequence) }
+            }
+        }
+
+        private mutating func parseMappingKey() -> String? {
+            skipWhitespace()
+            if peek() == "\"" || peek() == "'" {
+                return parseQuotedScalar()
+            }
+
+            var key = ""
+            while let character = peek(), character != ":" {
+                guard !["{", "}", "[", "]", ","].contains(character) else { return nil }
+                key.append(character)
+                index += 1
+            }
+            let trimmed = key.trimmingCharacters(in: .whitespaces)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+
+        private func plainMappingKeyIsString(_ key: String) -> Bool {
+            let lowercased = key.lowercased()
+            if ["<<", "=", "~", "null", "true", "false", "yes", "no", "on", "off"].contains(lowercased) {
+                return false
+            }
+            if key.hasPrefix("!") || key.hasPrefix("&") || key.hasPrefix("*") {
+                return false
+            }
+
+            if isImplicitYAMLNumber(key) { return false }
+            if key.range(
+                of: #"^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}(?:$|[Tt \t])"#,
+                options: .regularExpression
+            ) != nil {
+                return false
+            }
+            return true
+        }
+
+        private func isImplicitYAMLNumber(_ value: String) -> Bool {
+            // Match PyYAML's YAML 1.1 implicit int/float resolvers. Swift's
+            // Double parser is intentionally not used: values such as `1e2`,
+            // `inf`, and `Infinity` are valid unquoted string keys in YAML.
+            let integer = #"^[+-]?(?:0|[1-9][0-9_]*|0b[0-1_]+|0[0-7_]+|0x[0-9a-fA-F_]+|[1-9][0-9_]*(?::[0-5]?[0-9])+)$"#
+            let float = #"^(?:[-+]?(?:[0-9][0-9_]*)\.[0-9_]*(?:[eE][-+][0-9]+)?|[-+]?[0-9][0-9_]*(?:[eE][-+][0-9]+)|[-+]?\.[0-9_]+(?:[eE][-+][0-9]+)?|[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\.[0-9_]*|[-+]?\.(?:inf|Inf|INF)|\.(?:nan|NaN|NAN))$"#
+            return value.range(of: integer, options: .regularExpression) != nil
+                || value.range(of: float, options: .regularExpression) != nil
+        }
+
+        private mutating func parseQuotedScalar() -> String? {
+            guard let quote = peek(), quote == "\"" || quote == "'" else { return nil }
+            index += 1
+            var value = ""
+
+            while let character = peek() {
+                index += 1
+                if character == quote {
+                    if quote == "'", peek() == "'" {
+                        value.append("'")
+                        index += 1
+                        continue
+                    }
+                    return value
+                }
+                if character == "\\", quote == "\"" {
+                    guard let escaped = parseDoubleQuotedEscape() else { return nil }
+                    value.append(escaped)
+                    continue
+                }
+                value.append(character)
+            }
+            return nil
+        }
+
+        private mutating func parseDoubleQuotedEscape() -> String? {
+            guard let escape = peek() else { return nil }
+            index += 1
+            switch escape {
+            case "0": return "\0"
+            case "a": return "\u{0007}"
+            case "b": return "\u{0008}"
+            case "t": return "\t"
+            case "n": return "\n"
+            case "v": return "\u{000B}"
+            case "f": return "\u{000C}"
+            case "r": return "\r"
+            case "e": return "\u{001B}"
+            case " ": return " "
+            case "\"": return "\""
+            case "/": return "/"
+            case "\\": return "\\"
+            case "N": return "\u{0085}"
+            case "_": return "\u{00A0}"
+            case "L": return "\u{2028}"
+            case "P": return "\u{2029}"
+            case "x": return parseUnicodeEscape(digitCount: 2)
+            case "u": return parseUnicodeEscape(digitCount: 4)
+            case "U": return parseUnicodeEscape(digitCount: 8)
+            default: return nil
+            }
+        }
+
+        private mutating func parseUnicodeEscape(digitCount: Int) -> String? {
+            guard index + digitCount <= characters.count else { return nil }
+            let digits = String(characters[index..<(index + digitCount)])
+            guard digits.allSatisfy(\.isHexDigit),
+                  let value = UInt32(digits, radix: 16),
+                  let scalar = UnicodeScalar(value)
+            else { return nil }
+            index += digitCount
+            return String(scalar)
+        }
+
+        private mutating func parsePlainScalar() -> String? {
+            var value = ""
+            while let character = peek(), ![",", "]", "}"].contains(character) {
+                if character == ":", let next = peek(offset: 1),
+                   next.isWhitespace || [",", "]", "}"].contains(next) {
+                    return nil
+                }
+                value.append(character)
+                index += 1
+            }
+            let trimmed = value.trimmingCharacters(in: .whitespaces)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+
+        private mutating func skipWhitespace() {
+            while peek()?.isWhitespace == true { index += 1 }
+        }
+
+        private func peek(offset: Int = 0) -> Character? {
+            let target = index + offset
+            guard characters.indices.contains(target) else { return nil }
+            return characters[target]
+        }
+
+        private mutating func consume(_ expected: Character) -> Bool {
+            guard peek() == expected else { return false }
+            index += 1
+            return true
+        }
+    }
+
+    private static func stripInlineComment(
+        _ value: String,
+        startingInSingle: Bool = false,
+        startingInDouble: Bool = false
+    ) -> String {
+        let characters = Array(value)
+        var inSingle = startingInSingle
+        var inDouble = startingInDouble
+        var escaped = false
+        var previous: Character?
+        var index = 0
+        while index < characters.count {
+            let character = characters[index]
+            if inDouble {
+                if escaped {
+                    escaped = false
+                } else if character == "\\" {
+                    escaped = true
+                } else if character == "\"" {
+                    inDouble = false
+                }
+            } else if inSingle {
+                if character == "'" {
+                    if index + 1 < characters.count, characters[index + 1] == "'" {
+                        previous = "'"
+                        index += 2
+                        continue
+                    }
+                    inSingle = false
+                }
+            } else if character == "'" {
+                inSingle = true
+            } else if character == "\"" {
+                inDouble = true
+            } else if character == "#", previous?.isWhitespace == true {
+                return String(characters[..<index])
+            }
+            previous = character
+            index += 1
+        }
+        return value
+    }
+
+    private static func boundedNodeCount(_ root: YAMLNode) -> Int? {
+        var count = 0
+        var pending = [root]
+        while let node = pending.popLast() {
+            count += 1
+            guard count <= maximumNodes else { return nil }
+            switch node {
+            case .scalar:
+                break
+            case .sequence(let values):
+                pending.append(contentsOf: values)
+            case .mapping(let values):
+                // The runtime's node budget includes mapping-key scalar nodes.
+                count += values.count
+                guard count <= maximumNodes else { return nil }
+                pending.append(contentsOf: values.values)
+            }
+        }
+        return count
     }
 
     private static func nextIndent(_ lines: [(indent: Int, content: String)], _ index: Int, greaterThan indent: Int) -> Int {
@@ -490,8 +976,8 @@ actor ConfigStore {
         if let packDir = root["guardrail.rule_pack_dir"]?.string, !packDir.isEmpty {
             c.guardrailRulePack = (packDir as NSString).lastPathComponent
         }
-        // Source baseline only. Bucket and route overrides are intentionally
-        // summarized by the canonical `setup redaction status` command.
+        // Source baseline only. Bucket and route overrides belong to the
+        // runtime's canonical redaction-policy surface, not this YAML reader.
         c.redactionDefaultProfile = root["observability.defaults.redaction_profile"]?.string ?? ""
         c.hiltEnabled = root["hilt.enabled"]?.bool ?? false
         c.hiltMinSeverity = root["hilt.min_severity"]?.string ?? "HIGH"

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/DynamicConfigCatalog.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/DynamicConfigCatalog.swift
@@ -60,12 +60,11 @@ enum DynamicConfigCatalog {
         var values: [String: String]
     }
 
-    /// Dump the runtime's catalog. nil on any failure (missing venv, renamed
-    /// symbol in a future runtime, parse error) — callers fall back to the
-    /// static catalog.
+    /// Dump the runtime's catalog. nil on any failure (missing interpreter,
+    /// renamed symbol in a future runtime, parse error) — callers fall back to
+    /// the static v8-safe catalog.
     static func load(using cli: CLIRunner, context: InstallationContext) async -> LoadResult? {
-        let runtimePython = context.runtimePythonURL.path
-        guard FileManager.default.isExecutableFile(atPath: runtimePython) else { return nil }
+        guard let runtimePython = await cli.locateRuntimePython() else { return nil }
         let result = await cli.run(binary: runtimePython, arguments: ["-c", dumpScript], mutation: false)
         guard result.succeeded,
               let line = result.output.split(separator: "\n").first(where: { $0.hasPrefix(sentinel) }),

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/EventStreamReader.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/EventStreamReader.swift
@@ -31,6 +31,8 @@ struct StreamDelta: Sendable {
 actor EventStreamReader {
     static let tailBudget = 512 * 1024
     static let tailLineLimit = 2_000
+    static let maximumRecordBytes = 64 * 1024
+    static let maximumRetainedBytes = 8 * 1024 * 1024
 
     private let url: URL
     private let gatewayLogURL: URL
@@ -45,6 +47,7 @@ actor EventStreamReader {
     private(set) var findings: [ScanFindingEvent] = []
     private(set) var activity: [ActivityMutation] = []
     private(set) var egress: [EgressEvent] = []
+    private(set) var retainedBufferBytes = 0
 
     /// Scan blocks grouped by scan_id — mirrors load_gateway_scan_blocks,
     /// which reads the bounded gateway.jsonl tail (512 KiB / 2,000 lines).
@@ -56,16 +59,24 @@ actor EventStreamReader {
         scanBlockMap.values.sorted { $0.timestamp > $1.timestamp }
     }
 
-    private let bufferCap = 20_000
+    private let bufferCap: Int
+    private let recordByteLimit: Int
+    private let retainedByteLimit: Int
 
     init(
         url: URL,
         gatewayLogURL: URL,
-        watchdogLogURL: URL
+        watchdogLogURL: URL,
+        bufferCap: Int = 20_000,
+        maximumRecordBytes: Int = EventStreamReader.maximumRecordBytes,
+        maximumRetainedBytes: Int = EventStreamReader.maximumRetainedBytes
     ) {
         self.url = url
         self.gatewayLogURL = gatewayLogURL
         self.watchdogLogURL = watchdogLogURL
+        self.bufferCap = max(1, bufferCap)
+        self.recordByteLimit = max(1, maximumRecordBytes)
+        self.retainedByteLimit = max(1, maximumRetainedBytes)
     }
 
     /// Reload scan/scan_finding rows from the same bounded tail the TUI uses.
@@ -104,6 +115,7 @@ actor EventStreamReader {
         scanSummaryCounts = [:]
         observedFindingCounts = [:]
         for line in text.split(separator: "\n", omittingEmptySubsequences: false).suffix(Self.tailLineLimit) {
+            guard line.utf8.count <= recordByteLimit else { continue }
             guard line.contains("\"event_type\":\"scan") || line.contains("\"event_type\": \"scan") else { continue }
             guard let lineData = line.data(using: .utf8),
                   let obj = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any]
@@ -190,6 +202,12 @@ actor EventStreamReader {
                     offset += UInt64(complete.count)
                     let text = String(decoding: complete, as: UTF8.self)
                     for line in text.split(separator: "\n") {
+                        guard line.utf8.count <= recordByteLimit else {
+                            delta.logRows.append(
+                                oversizedRecordNotice(stream: .verdicts, actualBytes: line.utf8.count)
+                            )
+                            continue
+                        }
                         guard let lineData = line.data(using: .utf8),
                               let obj = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any]
                         else { continue }
@@ -201,18 +219,7 @@ actor EventStreamReader {
         ingestPlainLog(gatewayLogURL, stream: .gateway, offset: &gatewayLogOffset, into: &delta)
         ingestPlainLog(watchdogLogURL, stream: .watchdog, offset: &watchdogLogOffset, into: &delta)
 
-        for row in delta.logRows {
-            logBuffers[row.stream, default: []].append(row)
-            if logBuffers[row.stream]!.count > bufferCap {
-                logBuffers[row.stream]!.removeFirst(logBuffers[row.stream]!.count - bufferCap)
-            }
-        }
-        findings.append(contentsOf: delta.findings)
-        activity.append(contentsOf: delta.activity)
-        egress.append(contentsOf: delta.egress)
-        if findings.count > bufferCap { findings.removeFirst(findings.count - bufferCap) }
-        if activity.count > bufferCap { activity.removeFirst(activity.count - bufferCap) }
-        if egress.count > bufferCap { egress.removeFirst(egress.count - bufferCap) }
+        retain(delta)
         return delta
     }
 
@@ -223,6 +230,7 @@ actor EventStreamReader {
         findings = []
         activity = []
         egress = []
+        retainedBufferBytes = 0
         scanBlockMap = [:]
         scanSummaryCounts = [:]
         observedFindingCounts = [:]
@@ -254,7 +262,166 @@ actor EventStreamReader {
         for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
             let raw = String(line)
             guard !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
-            delta.logRows.append(plainLogRow(raw, stream: stream))
+            guard raw.utf8.count <= recordByteLimit else {
+                delta.logRows.append(
+                    oversizedRecordNotice(stream: stream, actualBytes: raw.utf8.count)
+                )
+                continue
+            }
+            let row = plainLogRow(raw, stream: stream)
+            if retainedBytes(of: row) <= recordByteLimit {
+                delta.logRows.append(row)
+            } else {
+                delta.logRows.append(
+                    oversizedRecordNotice(stream: stream, actualBytes: retainedBytes(of: row))
+                )
+            }
+        }
+    }
+
+    /// Return only newline-terminated bytes. A writer may be midway through a
+    /// JSON/log line when the size is sampled; leaving that suffix unconsumed
+    /// makes the next poll re-read and complete it instead of dropping it.
+    private func completeLinePrefix(_ data: Data) -> Data? {
+        guard let newline = data.lastIndex(of: 0x0A) else { return nil }
+        return data.prefix(through: newline)
+    }
+
+    private enum RetainedHead {
+        case log(LogStream)
+        case finding
+        case activity
+        case egress
+    }
+
+    private func retain(_ delta: StreamDelta) {
+        for row in delta.logRows {
+            logBuffers[row.stream, default: []].append(row)
+            retainedBufferBytes += retainedBytes(of: row)
+        }
+        for event in delta.findings {
+            findings.append(event)
+            retainedBufferBytes += retainedBytes(of: event)
+        }
+        for mutation in delta.activity {
+            activity.append(mutation)
+            retainedBufferBytes += retainedBytes(of: mutation)
+        }
+        for event in delta.egress {
+            egress.append(event)
+            retainedBufferBytes += retainedBytes(of: event)
+        }
+
+        enforceCountLimits()
+        while retainedBufferBytes > retainedByteLimit, removeOldestRetainedRecord() {}
+    }
+
+    private func enforceCountLimits() {
+        for stream in LogStream.allCases {
+            guard var rows = logBuffers[stream], rows.count > bufferCap else { continue }
+            let removalCount = rows.count - bufferCap
+            for row in rows.prefix(removalCount) {
+                subtractRetainedBytes(retainedBytes(of: row))
+            }
+            rows.removeFirst(removalCount)
+            logBuffers[stream] = rows
+        }
+        if findings.count > bufferCap {
+            let removalCount = findings.count - bufferCap
+            for event in findings.prefix(removalCount) {
+                subtractRetainedBytes(retainedBytes(of: event))
+            }
+            findings.removeFirst(removalCount)
+        }
+        if activity.count > bufferCap {
+            let removalCount = activity.count - bufferCap
+            for mutation in activity.prefix(removalCount) {
+                subtractRetainedBytes(retainedBytes(of: mutation))
+            }
+            activity.removeFirst(removalCount)
+        }
+        if egress.count > bufferCap {
+            let removalCount = egress.count - bufferCap
+            for event in egress.prefix(removalCount) {
+                subtractRetainedBytes(retainedBytes(of: event))
+            }
+            egress.removeFirst(removalCount)
+        }
+    }
+
+    @discardableResult
+    private func removeOldestRetainedRecord() -> Bool {
+        var oldest: (date: Date, head: RetainedHead)?
+        for stream in LogStream.allCases {
+            guard let row = logBuffers[stream]?.first else { continue }
+            if oldest == nil || row.timestamp < oldest!.date {
+                oldest = (row.timestamp, .log(stream))
+            }
+        }
+        if let event = findings.first, oldest == nil || event.timestamp < oldest!.date {
+            oldest = (event.timestamp, .finding)
+        }
+        if let mutation = activity.first, oldest == nil || mutation.timestamp < oldest!.date {
+            oldest = (mutation.timestamp, .activity)
+        }
+        if let event = egress.first, oldest == nil || event.timestamp < oldest!.date {
+            oldest = (event.timestamp, .egress)
+        }
+
+        guard let oldest else { return false }
+        switch oldest.head {
+        case .log(let stream):
+            guard var rows = logBuffers[stream], !rows.isEmpty else { return false }
+            let removed = rows.removeFirst()
+            subtractRetainedBytes(retainedBytes(of: removed))
+            logBuffers[stream] = rows
+        case .finding:
+            let removed = findings.removeFirst()
+            subtractRetainedBytes(retainedBytes(of: removed))
+        case .activity:
+            let removed = activity.removeFirst()
+            subtractRetainedBytes(retainedBytes(of: removed))
+        case .egress:
+            let removed = egress.removeFirst()
+            subtractRetainedBytes(retainedBytes(of: removed))
+        }
+        return true
+    }
+
+    private func subtractRetainedBytes(_ count: Int) {
+        retainedBufferBytes = max(0, retainedBufferBytes - count)
+    }
+
+    private func retainedBytes(of row: LogRow) -> Int {
+        textBytes([row.id, row.action, row.eventType, row.message, row.rawJSON, row.connector])
+    }
+
+    private func retainedBytes(of event: ScanFindingEvent) -> Int {
+        textBytes([
+            event.id, event.scanner, event.target, event.title, event.detail,
+            event.location, event.remediation, event.runID, event.connector,
+        ])
+    }
+
+    private func retainedBytes(of mutation: ActivityMutation) -> Int {
+        textBytes([
+            mutation.id, mutation.actor, mutation.action, mutation.targetType,
+            mutation.targetID, mutation.reason, mutation.versionFrom, mutation.versionTo,
+            mutation.beforeJSON, mutation.afterJSON, mutation.connector,
+        ])
+    }
+
+    private func retainedBytes(of event: EgressEvent) -> Int {
+        textBytes([
+            event.id, event.target, event.decision, event.reason, event.branch,
+            event.connector, event.targetPath, event.bodyShape, event.source,
+        ])
+    }
+
+    private func textBytes(_ values: [String]) -> Int {
+        values.reduce(into: 0) { total, value in
+            let count = value.utf8.count
+            total = total > Int.max - count ? Int.max : total + count
         }
     }
 
@@ -279,6 +446,21 @@ actor EventStreamReader {
             message: line,
             rawJSON: line,
             connector: metadata.connector
+        )
+    }
+
+    private func oversizedRecordNotice(stream: LogStream, actualBytes: Int) -> LogRow {
+        rowCounter += 1
+        return LogRow(
+            id: "oversized-record-\(rowCounter)",
+            timestamp: Date(),
+            stream: stream,
+            severity: .medium,
+            action: "omitted",
+            eventType: "oversized_record",
+            message: "Omitted oversized log record (\(actualBytes) bytes; limit \(recordByteLimit)).",
+            rawJSON: "",
+            connector: ""
         )
     }
 
@@ -363,7 +545,7 @@ actor EventStreamReader {
         case "scan_finding":
             let finding = (obj["scan_finding"] as? [String: Any]) ?? obj
             let findingTarget = (finding["target"] as? String) ?? target
-            delta.findings.append(ScanFindingEvent(
+            let event = ScanFindingEvent(
                 id: nextID(obj, "finding"),
                 timestamp: ts,
                 scanner: (finding["scanner"] as? String) ?? "scanner",
@@ -375,7 +557,14 @@ actor EventStreamReader {
                 severity: severity,
                 runID: (obj["run_id"] as? String) ?? "",
                 connector: connector.isEmpty ? ConnectorAttribution.fromTarget(findingTarget) : connector
-            ))
+            )
+            if retainedBytes(of: event) <= recordByteLimit {
+                delta.findings.append(event)
+            } else {
+                delta.logRows.append(
+                    oversizedRecordNotice(stream: .verdicts, actualBytes: retainedBytes(of: event))
+                )
+            }
         case "activity":
             // Mutation fields are nested under "activity" (gateway_events.py
             // load_gateway_activity); top level is a fallback for older rows.
@@ -386,7 +575,7 @@ actor EventStreamReader {
                let diff = act["diff"] as? [[String: Any]], !diff.isEmpty {
                 after = jsonString(diff) // JSON-patch style op/path entries
             }
-            delta.activity.append(ActivityMutation(
+            let mutation = ActivityMutation(
                 id: nextID(obj, "activity"),
                 timestamp: ts,
                 actor: firstString(act["actor"], obj["actor"], "system"),
@@ -399,7 +588,14 @@ actor EventStreamReader {
                 beforeJSON: before,
                 afterJSON: after,
                 connector: connector
-            ))
+            )
+            if retainedBytes(of: mutation) <= recordByteLimit {
+                delta.activity.append(mutation)
+            } else {
+                delta.logRows.append(
+                    oversizedRecordNotice(stream: .verdicts, actualBytes: retainedBytes(of: mutation))
+                )
+            }
         case "egress":
             // Egress fields are nested under "egress"; the TUI's
             // load_gateway_egress skips rows without that dict, and its
@@ -415,7 +611,7 @@ actor EventStreamReader {
             let synthesized: Severity = (decision == "block" || (branch == "shape" && looksLikeLLM))
                 ? .medium : .info
             let tsParsed = DCDates.parse(obj["ts"] ?? obj["timestamp"] ?? obj["time"]) != nil
-            delta.egress.append(EgressEvent(
+            let event = EgressEvent(
                 id: nextID(obj, "egress"),
                 timestamp: ts,
                 target: firstString(egress["target_host"]),
@@ -429,7 +625,14 @@ actor EventStreamReader {
                 bodyShape: firstString(egress["body_shape"]),
                 source: firstString(egress["source"]),
                 timestampParsed: tsParsed
-            ))
+            )
+            if retainedBytes(of: event) <= recordByteLimit {
+                delta.egress.append(event)
+            } else {
+                delta.logRows.append(
+                    oversizedRecordNotice(stream: .verdicts, actualBytes: retainedBytes(of: event))
+                )
+            }
         default:
             break
         }
@@ -440,7 +643,7 @@ actor EventStreamReader {
         // The TUI's Gateway and Watchdog tabs are backed by gateway.log and
         // watchdog.log. JSONL rows feed the structured tabs and counters.
         if stream != .gateway && stream != .watchdog {
-            delta.logRows.append(LogRow(
+            let row = LogRow(
                 id: nextID(obj, "log"),
                 timestamp: ts,
                 stream: stream,
@@ -450,7 +653,14 @@ actor EventStreamReader {
                 message: message.isEmpty ? raw : message,
                 rawJSON: raw,
                 connector: connector
-            ))
+            )
+            if retainedBytes(of: row) <= recordByteLimit {
+                delta.logRows.append(row)
+            } else {
+                delta.logRows.append(
+                    oversizedRecordNotice(stream: stream, actualBytes: retainedBytes(of: row))
+                )
+            }
         }
     }
 

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/EventStreamReader.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/EventStreamReader.swift
@@ -425,14 +425,6 @@ actor EventStreamReader {
         }
     }
 
-    /// Return only newline-terminated bytes. A writer may be midway through a
-    /// JSON/log line when the size is sampled; leaving that suffix unconsumed
-    /// makes the next poll re-read and complete it instead of dropping it.
-    private func completeLinePrefix(_ data: Data) -> Data? {
-        guard let newline = data.lastIndex(of: 0x0A) else { return nil }
-        return data.prefix(through: newline)
-    }
-
     private func plainLogRow(_ line: String, stream: LogStream) -> LogRow {
         plainLogCounter += 1
         let metadata = parsePlainLogMetadata(line, stream: stream)

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/GatewayClient.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/GatewayClient.swift
@@ -30,26 +30,31 @@ actor GatewayClient {
     private var mutationsAllowed: Bool
     private var mutationDenialReason: String
     private let session: URLSession
+    private let responseByteLimit: Int
 
     static let defaultTimeout: TimeInterval = 5
     static let pluginTimeout: TimeInterval = 90
     static let scanTimeout: TimeInterval = 120
+    static let maximumResponseBytes = 4 * 1024 * 1024
     private static let pathSegmentCharacters = CharacterSet.alphanumerics
         .union(CharacterSet(charactersIn: "-._~"))
 
     init(
         config: DefenseClawConfig = DefenseClawConfig(),
         mutationsAllowed: Bool = false,
-        mutationDenialReason: String = "This installation is read only."
+        mutationDenialReason: String = "This installation is read only.",
+        maximumResponseBytes: Int = GatewayClient.maximumResponseBytes,
+        session: URLSession? = nil
     ) {
         self.baseURL = config.baseURL
         self.token = config.gatewayToken
         self.mutationsAllowed = mutationsAllowed
         self.mutationDenialReason = mutationDenialReason
+        self.responseByteLimit = max(1, maximumResponseBytes)
         let conf = URLSessionConfiguration.ephemeral
         conf.timeoutIntervalForRequest = Self.defaultTimeout
         conf.waitsForConnectivity = false
-        self.session = URLSession(configuration: conf)
+        self.session = session ?? URLSession(configuration: conf)
     }
 
     func update(config: DefenseClawConfig) {
@@ -97,10 +102,45 @@ actor GatewayClient {
             req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
 
-        let data: Data
-        let response: URLResponse
         do {
-            (data, response) = try await session.data(for: req)
+            let (bytes, response) = try await session.bytes(for: req)
+            guard let http = response as? HTTPURLResponse else {
+                throw GatewayError.badResponse("non-HTTP response")
+            }
+            if http.statusCode == 401 || http.statusCode == 403 {
+                throw GatewayError.unauthorized
+            }
+            let expectedLength = http.expectedContentLength
+            guard expectedLength < 0 || expectedLength <= Int64(responseByteLimit) else {
+                throw GatewayError.badResponse(
+                    "response exceeds the \(responseByteLimit)-byte limit"
+                )
+            }
+
+            var data = Data()
+            if expectedLength > 0 {
+                data.reserveCapacity(Int(expectedLength))
+            }
+            for try await byte in bytes {
+                guard data.count < responseByteLimit else {
+                    throw GatewayError.badResponse(
+                        "response exceeds the \(responseByteLimit)-byte limit"
+                    )
+                }
+                data.append(byte)
+            }
+
+            switch http.statusCode {
+            case 200..<300:
+                return data
+            default:
+                throw GatewayError.degraded(
+                    status: http.statusCode,
+                    body: String(data: data, encoding: .utf8) ?? ""
+                )
+            }
+        } catch let error as GatewayError {
+            throw error
         } catch let err as URLError {
             switch err.code {
             case .cannotConnectToHost, .networkConnectionLost, .cannotFindHost:
@@ -110,17 +150,6 @@ actor GatewayClient {
             default:
                 throw GatewayError.offline
             }
-        }
-        guard let http = response as? HTTPURLResponse else {
-            throw GatewayError.badResponse("non-HTTP response")
-        }
-        switch http.statusCode {
-        case 200..<300:
-            return data
-        case 401, 403:
-            throw GatewayError.unauthorized
-        default:
-            throw GatewayError.degraded(status: http.statusCode, body: String(data: data, encoding: .utf8) ?? "")
         }
     }
 

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/InventoryOutputParser.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/InventoryOutputParser.swift
@@ -22,9 +22,63 @@ struct InventoryOutputParseResult {
 }
 
 enum InventoryOutputParser {
-    static let maximumInputBytes = CLIOutputLimits.maximumOutputBytes
+    // Keep aligned with CLIOutputLimits.maximumOutputBytes. This parser is also
+    // compiled independently by its focused regression tests.
+    static let maximumInputBytes = 4 * 1_024 * 1_024
     static let maximumCandidateCount = 64
     private static let maximumNestingDepth = 512
+
+    /// DefenseClaw 0.8.5+ serializes these expected connector limitations in
+    /// `errors` and emits a failure warning for them. They explain empty
+    /// categories; they do not represent failed inventory collection.
+    private static let nonActionableCapabilityNotes: [String: String] = [
+        "agents": "agents are not a first-class concept on this connector",
+        "tools": "tool registry is owned by each plugin's manifest",
+        "models": "model providers are configured inside the framework",
+        "memory": "memory backend is private to the framework",
+    ]
+
+    /// Count failures that require user action. Prefer the structured error
+    /// list so known runtime capability notes can be distinguished from real
+    /// subprocess, permission, or configuration failures. Older payloads that
+    /// omit that list retain their summary count.
+    static func actionableErrorCount(in document: [String: Any]) -> Int {
+        if let errors = document["errors"] as? [Any] {
+            return errors.reduce(into: 0) { count, error in
+                if !isNonActionableCapabilityNote(error, in: document) {
+                    count += 1
+                }
+            }
+        }
+        let summary = document["summary"] as? [String: Any]
+        if let count = summary?["errors"] as? Int { return max(0, count) }
+        if let count = summary?["errors"] as? NSNumber { return max(0, count.intValue) }
+        return 0
+    }
+
+    /// Collapse the runtime's per-connector aggregate warnings into one
+    /// accurate warning while preserving every unrelated diagnostic line.
+    static func userFacingDiagnostics(from result: InventoryOutputParseResult) -> String {
+        var removedAggregateWarning = false
+        var lines = result.diagnostics.components(separatedBy: .newlines).filter { line in
+            if isAggregateInventoryFailureWarning(line) {
+                removedAggregateWarning = true
+                return false
+            }
+            return !line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+
+        let failureCount = result.documents.reduce(0) {
+            $0 + actionableErrorCount(in: $1)
+        }
+        if removedAggregateWarning, failureCount > 0 {
+            lines.insert(
+                "Warning: \(failureCount) connector inventory command(s) failed",
+                at: 0
+            )
+        }
+        return lines.joined(separator: "\n")
+    }
 
     /// First syntactically valid top-level JSON array in mixed CLI output.
     /// Diagnostics may contain stray brackets before the real payload.
@@ -78,6 +132,36 @@ enum InventoryOutputParser {
         document["connector"] != nil
             || document["claw_mode"] != nil
             || document["summary"] != nil
+    }
+
+    private static func isNonActionableCapabilityNote(
+        _ value: Any,
+        in document: [String: Any]
+    ) -> Bool {
+        guard let error = value as? [String: Any],
+              let command = error["command"] as? String,
+              let message = error["error"] as? String
+        else { return false }
+
+        let connector = (document["connector"] as? String)
+            ?? (document["claw_mode"] as? String)
+            ?? ""
+        guard !connector.isEmpty else { return false }
+
+        return nonActionableCapabilityNotes.contains { category, expectedMessage in
+            command.caseInsensitiveCompare("\(connector):\(category)") == .orderedSame
+                && message == expectedMessage
+        }
+    }
+
+    private static func isAggregateInventoryFailureWarning(_ line: String) -> Bool {
+        let value = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefix = "Warning: "
+        let suffix = " connector inventory command(s) failed"
+        guard value.hasPrefix(prefix), value.hasSuffix(suffix) else { return false }
+        let countStart = value.index(value.startIndex, offsetBy: prefix.count)
+        let countEnd = value.index(value.endIndex, offsetBy: -suffix.count)
+        return Int(value[countStart..<countEnd]) != nil
     }
 
     private struct CandidateRange {

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/Models.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/Models.swift
@@ -508,34 +508,6 @@ struct ActivityMutation: Identifiable, Sendable, Hashable {
     var connector: String = ""
 }
 
-enum StructuredDetailParser {
-    static func pairs(_ details: String) -> [(String, String)] {
-        details.split(whereSeparator: \.isWhitespace).compactMap { token in
-            let components = token.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
-            guard components.count == 2 else { return nil }
-            let key = String(components[0])
-            let value = String(components[1])
-                .trimmingCharacters(in: CharacterSet(charactersIn: "\"'`"))
-            guard !key.isEmpty, !value.isEmpty else { return nil }
-            return (label(key), value)
-        }
-    }
-
-    static func prettyJSON(_ raw: String) -> String {
-        guard let data = raw.data(using: .utf8),
-              let object = try? JSONSerialization.jsonObject(with: data),
-              JSONSerialization.isValidJSONObject(object),
-              let pretty = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys]),
-              let text = String(data: pretty, encoding: .utf8)
-        else { return raw }
-        return text
-    }
-
-    static func label(_ key: String) -> String {
-        key.split(separator: "_").map { $0.capitalized }.joined(separator: " ")
-    }
-}
-
 // MARK: - Logs
 
 enum LogStream: String, CaseIterable, Identifiable {
@@ -710,8 +682,35 @@ struct AIUsageSnapshot: Sendable {
         return "The scan did not complete, so results may be incomplete."
     }
 
+    var isPartial: Bool {
+        result.trimmingCharacters(in: .whitespacesAndNewlines)
+            .caseInsensitiveCompare("partial") == .orderedSame
+            || errors > 0
+            || !detectorErrors.isEmpty
+    }
+
+    var reportedDiscoveryErrorCount: Int {
+        max(errors, detectorErrors.count)
+    }
+
+    var discoveryIssueLabel: String {
+        let count = reportedDiscoveryErrorCount
+        if count > 0 { return "\(count) error\(count == 1 ? "" : "s")" }
+        return isPartial ? "Scan did not complete" : "0 errors"
+    }
+
+    var partialDiscoveryDescription: String {
+        let count = reportedDiscoveryErrorCount
+        if count > 0 {
+            return "\(count) error\(count == 1 ? "" : "s") occurred during discovery."
+        }
+        return "The scan did not complete, so results may be incomplete."
+    }
+
     /// Non-model discoveries stay in the existing one-row-per-product table.
     var rows: [AIDiscoveryRow] { AIDiscoveryGrouping.rows(from: signals) }
+
+    var modelRows: [AIModelDiscoveryRow] { AIDiscoveryGrouping.modelRows(from: signals) }
 
     /// TUI `header_parts`: a reported zero remains `active=0`; churn counters
     /// only appear when non-zero.
@@ -724,10 +723,6 @@ struct AIUsageSnapshot: Sendable {
         parts.append("model-lookup=\(lookupModelProvenanceOnline ? "online" : "offline")")
         return parts
     }
-
-    /// Local model signals use a dedicated compact table so high-cardinality
-    /// model IDs and lineage metadata do not crowd the product inventory.
-    var modelRows: [AIModelDiscoveryRow] { AIDiscoveryGrouping.modelRows(from: signals) }
 }
 
 /// The diagnostic subset of an AI-discovery summary. Keeping coercion in the
@@ -742,7 +737,9 @@ struct AIDiscoveryDiagnostics: Sendable, Hashable {
         let errors = Int(clamping: AIUsageValueDecoding.nonnegativeInt64(raw["errors"]))
         let detectorErrors: [String: String]
         if let values = raw["detector_errors"] as? [String: String] {
-            detectorErrors = values.filter { !$0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            detectorErrors = values.filter {
+                !$0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }
         } else if let values = raw["detector_errors"] as? [String: Any] {
             detectorErrors = values.reduce(into: [:]) { decoded, entry in
                 guard let message = entry.value as? String,
@@ -1090,7 +1087,6 @@ enum AISignalDecoding {
         if let value = raw as? String { return value.isEmpty ? [] : [value] }
         return (raw as? [Any])?.compactMap { $0 as? String } ?? []
     }
-
 }
 
 /// Grouped product row — exact port of the TUI's AIDiscoveryRow (_rebuild()).
@@ -1526,11 +1522,11 @@ enum AIDiscoveryGrouping {
             if !value.isEmpty { parts.append("\(label)=\(value)") }
         }
         if let confidence = model.discoveryConfidence {
-            let percent = AIConfidence.percent(
+            let percentage = AIConfidence.percent(
                 confidence,
                 roundingRule: .toNearestOrAwayFromZero
             )
-            parts.append("discovery_confidence=\(percent)%")
+            parts.append("discovery_confidence=\(percentage)%")
         }
         if model.sizeBytes > 0 { parts.append("size_bytes=\(model.sizeBytes)") }
         if model.pinned { parts.append("pinned=true") }
@@ -1584,22 +1580,15 @@ enum AIDiscoveryGrouping {
         return Int64(exactly: seconds)
     }
 
-    /// Port of AIDiscoveryPanelModel._rebuild(): group non-model signals by
-    /// (state, product, vendor, ecosystem, component, version); aggregate
-    /// unique categories/detectors in first-seen order; sort by state
-    /// weight, then count desc, then product. Identified `local_model` signals
-    /// move to `modelRows(from:)`; compatible non-local signals that happen to
-    /// carry model metadata remain product rows.
+    /// Port of AIDiscoveryPanelModel._rebuild(): group by
+    /// (state, product, vendor, ecosystem, component, version, model ID);
+    /// aggregate unique values in first-seen order; sort by state weight,
+    /// count descending, product, then model ID.
     static func rows(from signals: [AISignal]) -> [AIDiscoveryRow] {
         var groups: [GroupKey: AIDiscoveryRow] = [:]
         var order: [GroupKey] = []
         for signal in signals {
-            if signal.category == "local_model",
-               let model = signal.model,
-               !model.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                continue
-            }
-            let modelID = ""
+            let modelID = signal.model?.id ?? ""
             let key = GroupKey(
                 state: signal.state,
                 product: signal.product,
@@ -1656,6 +1645,91 @@ enum AIDiscoveryGrouping {
         }.map(\.1)
     }
 }
+
+extension AIDiscoveryGrouping {
+
+    /// Collapse case variants of the same local-model ID across file, API, and
+    /// runtime detectors, surfacing the most actionable lifecycle state.
+    static func modelRows(from signals: [AISignal]) -> [AIModelDiscoveryRow] {
+        var groups: [AIModelDiscoveryRowID: AIModelDiscoveryRow] = [:]
+        var order: [AIModelDiscoveryRowID] = []
+        for signal in signals {
+            guard signal.category == "local_model",
+                  let model = signal.model
+            else { continue }
+            let modelID = model.id.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !modelID.isEmpty else { continue }
+            let key = AIModelDiscoveryRowID(
+                normalizedModelID: normalizedModelID(modelID)
+            )
+            var row = groups[key] ?? AIModelDiscoveryRow(
+                state: signal.state,
+                modelID: modelID,
+                statuses: [], formats: [], providers: [], products: [], vendors: [], detectors: [],
+                count: 0, provenance: nil, lastActive: nil, signals: []
+            )
+            if groups[key] == nil { order.append(key) }
+            if stateWeight(signal.state) < stateWeight(row.state) {
+                row.state = signal.state
+            }
+            row.count += 1
+            row.signals.append(signal)
+            appendUnique(model.status, to: &row.statuses)
+            appendUnique(model.format, to: &row.formats)
+            appendUnique(model.provider, to: &row.providers)
+            appendUnique(signal.product, to: &row.products)
+            appendUnique(signal.vendor, to: &row.vendors)
+            appendUnique(signal.detector, to: &row.detectors)
+            if prefersModelProvenance(model.provenance, over: row.provenance) {
+                let provenance = model.provenance
+                row.provenance = provenance
+            }
+            if let active = signal.lastActive, row.lastActive.map({ active > $0 }) ?? true {
+                row.lastActive = active
+            }
+            groups[key] = row
+        }
+        return order.compactMap { groups[$0] }.sorted {
+            (stateWeight($0.state), normalizedModelID($0.modelID))
+                < (stateWeight($1.state), normalizedModelID($1.modelID))
+        }
+    }
+
+    static func normalizedModelID(_ value: String) -> String {
+        value.folding(
+            options: [.caseInsensitive],
+            locale: Locale(identifier: "en_US_POSIX")
+        ).lowercased()
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String]) {
+        guard !value.isEmpty, !values.contains(value) else { return }
+        values.append(value)
+    }
+
+    private static func prefersModelProvenance(
+        _ candidate: AIModelProvenance?,
+        over current: AIModelProvenance?
+    ) -> Bool {
+        guard let candidate else { return false }
+        guard let current else { return true }
+        let confidenceRank = ["low": 1, "medium": 2, "high": 3]
+        func score(_ provenance: AIModelProvenance) -> (Int, Int) {
+            let populated = [
+                !provenance.publisher.isEmpty,
+                !provenance.countryCode.isEmpty,
+                !provenance.rootModel.isEmpty,
+                !provenance.baseModels.isEmpty,
+                !provenance.quantization.isEmpty,
+                !provenance.derivation.isEmpty,
+                !provenance.source.isEmpty,
+            ].filter { $0 }.count
+            return (confidenceRank[provenance.confidence.lowercased(), default: 0], populated)
+        }
+        return score(candidate) > score(current)
+    }
+}
+
 
 /// TUI-equivalent ordering and evidence deduplication for the Overview card.
 /// The card is explicitly agent-only; local models stay visible in the full
@@ -1811,91 +1885,6 @@ enum AIOverviewGrouping {
     private static func trimmed(_ value: String) -> String {
         value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
-
-}
-
-extension AIDiscoveryGrouping {
-
-    /// Collapse case variants of the same local-model ID across file, API, and
-    /// runtime detectors, surfacing the most actionable lifecycle state.
-    static func modelRows(from signals: [AISignal]) -> [AIModelDiscoveryRow] {
-        var groups: [AIModelDiscoveryRowID: AIModelDiscoveryRow] = [:]
-        var order: [AIModelDiscoveryRowID] = []
-        for signal in signals {
-            guard signal.category == "local_model",
-                  let model = signal.model
-            else { continue }
-            let modelID = model.id.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !modelID.isEmpty else { continue }
-            let key = AIModelDiscoveryRowID(
-                normalizedModelID: normalizedModelID(modelID)
-            )
-            var row = groups[key] ?? AIModelDiscoveryRow(
-                state: signal.state,
-                modelID: modelID,
-                statuses: [], formats: [], providers: [], products: [], vendors: [], detectors: [],
-                count: 0, provenance: nil, lastActive: nil, signals: []
-            )
-            if groups[key] == nil { order.append(key) }
-            if stateWeight(signal.state) < stateWeight(row.state) {
-                row.state = signal.state
-            }
-            row.count += 1
-            row.signals.append(signal)
-            appendUnique(model.status, to: &row.statuses)
-            appendUnique(model.format, to: &row.formats)
-            appendUnique(model.provider, to: &row.providers)
-            appendUnique(signal.product, to: &row.products)
-            appendUnique(signal.vendor, to: &row.vendors)
-            appendUnique(signal.detector, to: &row.detectors)
-            if prefersModelProvenance(model.provenance, over: row.provenance) {
-                let provenance = model.provenance
-                row.provenance = provenance
-            }
-            if let active = signal.lastActive, row.lastActive.map({ active > $0 }) ?? true {
-                row.lastActive = active
-            }
-            groups[key] = row
-        }
-        return order.compactMap { groups[$0] }.sorted {
-            (stateWeight($0.state), normalizedModelID($0.modelID))
-                < (stateWeight($1.state), normalizedModelID($1.modelID))
-        }
-    }
-
-    static func normalizedModelID(_ value: String) -> String {
-        value.folding(
-            options: [.caseInsensitive],
-            locale: Locale(identifier: "en_US_POSIX")
-        ).lowercased()
-    }
-
-    private static func appendUnique(_ value: String, to values: inout [String]) {
-        guard !value.isEmpty, !values.contains(value) else { return }
-        values.append(value)
-    }
-
-    private static func prefersModelProvenance(
-        _ candidate: AIModelProvenance?,
-        over current: AIModelProvenance?
-    ) -> Bool {
-        guard let candidate else { return false }
-        guard let current else { return true }
-        let confidenceRank = ["low": 1, "medium": 2, "high": 3]
-        func score(_ provenance: AIModelProvenance) -> (Int, Int) {
-            let populated = [
-                !provenance.publisher.isEmpty,
-                !provenance.countryCode.isEmpty,
-                !provenance.rootModel.isEmpty,
-                !provenance.baseModels.isEmpty,
-                !provenance.quantization.isEmpty,
-                !provenance.derivation.isEmpty,
-                !provenance.source.isEmpty,
-            ].filter { $0 }.count
-            return (confidenceRank[provenance.confidence.lowercased(), default: 0], populated)
-        }
-        return score(candidate) > score(current)
-    }
 }
 
 // MARK: - Inventory
@@ -2020,13 +2009,32 @@ enum GatewayError: LocalizedError {
         switch self {
         case .offline: "Gateway unreachable — is the DefenseClaw gateway running?"
         case .unauthorized: "Gateway token rejected. The token in config.yaml may have been rotated."
-        case .degraded(let status, _):
-            status == 502
-                ? "The gateway could not reach the connector agent (HTTP 502). Skill and tool catalogs need a running OpenClaw agent."
-                : "Gateway error (HTTP \(status))."
+        case .degraded(let status, let body):
+            if let message = GatewayErrorBody.userFacingMessage(status: status, body: body) {
+                message
+            } else if status == 502 {
+                "The gateway could not reach the connector agent (HTTP 502). Skill and tool catalogs need a running OpenClaw agent."
+            } else {
+                "Gateway error (HTTP \(status))."
+            }
         case .timeout: "Gateway request timed out."
         case .badResponse(let why): "Unexpected gateway response: \(why)"
         }
+    }
+}
+
+enum GatewayErrorBody {
+    static func userFacingMessage(status: Int, body: String) -> String? {
+        guard status == 503,
+              let data = body.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let message = object["error"] as? String,
+              message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                == "ai discovery disabled"
+        else {
+            return nil
+        }
+        return "AI Discovery is disabled. Enable it before starting a scan."
     }
 }
 

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/Models.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/Models.swift
@@ -682,31 +682,6 @@ struct AIUsageSnapshot: Sendable {
         return "The scan did not complete, so results may be incomplete."
     }
 
-    var isPartial: Bool {
-        result.trimmingCharacters(in: .whitespacesAndNewlines)
-            .caseInsensitiveCompare("partial") == .orderedSame
-            || errors > 0
-            || !detectorErrors.isEmpty
-    }
-
-    var reportedDiscoveryErrorCount: Int {
-        max(errors, detectorErrors.count)
-    }
-
-    var discoveryIssueLabel: String {
-        let count = reportedDiscoveryErrorCount
-        if count > 0 { return "\(count) error\(count == 1 ? "" : "s")" }
-        return isPartial ? "Scan did not complete" : "0 errors"
-    }
-
-    var partialDiscoveryDescription: String {
-        let count = reportedDiscoveryErrorCount
-        if count > 0 {
-            return "\(count) error\(count == 1 ? "" : "s") occurred during discovery."
-        }
-        return "The scan did not complete, so results may be incomplete."
-    }
-
     /// Non-model discoveries stay in the existing one-row-per-product table.
     var rows: [AIDiscoveryRow] { AIDiscoveryGrouping.rows(from: signals) }
 

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/RegistryStore.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/RegistryStore.swift
@@ -17,6 +17,22 @@
 import Foundation
 
 enum RegistryStore {
+    struct Limits: Sendable {
+        var maximumIndexBytes: Int
+        var maximumEntriesPerIndex: Int
+        var maximumAggregateIndexBytes: Int
+        var maximumAggregateEntries: Int
+        var maximumJSONNestingDepth: Int
+
+        static let production = Limits(
+            maximumIndexBytes: 4 * 1024 * 1024,
+            maximumEntriesPerIndex: 10_000,
+            maximumAggregateIndexBytes: 16 * 1024 * 1024,
+            maximumAggregateEntries: 25_000,
+            maximumJSONNestingDepth: 64
+        )
+    }
+
     static func load(config: DefenseClawConfig, dataDirectory: URL) -> RegistrySnapshot {
         load(
             sources: config.registrySources,
@@ -26,10 +42,12 @@ enum RegistryStore {
 
     static func load(
         sources: [DefenseClawConfig.RegistrySourceConfig],
-        dataDirectory: URL
+        dataDirectory: URL,
+        limits: Limits = .production
     ) -> RegistrySnapshot {
         var loadedSources: [RegistrySource] = []
         var loadedEntries: [RegistryEntry] = []
+        var aggregateIndexBytes = 0
 
         for sourceConfig in sources.sorted(by: { $0.id.localizedStandardCompare($1.id) == .orderedAscending }) {
             var source = RegistrySource(
@@ -48,7 +66,25 @@ enum RegistryStore {
             do {
                 let cacheURL = try indexURL(dataDirectory: dataDirectory, sourceID: source.id)
                 if FileManager.default.fileExists(atPath: cacheURL.path) {
-                    let index = try decodeIndex(data: Data(contentsOf: cacheURL), sourceID: source.id)
+                    let data = try readIndexData(at: cacheURL, maximumBytes: limits.maximumIndexBytes)
+                    guard data.count <= limits.maximumAggregateIndexBytes,
+                          aggregateIndexBytes <= limits.maximumAggregateIndexBytes - data.count
+                    else {
+                        throw RegistryStoreError.aggregateLimitExceeded(
+                            kind: "index bytes",
+                            maximum: limits.maximumAggregateIndexBytes
+                        )
+                    }
+                    let index = try decodeIndex(data: data, sourceID: source.id, limits: limits)
+                    guard index.entries.count <= limits.maximumAggregateEntries,
+                          loadedEntries.count <= limits.maximumAggregateEntries - index.entries.count
+                    else {
+                        throw RegistryStoreError.aggregateLimitExceeded(
+                            kind: "entries",
+                            maximum: limits.maximumAggregateEntries
+                        )
+                    }
+                    aggregateIndexBytes += data.count
                     source.fetchedAt = index.fetchedAt
                     source.publisher = index.publisher
                     source.entryCount = index.entryCount
@@ -86,6 +122,18 @@ enum RegistryStore {
     }
 
     static func decodeIndex(data: Data, sourceID: String) throws -> RegistryIndex {
+        try decodeIndex(data: data, sourceID: sourceID, limits: .production)
+    }
+
+    static func decodeIndex(data: Data, sourceID: String, limits: Limits) throws -> RegistryIndex {
+        guard data.count <= limits.maximumIndexBytes else {
+            throw RegistryStoreError.indexTooLarge(
+                actual: data.count,
+                maximum: limits.maximumIndexBytes
+            )
+        }
+        try validateJSONNesting(data, maximumDepth: limits.maximumJSONNestingDepth)
+
         let raw: Any
         do {
             raw = try JSONSerialization.jsonObject(with: data)
@@ -94,6 +142,14 @@ enum RegistryStore {
         }
         guard let document = raw as? [String: Any] else {
             throw RegistryStoreError.invalidDocument
+        }
+
+        let rawRows = document["verdicts"] as? [Any] ?? []
+        guard rawRows.count <= limits.maximumEntriesPerIndex else {
+            throw RegistryStoreError.tooManyEntries(
+                actual: rawRows.count,
+                maximum: limits.maximumEntriesPerIndex
+            )
         }
 
         let rows = (document["verdicts"] as? [[String: Any]] ?? []).map { row in
@@ -125,6 +181,54 @@ enum RegistryStore {
             errorCount: integer(document["error_count"], defaultValue: rows.filter { $0.status == "error" }.count),
             entries: rows
         )
+    }
+
+    private static func readIndexData(at url: URL, maximumBytes: Int) throws -> Data {
+        if let fileSize = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+           fileSize > maximumBytes {
+            throw RegistryStoreError.indexTooLarge(actual: fileSize, maximum: maximumBytes)
+        }
+
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        let data = try handle.read(upToCount: maximumBytes + 1) ?? Data()
+        guard data.count <= maximumBytes else {
+            throw RegistryStoreError.indexTooLarge(actual: data.count, maximum: maximumBytes)
+        }
+        return data
+    }
+
+    private static func validateJSONNesting(_ data: Data, maximumDepth: Int) throws {
+        var depth = 0
+        var inString = false
+        var escaped = false
+
+        for byte in data {
+            if inString {
+                if escaped {
+                    escaped = false
+                } else if byte == 0x5C {
+                    escaped = true
+                } else if byte == 0x22 {
+                    inString = false
+                }
+                continue
+            }
+
+            switch byte {
+            case 0x22:
+                inString = true
+            case 0x5B, 0x7B:
+                depth += 1
+                guard depth <= maximumDepth else {
+                    throw RegistryStoreError.nestingTooDeep(maximum: maximumDepth)
+                }
+            case 0x5D, 0x7D:
+                depth = max(0, depth - 1)
+            default:
+                break
+            }
+        }
     }
 
     private static func string(_ value: Any?) -> String {
@@ -164,6 +268,10 @@ struct RegistryIndex: Sendable {
 
 enum RegistryStoreError: LocalizedError {
     case unsafeSourceID(String)
+    case indexTooLarge(actual: Int, maximum: Int)
+    case tooManyEntries(actual: Int, maximum: Int)
+    case nestingTooDeep(maximum: Int)
+    case aggregateLimitExceeded(kind: String, maximum: Int)
     case invalidJSON(String)
     case invalidDocument
 
@@ -171,6 +279,14 @@ enum RegistryStoreError: LocalizedError {
         switch self {
         case .unsafeSourceID(let sourceID):
             "Unsafe registry source ID: \(sourceID)"
+        case .indexTooLarge(let actual, let maximum):
+            "Registry index is too large (\(actual) bytes; maximum \(maximum))."
+        case .tooManyEntries(let actual, let maximum):
+            "Registry index has too many entries (\(actual); maximum \(maximum))."
+        case .nestingTooDeep(let maximum):
+            "Registry index JSON nesting exceeds the maximum depth of \(maximum)."
+        case .aggregateLimitExceeded(let kind, let maximum):
+            "Registry cache exceeds the aggregate \(kind) limit of \(maximum)."
         case .invalidJSON(let detail):
             "Invalid registry index JSON: \(detail)"
         case .invalidDocument:

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/RuntimeInstaller.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/RuntimeInstaller.swift
@@ -272,44 +272,6 @@ struct RuntimePayload: Sendable {
     }
 }
 
-/// Produces the runnable, signed-release resolver command shared by native-app
-/// upgrade surfaces. The release tag is validated before URL interpolation.
-enum RuntimeUpgradeResolverCommand {
-    static func authenticated(releaseTag: String) -> String? {
-        let tag = releaseTag.hasPrefix("v") ? String(releaseTag.dropFirst()) : releaseTag
-        guard tag.range(
-            of: #"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"#,
-            options: .regularExpression
-        ) != nil else { return nil }
-        let assetBase = "https://github.com/cisco-ai-defense/defenseclaw/releases/download/\(tag)"
-        return """
-        (
-          set -eu
-          unset VERSION
-          umask 077
-          command -v cosign >/dev/null
-          checksums="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --tlsv1.2 '\(assetBase)/checksums.txt')"
-          signature="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --tlsv1.2 '\(assetBase)/checksums.txt.sig')"
-          certificate="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --tlsv1.2 '\(assetBase)/checksums.txt.pem')"
-          resolver="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --tlsv1.2 '\(assetBase)/defenseclaw-upgrade.sh')"
-          cosign verify-blob --certificate <(printf '%s\\n' "$certificate") --signature <(printf '%s\\n' "$signature") --certificate-identity 'https://github.com/cisco-ai-defense/defenseclaw/.github/workflows/release.yaml@refs/heads/main' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' <(printf '%s\\n' "$checksums")
-          line="$(printf '%s\\n' "$checksums" | grep -E '^[0-9a-f]{64}  defenseclaw-upgrade[.]sh$')"
-          [ "$(printf '%s\\n' "$line" | wc -l | tr -d ' ')" = 1 ]
-          expected="${line%% *}"
-          if command -v sha256sum >/dev/null; then
-            actual="$(printf '%s\\n' "$resolver" | sha256sum | awk '{print $1}')"
-          else
-            actual="$(printf '%s\\n' "$resolver" | shasum -a 256 | awk '{print $1}')"
-          fi
-          [ "$actual" = "$expected" ]
-          [ "$(printf '%s\\n' "$resolver" | tail -n 1)" = '# DefenseClaw upgrade resolver complete v1' ]
-          bash -n <(printf '%s\\n' "$resolver")
-          bash <(printf '%s\\n' "$resolver") --yes
-        )
-        """
-    }
-}
-
 struct RuntimeAuditRecoveryTarget {
     let homeRoot: URL
     let configURL: URL
@@ -611,6 +573,16 @@ extension AppState {
                 mode: 0o600,
                 expectedSourceSHA256: payload.dependencyLockSHA256
             )
+            if let overridesURL = payload.overridesURL,
+               let overridesSHA256 = payload.overridesSHA256 {
+                _ = try RuntimeInstallFilesystem.installRegularFileNoReplace(
+                    source: overridesURL.path,
+                    destination: dataHome + "/dependency-overrides-\(payload.version).txt",
+                    expectedParentIdentity: dataHomeIdentity,
+                    mode: 0o600,
+                    expectedSourceSHA256: overridesSHA256
+                )
+            }
         } catch {
             if let materializedWheelIdentity {
                 _ = RuntimeInstallFilesystem.cleanupOwnedPath(
@@ -1125,7 +1097,7 @@ extension AppState {
     }
 
     private static func existingRuntimeRefusal(marker: String, payload: RuntimePayload) -> String {
-        guard let resolverCommand = RuntimeUpgradeResolverCommand.authenticated(
+        guard let resolverCommand = authenticatedRuntimeUpgradeResolverCommand(
             releaseTag: payload.tag
         ) else {
             return """
@@ -1143,4 +1115,49 @@ extension AppState {
         """
     }
 
+    /// Produce only the runnable, signed-release resolver command shared by
+    /// every native-app refusal surface. Returning nil prevents a release tag
+    /// from being interpolated into a URL unless it is canonical SemVer.
+    static func authenticatedRuntimeUpgradeResolverCommand(releaseTag: String) -> String? {
+        RuntimeUpgradeResolverCommand.authenticated(releaseTag: releaseTag)
+    }
+
+}
+
+/// Produces the runnable, signed-release resolver command shared by native-app
+/// upgrade surfaces. The release tag is validated before URL interpolation.
+enum RuntimeUpgradeResolverCommand {
+    static func authenticated(releaseTag: String) -> String? {
+        let tag = releaseTag.hasPrefix("v") ? String(releaseTag.dropFirst()) : releaseTag
+        guard tag.range(
+            of: #"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"#,
+            options: .regularExpression
+        ) != nil else { return nil }
+        let assetBase = "https://github.com/cisco-ai-defense/defenseclaw/releases/download/\(tag)"
+        return """
+        (
+          set -eu
+          unset VERSION
+          umask 077
+          command -v cosign >/dev/null
+          checksums="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --tlsv1.2 '\(assetBase)/checksums.txt')"
+          signature="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --tlsv1.2 '\(assetBase)/checksums.txt.sig')"
+          certificate="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --tlsv1.2 '\(assetBase)/checksums.txt.pem')"
+          resolver="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --tlsv1.2 '\(assetBase)/defenseclaw-upgrade.sh')"
+          cosign verify-blob --certificate <(printf '%s\\n' "$certificate") --signature <(printf '%s\\n' "$signature") --certificate-identity 'https://github.com/cisco-ai-defense/defenseclaw/.github/workflows/release.yaml@refs/heads/main' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' <(printf '%s\\n' "$checksums")
+          line="$(printf '%s\\n' "$checksums" | grep -E '^[0-9a-f]{64}  defenseclaw-upgrade[.]sh$')"
+          [ "$(printf '%s\\n' "$line" | wc -l | tr -d ' ')" = 1 ]
+          expected="${line%% *}"
+          if command -v sha256sum >/dev/null; then
+            actual="$(printf '%s\\n' "$resolver" | sha256sum | awk '{print $1}')"
+          else
+            actual="$(printf '%s\\n' "$resolver" | shasum -a 256 | awk '{print $1}')"
+          fi
+          [ "$actual" = "$expected" ]
+          [ "$(printf '%s\\n' "$resolver" | tail -n 1)" = '# DefenseClaw upgrade resolver complete v1' ]
+          bash -n <(printf '%s\\n' "$resolver")
+          bash <(printf '%s\\n' "$resolver") --yes
+        )
+        """
+    }
 }

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/RuntimeInstaller.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/RuntimeInstaller.swift
@@ -25,12 +25,37 @@
 import CryptoKit
 import Foundation
 
+enum ProtectedArtifactError: Error, Equatable, LocalizedError {
+    case invalidEnvelope
+    case emptyPayload
+    case checksumMismatch
+    case invalidSize
+    case outputCreationFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidEnvelope:
+            return "Protected artifact header is invalid."
+        case .emptyPayload:
+            return "Protected artifact contains no payload."
+        case .checksumMismatch:
+            return "Protected artifact changed after verification."
+        case .invalidSize:
+            return "Protected artifact size is invalid."
+        case .outputCreationFailed:
+            return "Could not create a private decoded artifact."
+        }
+    }
+}
+
 /// The runtime release embedded in the app bundle at build time.
 struct RuntimePayload: Sendable {
     static let protectedArtifactMagic = Data(
         "DEFENSECLAW-PROTECTED-ARTIFACT-V1\n".utf8
     )
     static let protectedArtifactXORByte: UInt8 = 0xA5
+    static let maximumProtectedArtifactBytes: Int64 = 512 * 1024 * 1024
+
     var version: String
     var tag: String
     var arch: String
@@ -40,10 +65,15 @@ struct RuntimePayload: Sendable {
     var wheelSHA256: String
     /// Optional dependency overrides — upstream pyproject's [tool.uv]
     /// override-dependencies (CVE floors + the textual>=8.2.7 pin the
-    /// wheel's own scanner constraint would defeat). Applied with
-    /// `uv pip install --overrides` to reproduce upstream's resolution.
+    /// wheel's own scanner constraint would defeat). Retained as provenance
+    /// for the build-generated dependency lock; never resolved again on-device.
     var overridesURL: URL?
     var overridesSHA256: String?
+    /// Build-time resolution output for the target macOS/Python platform.
+    /// Every dependency is version-pinned and includes accepted SHA-256
+    /// distribution hashes; the root wheel remains separately authenticated.
+    var dependencyLockURL: URL
+    var dependencyLockSHA256: String
 
     /// Loaded once per launch — the bundle is immutable while running.
     static let bundled: RuntimePayload? = load()
@@ -61,6 +91,10 @@ struct RuntimePayload: Sendable {
               let wheel = root["wheel"] as? [String: Any],
               let wheelFile = wheel["file"] as? String,
               let wheelSHA = wheel["sha256"] as? String,
+              let dependencyLock = root["dependency_lock"] as? [String: Any],
+              let dependencyLockFile = dependencyLock["file"] as? String,
+              let dependencyLockSHA = dependencyLock["sha256"] as? String,
+              dependencyLockFile == "runtime-requirements.lock",
               wheelFile == "defenseclaw-\(version)-2-py3-none-any.dcwheel"
         else { return nil }
         let overrides = root["overrides"] as? [String: Any]
@@ -74,7 +108,9 @@ struct RuntimePayload: Sendable {
             wheelURL: payloadDir.appendingPathComponent(wheelFile),
             wheelSHA256: wheelSHA,
             overridesURL: overridesFile.map(payloadDir.appendingPathComponent),
-            overridesSHA256: overrides?["sha256"] as? String
+            overridesSHA256: overrides?["sha256"] as? String,
+            dependencyLockURL: payloadDir.appendingPathComponent(dependencyLockFile),
+            dependencyLockSHA256: dependencyLockSHA
         )
     }
 
@@ -106,6 +142,12 @@ struct RuntimePayload: Sendable {
                 return "Bundled dependency overrides do not match their manifest checksum."
             }
         }
+        guard let lockActual = Self.sha256(of: dependencyLockURL) else {
+            return "Bundled runtime dependency lock is missing or unreadable."
+        }
+        guard lockActual == dependencyLockSHA256 else {
+            return "Bundled runtime dependency lock does not match its manifest checksum."
+        }
         return nil
     }
 
@@ -113,30 +155,208 @@ struct RuntimePayload: Sendable {
         guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
         defer { try? handle.close() }
         var hasher = SHA256()
-        while let chunk = try? handle.read(upToCount: 4 << 20), !chunk.isEmpty {
-            hasher.update(data: chunk)
+        do {
+            while let chunk = try handle.read(upToCount: 4 << 20), !chunk.isEmpty {
+                hasher.update(data: chunk)
+            }
+        } catch {
+            return nil
         }
         return hasher.finalize().map { String(format: "%02x", $0) }.joined()
     }
 
+    static func expectedProtectedWheelFilename(version: String) -> String {
+        "defenseclaw-\(version)-2-py3-none-any.dcwheel"
+    }
+
     static func protectedPayloadSHA256(of url: URL) -> String? {
+        guard let size = encodedArtifactSize(of: url),
+              protectedArtifactSizeIsAllowed(size) else { return nil }
         guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
         defer { try? handle.close() }
         guard (try? handle.read(upToCount: protectedArtifactMagic.count))
                 == protectedArtifactMagic else { return nil }
         var hasher = SHA256()
         var sawPayload = false
-        while var chunk = try? handle.read(upToCount: 4 << 20), !chunk.isEmpty {
-            sawPayload = true
-            chunk.withUnsafeMutableBytes { bytes in
-                for index in bytes.indices {
-                    bytes[index] ^= protectedArtifactXORByte
-                }
+        var encodedBytesRead = Int64(protectedArtifactMagic.count)
+        do {
+            while var chunk = try handle.read(upToCount: 4 << 20), !chunk.isEmpty {
+                encodedBytesRead += Int64(chunk.count)
+                guard encodedBytesRead <= maximumProtectedArtifactBytes else { return nil }
+                sawPayload = true
+                decodeProtectedBytes(&chunk)
+                hasher.update(data: chunk)
             }
-            hasher.update(data: chunk)
+        } catch {
+            return nil
         }
         guard sawPayload else { return nil }
         return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+    /// Decode a protected release artifact into a private installer input.
+    /// The encoded checksum is revalidated while streaming so a development
+    /// build cannot swap the artifact between the initial integrity check and
+    /// materialization.
+    static func decodeProtectedArtifact(
+        from sourceURL: URL,
+        to destinationURL: URL,
+        expectedEncodedSHA256: String
+    ) throws {
+        guard let size = encodedArtifactSize(of: sourceURL),
+              protectedArtifactSizeIsAllowed(size) else {
+            throw ProtectedArtifactError.invalidSize
+        }
+        let source = try FileHandle(forReadingFrom: sourceURL)
+        defer { try? source.close() }
+
+        guard FileManager.default.createFile(
+            atPath: destinationURL.path,
+            contents: nil,
+            attributes: [.posixPermissions: 0o600]
+        ) else {
+            throw ProtectedArtifactError.outputCreationFailed
+        }
+
+        do {
+            let destination = try FileHandle(forWritingTo: destinationURL)
+            defer { try? destination.close() }
+
+            guard let header = try source.read(upToCount: protectedArtifactMagic.count),
+                  header == protectedArtifactMagic else {
+                throw ProtectedArtifactError.invalidEnvelope
+            }
+
+            var encodedHasher = SHA256()
+            encodedHasher.update(data: header)
+            var sawPayload = false
+            var encodedBytesRead = Int64(header.count)
+            while var chunk = try source.read(upToCount: 4 << 20), !chunk.isEmpty {
+                encodedBytesRead += Int64(chunk.count)
+                guard encodedBytesRead <= maximumProtectedArtifactBytes else {
+                    throw ProtectedArtifactError.invalidSize
+                }
+                sawPayload = true
+                encodedHasher.update(data: chunk)
+                decodeProtectedBytes(&chunk)
+                try destination.write(contentsOf: chunk)
+            }
+            guard sawPayload else { throw ProtectedArtifactError.emptyPayload }
+
+            let encodedSHA = encodedHasher.finalize()
+                .map { String(format: "%02x", $0) }
+                .joined()
+            guard encodedSHA == expectedEncodedSHA256 else {
+                throw ProtectedArtifactError.checksumMismatch
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: destinationURL)
+            throw error
+        }
+    }
+
+    private static func decodeProtectedBytes(_ data: inout Data) {
+        data.withUnsafeMutableBytes { bytes in
+            for index in bytes.indices {
+                bytes[index] ^= protectedArtifactXORByte
+            }
+        }
+    }
+
+    static func protectedArtifactSizeIsAllowed(_ size: Int64) -> Bool {
+        size >= Int64(protectedArtifactMagic.count) && size <= maximumProtectedArtifactBytes
+    }
+
+    private static func encodedArtifactSize(of url: URL) -> Int64? {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+        return (attributes?[.size] as? NSNumber)?.int64Value
+    }
+}
+
+/// Produces the runnable, signed-release resolver command shared by native-app
+/// upgrade surfaces. The release tag is validated before URL interpolation.
+enum RuntimeUpgradeResolverCommand {
+    static func authenticated(releaseTag: String) -> String? {
+        let tag = releaseTag.hasPrefix("v") ? String(releaseTag.dropFirst()) : releaseTag
+        guard tag.range(
+            of: #"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"#,
+            options: .regularExpression
+        ) != nil else { return nil }
+        let assetBase = "https://github.com/cisco-ai-defense/defenseclaw/releases/download/\(tag)"
+        return """
+        (
+          set -eu
+          unset VERSION
+          umask 077
+          command -v cosign >/dev/null
+          checksums="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --tlsv1.2 '\(assetBase)/checksums.txt')"
+          signature="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --tlsv1.2 '\(assetBase)/checksums.txt.sig')"
+          certificate="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --tlsv1.2 '\(assetBase)/checksums.txt.pem')"
+          resolver="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --tlsv1.2 '\(assetBase)/defenseclaw-upgrade.sh')"
+          cosign verify-blob --certificate <(printf '%s\\n' "$certificate") --signature <(printf '%s\\n' "$signature") --certificate-identity 'https://github.com/cisco-ai-defense/defenseclaw/.github/workflows/release.yaml@refs/heads/main' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' <(printf '%s\\n' "$checksums")
+          line="$(printf '%s\\n' "$checksums" | grep -E '^[0-9a-f]{64}  defenseclaw-upgrade[.]sh$')"
+          [ "$(printf '%s\\n' "$line" | wc -l | tr -d ' ')" = 1 ]
+          expected="${line%% *}"
+          if command -v sha256sum >/dev/null; then
+            actual="$(printf '%s\\n' "$resolver" | sha256sum | awk '{print $1}')"
+          else
+            actual="$(printf '%s\\n' "$resolver" | shasum -a 256 | awk '{print $1}')"
+          fi
+          [ "$actual" = "$expected" ]
+          [ "$(printf '%s\\n' "$resolver" | tail -n 1)" = '# DefenseClaw upgrade resolver complete v1' ]
+          bash -n <(printf '%s\\n' "$resolver")
+          bash <(printf '%s\\n' "$resolver") --yes
+        )
+        """
+    }
+}
+
+struct RuntimeAuditRecoveryTarget {
+    let homeRoot: URL
+    let configURL: URL
+    let venvURL: URL
+    let runtimeCLIURL: URL
+    let installedVersion: String
+    let permitsMutation: Bool
+}
+
+/// Targets the selected installation's CLI. Modern DefenseClaw handles this
+/// flag before config/audit initialization and authenticates the release-owned
+/// recovery resolver in a sanitized environment.
+enum RuntimeAuditRecoveryCommand {
+    static func command(for target: RuntimeAuditRecoveryTarget) -> String? {
+        guard target.permitsMutation,
+              FileManager.default.isExecutableFile(atPath: target.runtimeCLIURL.path),
+              let version = normalizedVersion(target.installedVersion),
+              let home = shellQuote(target.homeRoot.path),
+              let config = shellQuote(target.configURL.path),
+              let venv = shellQuote(target.venvURL.path),
+              let cli = shellQuote(target.runtimeCLIURL.path),
+              let quotedVersion = shellQuote(version) else {
+            return nil
+        }
+        return """
+        (
+          set -eu
+          export DEFENSECLAW_HOME=\(home)
+          export DEFENSECLAW_CONFIG=\(config)
+          export DEFENSECLAW_VENV=\(venv)
+          exec \(cli) upgrade --yes --version \(quotedVersion) --recover-corrupt-audit
+        )
+        """
+    }
+
+    private static func normalizedVersion(_ value: String) -> String? {
+        let version = value.hasPrefix("v") ? String(value.dropFirst()) : value
+        guard version.range(
+            of: #"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"#,
+            options: .regularExpression
+        ) != nil else { return nil }
+        return version
+    }
+
+    private static func shellQuote(_ value: String) -> String? {
+        guard !value.contains(where: { $0.isNewline || $0 == "\0" }) else { return nil }
+        return "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
     }
 }
 
@@ -371,9 +591,9 @@ extension AppState {
 
         runtimeInstallState = .running("Materializing authenticated runtime wheel")
         let materializedWheel = dataHome + "/defenseclaw-\(payload.version)-py3-none-any.whl"
-        let materializedOverrides = dataHome + "/dependency-overrides-\(payload.version).txt"
+        let materializedDependencyLock = dataHome + "/runtime-requirements-\(payload.version).lock"
         var materializedWheelIdentity: RuntimeInstallFilesystem.PathIdentity?
-        var materializedOverridesIdentity: RuntimeInstallFilesystem.PathIdentity?
+        var materializedDependencyLockIdentity: RuntimeInstallFilesystem.PathIdentity?
         do {
             materializedWheelIdentity = try RuntimeInstallFilesystem.installRegularFileNoReplace(
                 source: payload.wheelURL.path,
@@ -384,16 +604,13 @@ extension AppState {
                 decodeXORByte: RuntimePayload.protectedArtifactXORByte,
                 expectedSourceSHA256: payload.wheelSHA256
             )
-            if let overridesURL = payload.overridesURL,
-               let overridesSHA256 = payload.overridesSHA256 {
-                materializedOverridesIdentity = try RuntimeInstallFilesystem.installRegularFileNoReplace(
-                    source: overridesURL.path,
-                    destination: materializedOverrides,
-                    expectedParentIdentity: dataHomeIdentity,
-                    mode: 0o600,
-                    expectedSourceSHA256: overridesSHA256
-                )
-            }
+            materializedDependencyLockIdentity = try RuntimeInstallFilesystem.installRegularFileNoReplace(
+                source: payload.dependencyLockURL.path,
+                destination: materializedDependencyLock,
+                expectedParentIdentity: dataHomeIdentity,
+                mode: 0o600,
+                expectedSourceSHA256: payload.dependencyLockSHA256
+            )
         } catch {
             if let materializedWheelIdentity {
                 _ = RuntimeInstallFilesystem.cleanupOwnedPath(
@@ -413,34 +630,43 @@ extension AppState {
             return
         }
 
-        runtimeInstallState = .running("Installing DefenseClaw CLI \(payload.version) (network: PyPI dependencies)")
-        var wheelArguments = ["pip", "install", "--python", stagingDir + "/bin/python"]
-        if materializedOverridesIdentity != nil {
-            // Upstream's own override-dependencies: without them a fresh
-            // resolve honors the scanner's textual<8 cap and the TUI
-            // crashes, and the CVE-driven floors are lost.
-            wheelArguments += ["--overrides", materializedOverrides]
-        }
-        wheelArguments.append(materializedWheel)
-        let wheel = await installerStep(
-            "Install DefenseClaw CLI \(payload.version) (bundled wheel + PyPI dependencies)",
+        runtimeInstallState = .running("Installing hash-locked Python dependencies (network: PyPI)")
+        let dependencies = await installerStep(
+            "Install DefenseClaw CLI \(payload.version) hash-locked dependencies",
             binary: uv,
-            arguments: wheelArguments,
-            successEffects: ["DefenseClaw CLI \(payload.version) installed"]
+            arguments: [
+                "pip", "install", "--python", stagingDir + "/bin/python",
+                "--require-hashes",
+                "--requirements", materializedDependencyLock,
+            ],
+            successEffects: ["Authenticated Python dependency set installed"]
         )
+        var wheel = dependencies
+        if dependencies.succeeded {
+            runtimeInstallState = .running("Installing authenticated DefenseClaw CLI \(payload.version)")
+            wheel = await installerStep(
+                "Install authenticated DefenseClaw CLI \(payload.version) wheel",
+                binary: uv,
+                arguments: [
+                    "pip", "install", "--python", stagingDir + "/bin/python",
+                    "--no-deps", materializedWheel,
+                ],
+                successEffects: ["DefenseClaw CLI \(payload.version) installed"]
+            )
+        }
         let wheelCleanupSucceeded = materializedWheelIdentity.map {
             RuntimeInstallFilesystem.cleanupOwnedPath(
                 materializedWheel,
                 identity: $0
             )
         } ?? false
-        let overridesCleanupSucceeded = materializedOverridesIdentity.map {
+        let dependencyLockCleanupSucceeded = materializedDependencyLockIdentity.map {
             RuntimeInstallFilesystem.cleanupOwnedPath(
-                materializedOverrides,
+                materializedDependencyLock,
                 identity: $0
             )
-        } ?? true
-        guard wheelCleanupSucceeded, overridesCleanupSucceeded else {
+        } ?? false
+        guard wheelCleanupSucceeded, dependencyLockCleanupSucceeded else {
             RuntimeInstallFilesystem.cleanupFailedFreshInstall(
                 stagingDir: stagingDir,
                 stagingIdentity: stagingIdentity,
@@ -450,6 +676,22 @@ extension AppState {
             runtimeInstallState = .failed(
                 "Private runtime input cleanup could not prove ownership; installation was not activated."
             )
+            return
+        }
+        guard dependencies.succeeded else {
+            RuntimeInstallFilesystem.cleanupFailedFreshInstall(
+                stagingDir: stagingDir,
+                stagingIdentity: stagingIdentity,
+                dataHome: dataHome,
+                removeDataHomeIfEmpty: !dataHomeExistedBeforeInstall
+            )
+            if dependencies.cancelled {
+                runtimeInstallState = .failed("Installation cancelled. No pre-existing runtime was changed; retry when ready.")
+            } else {
+                runtimeInstallState = .failed(
+                    "Hash-locked dependency install failed (exit \(dependencies.exitCode)). Only distributions matching the signed runtime lock are accepted from pypi.org / files.pythonhosted.org. Check network or proxy access; no pre-existing runtime was changed. See Activity for output."
+                )
+            }
             return
         }
         guard wheel.succeeded else {
@@ -463,7 +705,7 @@ extension AppState {
                 runtimeInstallState = .failed("Installation cancelled. No pre-existing runtime was changed; retry when ready.")
             } else {
                 runtimeInstallState = .failed(
-                    "CLI wheel install failed (exit \(wheel.exitCode)). This step downloads Python dependencies from pypi.org / files.pythonhosted.org — check network or proxy access. No pre-existing runtime was changed; retry after correcting the network issue. See Activity for output."
+                    "Authenticated CLI wheel install failed (exit \(wheel.exitCode)). Dependency resolution was not retried or widened. No pre-existing runtime was changed; see Activity for output."
                 )
             }
             return
@@ -883,7 +1125,7 @@ extension AppState {
     }
 
     private static func existingRuntimeRefusal(marker: String, payload: RuntimePayload) -> String {
-        guard let resolverCommand = authenticatedRuntimeUpgradeResolverCommand(
+        guard let resolverCommand = RuntimeUpgradeResolverCommand.authenticated(
             releaseTag: payload.tag
         ) else {
             return """
@@ -901,40 +1143,4 @@ extension AppState {
         """
     }
 
-    /// Produce only the runnable, signed-release resolver command shared by
-    /// every native-app refusal surface. Returning nil prevents a release tag
-    /// from being interpolated into a URL unless it is canonical SemVer.
-    static func authenticatedRuntimeUpgradeResolverCommand(releaseTag: String) -> String? {
-        let tag = releaseTag.hasPrefix("v") ? String(releaseTag.dropFirst()) : releaseTag
-        guard tag.range(
-            of: #"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"#,
-            options: .regularExpression
-        ) != nil else { return nil }
-        let assetBase = "https://github.com/cisco-ai-defense/defenseclaw/releases/download/\(tag)"
-        return """
-        (
-          set -eu
-          unset VERSION
-          umask 077
-          command -v cosign >/dev/null
-          checksums="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --tlsv1.2 '\(assetBase)/checksums.txt')"
-          signature="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --tlsv1.2 '\(assetBase)/checksums.txt.sig')"
-          certificate="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --tlsv1.2 '\(assetBase)/checksums.txt.pem')"
-          resolver="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --tlsv1.2 '\(assetBase)/defenseclaw-upgrade.sh')"
-          cosign verify-blob --certificate <(printf '%s\\n' "$certificate") --signature <(printf '%s\\n' "$signature") --certificate-identity 'https://github.com/cisco-ai-defense/defenseclaw/.github/workflows/release.yaml@refs/heads/main' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' <(printf '%s\\n' "$checksums")
-          line="$(printf '%s\\n' "$checksums" | grep -E '^[0-9a-f]{64}  defenseclaw-upgrade[.]sh$')"
-          [ "$(printf '%s\\n' "$line" | wc -l | tr -d ' ')" = 1 ]
-          expected="${line%% *}"
-          if command -v sha256sum >/dev/null; then
-            actual="$(printf '%s\\n' "$resolver" | sha256sum | awk '{print $1}')"
-          else
-            actual="$(printf '%s\\n' "$resolver" | shasum -a 256 | awk '{print $1}')"
-          fi
-          [ "$actual" = "$expected" ]
-          [ "$(printf '%s\\n' "$resolver" | tail -n 1)" = '# DefenseClaw upgrade resolver complete v1' ]
-          bash -n <(printf '%s\\n' "$resolver")
-          bash <(printf '%s\\n' "$resolver") --yes
-        )
-        """
-    }
 }

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/StructuredDetailParser.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/StructuredDetailParser.swift
@@ -1,0 +1,183 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+/// Parses the gateway's human-readable `key=value` detail format without
+/// mistaking metadata inside `<redacted ...>` placeholders for event fields.
+enum StructuredDetailParser {
+    private static let safeMetadataKeys: Set<String> = [
+        "action", "connector", "decision", "evaluation_id", "finding_count",
+        "findings", "max_severity", "rule_ids", "scan_id", "scanner",
+    ]
+
+    /// Parses a contiguous structured record. If the record starts with prose
+    /// or a redaction placeholder, callers should preserve it as raw text.
+    static func pairs(_ details: String) -> [(String, String)] {
+        let characters = Array(details)
+        var index = skipWhitespace(in: characters, from: 0)
+        var result: [(String, String)] = []
+
+        while index < characters.count {
+            guard let pair = parsePair(in: characters, from: index) else { break }
+            result.append((label(pair.key), displayValue(pair.value)))
+            index = skipWhitespace(in: characters, from: pair.nextIndex)
+        }
+        return result
+    }
+
+    /// Extracts only useful top-level metadata from an otherwise raw record.
+    /// Angle-bracket placeholders are skipped as a unit, so their `len` and
+    /// `sha` attributes can never become inspector rows.
+    static func safeMetadataPairs(_ details: String) -> [(String, String)] {
+        let characters = Array(details)
+        var index = 0
+        var seen = Set<String>()
+        var result: [(String, String)] = []
+
+        while index < characters.count {
+            index = skipWhitespace(in: characters, from: index)
+            guard index < characters.count else { break }
+
+            if characters[index] == "<" {
+                index = skipAngleGroup(in: characters, from: index)
+                continue
+            }
+
+            if let pair = parsePair(in: characters, from: index) {
+                let normalizedKey = pair.key.lowercased()
+                if safeMetadataKeys.contains(normalizedKey), seen.insert(normalizedKey).inserted {
+                    result.append((label(normalizedKey), displayValue(pair.value)))
+                }
+                index = pair.nextIndex
+            } else {
+                index = skipToken(in: characters, from: index)
+            }
+        }
+        return result
+    }
+
+    static func prettyJSON(_ raw: String) -> String {
+        guard let data = raw.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              JSONSerialization.isValidJSONObject(object),
+              let pretty = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys]),
+              let text = String(data: pretty, encoding: .utf8)
+        else { return raw }
+        return text
+    }
+
+    static func label(_ key: String) -> String {
+        switch key.lowercased() {
+        case "evaluation_id": return "Evaluation ID"
+        case "rule_ids": return "Rule IDs"
+        case "scan_id": return "Scan ID"
+        default:
+            return key.split(separator: "_").map { $0.capitalized }.joined(separator: " ")
+        }
+    }
+
+    private static func parsePair(
+        in characters: [Character],
+        from startIndex: Int
+    ) -> (key: String, value: String, nextIndex: Int)? {
+        var index = startIndex
+        let keyStart = index
+        while index < characters.count,
+              characters[index] != "=",
+              !characters[index].isWhitespace {
+            if characters[index] == "<" || characters[index] == ">" { return nil }
+            index += 1
+        }
+        guard index > keyStart, index < characters.count, characters[index] == "=" else { return nil }
+
+        let key = String(characters[keyStart..<index])
+        index += 1
+        guard index < characters.count else { return nil }
+
+        let valueStart = index
+        if characters[index] == "\"" || characters[index] == "'" || characters[index] == "`" {
+            let quote = characters[index]
+            index += 1
+            var value: [Character] = []
+            var escaped = false
+            while index < characters.count {
+                let character = characters[index]
+                index += 1
+                if escaped {
+                    value.append(character)
+                    escaped = false
+                } else if character == "\\" {
+                    escaped = true
+                } else if character == quote {
+                    return (key, String(value), index)
+                } else {
+                    value.append(character)
+                }
+            }
+            return nil
+        }
+
+        if characters[index] == "<" {
+            let nextIndex = skipAngleGroup(in: characters, from: index)
+            guard nextIndex > index, characters[nextIndex - 1] == ">" else { return nil }
+            return (key, String(characters[index..<nextIndex]), nextIndex)
+        }
+
+        while index < characters.count, !characters[index].isWhitespace { index += 1 }
+        guard index > valueStart else { return nil }
+        return (key, String(characters[valueStart..<index]), index)
+    }
+
+    private static func displayValue(_ value: String) -> String {
+        guard value.hasPrefix("<redacted"), value.hasSuffix(">") else { return value }
+        let body = value.dropFirst().dropLast()
+        let attributes = pairs(String(body.dropFirst("redacted".count)))
+        let length = attributes.first { $0.0 == "Len" }?.1
+        let digest = attributes.first { $0.0 == "Sha" }?.1
+        return [
+            "redacted",
+            length.map { "\($0) bytes" },
+            digest.map { "sha:\($0)" },
+        ].compactMap { $0 }.joined(separator: " · ")
+    }
+
+    private static func skipWhitespace(in characters: [Character], from startIndex: Int) -> Int {
+        var index = startIndex
+        while index < characters.count, characters[index].isWhitespace { index += 1 }
+        return index
+    }
+
+    private static func skipToken(in characters: [Character], from startIndex: Int) -> Int {
+        var index = startIndex
+        while index < characters.count, !characters[index].isWhitespace { index += 1 }
+        return index
+    }
+
+    private static func skipAngleGroup(in characters: [Character], from startIndex: Int) -> Int {
+        var index = startIndex
+        var depth = 0
+        while index < characters.count {
+            if characters[index] == "<" { depth += 1 }
+            if characters[index] == ">" {
+                depth -= 1
+                if depth == 0 { return index + 1 }
+            }
+            index += 1
+        }
+        return index
+    }
+}

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/UpdateChecker.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/UpdateChecker.swift
@@ -34,6 +34,32 @@ struct ReleaseInfo: Sendable, Equatable {
     var notes: String
 }
 
+struct RuntimeInstallerInfo: Sendable, Equatable {
+    var tag: String
+    var assetURL: URL
+    var assetSHA256: String
+    var releaseURL: URL
+
+    var localFileName: String {
+        "defenseclaw-install-\(tag).sh"
+    }
+
+    var downloadCommand: String {
+        let destination = "$HOME/Downloads/\(localFileName)"
+        let temporary = destination + ".download"
+        return "tmp=\"\(temporary)\"; dest=\"\(destination)\"; /usr/bin/curl -fL --proto '=https' --tlsv1.2 --output \"$tmp\" '\(assetURL.absoluteString)' && actual=\"$(/usr/bin/shasum -a 256 \"$tmp\" | /usr/bin/awk '{print $1}')\" && test \"$actual\" = '\(assetSHA256)' && /bin/mv -f \"$tmp\" \"$dest\""
+    }
+
+    var reviewCommand: String {
+        "/usr/bin/open -a TextEdit \"$HOME/Downloads/\(localFileName)\""
+    }
+
+    var runCommand: String {
+        let script = "$HOME/Downloads/\(localFileName)"
+        return "script=\"\(script)\"; actual=\"$(/usr/bin/shasum -a 256 \"$script\" | /usr/bin/awk '{print $1}')\"; test \"$actual\" = '\(assetSHA256)' && /bin/bash \"$script\""
+    }
+}
+
 enum UpgradeState: Equatable {
     case idle
     case checking
@@ -51,6 +77,10 @@ actor UpdateChecker {
     /// The underlying DefenseClaw runtime (CLI + gateway) — upgraded via
     /// `defenseclaw upgrade`, but version-checked against its releases here.
     static let runtimeRepo = "cisco-ai-defense/defenseclaw"
+    nonisolated static let expectedBundleIdentifier = "com.cisco.defenseclaw.macos"
+    nonisolated static let expectedTeamIdentifier = ""
+    nonisolated static let expectedCodeRequirement =
+        #"anchor apple generic and identifier "com.cisco.defenseclaw.macos""#
 
     static var currentVersion: String {
         (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "0"
@@ -83,6 +113,24 @@ actor UpdateChecker {
     /// Latest DefenseClaw runtime release (upstream repo).
     func latestRuntimeRelease() async -> ReleaseInfo? {
         await fetchLatest(repo: Self.runtimeRepo, requireSelfUpdateAsset: false)
+    }
+
+    /// Latest release-owned shell installer. Unlike a raw branch URL, this
+    /// asset is bound to the release's GitHub-provided SHA-256 digest; the
+    /// generated Terminal commands verify that digest before both review and
+    /// execution.
+    func latestRuntimeInstaller() async -> RuntimeInstallerInfo? {
+        guard let url = URL(
+            string: "https://api.github.com/repos/\(Self.runtimeRepo)/releases/latest"
+        ) else { return nil }
+        var request = URLRequest(url: url, timeoutInterval: 10)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              (response as? HTTPURLResponse)?.statusCode == 200,
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let tag = dict["tag_name"] as? String
+        else { return nil }
+        return Self.runtimeInstallerInfo(from: dict, tag: tag)
     }
 
     /// Parse "defenseclaw, version 0.7.0"-style output into "0.7.0".
@@ -145,6 +193,37 @@ actor UpdateChecker {
             let name = ($0["name"] as? String) ?? ""
             return Self.isEligibleSelfUpdateAsset(name: name, version: version)
         }
+    }
+
+    nonisolated static func runtimeInstallerInfo(
+        from dict: [String: Any],
+        tag: String
+    ) -> RuntimeInstallerInfo? {
+        guard tag.range(of: #"^[A-Za-z0-9._-]+$"#, options: .regularExpression) != nil else {
+            return nil
+        }
+        let assets = (dict["assets"] as? [[String: Any]]) ?? []
+        guard let asset = assets.first(where: { ($0["name"] as? String) == "install.sh" }),
+              let urlString = asset["browser_download_url"] as? String,
+              let assetURL = URL(string: urlString),
+              assetURL.scheme == "https",
+              assetURL.host == "github.com",
+              assetURL.path == "/cisco-ai-defense/defenseclaw/releases/download/\(tag)/install.sh"
+        else { return nil }
+        let digest = ((asset["digest"] as? String) ?? "")
+            .replacingOccurrences(of: "sha256:", with: "")
+            .lowercased()
+        guard digest.range(of: #"^[0-9a-f]{64}$"#, options: .regularExpression) != nil,
+              let releaseURL = URL(
+                  string: "https://github.com/cisco-ai-defense/defenseclaw/releases/tag/\(tag)"
+              )
+        else { return nil }
+        return RuntimeInstallerInfo(
+            tag: tag,
+            assetURL: assetURL,
+            assetSHA256: digest,
+            releaseURL: releaseURL
+        )
     }
 
     // MARK: - Download + install + restart
@@ -227,7 +306,7 @@ actor UpdateChecker {
         let newApp = unpackDir.appendingPathComponent(appName)
 
         guard let bundle = Bundle(url: newApp),
-              bundle.bundleIdentifier == "com.cisco.defenseclaw.macos",
+              bundle.bundleIdentifier == Self.expectedBundleIdentifier,
               (bundle.infoDictionary?["CFBundleShortVersionString"] as? String) == release.version
         else {
             return "The downloaded app has an unexpected bundle identifier or version."
@@ -237,7 +316,10 @@ actor UpdateChecker {
             return "The app-only update unexpectedly contains a runtime payload."
         }
         let signature = await Self.runProcess(
-            "/usr/bin/codesign", ["--verify", "--deep", "--strict", "--verbose=2", newApp.path]
+            "/usr/bin/codesign", [
+                "--verify", "--deep", "--strict", "--verbose=2",
+                "-R=\(Self.expectedCodeRequirement)", newApp.path,
+            ]
         )
         guard signature.exitCode == 0 else {
             return "The downloaded app failed code-signature verification: \(signature.output)"
@@ -264,7 +346,10 @@ actor UpdateChecker {
             return "Install failed: \(copy.output)\(rollback.map { " Rollback also failed: \($0)" } ?? "")"
         }
         let installedSignature = await Self.runProcess(
-            "/usr/bin/codesign", ["--verify", "--deep", "--strict", "--verbose=2", targetPath]
+            "/usr/bin/codesign", [
+                "--verify", "--deep", "--strict", "--verbose=2",
+                "-R=\(Self.expectedCodeRequirement)", targetPath,
+            ]
         )
         if installedSignature.exitCode != 0 {
             let rollback = Self.restoreBackup(backup: backup, targetPath: targetPath)

--- a/macos/DefenseClawMac/DefenseClawMac/DesignSystem/Components.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DesignSystem/Components.swift
@@ -19,6 +19,16 @@
 
 import SwiftUI
 
+extension View {
+    func dcInspectorColumnWidth() -> some View {
+        inspectorColumnWidth(
+            min: InspectorLayoutPolicy.minimumWidth,
+            ideal: InspectorLayoutPolicy.idealWidth,
+            max: InspectorLayoutPolicy.maximumWidth
+        )
+    }
+}
+
 struct SeverityBadge: View {
     let severity: Severity
 
@@ -246,11 +256,19 @@ struct KeyValueGrid: View {
         Grid(alignment: .leading, horizontalSpacing: 14, verticalSpacing: 5) {
             ForEach(Array(pairs.enumerated()), id: \.offset) { _, pair in
                 GridRow {
-                    Text(pair.0).font(.caption).foregroundStyle(.secondary)
-                    Text(pair.1).font(.caption).textSelection(.enabled)
+                    Text(pair.0)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: true, vertical: false)
+                    Text(pair.1)
+                        .font(.caption)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .textSelection(.enabled)
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/macos/DefenseClawMac/DefenseClawMac/DesignSystem/InspectorLayoutPolicy.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DesignSystem/InspectorLayoutPolicy.swift
@@ -1,0 +1,23 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import CoreGraphics
+
+enum InspectorLayoutPolicy {
+    static let minimumWidth: CGFloat = 250
+    static let idealWidth: CGFloat = 320
+    static let maximumWidth: CGFloat = 380
+}

--- a/macos/DefenseClawMac/DefenseClawMac/DesignSystem/QuickHoverHelp.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DesignSystem/QuickHoverHelp.swift
@@ -1,0 +1,267 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import AppKit
+import SwiftUI
+
+extension View {
+    /// Keeps a concise accessibility description beside the visual toolbar
+    /// help supplied by `DCToolbarQuickHelpMonitor`.
+    func dcQuickHelp(_ text: String) -> some View {
+        accessibilityHint(Text(text))
+    }
+}
+
+/// SwiftUI converts toolbar content into AppKit toolbar items and may discard
+/// ordinary hover modifiers. Monitor the real toolbar item views so every page
+/// gets the same short, predictable help delay.
+final class DCToolbarQuickHelpMonitor {
+    static let shared = DCToolbarQuickHelpMonitor()
+    static let displayDelay: TimeInterval = 0.15
+
+    private var eventMonitor: Any?
+    private var observers: [NSObjectProtocol] = []
+    private weak var currentAnchor: NSView?
+    private var currentHelp: String?
+
+    private init() {}
+
+    func start() {
+        guard eventMonitor == nil else { return }
+
+        NSApp.windows.forEach(configure)
+        let center = NotificationCenter.default
+        observers.append(center.addObserver(
+            forName: NSWindow.didBecomeKeyNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let window = notification.object as? NSWindow else { return }
+            self?.configure(window)
+        })
+        observers.append(center.addObserver(
+            forName: NSWindow.didResignKeyNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.clearHover()
+        })
+        observers.append(center.addObserver(
+            forName: NSApplication.didResignActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.clearHover()
+        })
+
+        eventMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.mouseMoved, .leftMouseDown, .rightMouseDown, .scrollWheel]
+        ) { [weak self] event in
+            if event.type == .mouseMoved {
+                self?.handleMouseMoved(event)
+            } else {
+                self?.clearHover()
+            }
+            return event
+        }
+    }
+
+    private func configure(_ window: NSWindow) {
+        window.acceptsMouseMovedEvents = true
+    }
+
+    private func handleMouseMoved(_ event: NSEvent) {
+        guard NSApp.isActive,
+              let window = event.window,
+              window.isKeyWindow,
+              let toolbar = window.toolbar,
+              let match = matchingItem(
+                  in: toolbar,
+                  window: window,
+                  windowPoint: event.locationInWindow
+              )
+        else {
+            clearHover()
+            return
+        }
+
+        if currentAnchor === match.view, currentHelp == match.help {
+            return
+        }
+
+        currentAnchor = match.view
+        currentHelp = match.help
+        DCQuickHelpPresenter.shared.schedule(
+            text: match.help,
+            from: match.view,
+            delay: Self.displayDelay
+        )
+    }
+
+    private func matchingItem(
+        in toolbar: NSToolbar,
+        window: NSWindow,
+        windowPoint: NSPoint
+    ) -> (view: NSView, help: String)? {
+        let items = (toolbar.visibleItems ?? []).flatMap(expandedItems)
+        for item in items {
+            guard let help = DCToolbarQuickHelpCatalog.text(
+                windowTitle: window.title,
+                itemLabel: item.label
+            ),
+            let view = item.view,
+            view.window === window
+            else { continue }
+
+            let point = view.convert(windowPoint, from: nil)
+            if view.bounds.insetBy(dx: -3, dy: -3).contains(point) {
+                return (view, help)
+            }
+        }
+        return nil
+    }
+
+    private func expandedItems(_ item: NSToolbarItem) -> [NSToolbarItem] {
+        guard let group = item as? NSToolbarItemGroup else { return [item] }
+        return group.subitems.flatMap(expandedItems)
+    }
+
+    private func clearHover() {
+        currentAnchor = nil
+        currentHelp = nil
+        DCQuickHelpPresenter.shared.hide()
+    }
+}
+
+private enum DCToolbarQuickHelpCatalog {
+    private static let pageHelp: [String: [String: String]] = [
+        "Overview": [
+            "Run Health Check": "Run DefenseClaw Doctor",
+            "Refresh": "Refresh overview",
+        ],
+        "Alerts": [
+            "Acknowledge Selection": "Acknowledge selected alerts",
+            "Refresh": "Refresh alerts",
+        ],
+        "Logs": [
+            "Auto-scroll": "Follow new log lines",
+            "Reload from disk": "Reload logs from disk",
+        ],
+        "Audit": [
+            "Export JSON": "Export audit events as JSON",
+            "Refresh": "Refresh audit events",
+        ],
+        "Activity": [
+            "Run Command": "Open Command Palette",
+            "Clear Completed": "Clear completed commands",
+            "Refresh": "Refresh mutations",
+        ],
+        "Inventory": [
+            "Rescan All": "Rescan connector inventories",
+        ],
+        "AI Discovery": [
+            "Enable AI Discovery": "Enable AI Discovery",
+            "Scan Now": "Scan this Mac for AI products and models",
+            "Refresh": "Refresh AI Discovery results",
+        ],
+        "Registries": [
+            "Add Source": "Add Registry Source",
+            "Remove Source": "Remove Selected Source",
+            "Approve": "Approve selected registry entry",
+            "Reject": "Reject selected registry entry",
+            "Require Registry": "Require Registry",
+            "Make Registry Optional": "Make Registry Optional",
+            "Sync Selected": "Sync selected registry source",
+            "Sync All": "Sync all registry sources",
+            "Refresh": "Refresh registries",
+        ],
+        "Skills": [
+            "Install Skill": "Install a skill",
+            "Refresh": "Refresh catalog",
+        ],
+        "MCPs": [
+            "Set MCP Server": "Scan and add or update an MCP server",
+            "Refresh": "Refresh catalog",
+        ],
+        "Plugins": [
+            "Install Plugin": "Install a plugin",
+            "Refresh": "Refresh catalog",
+        ],
+        "Tools": [
+            "Refresh": "Refresh catalog",
+        ],
+    ]
+
+    static func text(windowTitle: String, itemLabel: String) -> String? {
+        if itemLabel == "Command Palette" {
+            return "Command Palette (Command-Shift-P)"
+        }
+        return pageHelp[windowTitle]?[itemLabel]
+    }
+}
+
+private final class DCQuickHelpPresenter {
+    static let shared = DCQuickHelpPresenter()
+
+    private let popover: NSPopover
+    private var pendingPresentation: DispatchWorkItem?
+    private weak var anchor: NSView?
+
+    private init() {
+        popover = NSPopover()
+        popover.animates = false
+        popover.behavior = .applicationDefined
+    }
+
+    func schedule(text: String, from anchor: NSView, delay: TimeInterval) {
+        hide()
+        self.anchor = anchor
+
+        let presentation = DispatchWorkItem { [weak self, weak anchor] in
+            guard let self, let anchor, self.anchor === anchor,
+                  anchor.window?.isKeyWindow == true else { return }
+            self.present(text: text, from: anchor)
+        }
+        pendingPresentation = presentation
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + max(0, delay),
+            execute: presentation
+        )
+    }
+
+    func hide() {
+        pendingPresentation?.cancel()
+        pendingPresentation = nil
+        popover.close()
+        anchor = nil
+    }
+
+    private func present(text: String, from anchor: NSView) {
+        let controller = NSHostingController(
+            rootView: Text(text)
+                .font(.system(size: 12, weight: .medium))
+                .lineLimit(2)
+                .fixedSize(horizontal: true, vertical: true)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 5)
+                .accessibilityHidden(true)
+        )
+        controller.view.layoutSubtreeIfNeeded()
+        popover.contentViewController = controller
+        popover.contentSize = controller.view.fittingSize
+        popover.show(relativeTo: anchor.bounds, of: anchor, preferredEdge: .minY)
+    }
+}

--- a/macos/DefenseClawMac/DefenseClawMac/Features/ActivityView.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/ActivityView.swift
@@ -73,10 +73,10 @@ struct ActivityView: View {
         .inspector(isPresented: inspectorPresented) {
             if tab == .commands, let entry = selectedCommand {
                 commandInspector(entry)
-                    .inspectorColumnWidth(min: 340, ideal: 460)
+                    .dcInspectorColumnWidth()
             } else if let mutation = selectedMutation {
                 mutationInspector(mutation)
-                    .inspectorColumnWidth(min: 320, ideal: 420)
+                    .dcInspectorColumnWidth()
             }
         }
         .searchable(text: $search, placement: .toolbar, prompt: "Search activity")
@@ -88,16 +88,19 @@ struct ActivityView: View {
                     } label: {
                         Label("Run Command", systemImage: "play.circle")
                     }
+                    .dcQuickHelp("Open Command Palette")
                     Button {
                         appState.activity.clearCompleted()
                     } label: {
                         Label("Clear Completed", systemImage: "trash")
                     }
                     .disabled(!appState.activity.entries.contains { !$0.status.isActive })
+                    .dcQuickHelp("Clear completed commands")
                 } else {
                     Button { Task { await loadMutations() } } label: {
                         Label("Refresh", systemImage: "arrow.clockwise")
                     }
+                    .dcQuickHelp("Refresh mutations")
                 }
             }
         }
@@ -197,66 +200,69 @@ struct ActivityView: View {
     }
 
     private func commandInspector(_ entry: CommandActivityEntry) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack {
-                Text(entry.title).font(.headline)
-                Spacer()
-                if entry.status == .running {
-                    Button(role: .destructive) {
-                        appState.activity.cancel(entry.id)
-                    } label: {
-                        Label("Cancel", systemImage: "stop.fill")
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top) {
+                    Text(entry.title).font(.headline).lineLimit(2)
+                    Spacer(minLength: 8)
+                    if entry.status == .running {
+                        Button(role: .destructive) {
+                            appState.activity.cancel(entry.id)
+                        } label: {
+                            Label("Cancel", systemImage: "stop.fill")
+                        }
+                        .controlSize(.small)
+                    } else if entry.status == .cancelling {
+                        Button(role: .destructive) {} label: {
+                            Label("Cancelling...", systemImage: "stop.fill")
+                        }
+                        .controlSize(.small)
+                        .disabled(true)
+                    } else if entry.status == .finishing {
+                        Button {} label: {
+                            Label("Finishing...", systemImage: "hourglass")
+                        }
+                        .controlSize(.small)
+                        .disabled(true)
                     }
-                    .controlSize(.small)
-                } else if entry.status == .cancelling {
-                    Button(role: .destructive) {} label: {
-                        Label("Cancelling…", systemImage: "stop.fill")
-                    }
-                    .controlSize(.small)
-                    .disabled(true)
-                } else if entry.status == .finishing {
-                    Button {} label: {
-                        Label("Finishing…", systemImage: "hourglass")
-                    }
-                    .controlSize(.small)
-                    .disabled(true)
+                    Button { appState.activity.selectedID = nil } label: { Image(systemName: "xmark.circle.fill") }
+                        .buttonStyle(.borderless)
+                        .accessibilityLabel("Close command details")
                 }
-                Button { appState.activity.selectedID = nil } label: { Image(systemName: "xmark.circle.fill") }
+                KeyValueGrid(pairs: [
+                    ("Status", entry.statusLabel),
+                    ("Started", entry.startedAt.formatted()),
+                    ("Duration", durationLabel(entry.duration)),
+                    ("Origin", entry.origin),
+                    ("Category", entry.category),
+                    ("Side effects", entry.sideEffects.joined(separator: ", ")),
+                    ("Next", entry.suggestedNextAction),
+                ].filter { !$0.1.isEmpty })
+                Text(entry.command)
+                    .font(.caption.monospaced())
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                Divider()
+                HStack {
+                    Text("Output").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                    Spacer()
+                    Button {
+                        copyToPasteboard(entry.output)
+                    } label: { Image(systemName: "doc.on.doc") }
                     .buttonStyle(.borderless)
-                    .accessibilityLabel("Close command details")
-            }
-            KeyValueGrid(pairs: [
-                ("Status", entry.statusLabel),
-                ("Started", entry.startedAt.formatted()),
-                ("Duration", durationLabel(entry.duration)),
-                ("Origin", entry.origin),
-                ("Category", entry.category),
-                ("Side effects", entry.sideEffects.joined(separator: ", ")),
-                ("Next", entry.suggestedNextAction),
-            ].filter { !$0.1.isEmpty })
-            Text(entry.command)
-                .font(.caption.monospaced())
-                .textSelection(.enabled)
-            Divider()
-            HStack {
-                Text("Output").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-                Spacer()
-                Button {
-                    copyToPasteboard(entry.output)
-                } label: { Image(systemName: "doc.on.doc") }
-                .buttonStyle(.borderless)
-                .help("Copy Output")
-                .accessibilityLabel("Copy command output")
-            }
-            ScrollView {
+                    .help("Copy Output")
+                    .accessibilityLabel("Copy command output")
+                }
                 Text(entry.output.isEmpty ? emptyOutputLabel(entry.status) : entry.output)
                     .font(.system(.caption, design: .monospaced))
                     .textSelection(.enabled)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
             }
-            Spacer()
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(12)
     }
 
     private func mutationInspector(_ mutation: ActivityMutation) -> some View {

--- a/macos/DefenseClawMac/DefenseClawMac/Features/AlertsView.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/AlertsView.swift
@@ -31,6 +31,11 @@ struct AlertsView: View {
     @State private var confirmAck = false
     @State private var findingDetails: [ScanFindingEvent] = []
     @State private var findingHistory: [AuditEvent] = []
+    @State private var hydratedAuditEvent: AuditEvent?
+
+    private var connectorScopedAlerts: [AlertRow] {
+        appState.unackedAlerts.filter { appState.connectorFilterAllows($0.connectorName) }
+    }
 
     private var connectorScopedAlerts: [AlertRow] {
         appState.unackedAlerts.filter { appState.connectorFilterAllows($0.connectorName) }
@@ -60,6 +65,15 @@ struct AlertsView: View {
 
     private var selectedRow: AlertRow? {
         rows.first { selection.contains($0.id) }
+    }
+
+    private var selectedInspectorRow: AlertRow? {
+        guard let row = selectedRow,
+              case .audit(let summary) = row,
+              let hydratedAuditEvent,
+              hydratedAuditEvent.id == summary.id
+        else { return selectedRow }
+        return .audit(hydratedAuditEvent)
     }
 
     var body: some View {
@@ -122,9 +136,9 @@ struct AlertsView: View {
             get: { selectedRow != nil },
             set: { if !$0 { selection = [] } }
         )) {
-            if let row = selectedRow {
+            if let row = selectedInspectorRow {
                 alertInspector(row)
-                    .inspectorColumnWidth(min: 340, ideal: 440)
+                    .dcInspectorColumnWidth()
             }
         }
         .searchable(text: $search, placement: .toolbar, prompt: "Search action, target, details")
@@ -137,14 +151,17 @@ struct AlertsView: View {
                 }
                 .disabled(
                     selectedRows.isEmpty
+                        || appState.ackInProgress
                         || (!selectedAuditSeverities.isEmpty
                             && !appState.installationMutationsAllowed)
                 )
+                .dcQuickHelp("Acknowledge selected alerts")
                 Button {
                     Task { await appState.refreshAlerts() }
                 } label: {
                     Label("Refresh", systemImage: "arrow.clockwise")
                 }
+                .dcQuickHelp("Refresh alerts")
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .dcRefreshPanel)) { _ in
@@ -179,42 +196,57 @@ struct AlertsView: View {
     }
 
     private func alertInspector(_ row: AlertRow) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(row.action).font(.headline)
-                    HStack(spacing: 6) {
-                        SeverityBadge(severity: row.severity)
-                        Text(row.kind.capitalized).font(.caption).foregroundStyle(.secondary)
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(row.action).font(.headline)
+                        HStack(spacing: 6) {
+                            SeverityBadge(severity: row.severity)
+                            Text(row.kind.capitalized).font(.caption).foregroundStyle(.secondary)
+                        }
                     }
+                    Spacer()
+                    Button { selection = [] } label: { Image(systemName: "xmark.circle.fill") }
+                        .buttonStyle(.borderless)
+                        .accessibilityLabel("Close alert details")
                 }
-                Spacer()
-                Button { selection = [] } label: { Image(systemName: "xmark.circle.fill") }
-                    .buttonStyle(.borderless)
-                    .accessibilityLabel("Close alert details")
-            }
-            KeyValueGrid(pairs: [
-                ("Target", row.target),
-                ("Time", row.timestamp.formatted()),
-                ("Connector", row.connectorName),
-                ("Run ID", row.runID),
-            ].filter { !$0.1.isEmpty })
+                KeyValueGrid(pairs: [
+                    ("Target", row.target),
+                    ("Time", row.timestamp.formatted()),
+                    ("Connector", row.connectorName),
+                    ("Run ID", row.runID),
+                ].filter { !$0.1.isEmpty })
 
-            let structured = StructuredDetailParser.pairs(row.details)
-            if structured.isEmpty {
+                let structured = StructuredDetailParser.pairs(row.details)
+                let safeMetadata = structured.isEmpty
+                    ? StructuredDetailParser.safeMetadataPairs(row.details)
+                    : []
+                if !safeMetadata.isEmpty {
+                    Divider()
+                    Text("Security Metadata").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                    KeyValueGrid(pairs: safeMetadata)
+                }
+                if !structured.isEmpty {
+                    Divider()
+                    Text("Event Details").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                    KeyValueGrid(pairs: structured)
+                }
                 if !row.details.isEmpty {
-                    Text(row.details).font(.callout).textSelection(.enabled)
+                    Divider()
+                    Text("Raw Details").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                    Text(row.details)
+                        .font(.system(.caption, design: .monospaced))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(8)
+                        .background(Cisco.surfacePanel, in: RoundedRectangle(cornerRadius: 6))
+                        .textSelection(.enabled)
                 }
-            } else {
-                Divider()
-                Text("Event Details").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-                KeyValueGrid(pairs: structured)
-            }
 
-            if !findingDetails.isEmpty {
-                Divider()
-                Text("Findings").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-                ScrollView {
+                if !findingDetails.isEmpty {
+                    Divider()
+                    Text("Findings").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
                     VStack(alignment: .leading, spacing: 8) {
                         ForEach(findingDetails) { finding in
                             VStack(alignment: .leading, spacing: 4) {
@@ -237,51 +269,64 @@ struct AlertsView: View {
                             .background(Cisco.surfacePanel, in: RoundedRectangle(cornerRadius: 6))
                         }
                     }
+                } else if case .scan(let scan) = row, !scan.findingTitles.isEmpty {
+                    Divider()
+                    Text("Findings").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                    ForEach(scan.findingTitles, id: \.self) { Text($0).font(.caption) }
                 }
-                .frame(maxHeight: 230)
-            } else if case .scan(let scan) = row, !scan.findingTitles.isEmpty {
-                Divider()
-                Text("Findings").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-                ForEach(scan.findingTitles, id: \.self) { Text($0).font(.caption) }
-            }
 
-            if !findingHistory.isEmpty {
-                Divider()
-                Text("History for This Target").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-                ForEach(findingHistory.prefix(5)) { event in
-                    HStack {
-                        Text(event.timestamp, format: .dateTime.month().day().hour().minute())
-                            .font(.caption2.monospacedDigit()).foregroundStyle(.secondary)
-                        Text(event.action).font(.caption).lineLimit(1)
-                        Spacer()
-                        SeverityBadge(severity: event.severity)
+                if !findingHistory.isEmpty {
+                    Divider()
+                    Text("History for This Target").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                    ForEach(findingHistory.prefix(5)) { event in
+                        HStack {
+                            Text(event.timestamp, format: .dateTime.month().day().hour().minute())
+                                .font(.caption2.monospacedDigit()).foregroundStyle(.secondary)
+                            Text(event.action).font(.caption).lineLimit(1)
+                            Spacer()
+                            SeverityBadge(severity: event.severity)
+                        }
                     }
                 }
             }
-            Spacer()
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(12)
     }
 
     private func loadSelectedDetail() {
         guard let row = selectedRow else {
+            hydratedAuditEvent = nil
             findingDetails = []
             findingHistory = []
             return
         }
-        let selectedID = row.id
+        hydratedAuditEvent = nil
+        let rowID = row.id
         Task {
             let installationGeneration = appState.installationGeneration
+            var detailRow = row
+            var selectedAuditID: String?
+            if case .audit(let event) = row {
+                selectedAuditID = event.id
+                if let fullEvent = await appState.audit.event(id: event.id) {
+                    detailRow = .audit(fullEvent)
+                }
+                guard installationGeneration == appState.installationGeneration else { return }
+            }
             let details = await appState.audit.scanFindings(
-                runID: row.runID.nonEmpty,
-                target: row.target.nonEmpty,
+                runID: detailRow.runID.nonEmpty,
+                target: detailRow.target.nonEmpty,
                 limit: 20
             )
             guard installationGeneration == appState.installationGeneration else { return }
-            let history = await appState.audit.relatedEvents(target: row.target, limit: 10)
-                .filter { $0.id != row.id }
+            let history = await appState.audit.relatedEvents(target: detailRow.target, limit: 10)
+                .filter { $0.id != selectedAuditID }
             guard installationGeneration == appState.installationGeneration,
-                  selectedRow?.id == selectedID else { return }
+                  selectedRow?.id == rowID else { return }
+            if case .audit(let fullEvent) = detailRow {
+                hydratedAuditEvent = fullEvent
+            }
             findingDetails = details
             findingHistory = history
         }

--- a/macos/DefenseClawMac/DefenseClawMac/Features/AlertsView.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/AlertsView.swift
@@ -37,10 +37,6 @@ struct AlertsView: View {
         appState.unackedAlerts.filter { appState.connectorFilterAllows($0.connectorName) }
     }
 
-    private var connectorScopedAlerts: [AlertRow] {
-        appState.unackedAlerts.filter { appState.connectorFilterAllows($0.connectorName) }
-    }
-
     private var rows: [AlertRow] {
         connectorScopedAlerts.filter { row in
             if let severityFilter, row.severity != severityFilter { return false }

--- a/macos/DefenseClawMac/DefenseClawMac/Features/AppSettingsView.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/AppSettingsView.swift
@@ -20,20 +20,27 @@ import SwiftUI
 import ServiceManagement
 
 struct AppSettingsView: View {
+    @Environment(AppState.self) private var appState
+
     var body: some View {
-        TabView {
+        @Bindable var state = appState
+        TabView(selection: $state.selectedSettingsTab) {
             GeneralSettings()
                 .frame(width: 560, height: 620)
                 .tabItem { Label("General", systemImage: "gearshape") }
+                .tag(AppSettingsTab.general)
             MonitoringSettings()
                 .frame(width: 560, height: 350)
                 .tabItem { Label("Monitoring", systemImage: "waveform.path.ecg") }
+                .tag(AppSettingsTab.monitoring)
             NotificationSettings()
                 .frame(width: 560, height: 300)
                 .tabItem { Label("Notifications", systemImage: "bell.badge") }
+                .tag(AppSettingsTab.notifications)
             ConnectionSettings()
                 .frame(width: 560, height: 540)
                 .tabItem { Label("Connection", systemImage: "network") }
+                .tag(AppSettingsTab.connection)
         }
     }
 }

--- a/macos/DefenseClawMac/DefenseClawMac/Features/AuditView.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/AuditView.swift
@@ -107,7 +107,7 @@ struct AuditView: View {
         )) {
             if let event = selectedEvent {
                 auditInspector(event)
-                    .inspectorColumnWidth(min: 360, ideal: 480)
+                    .dcInspectorColumnWidth()
             }
         }
         .searchable(text: $search, placement: .toolbar, prompt: "Search action, target, details")
@@ -119,11 +119,13 @@ struct AuditView: View {
                     Label("Export JSON", systemImage: "square.and.arrow.up")
                 }
                 .keyboardShortcut("e", modifiers: .command)
+                .dcQuickHelp("Export audit events as JSON")
                 Button {
                     load(reset: true)
                 } label: {
                     Label("Refresh", systemImage: "arrow.clockwise")
                 }
+                .dcQuickHelp("Refresh audit events")
             }
         }
         .task {

--- a/macos/DefenseClawMac/DefenseClawMac/Features/CatalogViews.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/CatalogViews.swift
@@ -21,36 +21,52 @@ import SwiftUI
 /// stays consistent in one place.
 private struct CatalogListScaffold<Content: View, Action: View>: View {
     @Binding var error: String?
+    @Binding var warning: String?
     let isEmpty: Bool
+    let isUnavailable: Bool
     let emptyMessage: String
     let searchPrompt: String
     @Binding var search: String
     let load: () async -> Void
+    let recoveryCommand: (() async -> String?)?
     @ViewBuilder let action: Action
     @ViewBuilder let content: Content
 
     init(
         error: Binding<String?>,
+        warning: Binding<String?>,
         isEmpty: Bool,
+        isUnavailable: Bool,
         emptyMessage: String,
         searchPrompt: String,
         search: Binding<String>,
         load: @escaping () async -> Void,
+        recoveryCommand: (() async -> String?)? = nil,
         @ViewBuilder action: () -> Action,
         @ViewBuilder content: () -> Content
     ) {
         _error = error
+        _warning = warning
         self.isEmpty = isEmpty
+        self.isUnavailable = isUnavailable
         self.emptyMessage = emptyMessage
         self.searchPrompt = searchPrompt
         _search = search
         self.load = load
+        self.recoveryCommand = recoveryCommand
         self.action = action()
         self.content = content()
     }
 
     var body: some View {
-        CatalogContainer(error: $error, isEmpty: isEmpty, emptyMessage: emptyMessage) {
+        CatalogContainer(
+            error: $error,
+            warning: $warning,
+            isEmpty: isEmpty,
+            isUnavailable: isUnavailable,
+            emptyMessage: emptyMessage,
+            recoveryCommand: recoveryCommand
+        ) {
             content
         }
         .searchable(text: $search, placement: .toolbar, prompt: searchPrompt)
@@ -73,7 +89,11 @@ struct SkillsView: View {
     @State private var items: [SkillItem] = []
     @State private var search = ""
     @State private var error: String?
+    @State private var warning: String?
     @State private var loaded = false
+    @State private var actionsAvailable = false
+    @State private var loadedInstallationGeneration = -1
+    @State private var loadedBinaryPath: String?
     @State private var invocation: CatalogInvocation?
     @State private var showingInstall = false
 
@@ -86,15 +106,25 @@ struct SkillsView: View {
     var body: some View {
         CatalogListScaffold(
             error: $error,
-            isEmpty: loaded && filtered.isEmpty,
+            warning: $warning,
+            isEmpty: loaded && error == nil && filtered.isEmpty,
+            isUnavailable: loaded && error != nil && items.isEmpty,
             emptyMessage: "No skills were reported by `defenseclaw skill list --json`.",
             searchPrompt: "Search skills",
             search: $search,
-            load: load
+            load: load,
+            recoveryCommand: {
+                await appState.auditStoreRecoveryCommand(
+                    expectedGeneration: loadedInstallationGeneration,
+                    expectedBinaryPath: loadedBinaryPath
+                )
+            }
         ) {
             Button { showingInstall = true } label: {
                 Label("Install Skill", systemImage: "square.and.arrow.down")
             }
+            .dcQuickHelp("Install a skill")
+            .disabled(!actionsAvailable)
         } content: {
             Table(filtered) {
                 TableColumn("Status") { item in CatalogStatusLabel(status: item.status, verdict: item.verdict) }
@@ -110,6 +140,7 @@ struct SkillsView: View {
                     CatalogActionMenu(actions: CatalogActions.skills(item)) { action in
                         invocation = CatalogActions.invocation(action, skill: item)
                     }
+                    .disabled(!actionsAvailable)
                 }
                 .width(34)
             }
@@ -127,11 +158,31 @@ struct SkillsView: View {
     }
 
     private func load() async {
+        let installationGeneration = appState.installationGeneration
+        actionsAvailable = false
         do {
-            items = try await CatalogCLI.skills(using: appState.cli)
+            let listing = try await CatalogCLI.skills(using: appState.cli)
+            guard installationGeneration == appState.installationGeneration else { return }
+            items = listing.items
+            loadedInstallationGeneration = installationGeneration
+            loadedBinaryPath = listing.selectedBinaryPath
+            actionsAvailable = !listing.auditHistoryUnavailable
+            warning = listing.auditHistoryUnavailable
+                ? CatalogCLI.auditHistoryUnavailableMessage
+                : nil
+            if listing.auditHistoryUnavailable {
+                invocation = nil
+                showingInstall = false
+            }
             error = nil
         } catch {
+            guard installationGeneration == appState.installationGeneration else { return }
             self.error = error.localizedDescription
+            warning = nil
+            actionsAvailable = false
+            loadedBinaryPath = nil
+            invocation = nil
+            showingInstall = false
         }
         loaded = true
     }
@@ -148,7 +199,11 @@ struct MCPsView: View {
     @State private var items: [MCPItem] = []
     @State private var search = ""
     @State private var error: String?
+    @State private var warning: String?
     @State private var loaded = false
+    @State private var actionsAvailable = false
+    @State private var loadedInstallationGeneration = -1
+    @State private var loadedBinaryPath: String?
     @State private var invocation: CatalogInvocation?
     @State private var showingSetForm = false
 
@@ -163,16 +218,25 @@ struct MCPsView: View {
     var body: some View {
         CatalogListScaffold(
             error: $error,
-            isEmpty: loaded && filtered.isEmpty,
+            warning: $warning,
+            isEmpty: loaded && error == nil && filtered.isEmpty,
+            isUnavailable: loaded && error != nil && items.isEmpty,
             emptyMessage: "No MCP servers were reported by `defenseclaw mcp list --json`.",
             searchPrompt: "Search MCPs",
             search: $search,
-            load: load
+            load: load,
+            recoveryCommand: {
+                await appState.auditStoreRecoveryCommand(
+                    expectedGeneration: loadedInstallationGeneration,
+                    expectedBinaryPath: loadedBinaryPath
+                )
+            }
         ) {
             Button { showingSetForm = true } label: {
                 Label("Set MCP Server", systemImage: "plus")
             }
-            .help("Scan and add or update an MCP server")
+            .dcQuickHelp("Scan and add or update an MCP server")
+            .disabled(!actionsAvailable)
         } content: {
             Table(filtered) {
                 TableColumn("Status") { item in CatalogStatusLabel(status: item.status, verdict: item.verdict) }
@@ -188,6 +252,7 @@ struct MCPsView: View {
                     CatalogActionMenu(actions: CatalogActions.mcps(item)) { action in
                         invocation = CatalogActions.invocation(action, mcp: item)
                     }
+                    .disabled(!actionsAvailable)
                 }
                 .width(34)
             }
@@ -205,11 +270,31 @@ struct MCPsView: View {
     }
 
     private func load() async {
+        let installationGeneration = appState.installationGeneration
+        actionsAvailable = false
         do {
-            items = try await CatalogCLI.mcps(using: appState.cli)
+            let listing = try await CatalogCLI.mcps(using: appState.cli)
+            guard installationGeneration == appState.installationGeneration else { return }
+            items = listing.items
+            loadedInstallationGeneration = installationGeneration
+            loadedBinaryPath = listing.selectedBinaryPath
+            actionsAvailable = !listing.auditHistoryUnavailable
+            warning = listing.auditHistoryUnavailable
+                ? CatalogCLI.auditHistoryUnavailableMessage
+                : nil
+            if listing.auditHistoryUnavailable {
+                invocation = nil
+                showingSetForm = false
+            }
             error = nil
         } catch {
+            guard installationGeneration == appState.installationGeneration else { return }
             self.error = error.localizedDescription
+            warning = nil
+            actionsAvailable = false
+            loadedBinaryPath = nil
+            invocation = nil
+            showingSetForm = false
         }
         loaded = true
     }
@@ -222,7 +307,11 @@ struct PluginsView: View {
     @State private var items: [PluginItem] = []
     @State private var search = ""
     @State private var error: String?
+    @State private var warning: String?
     @State private var loaded = false
+    @State private var actionsAvailable = false
+    @State private var loadedInstallationGeneration = -1
+    @State private var loadedBinaryPath: String?
     @State private var invocation: CatalogInvocation?
     @State private var showingInstall = false
 
@@ -237,15 +326,25 @@ struct PluginsView: View {
     var body: some View {
         CatalogListScaffold(
             error: $error,
-            isEmpty: loaded && filtered.isEmpty,
+            warning: $warning,
+            isEmpty: loaded && error == nil && filtered.isEmpty,
+            isUnavailable: loaded && error != nil && items.isEmpty,
             emptyMessage: "No plugins were reported by `defenseclaw plugin list --json`.",
             searchPrompt: "Search plugins",
             search: $search,
-            load: load
+            load: load,
+            recoveryCommand: {
+                await appState.auditStoreRecoveryCommand(
+                    expectedGeneration: loadedInstallationGeneration,
+                    expectedBinaryPath: loadedBinaryPath
+                )
+            }
         ) {
             Button { showingInstall = true } label: {
                 Label("Install Plugin", systemImage: "square.and.arrow.down")
             }
+            .dcQuickHelp("Install a plugin")
+            .disabled(!actionsAvailable)
         } content: {
             Table(filtered) {
                 TableColumn("Status") { item in CatalogStatusLabel(status: item.status, verdict: item.verdict) }
@@ -260,6 +359,7 @@ struct PluginsView: View {
                     CatalogActionMenu(actions: CatalogActions.plugins(item)) { action in
                         invocation = CatalogActions.invocation(action, plugin: item)
                     }
+                    .disabled(!actionsAvailable)
                 }
                 .width(34)
             }
@@ -277,11 +377,31 @@ struct PluginsView: View {
     }
 
     private func load() async {
+        let installationGeneration = appState.installationGeneration
+        actionsAvailable = false
         do {
-            items = try await CatalogCLI.plugins(using: appState.cli)
+            let listing = try await CatalogCLI.plugins(using: appState.cli)
+            guard installationGeneration == appState.installationGeneration else { return }
+            items = listing.items
+            loadedInstallationGeneration = installationGeneration
+            loadedBinaryPath = listing.selectedBinaryPath
+            actionsAvailable = !listing.auditHistoryUnavailable
+            warning = listing.auditHistoryUnavailable
+                ? CatalogCLI.auditHistoryUnavailableMessage
+                : nil
+            if listing.auditHistoryUnavailable {
+                invocation = nil
+                showingInstall = false
+            }
             error = nil
         } catch {
+            guard installationGeneration == appState.installationGeneration else { return }
             self.error = error.localizedDescription
+            warning = nil
+            actionsAvailable = false
+            loadedBinaryPath = nil
+            invocation = nil
+            showingInstall = false
         }
         loaded = true
     }
@@ -294,6 +414,7 @@ struct ToolsView: View {
     @State private var items: [ToolItem] = []
     @State private var search = ""
     @State private var error: String?
+    @State private var warning: String?
     @State private var loaded = false
     @State private var invocation: CatalogInvocation?
 
@@ -314,7 +435,9 @@ struct ToolsView: View {
     var body: some View {
         CatalogListScaffold(
             error: $error,
-            isEmpty: loaded && filtered.isEmpty,
+            warning: $warning,
+            isEmpty: loaded && error == nil && filtered.isEmpty,
+            isUnavailable: loaded && error != nil && items.isEmpty,
             emptyMessage: "No tool policy rows. Unblocked tools do not appear in this table.",
             searchPrompt: "Search tools",
             search: $search,
@@ -562,7 +685,7 @@ private struct CatalogCommandSheet: View {
                 runID: commandID,
                 title: invocation.title,
                 arguments: invocation.arguments,
-                mutation: invocation.requiresConfirmation,
+                mutation: invocation.changesState,
                 category: "catalog",
                 origin: "Catalog",
                 refreshOnSuccess: true
@@ -814,9 +937,13 @@ private struct SourceText: View {
 
 private struct CatalogContainer<Content: View>: View {
     @Binding var error: String?
+    @Binding var warning: String?
     let isEmpty: Bool
+    let isUnavailable: Bool
     let emptyMessage: String
+    let recoveryCommand: (() async -> String?)?
     @ViewBuilder var content: Content
+    @State private var recoveryStatus: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -832,12 +959,52 @@ private struct CatalogContainer<Content: View>: View {
                 .padding(8)
                 .background(Cisco.red.opacity(0.08))
             }
-            if isEmpty {
+            if let warning {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 8) {
+                        Label(warning, systemImage: "exclamationmark.shield")
+                            .font(.caption)
+                            .foregroundStyle(Cisco.orange)
+                        Spacer()
+                        if recoveryCommand != nil {
+                            Button("Copy Repair Command") { copyRecoveryCommand() }
+                                .controlSize(.small)
+                        }
+                    }
+                    if let recoveryStatus {
+                        Text(recoveryStatus)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(8)
+                .background(Cisco.orange.opacity(0.08))
+            }
+            if isUnavailable {
+                DCEmptyState(
+                    title: "Catalog unavailable",
+                    message: "DefenseClaw could not load this catalog. Review the error above and refresh after it is resolved.",
+                    systemImage: "exclamationmark.triangle"
+                )
+                .frame(maxHeight: .infinity)
+            } else if isEmpty {
                 DCEmptyState(title: "Nothing here", message: emptyMessage, systemImage: "tray")
                     .frame(maxHeight: .infinity)
             } else {
                 content
             }
+        }
+    }
+
+    private func copyRecoveryCommand() {
+        guard let recoveryCommand else { return }
+        Task {
+            guard let command = await recoveryCommand() else {
+                error = "Could not prepare an audit repair command for this DefenseClaw installation. Refresh the panel and verify the installation is writable."
+                return
+            }
+            copyToPasteboard(command)
+            recoveryStatus = "Copied. Quit DefenseClaw completely, then run the command in Terminal. The runtime preserves the corrupt database family before creating a healthy store."
         }
     }
 }
@@ -849,6 +1016,7 @@ struct RefreshButton: ToolbarContent {
             Button { Task { await action() } } label: {
                 Label("Refresh", systemImage: "arrow.clockwise")
             }
+            .dcQuickHelp("Refresh catalog")
         }
     }
 }

--- a/macos/DefenseClawMac/DefenseClawMac/Features/CommandPaletteView.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/CommandPaletteView.swift
@@ -31,12 +31,16 @@ struct CommandPaletteView: View {
     @State private var parseError: String?
     @State private var pendingConfirmedRun = false
 
+    private var commands: [CommandDefinition] {
+        CommandRegistry.paletteCommands(supportedSetupCommands: appState.runtimeSetupCommands)
+    }
+
     private var categories: [String] {
-        ["all"] + Array(Set(CommandRegistry.all.map(\.category))).sorted()
+        ["all"] + Array(Set(commands.map(\.category))).sorted()
     }
 
     private var filtered: [CommandDefinition] {
-        CommandRegistry.all.filter { command in
+        commands.filter { command in
             let categoryMatches = category == "all" || command.category == category
             let searchMatches = search.isEmpty ||
                 "\(command.title) \(command.summary) \(command.category) \(command.usage)"
@@ -46,13 +50,13 @@ struct CommandPaletteView: View {
     }
 
     private var selected: CommandDefinition? {
-        CommandRegistry.all.first { $0.id == selectedID }
+        commands.first { $0.id == selectedID }
     }
 
     var body: some View {
         NavigationSplitView {
             VStack(spacing: 8) {
-                TextField("Search \(CommandRegistry.sourceCount) commands", text: $search)
+                TextField("Search \(commands.count) commands", text: $search)
                     .textFieldStyle(.roundedBorder)
                     .padding(.horizontal, 10)
                     .padding(.top, 10)
@@ -72,7 +76,7 @@ struct CommandPaletteView: View {
                     .tag(command.id)
                 }
                 .listStyle(.sidebar)
-                Text("\(filtered.count) of \(CommandRegistry.sourceCount) commands")
+                Text("\(filtered.count) of \(commands.count) commands")
                     .font(.caption2).foregroundStyle(.secondary).padding(.bottom, 8)
             }
             .navigationSplitViewColumnWidth(min: 250, ideal: 300)

--- a/macos/DefenseClawMac/DefenseClawMac/Features/ConfigEditorDefinitions.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/ConfigEditorDefinitions.swift
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Typed config-editor catalog — a port of the TUI's Setup config sections
-// (tui/panels/setup.py build of ConfigSection/ConfigField, DefenseClaw 0.8.3).
+// (tui/panels/setup.py build of ConfigSection/ConfigField, DefenseClaw 0.8.5).
 // Every editable field carries its exact config.yaml dotted key, kind, choice
 // options, and hint; read-only sections render as headers with guidance.
 
@@ -587,12 +587,12 @@ enum ConfigEditorCatalog {
         ))
 
         sections.append(ConfigEditorSection(
-            name: "Audit Sinks",
-            summary: "Read-only audit sink summary.",
-            help: "Manage via Setup → Observability (Splunk) or `defenseclaw setup observability`.",
+            name: "Observability",
+            summary: "Read-only config v8 destination summary.",
+            help: "Manage via Setup → Observability or `defenseclaw setup observability`.",
             fields: [
                 .init(label: "How to edit", key: "", kind: .header,
-                      headerValue: "Use the Observability / Splunk wizards; sinks appear in the Overview destinations table."),
+                      headerValue: "Use the Observability wizards; named destinations appear in the Overview destinations table."),
             ]
         ))
 
@@ -603,37 +603,6 @@ enum ConfigEditorCatalog {
             fields: [
                 .init(label: "How to edit", key: "", kind: .header,
                       headerValue: "Use the Webhooks wizard in Setup to add or change notifier webhooks."),
-            ]
-        ))
-
-        sections.append(ConfigEditorSection(
-            name: "OTel",
-            summary: "OpenTelemetry exporter config.",
-            fields: [
-                .init(label: ".. Process-wide policy ..", key: "", kind: .header),
-                .init(label: "Enabled", key: "otel.enabled", kind: .bool, hint: "Master OpenTelemetry export switch."),
-                .init(label: ".. Traces ..", key: "", kind: .header),
-                .init(label: "Sampler", key: "otel.traces.sampler", kind: .choice,
-                      options: ["always_on", "always_off", "traceidratio",
-                                "parentbased_always_on", "parentbased_always_off", "parentbased_traceidratio"],
-                      hint: "Trace sampler."),
-                .init(label: "Sampler Arg", key: "otel.traces.sampler_arg", hint: "Trace sampler argument."),
-                .init(label: ".. Logs ..", key: "", kind: .header),
-                .init(label: "Emit individual findings", key: "otel.logs.emit_individual_findings", kind: .bool,
-                      hint: "One record per finding."),
-                .init(label: ".. Metrics ..", key: "", kind: .header),
-                .init(label: "Export interval (s)", key: "otel.metrics.export_interval_s", kind: .int,
-                      hint: "Seconds between metric pushes."),
-                .init(label: "Temporality", key: "otel.metrics.temporality", kind: .choice,
-                      options: ["delta", "cumulative"], hint: "Metric temporality."),
-                .init(label: ".. Batch ..", key: "", kind: .header),
-                .init(label: "Max export batch size", key: "otel.batch.max_export_batch_size", kind: .int,
-                      hint: "Max records per request."),
-                .init(label: "Scheduled delay (ms)", key: "otel.batch.scheduled_delay_ms", kind: .int,
-                      hint: "Batch flush delay."),
-                .init(label: "Max queue size", key: "otel.batch.max_queue_size", kind: .int, hint: "In-memory queue size."),
-                .init(label: ".. Resource ..", key: "", kind: .header),
-                .init(label: "Attributes", key: "otel.resource.attributes", hint: "CSV resource attributes."),
             ]
         ))
 

--- a/macos/DefenseClawMac/DefenseClawMac/Features/DiscoverViews.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/DiscoverViews.swift
@@ -191,6 +191,7 @@ struct InventoryView: View {
                     Label("Rescan All", systemImage: "arrow.triangle.2.circlepath")
                 }
                 .disabled(scanning || !appState.installationMutationsAllowed)
+                .dcQuickHelp("Rescan connector inventories")
             }
         }
         .task {
@@ -302,7 +303,7 @@ struct InventoryView: View {
             }
             items = parsed.documents.flatMap(Self.rows(from:))
             summaries = parsed.documents.map(Self.summary(from:))
-            warning = parsed.diagnostics.nonEmpty
+            warning = InventoryOutputParser.userFacingDiagnostics(from: parsed).nonEmpty
             lastScan = Date()
         }
     }
@@ -399,11 +400,6 @@ struct InventoryView: View {
 
     private static func summary(from doc: [String: Any]) -> InventoryConnectorSummary {
         func arrayCount(_ key: String) -> Int { (doc[key] as? [Any])?.count ?? 0 }
-        let summary = doc["summary"] as? [String: Any]
-        let errors: Int = {
-            if let value = summary?["errors"] as? Int { return value }
-            return (doc["errors"] as? [Any])?.count ?? 0
-        }()
         let connector = (doc["connector"] as? String) ?? (doc["claw_mode"] as? String) ?? "default"
         let configFiles = doc["connector_config_files"] as? [String]
         return InventoryConnectorSummary(
@@ -413,7 +409,7 @@ struct InventoryView: View {
             home: (doc["connector_home"] as? String) ?? (doc["claw_home"] as? String) ?? "",
             config: configFiles?.first ?? (doc["openclaw_config"] as? String) ?? "",
             live: (doc["live"] as? Bool) ?? false,
-            errors: errors,
+            errors: InventoryOutputParser.actionableErrorCount(in: doc),
             counts: [
                 .skills: arrayCount("skills"), .plugins: arrayCount("plugins"), .mcps: arrayCount("mcp"),
                 .agents: arrayCount("agents"), .tools: arrayCount("tools"),
@@ -440,475 +436,219 @@ struct InventoryView: View {
 
 // MARK: - AI Discovery
 
-private enum AIDiscoverySelection: Hashable {
-    case product(String)
-    case model(AIModelDiscoveryRowID)
-}
-
 struct AIDiscoveryView: View {
     @Environment(AppState.self) private var appState
-    @AppStorage("aiDiscovery.showAllModels") private var showAllModels = false
-    @AppStorage("aiDiscovery.modelModality") private var modelModalityRaw = AIModelModalityFilter.all.rawValue
-    @AppStorage("aiDiscovery.modelRelevance") private var modelRelevanceRaw = AIModelRelevanceFilter.all.rawValue
     @State private var snapshot = AIUsageSnapshot()
     @State private var search = ""
-    @State private var selection: AIDiscoverySelection?
+    @State private var selected: AIDiscoveryRow?
     @State private var scanning = false
     @State private var error: String?
     @State private var loaded = false
+    @State private var scanRequested = false
 
-    /// Grouped non-model rows, filtered like the TUI's product table:
-    /// substring match across state/product/vendor/component/version/bands/categories/detectors.
-    private var filteredProducts: [AIDiscoveryRow] {
-        let rows = snapshot.rows.filter {
-            $0.model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        }
+    /// Grouped rows filtered like the TUI's `_apply_filter`, including local
+    /// model identity without treating status/format as search dimensions.
+    private var filtered: [AIDiscoveryRow] {
+        let rows = snapshot.rows
         guard !search.isEmpty else { return rows }
-        return rows.filter { row in
-            let haystack = ([row.state, row.product, row.vendor, row.ecosystem, row.component,
-                             row.version, row.identityBand, row.presenceBand]
-                            + row.categories + row.detectors).joined(separator: " ")
-            return haystack.localizedCaseInsensitiveContains(search)
-        }
+        return rows.filter { AIDiscoveryGrouping.matches($0, query: search) }
     }
 
-    private var modelModality: AIModelModalityFilter {
-        AIModelModalityFilter(rawValue: modelModalityRaw) ?? .all
+    private var primaryAction: AIDiscoveryPrimaryAction {
+        .resolve(enabled: snapshot.enabled)
     }
 
-    private var modelRelevance: AIModelRelevanceFilter {
-        AIModelRelevanceFilter(rawValue: modelRelevanceRaw) ?? .all
-    }
-
-    private var modelFilter: AIModelDiscoveryFilter {
-        AIModelDiscoveryFilter(
-            showAllModels: showAllModels,
-            modality: modelModality,
-            relevance: modelRelevance
-        ).preservingLegacySnapshot(snapshot.modelRows)
-    }
-
-    private var searchMatchedModels: [AIModelDiscoveryRow] {
-        snapshot.modelRows.filter { $0.matches(search) }
-    }
-
-    private var filteredModels: [AIModelDiscoveryRow] {
-        searchMatchedModels.filter(modelFilter.includes)
-    }
-
-    private var hiddenModelCount: Int {
-        max(searchMatchedModels.count - filteredModels.count, 0)
-    }
-
-    private var displayedDetectorErrorKeys: [String] {
-        Array(snapshot.detectorErrors.keys.sorted().prefix(6))
-    }
-
-    private var emptyState: (title: String, message: String) {
+    private var emptyState: (title: String, message: String, systemImage: String) {
         if !appState.gatewayReachable || !loaded {
             return (
                 "AI discovery unavailable",
-                "Ensure the gateway is running and the macOS app is connected to it."
+                "Ensure the gateway is running and the macOS app is connected to it.",
+                "sparkle.magnifyingglass"
             )
         }
         if !snapshot.enabled {
             return (
                 "AI discovery disabled",
-                "Enable AI discovery in Setup or run: defenseclaw agent discovery enable"
-            )
-        }
-        if hiddenModelCount > 0, filteredModels.isEmpty {
-            return (
-                "Models hidden by filters",
-                "Use Model Filters in the toolbar, or choose Show All Models to review every discovery."
+                "Use Enable AI Discovery above to enable the service, restart the gateway, and run the first scan.",
+                "power"
             )
         }
         if !search.isEmpty {
-            return ("No matching signals", "Clear or change the current product/model filter.")
+            return ("No matching signals", "Clear or change the current product/model filter.", "line.3.horizontal.decrease.circle")
         }
         return (
             "No AI agents or local models",
-            "Run a scan to detect AI agents, SDKs, frameworks, and local models on this Mac."
+            "Run a scan to detect AI agents, SDKs, frameworks, and local models on this Mac.",
+            "sparkle.magnifyingglass"
         )
-    }
-
-    private var selectedProduct: AIDiscoveryRow? {
-        guard case let .product(id) = selection else { return nil }
-        return filteredProducts.first { $0.id == id }
-    }
-
-    private var selectedModel: AIModelDiscoveryRow? {
-        guard case let .model(id) = selection else { return nil }
-        return filteredModels.first { $0.id == id }
     }
 
     var body: some View {
         VStack(spacing: 0) {
+            // Exact TUI header parts: active is always present (including a
+            // real zero), churn appears only when non-zero, then files. Like
+            // the TUI, no synthetic zero header appears before the first load.
             if loaded {
-                scanSummaryHeader
-                Divider()
-            }
-            if snapshot.isPartial {
-                partialScanBanner
+                HStack(spacing: 14) {
+                    ForEach(snapshot.discoveryHeaderParts, id: \.self) { part in
+                        Text(part)
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                }
+                .padding(12)
                 Divider()
             }
             if let error {
                 Label(error, systemImage: "exclamationmark.triangle")
                     .font(.caption).foregroundStyle(Cisco.red).padding(6)
             }
-            if hiddenModelCount > 0 {
-                modelFilterNotice
-                Divider()
-            }
-            if filteredProducts.isEmpty, filteredModels.isEmpty {
+            if filtered.isEmpty {
                 DCEmptyState(
                     title: emptyState.title,
                     message: emptyState.message,
-                    systemImage: "sparkle.magnifyingglass"
+                    systemImage: emptyState.systemImage
                 )
                 .frame(maxHeight: .infinity)
             } else {
-                discoveryTables
+                discoveryTable
             }
         }
         .inspector(isPresented: Binding(
-            get: { selectedProduct != nil || selectedModel != nil },
-            set: { if !$0 { selection = nil } }
+            get: { selected != nil },
+            set: { if !$0 { selected = nil } }
         )) {
-            if let row = selectedModel {
-                modelInspector(row)
-                    .inspectorColumnWidth(min: 320, ideal: 400)
-            } else if let row = selectedProduct {
-                productInspector(row)
+            if let row = selected {
+                rowInspector(row)
                     .inspectorColumnWidth(min: 320, ideal: 400)
             }
         }
         .searchable(text: $search, placement: .toolbar, prompt: "Filter products and models")
         .toolbar {
             ToolbarItemGroup {
-                modelFilterMenu
                 Button {
-                    scan()
+                    run(primaryAction)
                 } label: {
-                    Label("Scan Now", systemImage: "wand.and.rays")
+                    Label(primaryAction.label, systemImage: primaryAction.systemImage)
                 }
                 .disabled(
                     scanning
                         || !appState.gatewayReachable
+                        || !loaded
                         || !appState.installationMutationsAllowed
                 )
+                .dcQuickHelp(primaryAction.label)
                 Button {
                     Task { await load() }
                 } label: {
                     Label("Refresh", systemImage: "arrow.clockwise")
                 }
+                .dcQuickHelp("Refresh AI Discovery results")
             }
         }
         .task { await load() }
         // Pulse-fed retry: a transient gateway failure (restart mid-fetch,
         // token rotation) must not freeze the panel on a stale error.
-        .task(id: appState.health.fetchedAt) { if error != nil || !loaded { await load() } }
-        .onChange(of: search) { reconcileSelection() }
-        .onChange(of: showAllModels) { reconcileSelection() }
-        .onChange(of: modelModalityRaw) { reconcileSelection() }
-        .onChange(of: modelRelevanceRaw) { reconcileSelection() }
+        .task(id: appState.health.fetchedAt) {
+            if error != nil || !loaded || scanRequested { await load() }
+            if scanRequested { await fulfillScanRequest() }
+        }
         .onReceive(NotificationCenter.default.publisher(for: .dcRefreshPanel)) { _ in Task { await load() } }
         .onReceive(NotificationCenter.default.publisher(for: .dcScanAIDiscovery)) { _ in
-            guard !scanning,
-                  appState.gatewayReachable,
-                  appState.installationMutationsAllowed
-            else { return }
-            scan()
+            requestScan()
         }
     }
 
-    private var scanSummaryHeader: some View {
-        HStack(spacing: 14) {
-            if !snapshot.result.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                || snapshot.isPartial {
-                Label(scanResultTitle, systemImage: scanResultSystemImage)
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(scanResultColor)
-                    .accessibilityLabel("Last AI discovery result: \(scanResultTitle)")
-                Text(snapshot.discoveryIssueLabel)
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(snapshot.isPartial ? Cisco.orange : Color.secondary)
-                    .accessibilityLabel(snapshot.discoveryIssueLabel)
-            }
-            ForEach(snapshot.discoveryHeaderParts, id: \.self) { part in
-                Text(part)
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
-            }
-            Spacer()
-        }
-        .padding(12)
-    }
-
-    private var scanResultTitle: String {
-        if snapshot.isPartial { return "Partial scan" }
-        switch snapshot.result.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-        case "ok", "complete", "completed": return "Scan complete"
-        case "disabled": return "Discovery disabled"
-        case let value where !value.isEmpty:
-            return value.replacingOccurrences(of: "_", with: " ").capitalized
-        default: return "Scan status unavailable"
-        }
-    }
-
-    private var scanResultSystemImage: String {
-        if snapshot.isPartial { return "exclamationmark.triangle.fill" }
-        switch snapshot.result.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-        case "ok", "complete", "completed": return "checkmark.circle.fill"
-        case "disabled": return "pause.circle.fill"
-        default: return "info.circle.fill"
-        }
-    }
-
-    private var scanResultColor: Color {
-        if snapshot.isPartial { return Cisco.orange }
-        switch snapshot.result.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-        case "ok", "complete", "completed": return Cisco.green
-        default: return .secondary
-        }
-    }
-
-    private var partialScanBanner: some View {
-        VStack(alignment: .leading, spacing: 7) {
-            Label("Partial scan — results may be incomplete", systemImage: "exclamationmark.triangle.fill")
-                .font(.callout.weight(.semibold))
-                .foregroundStyle(Cisco.orange)
-            Text(snapshot.partialDiscoveryDescription)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            ForEach(displayedDetectorErrorKeys, id: \.self) { detector in
-                if let message = snapshot.detectorErrors[detector] {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(detector.replacingOccurrences(of: "_", with: " ").capitalized)
-                            .font(.caption.weight(.semibold))
-                        Text(message)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .textSelection(.enabled)
-                    }
-                    .accessibilityElement(children: .combine)
-                    .accessibilityLabel("\(detector) detector error: \(message)")
-                }
-            }
-            if snapshot.detectorErrors.count > displayedDetectorErrorKeys.count {
-                Text("\(snapshot.detectorErrors.count - displayedDetectorErrorKeys.count) additional detector errors not shown.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .accessibilityLabel(
-                        "\(snapshot.detectorErrors.count - displayedDetectorErrorKeys.count) additional detector errors"
-                    )
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
-        .background(Cisco.orange.opacity(0.09))
-    }
-
-    private var modelFilterNotice: some View {
-        HStack(spacing: 8) {
-            Label(
-                "\(hiddenModelCount) model\(hiddenModelCount == 1 ? "" : "s") hidden by filters",
-                systemImage: "line.3.horizontal.decrease.circle"
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
-            Spacer()
-            Button("Show All Models") {
-                showAllModels = true
-                modelModalityRaw = AIModelModalityFilter.all.rawValue
-                modelRelevanceRaw = AIModelRelevanceFilter.all.rawValue
-            }
-            .buttonStyle(.borderless)
-            .accessibilityHint("Shows embedded, unknown, low-confidence, and other non-recommended models")
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 7)
-        .background(Cisco.surfacePanel)
-    }
-
-    private var modelFilterMenu: some View {
-        Menu {
-            Toggle("Show All Models", isOn: $showAllModels)
-            Divider()
-            Picker("Modality", selection: $modelModalityRaw) {
-                ForEach(AIModelModalityFilter.allCases) { option in
-                    Text(option.displayName).tag(option.rawValue)
-                }
-            }
-            Picker("Relevance", selection: $modelRelevanceRaw) {
-                ForEach(AIModelRelevanceFilter.allCases) { option in
-                    Text(option.displayName).tag(option.rawValue)
-                }
-            }
-            Divider()
-            Button("Reset to Recommended") {
-                showAllModels = false
-                modelModalityRaw = AIModelModalityFilter.all.rawValue
-                modelRelevanceRaw = AIModelRelevanceFilter.all.rawValue
-            }
-        } label: {
-            Label("Model Filters", systemImage: "line.3.horizontal.decrease.circle")
-        }
-        .help("Choose which discovered models appear")
-        .accessibilityLabel("Model Filters")
-        .accessibilityHint("Filter models by modality and relevance, or show all models")
-    }
-
-    private var productSelection: Binding<String?> {
+    private var rowSelection: Binding<String?> {
         Binding<String?>(
-            get: {
-                guard case let .product(id) = selection else { return nil }
-                return id
-            },
-            set: { id in
-                if let id {
-                    selection = .product(id)
-                } else if case .product = selection {
-                    selection = nil
-                }
-            }
+            get: { selected?.id },
+            set: { (id: String?) in selected = filtered.first { $0.id == id } }
         )
     }
 
-    private var modelSelection: Binding<AIModelDiscoveryRowID?> {
-        Binding<AIModelDiscoveryRowID?>(
-            get: {
-                guard case let .model(id) = selection else { return nil }
-                return id
-            },
-            set: { id in
-                if let id {
-                    selection = .model(id)
-                } else if case .model = selection {
-                    selection = nil
-                }
-            }
-        )
-    }
-
-    @ViewBuilder
-    private var discoveryTables: some View {
-        if !filteredModels.isEmpty, !filteredProducts.isEmpty {
-            VSplitView {
-                modelSection
-                    .frame(minHeight: 140, idealHeight: 210, maxHeight: 280)
-                productSection
-                    .frame(minHeight: 220)
-            }
-        } else if !filteredModels.isEmpty {
-            modelSection
+    /// Model columns are based on the complete snapshot, not the filtered
+    /// rows, so searching never makes the table schema jump.
+    @ViewBuilder private var discoveryTable: some View {
+        if AIDiscoveryGrouping.hasModels(in: snapshot.rows) {
+            modelDiscoveryTable
         } else {
-            productSection
+            standardDiscoveryTable
         }
     }
 
-    private var modelSection: some View {
-        VStack(spacing: 0) {
-            tableSectionHeader(
-                "Models",
-                count: filteredModels.count,
-                total: searchMatchedModels.count,
-                systemImage: "cpu"
-            )
-            Divider()
-            modelTable
+    /// SwiftUI's table-column result builder supports ten top-level columns.
+    /// Grouping the column content preserves the TUI's complete thirteen-column
+    /// model table without replacing the native selectable macOS table.
+    private var modelDiscoveryTable: some View {
+        Table(filtered, selection: rowSelection) {
+            Group {
+                TableColumn("State") { (r: AIDiscoveryRow) in
+                    StatePill(raw: r.state)
+                }
+                .width(80)
+                TableColumn("Categories") { (r: AIDiscoveryRow) in
+                    Text(AIDiscoveryGrouping.csvTruncated(r.categories))
+                        .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                }
+                .width(min: 130, ideal: 190)
+                TableColumn("Product") { (r: AIDiscoveryRow) in
+                    Text(r.product).font(.callout.weight(.medium))
+                }
+                .width(min: 110, ideal: 150)
+                TableColumn("Model") { (r: AIDiscoveryRow) in
+                    Text(r.model).font(.caption).lineLimit(1)
+                }
+                .width(min: 130, ideal: 210)
+                TableColumn("Model status") { (r: AIDiscoveryRow) in
+                    Text(AIDiscoveryGrouping.csvTruncated(r.modelStatuses))
+                        .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                }
+                .width(min: 100, ideal: 130)
+                TableColumn("Format") { (r: AIDiscoveryRow) in
+                    Text(AIDiscoveryGrouping.csvTruncated(r.modelFormats))
+                        .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                }
+                .width(min: 70, ideal: 90)
+            }
+            Group {
+                TableColumn("Component") { (r: AIDiscoveryRow) in
+                    Text(r.componentLabel).font(.caption)
+                }
+                .width(90)
+                TableColumn("Version") { (r: AIDiscoveryRow) in
+                    Text(r.version.isEmpty ? "—" : r.version).font(.caption)
+                }
+                .width(70)
+                TableColumn("Vendor") { (r: AIDiscoveryRow) in
+                    Text(r.vendor).font(.caption)
+                }
+                .width(90)
+                TableColumn("Detectors") { (r: AIDiscoveryRow) in
+                    Text(AIDiscoveryGrouping.csvTruncated(r.detectors))
+                        .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                }
+                .width(min: 130, ideal: 190)
+                TableColumn("Count") { (r: AIDiscoveryRow) in
+                    Text("\(r.count)").font(.caption.monospacedDigit())
+                }
+                .width(46)
+                TableColumn("Identity") { (r: AIDiscoveryRow) in
+                    Text(AIDiscoveryGrouping.formatConfidence(score: r.identityScore, band: r.identityBand))
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+                .width(90)
+                TableColumn("Presence") { (r: AIDiscoveryRow) in
+                    Text(AIDiscoveryGrouping.formatConfidence(score: r.presenceScore, band: r.presenceBand))
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+                .width(90)
+            }
         }
     }
 
-    private var productSection: some View {
-        VStack(spacing: 0) {
-            tableSectionHeader("AI Products & Surfaces", count: filteredProducts.count,
-                               systemImage: "sparkle.magnifyingglass")
-            Divider()
-            productTable
-        }
-    }
-
-    private func tableSectionHeader(
-        _ title: String,
-        count: Int,
-        total: Int? = nil,
-        systemImage: String
-    ) -> some View {
-        HStack(spacing: 7) {
-            Label(title, systemImage: systemImage)
-                .font(.caption.weight(.semibold))
-            Text(total.map { $0 == count ? "\(count)" : "\(count) of \($0)" } ?? "\(count)")
-                .font(.caption2.monospacedDigit())
-                .foregroundStyle(.secondary)
-            Spacer()
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
-        .background(Cisco.surfacePanel)
-    }
-
-    /// Compact model-centric table. Detailed lineage evidence remains in the
-    /// inspector so the model list stays useful in a short split pane.
-    private var modelTable: some View {
-        Table(filteredModels, selection: modelSelection) {
-            TableColumn("State") { (row: AIModelDiscoveryRow) in
-                StatePill(raw: row.state)
-            }
-            .width(80)
-            TableColumn("Model") { (row: AIModelDiscoveryRow) in
-                Text(row.modelID)
-                    .font(.callout.weight(.medium))
-                    .lineLimit(1)
-                    .help(row.modelID)
-            }
-            .width(min: 150, ideal: 240)
-            TableColumn("Owner") { (row: AIModelDiscoveryRow) in
-                let owners = AIDiscoveryGrouping.csvTruncated(row.ownerApplications)
-                Text(owners.isEmpty ? "Unknown app" : owners)
-                    .font(.caption)
-                    .foregroundStyle(owners.isEmpty ? .secondary : .primary)
-                    .lineLimit(1)
-                    .help(owners)
-            }
-            .width(min: 105, ideal: 140)
-            TableColumn("Modality") { (row: AIModelDiscoveryRow) in
-                Text(row.effectiveModality.displayName)
-                    .font(.caption)
-            }
-            .width(82)
-            TableColumn("Relevance") { (row: AIModelDiscoveryRow) in
-                Text(row.effectiveRelevance.displayName)
-                    .font(.caption)
-                    .foregroundStyle(row.effectiveRelevance == .primary ? .primary : .secondary)
-            }
-            .width(82)
-            TableColumn("Confidence") { (row: AIModelDiscoveryRow) in
-                Text(row.confidenceDisplayLabel)
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
-                    .accessibilityLabel(row.confidenceAccessibilityLabel)
-            }
-            .width(84)
-            TableColumn("Status") { (row: AIModelDiscoveryRow) in
-                Text(AIDiscoveryGrouping.csvTruncated(row.statuses))
-                    .font(.caption).foregroundStyle(.secondary).lineLimit(1)
-            }
-            .width(100)
-            TableColumn("Format") { (row: AIModelDiscoveryRow) in
-                Text(AIDiscoveryGrouping.csvTruncated(row.formats))
-                    .font(.caption).foregroundStyle(.secondary).lineLimit(1)
-            }
-            .width(82)
-        }
-        .accessibilityLabel("Discovered local models")
-    }
-
-    /// Column set mirrors the TUI: State · Categories · Product · Component ·
-    /// Version · Vendor · Detectors · Count · Identity · Presence.
-    private var productTable: some View {
-        Table(filteredProducts, selection: productSelection) {
+    private var standardDiscoveryTable: some View {
+        Table(filtered, selection: rowSelection) {
             Group {
                 TableColumn("State") { (r: AIDiscoveryRow) in
                     StatePill(raw: r.state)
@@ -960,82 +700,13 @@ struct AIDiscoveryView: View {
         }
     }
 
-    private func modelInspector(_ row: AIModelDiscoveryRow) -> some View {
-        let provenance = row.provenance
-        let country = provenance?.countryDisplay ?? ""
-        let provenancePairs: [(String, String)]
-        if let provenance {
-            provenancePairs = [
-                ("Country", country.isEmpty ? "Unknown" : country),
-                ("Publisher", provenance.publisher),
-                ("Root model", provenance.rootDisplay),
-                ("Base models", provenance.baseModels.joined(separator: ", ")),
-                ("Derivation", provenance.derivationDisplay),
-                ("Quantized", optionalBooleanLabel(provenance.quantized)),
-                ("Quantization", provenance.quantization),
-                ("Distilled", optionalBooleanLabel(provenance.distilled)),
-                ("Provenance source", displayToken(provenance.source)),
-                ("Provenance confidence", displayToken(provenance.confidence)),
-            ]
-        } else {
-            provenancePairs = [("Provenance", "Unknown")]
-        }
-        let size = row.maxSizeBytes > 0
-            ? ByteCountFormatter.string(fromByteCount: row.maxSizeBytes, countStyle: .file)
-            : ""
-        let modelPairs: [(String, String)] = [
-            ("State", row.state),
-            ("Signals", "\(row.count)"),
-            ("Owner application", row.ownerApplications.joined(separator: ", ").nonEmpty ?? "Unknown"),
-            ("Modality", row.modalities.map(\.displayName).joined(separator: ", ")),
-            ("Relevance", row.relevances.map(\.displayName).joined(separator: ", ")),
-            ("Confidence", row.confidenceDisplayLabel),
-            ("Status", row.statuses.joined(separator: ", ")),
-            ("Format", row.formats.joined(separator: ", ")),
-            ("Runtime / provider", row.providers.joined(separator: ", ")),
-            ("Products", row.products.joined(separator: ", ")),
-            ("Vendors", row.vendors.joined(separator: ", ")),
-            ("Detectors", row.detectors.joined(separator: ", ")),
-            ("Size", size),
-            ("Pinned", row.isPinned ? "Yes" : ""),
-            ("Last active", DCDates.relative(row.lastActive)),
-        ]
-        let inspectorPairs = (modelPairs + provenancePairs).filter { !$0.1.isEmpty }
-
-        return VStack(alignment: .leading, spacing: 10) {
-            HStack {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(row.modelID).font(.headline).textSelection(.enabled)
-                    Text("Local model").font(.caption).foregroundStyle(.secondary)
-                }
-                Spacer()
-                Button { selection = nil } label: { Image(systemName: "xmark.circle.fill") }
-                    .buttonStyle(.borderless)
-            }
-            ScrollView {
-                VStack(alignment: .leading, spacing: 10) {
-                    KeyValueGrid(pairs: inspectorPairs)
-                    Divider()
-                    Text("Signals").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-                    VStack(alignment: .leading, spacing: 6) {
-                        ForEach(Array(row.signals.enumerated()), id: \.offset) { _, signal in
-                            modelSignalCard(signal)
-                        }
-                    }
-                }
-            }
-            Spacer()
-        }
-        .padding(12)
-    }
-
-    private func productInspector(_ row: AIDiscoveryRow) -> some View {
+    private func rowInspector(_ row: AIDiscoveryRow) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
                 Text(row.vendor.isEmpty ? row.product : "\(row.vendor) / \(row.product)")
                     .font(.headline)
                 Spacer()
-                Button { selection = nil } label: { Image(systemName: "xmark.circle.fill") }
+                Button { selected = nil } label: { Image(systemName: "xmark.circle.fill") }
                     .buttonStyle(.borderless)
             }
             KeyValueGrid(pairs: [
@@ -1106,58 +777,77 @@ struct AIDiscoveryView: View {
         .background(Cisco.surfacePanel, in: RoundedRectangle(cornerRadius: 6))
     }
 
-    private func modelSignalCard(_ signal: AISignal) -> some View {
-        signalInspector(signal)
-    }
-
-    private func optionalBooleanLabel(_ value: Bool?) -> String {
-        guard let value else { return "Unknown" }
-        return value ? "Yes" : "No"
-    }
-
-    private func displayToken(_ value: String) -> String {
-        value.replacingOccurrences(of: "_", with: " ").capitalized
-    }
-
-    private func reconcileSelection() {
-        switch selection {
-        case let .product(id) where !filteredProducts.contains(where: { $0.id == id }):
-            selection = nil
-        case let .model(id) where !filteredModels.contains(where: { $0.id == id }):
-            selection = nil
-        default:
-            break
-        }
-    }
-
     private func load() async {
-        guard appState.gatewayReachable else { return }
         let installationGeneration = appState.installationGeneration
         do {
             let freshSnapshot = try await appState.gateway.aiUsage()
             guard installationGeneration == appState.installationGeneration else { return }
             snapshot = freshSnapshot
             loaded = true
-            reconcileSelection()
             error = nil
         } catch {
             guard installationGeneration == appState.installationGeneration else { return }
+            loaded = false
             self.error = error.localizedDescription
         }
     }
 
-    private func scan() {
+    private func requestScan() {
+        guard !scanning else { return }
+        scanRequested = true
+        Task { await fulfillScanRequest() }
+    }
+
+    private func fulfillScanRequest() async {
+        guard scanRequested, !scanning else { return }
+        switch AIDiscoveryScanRequestStep.resolve(
+            statusLoaded: loaded && error == nil,
+            enabled: snapshot.enabled
+        ) {
+        case .loadStatus:
+            await load()
+            guard loaded else { return }
+            await fulfillScanRequest()
+        case .showDisabled:
+            scanRequested = false
+            error = "AI Discovery is disabled. Use Enable AI Discovery above before scanning."
+        case .scan:
+            scanRequested = false
+            run(.scan)
+        }
+    }
+
+    private func run(_ action: AIDiscoveryPrimaryAction) {
         guard appState.installationMutationsAllowed else {
             error = appState.installationReadOnlyReason ?? "This installation is read only."
             return
         }
+        guard !scanning else { return }
         scanning = true
         appState.scanInFlight = true
+        error = nil
         Task {
-            do {
-                try await appState.gateway.aiScan()
+            let result = await appState.runCommand(
+                title: action.title,
+                arguments: action.arguments,
+                mutation: true,
+                category: action.category,
+                origin: "AI Discovery",
+                successEffects: action.successEffects,
+                suggestedNextAction: "Review the refreshed AI Discovery inventory.",
+                refreshOnSuccess: true
+            )
+            if result.succeeded {
+                await appState.pulse()
                 await load()
-            } catch { self.error = "Scan failed: \(error.localizedDescription)" }
+            } else {
+                let detail = result.output
+                    .split(separator: "\n")
+                    .last(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })
+                    .map(String.init)
+                error = detail.map { "\(action.title) failed: \($0)" }
+                    ?? "\(action.title) failed with exit \(result.exitCode)."
+            }
             scanning = false
             appState.scanInFlight = false
         }
@@ -1256,7 +946,7 @@ struct RegistriesView: View {
                         Label("Add Source", systemImage: "plus")
                     }
                     .disabled(!appState.installationMutationsAllowed)
-                    .help("Add Registry Source")
+                    .dcQuickHelp("Add Registry Source")
 
                     Button(role: .destructive) {
                         sourcePendingRemoval = selectedSource
@@ -1268,7 +958,7 @@ struct RegistriesView: View {
                             || running
                             || !appState.installationMutationsAllowed
                     )
-                    .help("Remove Selected Source")
+                    .dcQuickHelp("Remove Selected Source")
                 } else {
                     Button {
                         if let entry = selectedEntry { approve(entry) }
@@ -1280,6 +970,7 @@ struct RegistriesView: View {
                             || running
                             || !appState.installationMutationsAllowed
                     )
+                    .dcQuickHelp("Approve selected registry entry")
 
                     Button(role: .destructive) {
                         entryPendingRejection = selectedEntry
@@ -1291,6 +982,7 @@ struct RegistriesView: View {
                             || running
                             || !appState.installationMutationsAllowed
                     )
+                    .dcQuickHelp("Reject selected registry entry")
 
                     Button {
                         if let entry = selectedEntry { toggleRequirement(for: entry) }
@@ -1302,7 +994,7 @@ struct RegistriesView: View {
                             || running
                             || !appState.installationMutationsAllowed
                     )
-                    .help(requirementActionLabel)
+                    .dcQuickHelp(requirementActionLabel)
                 }
 
                 Button {
@@ -1315,6 +1007,7 @@ struct RegistriesView: View {
                         || selectedSourceForSync == nil
                         || !appState.installationMutationsAllowed
                 )
+                .dcQuickHelp("Sync selected registry source")
 
                 Button {
                     syncAll()
@@ -1326,6 +1019,7 @@ struct RegistriesView: View {
                         || snapshot.sources.isEmpty
                         || !appState.installationMutationsAllowed
                 )
+                .dcQuickHelp("Sync all registry sources")
 
                 Button {
                     Task { await load() }
@@ -1333,6 +1027,7 @@ struct RegistriesView: View {
                     Label("Refresh", systemImage: "arrow.clockwise")
                 }
                 .disabled(running)
+                .dcQuickHelp("Refresh registries")
             }
         }
         .task { await load() }

--- a/macos/DefenseClawMac/DefenseClawMac/Features/FirstRunView.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/FirstRunView.swift
@@ -194,9 +194,6 @@ struct FirstRunView: View {
                         .keyboardShortcut(.defaultAction)
                         .disabled(setupInvalid || !appState.installationMutationsAllowed)
                     }
-                    .buttonStyle(.borderedProminent)
-                    .keyboardShortcut(.defaultAction)
-                    .disabled(setupInvalid || !appState.installationMutationsAllowed)
                 }
             }
         }

--- a/macos/DefenseClawMac/DefenseClawMac/Features/FirstRunView.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/FirstRunView.swift
@@ -55,6 +55,7 @@ struct FirstRunView: View {
     @State private var checked = false
     @State private var connector = "codex"
     @State private var detectedConnectors: [String] = []
+    @State private var detectedProxyConnectors: [String] = []
     @State private var registeredConnectors: Set<String> = []
     @State private var actionConnectors: Set<String> = []
     @State private var discoveryRequested = false
@@ -70,6 +71,9 @@ struct FirstRunView: View {
     @State private var verify = true
     @State private var runID: UUID?
     @State private var exitCode: Int32?
+    @State private var installerRelease: RuntimeInstallerInfo?
+    @State private var installerMetadataLoading = false
+    @State private var installerMetadataError: String?
 
     private static let connectors = ConnectorDiscoverySelection.onboardingConnectors
     private static let installerURL = URL(
@@ -154,8 +158,8 @@ struct FirstRunView: View {
                     } label: {
                         Label(
                             runtimeInstallIsCancelling
-                                ? "Cancelling…"
-                                : (runtimeInstallIsFinishing ? "Finishing…" : "Cancel Install"),
+                                ? "Cancelling..."
+                                : (runtimeInstallIsFinishing ? "Finishing..." : "Cancel Install"),
                             systemImage: runtimeInstallIsFinishing ? "hourglass" : "stop.fill"
                         )
                     }
@@ -165,16 +169,30 @@ struct FirstRunView: View {
                         if let runID { appState.activity.cancel(runID) }
                     } label: {
                         Label(
-                            isCancelling ? "Cancelling…" : (isFinishing ? "Finishing…" : "Cancel"),
+                            isCancelling ? "Cancelling..." : (isFinishing ? "Finishing..." : "Cancel"),
                             systemImage: isFinishing ? "hourglass" : "stop.fill"
                         )
                     }
                     .disabled(isCancelling || isFinishing)
                 } else if cliFound {
-                    Button {
-                        initialize()
-                    } label: {
-                        Label(exitCode == 0 ? "Run Setup Again" : "Initialize DefenseClaw", systemImage: "play.fill")
+                    if detectedConnectors.isEmpty, !detectedProxyConnectors.isEmpty {
+                        Button {
+                            appState.selectedPanel = .setup
+                            dismiss()
+                        } label: {
+                            Label("Open Proxy Connector Setup", systemImage: "cable.connector")
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .keyboardShortcut(.defaultAction)
+                    } else {
+                        Button {
+                            initialize()
+                        } label: {
+                            Label(exitCode == 0 ? "Run Setup Again" : "Initialize DefenseClaw", systemImage: "play.fill")
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .keyboardShortcut(.defaultAction)
+                        .disabled(setupInvalid || !appState.installationMutationsAllowed)
                     }
                     .buttonStyle(.borderedProminent)
                     .keyboardShortcut(.defaultAction)
@@ -192,6 +210,9 @@ struct FirstRunView: View {
             // until a config exists — never exec other binaries without an
             // explicit user action.
             cliFound = await appState.cli.locateBinary() != nil
+            if !cliFound {
+                await loadInstallerRelease()
+            }
         }
     }
 
@@ -244,10 +265,20 @@ struct FirstRunView: View {
                         }
                     }
                 } else {
-                    Picker("Fallback hook connector", selection: $connector) {
-                        ForEach(Self.connectors, id: \.self) {
-                            Text(friendlyConnectorName($0)).tag($0)
+                    if detectedProxyConnectors.isEmpty {
+                        Picker("Fallback hook connector", selection: $connector) {
+                            ForEach(TUIWizards.hookConnectors, id: \.self) {
+                                Text(friendlyConnectorName($0)).tag($0)
+                            }
                         }
+                    } else {
+                        LabeledContent("Detected proxy connectors") {
+                            Text(detectedProxyConnectors.map(friendlyConnectorName).joined(separator: ", "))
+                                .multilineTextAlignment(.trailing)
+                        }
+                        Text("Proxy connectors require their dedicated Setup flow. Continue with Open Proxy Connector Setup below.")
+                            .font(.caption)
+                            .foregroundStyle(Cisco.orange)
                     }
                     HStack(spacing: 8) {
                         Button {
@@ -262,11 +293,13 @@ struct FirstRunView: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
-                    Text(discoveryRequested
-                         ? "No installed hook connectors were returned by discovery. Setup will use this explicit hook connector fallback."
-                         : "Choose a hook connector directly, or detect the agents installed on this Mac.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    if detectedProxyConnectors.isEmpty {
+                        Text(discoveryRequested
+                             ? "No installed hook connectors were returned by discovery. Setup will use this explicit hook connector fallback."
+                             : "Choose a hook connector directly, or detect the agents installed on this Mac.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                     if let connectorDiscoveryError {
                         Label(connectorDiscoveryError, systemImage: "exclamationmark.triangle.fill")
                             .font(.caption)
@@ -368,15 +401,56 @@ struct FirstRunView: View {
 
     private var scriptInstaller: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("Download the installer, review its contents, then run it from Terminal. The Mac app does not execute a remote script automatically.")
+            Text("Download the release installer, verify its published SHA-256 digest, review the verified local file, then run it from Terminal. The Mac app does not execute a remote script automatically.")
                 .font(.callout).foregroundStyle(.secondary)
-            Link(destination: Self.installerURL) {
-                Label("Review Install Script", systemImage: "safari")
+            if installerMetadataLoading {
+                HStack(spacing: 6) {
+                    ProgressView().controlSize(.small)
+                    Text("Loading authenticated release metadata...")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } else if let installerRelease {
+                Link(destination: installerRelease.releaseURL) {
+                    Label("Open DefenseClaw \(installerRelease.tag) Release", systemImage: "safari")
+                }
+                installCommandRow("1. Download and Verify", command: installerRelease.downloadCommand)
+                installCommandRow("2. Review Verified Local File", command: installerRelease.reviewCommand)
+                installCommandRow("3. Verify Again and Run", command: installerRelease.runCommand)
+                Text("Expected SHA-256: \(installerRelease.assetSHA256)")
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            } else {
+                Label(
+                    installerMetadataError
+                        ?? "Authenticated installer metadata is unavailable. No shell command was generated.",
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .font(.caption)
+                .foregroundStyle(Cisco.orange)
+                Link(
+                    "Open Official DefenseClaw Releases",
+                    destination: URL(
+                        string: "https://github.com/cisco-ai-defense/defenseclaw/releases"
+                    )!
+                )
             }
-            installCommandRow("1. Download", command: Self.downloadCommand)
-            installCommandRow("2. Run After Review", command: Self.runCommand)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @MainActor
+    private func loadInstallerRelease() async {
+        guard !installerMetadataLoading else { return }
+        installerMetadataLoading = true
+        installerMetadataError = nil
+        defer { installerMetadataLoading = false }
+        guard let release = await appState.updater.latestRuntimeInstaller() else {
+            installerMetadataError = "The latest release has no digest-bound install.sh asset. Use the official release page and verify its published checksum manually."
+            return
+        }
+        installerRelease = release
     }
 
     private func execution(_ entry: CommandActivityEntry) -> some View {
@@ -460,6 +534,7 @@ struct FirstRunView: View {
         Task {
             cliFound = await appState.cli.locateBinary() != nil
             appState.installDetected = await appState.configStore.installPresent
+            if !cliFound { await loadInstallerRelease() }
             // Re-discover only after the user opted into discovery — Check
             // Again must not become a back door into exec'ing agent CLIs.
             if cliFound, discoveryRequested { await discoverConnectors() }
@@ -481,21 +556,23 @@ struct FirstRunView: View {
             arguments: ["agent", "discover", "--json", "--no-emit-otel", "--refresh"],
             mutation: true
         )
-        let detected = result.succeeded
+        let allDetected = result.succeeded
             ? ConnectorOnboarding.installedConnectors(from: result.output, supportedOrder: Self.connectors)
             : []
+        let detected = allDetected.filter { TUIWizards.hookConnectors.contains($0) }
         let selection = ConnectorDiscoverySelection.reconciling(
             previouslyDetected: detectedConnectors,
             detected: detected,
             registered: registeredConnectors,
             action: actionConnectors
         )
+        detectedProxyConnectors = allDetected.filter { TUIWizards.proxyConnectors.contains($0) }
         detectedConnectors = detected
         // Pre-check the first discovery and later additions, while preserving
         // explicit choices for connectors that remain installed.
         registeredConnectors = selection.registered
         actionConnectors = selection.action
-        if detected.isEmpty {
+        if allDetected.isEmpty {
             connectorDiscoveryError = result.succeeded
                 ? "Agent discovery completed but did not identify a supported connector."
                 : "Agent discovery failed (exit \(result.exitCode)); choose a fallback connector."

--- a/macos/DefenseClawMac/DefenseClawMac/Features/LogsView.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/LogsView.swift
@@ -100,7 +100,7 @@ struct LogsView: View {
         .inspector(isPresented: inspectorPresented) {
             if let selectedDisplayRow {
                 logInspector(selectedDisplayRow)
-                    .inspectorColumnWidth(min: 300, ideal: 380)
+                    .dcInspectorColumnWidth()
             }
         }
         .searchable(text: $search, placement: .toolbar, prompt: "Search log lines")
@@ -110,11 +110,13 @@ struct LogsView: View {
                     Label("Auto-scroll", systemImage: "arrow.down.to.line")
                 }
                 .toggleStyle(.button)
+                .dcQuickHelp("Follow new log lines")
                 Button {
                     reload()
                 } label: {
                     Label("Reload from disk", systemImage: "arrow.clockwise")
                 }
+                .dcQuickHelp("Reload logs from disk")
             }
         }
         .task {
@@ -145,49 +147,93 @@ struct LogsView: View {
     private var filterBar: some View {
         @Bindable var state = appState
         return VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 12) {
-                Picker("Stream", selection: $stream) {
-                    ForEach(LogStream.allCases) { s in Text(s.title).tag(s) }
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 12) {
+                    streamPicker.frame(maxWidth: 440)
+                    Spacer()
+                    Button("Redaction policy…") { showRedactionPolicy = true }
+                        .controlSize(.small)
+                        .help("Inspect or apply the v8 redaction policy")
+                    ConnectorFilterChip(names: appState.activeConnectorNames, selection: $state.connectorFilter)
                 }
-                .pickerStyle(.segmented)
-                .frame(maxWidth: 440)
-                .onChange(of: stream) { _, _ in Task { await load(force: true) } }
-                Spacer()
-                Button("Redaction policy…") { showRedactionPolicy = true }
-                    .controlSize(.small)
-                    .help("Inspect or apply the v8 redaction policy")
-                ConnectorFilterChip(names: appState.activeConnectorNames, selection: $state.connectorFilter)
+                HStack(spacing: 10) {
+                    streamPicker.frame(maxWidth: .infinity)
+                    Button("Redaction policy…") { showRedactionPolicy = true }
+                        .controlSize(.small)
+                        .help("Inspect or apply the v8 redaction policy")
+                    ConnectorFilterChip(names: appState.activeConnectorNames, selection: $state.connectorFilter)
+                }
             }
 
-            HStack(spacing: 12) {
-                FilterChipRow(
-                    "Preset",
-                    options: [("Preset: all", LogPreset.all)] +
-                        LogPreset.allCases.dropFirst().map { ($0.rawValue, $0) },
-                    selection: $preset
-                )
-                Picker("Severity ≥", selection: $severityFloor) {
-                    Text("Any severity").tag(Optional<Severity>.none)
-                    ForEach([Severity.critical, .high, .medium, .low], id: \.self) {
-                        Text("≥ \($0.rawValue)").tag(Optional($0))
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 12) {
+                    FilterChipRow(
+                        "Preset",
+                        options: [("Preset: all", LogPreset.all)] +
+                            LogPreset.allCases.dropFirst().map { ($0.rawValue, $0) },
+                        selection: $preset
+                    )
+                    severityPicker.frame(width: 150)
+                    actionPicker.frame(width: 120)
+                    eventPicker.frame(width: 120)
+                    Spacer()
+                    resultCount
+                }
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 10) {
+                        Picker("Preset", selection: $preset) {
+                            ForEach(LogPreset.allCases) { Text($0.rawValue).tag($0) }
+                        }
+                        .pickerStyle(.menu)
+                        .fixedSize()
+                        severityPicker.frame(maxWidth: 170)
+                        Spacer()
+                    }
+                    HStack(spacing: 10) {
+                        actionPicker.frame(maxWidth: 130)
+                        eventPicker.frame(maxWidth: 130)
+                        Spacer()
+                        resultCount
                     }
                 }
-                .frame(width: 150)
-                Picker("Action", selection: $actionFilter) {
-                    ForEach(Self.actionOptions, id: \.self) { Text($0).tag($0) }
-                }
-                .frame(width: 120)
-                Picker("Event", selection: $eventTypeFilter) {
-                    ForEach(Self.eventTypeOptions, id: \.self) { Text($0).tag($0) }
-                }
-                .frame(width: 120)
-                Spacer()
-                Text("\(displayRows.count) shown · \(filtered.count) matching · \(rows.count) total")
-                    .font(.caption2.monospacedDigit())
-                    .foregroundStyle(.secondary)
             }
         }
         .padding(10)
+    }
+
+    private var streamPicker: some View {
+        Picker("Stream", selection: $stream) {
+            ForEach(LogStream.allCases) { Text($0.title).tag($0) }
+        }
+        .pickerStyle(.segmented)
+        .onChange(of: stream) { _, _ in Task { await load(force: true) } }
+    }
+
+    private var severityPicker: some View {
+        Picker("Severity ≥", selection: $severityFloor) {
+            Text("Any severity").tag(Optional<Severity>.none)
+            ForEach([Severity.critical, .high, .medium, .low], id: \.self) {
+                Text("≥ \($0.rawValue)").tag(Optional($0))
+            }
+        }
+    }
+
+    private var actionPicker: some View {
+        Picker("Action", selection: $actionFilter) {
+            ForEach(Self.actionOptions, id: \.self) { Text($0).tag($0) }
+        }
+    }
+
+    private var eventPicker: some View {
+        Picker("Event", selection: $eventTypeFilter) {
+            ForEach(Self.eventTypeOptions, id: \.self) { Text($0).tag($0) }
+        }
+    }
+
+    private var resultCount: some View {
+        Text("\(displayRows.count) shown · \(filtered.count) matching · \(rows.count) total")
+            .font(.caption2.monospacedDigit())
+            .foregroundStyle(.secondary)
     }
 
     private var logList: some View {
@@ -321,39 +367,43 @@ struct LogsView: View {
     }
 
     private func logInspector(_ item: DisplayLogRow) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Text("Event Details").font(.headline)
-                Spacer()
-                Button { selectedRowID = nil } label: {
-                    Image(systemName: "xmark.circle.fill")
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text("Event Details").font(.headline)
+                    Spacer()
+                    Button { selectedRowID = nil } label: {
+                        Image(systemName: "xmark.circle.fill")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Close Inspector")
                 }
-                .buttonStyle(.borderless)
-                .help("Close Inspector")
-            }
-            Text(item.message)
-                .font(.system(.callout, design: .monospaced))
-                .textSelection(.enabled)
-            KeyValueGrid(pairs: [
-                ("First", item.row.timestamp.formatted(date: .abbreviated, time: .standard)),
-                ("Last", item.lastTimestamp.formatted(date: .abbreviated, time: .standard)),
-                ("Stream", item.row.stream.title),
-                ("Event", item.row.eventType),
-                ("Action", item.row.action),
-                ("Severity", item.row.severity.rawValue),
-                ("Connector", item.row.connector),
-                ("Occurrences", "\(item.count)"),
-            ].filter { !$0.1.isEmpty })
-            Divider()
-            Text("Raw Event").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-            ScrollView {
+                Text(item.message)
+                    .font(.system(.callout, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                KeyValueGrid(pairs: [
+                    ("First", item.row.timestamp.formatted(date: .abbreviated, time: .standard)),
+                    ("Last", item.lastTimestamp.formatted(date: .abbreviated, time: .standard)),
+                    ("Stream", item.row.stream.title),
+                    ("Event", item.row.eventType),
+                    ("Action", item.row.action),
+                    ("Severity", item.row.severity.rawValue),
+                    ("Connector", item.row.connector),
+                    ("Occurrences", "\(item.count)"),
+                ].filter { !$0.1.isEmpty })
+                Divider()
+                Text("Raw Event").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
                 Text(item.row.rawJSON)
                     .font(.system(.caption, design: .monospaced))
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
                     .textSelection(.enabled)
             }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(12)
     }
 
     /// Refreshes from the stream buffer, but only publishes when the tail

--- a/macos/DefenseClawMac/DefenseClawMac/Features/MainWindow.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/MainWindow.swift
@@ -31,6 +31,9 @@ struct MainWindow: View {
     ]
 
     var body: some View {
+        // Keep sidebar visibility under NavigationSplitView/user control.
+        // Coupling it to inspector lifecycle events can create a re-entrant
+        // AppKit constraint pass while SwiftUI is inserting the inspector.
         NavigationSplitView {
             List(selection: selectedPanelBinding) {
                 ForEach(groups, id: \.0) { group in
@@ -88,7 +91,7 @@ struct MainWindow: View {
                 Button { appState.commandPalettePresented = true } label: {
                     Label("Command Palette", systemImage: "command")
                 }
-                .help("Command Palette (Command-Shift-P)")
+                .dcQuickHelp("Command Palette (Command-Shift-P)")
             }
         }
         .onAppear {

--- a/macos/DefenseClawMac/DefenseClawMac/Features/MenuBarPopover.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/MenuBarPopover.swift
@@ -190,8 +190,8 @@ struct MenuBarPopover: View {
     }
 
     private func openMainWindow() {
-        AppDelegate.recreateMainWindow = { openWindow(id: "main") }
-        AppDelegate.openMainWindow()
+        AppDelegate.prepareForMainWindowPresentation()
+        openWindow(id: "main")
     }
 
     private var displayedConnectors: [ConnectorHealth] {
@@ -275,6 +275,7 @@ struct MenuBarPopover: View {
             .controlSize(.small)
             .disabled(
                 appState.unackedAlerts.isEmpty
+                    || appState.ackInProgress
                     || !appState.installationMutationsAllowed
             )
             Button(appState.monitoringPaused ? "Resume" : "Pause") {

--- a/macos/DefenseClawMac/DefenseClawMac/Features/OverviewView.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/OverviewView.swift
@@ -22,6 +22,7 @@ import Charts
 
 struct OverviewView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.openSettings) private var openSettings
     @State private var summary: (blockedSkills: Int, allowedSkills: Int, blockedMCPs: Int, allowedMCPs: Int, totalScans: Int, activeAlerts: Int) = (0, 0, 0, 0, 0, 0)
     @State private var hourly: [HourlyPoint] = []
     @State private var doctorRunning = false
@@ -75,18 +76,23 @@ struct OverviewView: View {
         .toolbar {
             ToolbarItemGroup {
                 connectorScopeChip
-                StaleBadge(date: appState.health.fetchedAt)
+            }
+            ToolbarItem {
                 Button {
                     runDoctor()
                 } label: {
                     Label("Run Health Check", systemImage: "stethoscope")
                 }
                 .disabled(doctorRunning || !appState.installationMutationsAllowed)
+                .dcQuickHelp("Run DefenseClaw Doctor")
+            }
+            ToolbarItem {
                 Button {
                     refresh()
                 } label: {
                     Label("Refresh", systemImage: "arrow.clockwise")
                 }
+                .dcQuickHelp("Refresh overview")
             }
         }
         .task { refresh() }
@@ -174,64 +180,88 @@ struct OverviewView: View {
 
     private var quickActionsCard: some View {
         DCCard("Quick Actions", systemImage: "bolt") {
-            HStack(spacing: 8) {
-                Button {
-                    runOverviewCommand(
-                        title: "Scan all skills",
-                        arguments: ["skill", "scan", "--all"],
-                        category: "scan",
-                        effects: ["Skill scan results refreshed"]
-                    )
-                } label: {
-                    Label("Scan Skills", systemImage: "wand.and.rays")
-                }
-                .disabled(!appState.installationMutationsAllowed)
-                Button {
-                    appState.selectedPanel = .inventory
-                } label: {
-                    Label("Open Inventory", systemImage: "shippingbox")
-                }
-                Button {
-                    let action = appState.gatewayReachable ? "restart" : "start"
-                    runOverviewCommand(
-                        title: "\(action.capitalized) gateway",
-                        binary: "defenseclaw-gateway",
-                        arguments: [action],
-                        category: "daemon",
-                        effects: [appState.gatewayReachable ? "Gateway restarted" : "Gateway started"]
-                    )
-                } label: {
-                    Label(appState.gatewayReachable ? "Restart Gateway" : "Start Gateway",
-                          systemImage: appState.gatewayReachable ? "arrow.clockwise.circle" : "play.circle")
-                }
-                .disabled(!appState.installationMutationsAllowed)
-                Button {
-                    runDoctor()
-                } label: {
-                    Label("Run Doctor", systemImage: "stethoscope")
-                }
-                .disabled(doctorRunning || !appState.installationMutationsAllowed)
-                Menu {
-                    Button("Validate Configuration") {
-                        runOverviewCommand(title: "Validate configuration", arguments: ["config", "validate"], category: "info")
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 8) {
+                    Button {
+                        runOverviewCommand(
+                            title: "Scan all skills",
+                            arguments: ["skill", "scan", "--all"],
+                            category: "scan",
+                            effects: ["Skill scan results refreshed"]
+                        )
+                    } label: {
+                        Label("Scan Skills", systemImage: "wand.and.rays")
                     }
-                    Button("Check Credentials") {
-                        runOverviewCommand(title: "Check credentials", arguments: ["keys", "check"], category: "info")
+                    .disabled(!appState.installationMutationsAllowed)
+                    Button {
+                        appState.selectedPanel = .inventory
+                    } label: {
+                        Label("Open Inventory", systemImage: "shippingbox")
                     }
-                    Button("Gateway Status") {
-                        runOverviewCommand(title: "Gateway status", binary: "defenseclaw-gateway", arguments: ["status"], category: "info")
+                    Button {
+                        let action = appState.gatewayReachable ? "restart" : "start"
+                        runOverviewCommand(
+                            title: "\(action.capitalized) gateway",
+                            binary: "defenseclaw-gateway",
+                            arguments: [action],
+                            category: "daemon",
+                            effects: [appState.gatewayReachable ? "Gateway restarted" : "Gateway started"]
+                        )
+                    } label: {
+                        Label(appState.gatewayReachable ? "Restart Gateway" : "Start Gateway",
+                              systemImage: appState.gatewayReachable ? "arrow.clockwise.circle" : "play.circle")
                     }
-                    Button("Show Provenance") {
-                        runOverviewCommand(title: "Show gateway provenance", binary: "defenseclaw-gateway", arguments: ["provenance", "show"], category: "info")
+                    .disabled(!appState.installationMutationsAllowed)
+                    Button {
+                        runDoctor()
+                    } label: {
+                        Label("Run Doctor", systemImage: "stethoscope")
                     }
+                    .disabled(doctorRunning || !appState.installationMutationsAllowed)
+                    Menu {
+                        Button("Validate Configuration") {
+                            runOverviewCommand(title: "Validate configuration", arguments: ["config", "validate"], category: "info")
+                        }
+                        Button("Check Credentials") {
+                            runOverviewCommand(title: "Check credentials", arguments: ["keys", "check"], category: "info")
+                        }
+                        Button("Gateway Status") {
+                            runOverviewCommand(title: "Gateway status", binary: "defenseclaw-gateway", arguments: ["status"], category: "info")
+                        }
+                        Button("Show Provenance") {
+                            runOverviewCommand(title: "Show gateway provenance", binary: "defenseclaw-gateway", arguments: ["provenance", "show"], category: "info")
+                        }
+                        Divider()
+                        Button("Open Command Palette") { appState.commandPalettePresented = true }
+                    } label: {
+                        Label("Diagnostics", systemImage: "ellipsis.circle")
+                    }
+                    Spacer()
+                }
+                .controlSize(.small)
+
+                if let reason = appState.installationReadOnlyReason {
                     Divider()
-                    Button("Open Command Palette") { appState.commandPalettePresented = true }
-                } label: {
-                    Label("Diagnostics", systemImage: "ellipsis.circle")
+                    HStack(spacing: 12) {
+                        Label("State-changing actions disabled: \(reason)", systemImage: "lock.shield")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .textSelection(.enabled)
+                            .layoutPriority(1)
+                        Spacer(minLength: 8)
+                        Button("Review Installation") {
+                            appState.selectedSettingsTab = .connection
+                            openSettings()
+                        }
+                        .controlSize(.small)
+                        .fixedSize()
+                    }
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Cisco.orange.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
                 }
-                Spacer()
             }
-            .controlSize(.small)
         }
     }
 

--- a/macos/DefenseClawMac/DefenseClawMac/Features/SetupDefinitions.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/SetupDefinitions.swift
@@ -16,6 +16,25 @@
 
 import Foundation
 
+enum SetupSecretTransportPolicy {
+    static func validationMessage(
+        wizard: WizardDefinition,
+        values: [String: String],
+        visibleFields: [WizardField]
+    ) -> String? {
+        let environmentValues = Set<String>((wizard.secretEnvironment?(values) ?? [:]).values)
+        guard let field = visibleFields.first(where: { field in
+            guard case .secure = field.kind else { return false }
+            let secret = values[field.key] ?? ""
+            return !secret.isEmpty
+                && wizard.secretInputField != field.key
+                && !environmentValues.contains(secret)
+        }) else { return nil }
+        return "\(field.label) cannot be submitted securely by the installed DefenseClaw runtime. "
+            + "Leave it blank to use an existing credential, or save it separately in Setup > Credentials."
+    }
+}
+
 /// Setup areas exposed by the DefenseClaw TUI. Definitions stay
 /// data-driven so the native form, command review, and CLI execution use one
 /// source of truth.
@@ -628,7 +647,7 @@ enum TUIWizards {
 
     private static let observability = WizardDefinition(
         id: "observability", title: "Observability", icon: "chart.xyaxis.line",
-        blurb: "Add, list, enable, disable, or remove OTel and audit destinations.",
+        blurb: "Add, list, enable, disable, remove, or test OTel and audit destinations.",
         baseArgs: ["setup", "observability"], commandBuilder: observabilityCommands,
         secretEnvironment: { v in
             let token = value(v, "token")
@@ -659,7 +678,7 @@ enum TUIWizards {
             WizardField(key: "url", label: "Webhook URL", kind: .text(placeholder: "https://…"), visibleWhen: (key: "action", equals: ["add"]), visibleWhen2: (key: "preset", equals: ["webhook"])),
             WizardField(key: "method", label: "Webhook method", kind: .choice(options: ["POST", "PUT"]), defaultValue: "POST", visibleWhen: (key: "action", equals: ["add"]), visibleWhen2: (key: "preset", equals: ["webhook"])),
             WizardField(key: "url-path", label: "Webhook URL path", kind: .text(placeholder: "/events"), visibleWhen: (key: "action", equals: ["add"]), visibleWhen2: (key: "preset", equals: ["webhook"])),
-            WizardField(key: "verify-tls-hec", label: "Verify HEC TLS", kind: .bool, defaultValue: "no", visibleWhen: (key: "action", equals: ["add"]), visibleWhen2: (key: "preset", equals: ["splunk-hec"])),
+            WizardField(key: "verify-tls-hec", label: "Verify HEC TLS", kind: .bool, defaultValue: "yes", visibleWhen: (key: "action", equals: ["add"]), visibleWhen2: (key: "preset", equals: ["splunk-hec"])),
             WizardField(key: "verify-tls-webhook", label: "Verify webhook TLS", kind: .bool, defaultValue: "yes", visibleWhen: (key: "action", equals: ["add"]), visibleWhen2: (key: "preset", equals: ["webhook"])),
             WizardField(key: "token", label: "Token / API key", kind: .secure(placeholder: "optional token"), visibleWhen: (key: "action", equals: ["add"])),
             WizardField(key: "dry-run", label: "Preview without writing", kind: .flagOnly, defaultValue: "no", visibleWhen: (key: "action", equals: ["add"])),
@@ -1231,9 +1250,13 @@ enum TUIWizards {
             }
             for key in keys { append(v, key, flag: "--\(key)", to: &args) }
             if preset == "splunk-hec" {
-                args.append(yes(v, "verify-tls-hec") ? "--verify-tls" : "--no-verify-tls")
+                let verifyTLS = value(v, "verify-tls-hec", "yes") != "no"
+                let insecureLoopback = !verifyTLS
+                    && splunkHECHostAllowsInsecureTLS(value(v, "host", "localhost"))
+                args.append(insecureLoopback ? "--no-verify-tls" : "--verify-tls")
             } else if preset == "webhook" {
-                args.append(yes(v, "verify-tls-webhook") ? "--verify-tls" : "--no-verify-tls")
+                let verifyTLS = value(v, "verify-tls-webhook", "yes") != "no"
+                args.append(verifyTLS ? "--verify-tls" : "--no-verify-tls")
             }
         } else if ["enable", "disable", "remove"].contains(action) {
             let name = value(v, "name")
@@ -1297,7 +1320,37 @@ enum TUIWizards {
         if preset == "splunk-hec", Int(value(v, "port")).map({ $0 > 0 }) != true {
             return "Splunk HEC port must be a positive integer."
         }
+        if preset == "splunk-hec",
+           value(v, "verify-tls-hec", "yes") == "no",
+           !splunkHECHostAllowsInsecureTLS(value(v, "host", "localhost")) {
+            return "TLS verification can only be disabled for a loopback Splunk HEC host "
+                + "(localhost, *.localhost, 127.0.0.0/8, or ::1)."
+        }
         return nil
+    }
+
+    static func splunkHECHostAllowsInsecureTLS(_ rawHost: String) -> Bool {
+        var host = rawHost.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if host == "::1" || host == "[::1]" { return true }
+
+        let candidate = host.contains("://") ? host : "https://\(host)"
+        if let parsed = URL(string: candidate)?.host?.lowercased(), !parsed.isEmpty {
+            host = parsed
+        }
+        while host.hasSuffix(".") { host.removeLast() }
+        if host == "localhost" || host.hasSuffix(".localhost") || host == "::1" {
+            return true
+        }
+
+        let octets = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard octets.count == 4,
+              octets.allSatisfy({ part in
+                  guard !part.isEmpty,
+                        part.allSatisfy(\.isNumber),
+                        let number = Int(part) else { return false }
+                  return number <= 255
+              }) else { return false }
+        return octets[0] == "127"
     }
 
     static func webhookCommands(_ v: [String: String], _ mask: Bool) -> [[String]] {

--- a/macos/DefenseClawMac/DefenseClawMac/Features/SetupView.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/SetupView.swift
@@ -229,15 +229,11 @@ struct WizardSheet: View {
 
     private var validationMessage: String? {
         if let message = wizard.validation?(values) { return message }
-        if wizard.commandBuilder == nil,
-           wizard.secretEnvironment == nil,
-           let field = visibleFields.first(where: { field in
-               guard case .secure = field.kind else { return false }
-               return !(values[field.key] ?? "").isEmpty && wizard.secretInputField != field.key
-           }) {
-            return "\(field.label) has no secure CLI transport configured."
-        }
-        return nil
+        return SetupSecretTransportPolicy.validationMessage(
+            wizard: wizard,
+            values: values,
+            visibleFields: visibleFields
+        )
     }
 
     private var replacesConnectorRoster: Bool {
@@ -249,9 +245,11 @@ struct WizardSheet: View {
     private var displayCommand: String {
         let commands = buildCommands(maskSecrets: true)
         guard !commands.isEmpty else { return "(no changes selected — nothing to apply)" }
-        return commands
-            .map { command in
-                let environment = commandEnvironment.keys.sorted().map { "\($0)=••••••" }
+        return commands.enumerated()
+            .map { index, command in
+                let environment = index == 0
+                    ? commandEnvironment.keys.sorted().map { "\($0)=••••••" }
+                    : []
                 return (environment + ["defenseclaw"] + command).joined(separator: " ")
             }
             .joined(separator: "\n")
@@ -468,6 +466,12 @@ struct WizardSheet: View {
     private func apply() {
         phase = .running
         output = ""
+        if let validationMessage {
+            output = "Setup blocked: \(validationMessage)"
+            exitCode = 1
+            phase = .done
+            return
+        }
         Task {
             let commands = cliCommands
             guard !commands.isEmpty else {

--- a/macos/DefenseClawMac/Tests/AIDiscoveryActionPolicyTests.swift
+++ b/macos/DefenseClawMac/Tests/AIDiscoveryActionPolicyTests.swift
@@ -1,0 +1,75 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+@main
+enum AIDiscoveryActionPolicyTests {
+    static func main() {
+        let disabled = AIDiscoveryPrimaryAction.resolve(enabled: false)
+        expect(disabled == .enable, "disabled discovery must offer Enable")
+        expect(disabled.label == "Enable AI Discovery", "enable action label drifted")
+        expect(
+            disabled.arguments == ["agent", "discovery", "enable", "--yes"],
+            "enable action must use the canonical non-interactive runtime command"
+        )
+
+        let enabled = AIDiscoveryPrimaryAction.resolve(enabled: true)
+        expect(enabled == .scan, "enabled discovery must offer Scan")
+        expect(enabled.label == "Scan Now", "scan action label drifted")
+        expect(
+            enabled.arguments == ["agent", "discovery", "scan"],
+            "scan action must use the canonical runtime command"
+        )
+
+        expect(
+            AIDiscoveryScanRequestStep.resolve(statusLoaded: false, enabled: false) == .loadStatus,
+            "a first-open scan request must wait for status instead of being dropped"
+        )
+        expect(
+            AIDiscoveryScanRequestStep.resolve(statusLoaded: true, enabled: false) == .showDisabled,
+            "a disabled status must explain how to enable discovery"
+        )
+        expect(
+            AIDiscoveryScanRequestStep.resolve(statusLoaded: true, enabled: true) == .scan,
+            "an enabled status must run the requested scan"
+        )
+
+        let disabledBody = #"{"error":"ai discovery disabled"}"#
+        expect(
+            GatewayErrorBody.userFacingMessage(status: 503, body: disabledBody)
+                == "AI Discovery is disabled. Enable it before starting a scan.",
+            "canonical disabled response must be actionable"
+        )
+        expect(
+            GatewayErrorBody.userFacingMessage(status: 500, body: disabledBody) == nil,
+            "non-503 responses must retain their normal error handling"
+        )
+        expect(
+            GatewayErrorBody.userFacingMessage(status: 503, body: #"{"error":"internal details"}"#) == nil,
+            "unknown gateway bodies must not be surfaced"
+        )
+
+        print("AI Discovery action policy tests passed")
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        guard condition() else {
+            fputs("FAILED: \(message)\n", stderr)
+            exit(1)
+        }
+    }
+}

--- a/macos/DefenseClawMac/Tests/AlertQueueProjectionTests.swift
+++ b/macos/DefenseClawMac/Tests/AlertQueueProjectionTests.swift
@@ -1,0 +1,154 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Darwin
+import Foundation
+import SQLite3
+
+enum ConfigStore {
+    static let auditDBURL = URL(fileURLWithPath: "/dev/null")
+}
+
+@main
+enum AlertQueueProjectionTests {
+    static func main() async {
+        await currentSchemaExcludesAcknowledgedAndNonFindingRows()
+        await legacySchemaRemainsReadable()
+        await reopensAfterSamePathReplacement()
+        await dropsStaleHandleWhilePathIsMissing()
+        print("AlertQueueProjectionTests passed")
+    }
+
+    private static func currentSchemaExcludesAcknowledgedAndNonFindingRows() async {
+        let url = temporaryDatabaseURL("current")
+        defer { try? FileManager.default.removeItem(at: url) }
+        execute(url, """
+            CREATE TABLE audit_events (
+                id TEXT, timestamp TEXT, action TEXT, target TEXT, actor TEXT,
+                details TEXT, severity TEXT, run_id TEXT, structured_json TEXT,
+                connector TEXT, bucket TEXT, event_name TEXT
+            );
+            CREATE TABLE alert_acknowledgement_projection (alert_id TEXT);
+            INSERT INTO audit_events VALUES
+                ('active', '2026-07-22T12:00:00Z', 'scan', '', '', '', 'HIGH', '', '', '', NULL, NULL),
+                ('observed', '2026-07-22T12:01:00Z', 'scan', '', '', '', 'HIGH', '', '', '', 'security.finding', 'finding.observed'),
+                ('acked', '2026-07-22T12:02:00Z', 'scan', '', '', '', 'HIGH', '', '', '', NULL, NULL),
+                ('telemetry', '2026-07-22T12:03:00Z', 'scan', '', '', '', 'HIGH', '', '', '', 'telemetry', 'span.received'),
+                ('warning', '2026-07-22T12:04:00Z', 'scan', '', '', '', 'WARNING', '', '', '', NULL, NULL),
+                ('dismissed', '2026-07-22T12:05:00Z', 'dismiss-alert', '', '', '', 'HIGH', '', '', '', NULL, NULL);
+            INSERT INTO alert_acknowledgement_projection VALUES ('acked');
+            """)
+
+        let rows = await AuditStore(url: url).alertQueueEvents(limit: 500)
+        expect(Set(rows.map(\.id)) == ["active", "observed"], "v8 queue matches the canonical active projection")
+    }
+
+    private static func legacySchemaRemainsReadable() async {
+        let url = temporaryDatabaseURL("legacy")
+        defer { try? FileManager.default.removeItem(at: url) }
+        execute(url, """
+            CREATE TABLE audit_events (
+                id TEXT, timestamp TEXT, action TEXT, target TEXT, actor TEXT,
+                details TEXT, severity TEXT, run_id TEXT, structured_json TEXT,
+                connector TEXT
+            );
+            INSERT INTO audit_events VALUES
+                ('legacy', '2026-07-22T12:00:00Z', 'scan-finding', '', '', '', 'HIGH', '', '', '');
+            """)
+
+        let rows = await AuditStore(url: url).alertQueueEvents(limit: 500)
+        expect(rows.map(\.id) == ["legacy"], "legacy queue remains available without v8 projection columns")
+    }
+
+    private static func reopensAfterSamePathReplacement() async {
+        let url = temporaryDatabaseURL("replace-live")
+        let replacement = temporaryDatabaseURL("replace-new")
+        defer {
+            try? FileManager.default.removeItem(at: url)
+            try? FileManager.default.removeItem(at: replacement)
+        }
+        createSingleAlertDatabase(url, id: "old")
+        createSingleAlertDatabase(replacement, id: "new")
+
+        let store = AuditStore(url: url)
+        let originalRows = await store.alertQueueEvents()
+        expect(originalRows.map(\.id) == ["old"], "fixture opens the original inode")
+        expect(rename(replacement.path, url.path) == 0, "fixture atomically replaces audit.db")
+        let replacementRows = await store.alertQueueEvents()
+        expect(
+            replacementRows.map(\.id) == ["new"],
+            "the same AuditStore instance reopens a replaced database"
+        )
+    }
+
+    private static func dropsStaleHandleWhilePathIsMissing() async {
+        let url = temporaryDatabaseURL("missing")
+        defer { try? FileManager.default.removeItem(at: url) }
+        createSingleAlertDatabase(url, id: "before")
+
+        let store = AuditStore(url: url)
+        let beforeRows = await store.alertQueueEvents()
+        expect(beforeRows.map(\.id) == ["before"], "fixture opens before removal")
+        try? FileManager.default.removeItem(at: url)
+        let missingRows = await store.alertQueueEvents()
+        expect(missingRows.isEmpty, "a missing path cannot serve stale rows")
+
+        createSingleAlertDatabase(url, id: "after")
+        let afterRows = await store.alertQueueEvents()
+        expect(
+            afterRows.map(\.id) == ["after"],
+            "the store reopens when audit.db returns"
+        )
+    }
+
+    private static func createSingleAlertDatabase(_ url: URL, id: String) {
+        execute(url, """
+            CREATE TABLE audit_events (
+                id TEXT, timestamp TEXT, action TEXT, target TEXT, actor TEXT,
+                details TEXT, severity TEXT, run_id TEXT, structured_json TEXT,
+                connector TEXT
+            );
+            INSERT INTO audit_events VALUES
+                ('\(id)', '2026-07-22T12:00:00Z', 'scan', '', '', '', 'HIGH', '', '', '');
+            """)
+    }
+
+    private static func temporaryDatabaseURL(_ suffix: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("DefenseClaw-alert-queue-\(suffix)-\(UUID().uuidString).db")
+    }
+
+    private static func execute(_ url: URL, _ sql: String) {
+        var database: OpaquePointer?
+        guard sqlite3_open(url.path, &database) == SQLITE_OK, let database else {
+            fatalError("could not create test database")
+        }
+        defer { sqlite3_close(database) }
+        var error: UnsafeMutablePointer<CChar>?
+        guard sqlite3_exec(database, sql, nil, nil, &error) == SQLITE_OK else {
+            let detail = error.map { String(cString: $0) } ?? "unknown SQLite error"
+            sqlite3_free(error)
+            fatalError(detail)
+        }
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if !condition() {
+            fputs("FAIL: \(message)\n", stderr)
+            exit(1)
+        }
+    }
+}

--- a/macos/DefenseClawMac/Tests/CLICancellationTests.swift
+++ b/macos/DefenseClawMac/Tests/CLICancellationTests.swift
@@ -1,0 +1,451 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Darwin
+import Foundation
+
+// Minimal standalone-test dependency for CLIRunner.doctor(). The app target
+// supplies the production model from DataLayer/Models.swift.
+struct DoctorCheck {
+    enum Result { case pass, warn, fail }
+    var name: String
+    var result: Result
+    var detail: String
+}
+
+@main
+struct CLICancellationTests {
+    static func main() async {
+        CLIProcessGroupLauncher.execIfRequested()
+        await launcherRejectsExternalInvocation()
+        await launcherPreservesArgumentsAndStandardInput()
+        await explicitCancellationInterruptsChild()
+        await pendingCancellationIsHonoredAndConsumed()
+        await ignoredSignalsEscalateToForcedTermination()
+        await cancelledParentDoesNotLeaveDescendant()
+        await forkedReparentedGrandchildIsKilled()
+        await closedOutputDoesNotBlockCancellation()
+        await inheritedPipeDoesNotHoldRunOpen()
+        await standardInputIsWrittenAndClosed()
+        cancelledResultIsNotSuccessful()
+        print("CLICancellationTests passed")
+    }
+
+    private static func launcherRejectsExternalInvocation() async {
+        let marker = temporaryMarker("external-launcher")
+        defer { try? FileManager.default.removeItem(at: marker) }
+        guard let executable = Bundle.main.executableURL?.path else {
+            expect(false, "test executable path is available")
+            return
+        }
+
+        let program = """
+        import subprocess
+        import sys
+
+        result = subprocess.run([
+            sys.argv[1],
+            "--defenseclaw-internal-command-launcher-v1",
+            "/usr/bin/touch",
+            sys.argv[2],
+        ])
+        sys.exit(0 if result.returncode == 126 else 1)
+        """
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        process.arguments = ["-c", program, executable, marker.path]
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            expect(false, "external-launcher rejection probe starts")
+            return
+        }
+
+        expect(process.terminationStatus == 0, "external launcher invocation is rejected")
+        expect(!FileManager.default.fileExists(atPath: marker.path), "external target is not executed")
+    }
+
+    private static func launcherPreservesArgumentsAndStandardInput() async {
+        let runner = CLIRunner()
+        let program = """
+        import os
+        import sys
+
+        print(f"group={os.getpid() == os.getpgrp()}")
+        print(f"argument={sys.argv[1]}")
+        print(f"input={sys.stdin.readline().strip()}")
+        """
+        let result = await runner.run(
+            binary: "/usr/bin/python3",
+            arguments: ["-c", program, "two words"],
+            standardInput: "standard input",
+            mutation: false
+        )
+        expect(result.succeeded, "launcher preserves normal command success")
+        expect(result.output.contains("group=True"), "launcher establishes a dedicated process group")
+        expect(result.output.contains("argument=two words"), "launcher preserves exact argv entries")
+        expect(result.output.contains("input=standard input"), "launcher preserves standard input")
+    }
+
+    private static func explicitCancellationInterruptsChild() async {
+        let runner = CLIRunner()
+        let runID = UUID()
+        let marker = temporaryMarker("explicit")
+        defer { try? FileManager.default.removeItem(at: marker) }
+        let childProgram = """
+        import signal
+        import sys
+        import time
+
+        def handle_interrupt(_signal, _frame):
+            print("explicit-sigint-drained", flush=True)
+            sys.exit(130)
+
+        signal.signal(signal.SIGINT, handle_interrupt)
+        signal.alarm(8)
+        with open(sys.argv[1], "w", encoding="utf-8") as ready:
+            ready.write("ready")
+        time.sleep(30)
+        """
+        let task = Task {
+            await runner.run(
+                binary: "/usr/bin/python3",
+                arguments: ["-c", childProgram, marker.path],
+                mutation: false,
+                runID: runID
+            )
+        }
+        let childStarted = await waitForFile(marker)
+        expect(childStarted, "explicit-cancellation child starts")
+        let disposition = await runner.cancel(runID: runID)
+        expect(disposition == .requested, "explicit cancellation is accepted")
+        let result = await task.value
+        expect(result.cancelled, "explicit cancellation marks the result cancelled")
+        expect(!result.succeeded, "cancelled command is not successful")
+        expect(result.output.contains("explicit-sigint-drained"), "SIGINT output is drained")
+    }
+
+    private static func pendingCancellationIsHonoredAndConsumed() async {
+        let runner = CLIRunner()
+        let runID = UUID()
+        let reserved = await runner.reserve(runID: runID)
+        expect(reserved, "run ID can be reserved")
+        let cancellation = await runner.cancel(runID: runID)
+        expect(cancellation == .requested, "reserved run accepts cancellation")
+
+        let cancelled = await runner.run(
+            binary: "/usr/bin/python3",
+            arguments: ["-c", "print('must-not-launch')"],
+            mutation: false,
+            runID: runID
+        )
+        expect(cancelled.cancelled, "pre-launch cancellation prevents launch")
+        expect(!cancelled.output.contains("must-not-launch"), "cancelled child did not execute")
+
+        let reused = await runner.run(
+            binary: "/usr/bin/python3",
+            arguments: ["-c", "print('run-id-reused')"],
+            mutation: false,
+            runID: runID
+        )
+        expect(reused.succeeded, "pre-launch cancellation is consumed once")
+        expect(reused.output.contains("run-id-reused"), "run ID can be reused safely")
+    }
+
+    private static func ignoredSignalsEscalateToForcedTermination() async {
+        let runner = CLIRunner()
+        let runID = UUID()
+        let marker = temporaryMarker("forced")
+        defer { try? FileManager.default.removeItem(at: marker) }
+        let childProgram = """
+        import signal
+        import sys
+        import time
+
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        signal.alarm(8)
+        with open(sys.argv[1], "w", encoding="utf-8") as ready:
+            ready.write("ready")
+        time.sleep(30)
+        """
+        let task = Task {
+            await runner.run(
+                binary: "/usr/bin/python3",
+                arguments: ["-c", childProgram, marker.path],
+                mutation: false,
+                runID: runID
+            )
+        }
+        let childStarted = await waitForFile(marker)
+        expect(childStarted, "signal-ignoring child starts")
+        let started = ContinuousClock.now
+        let cancellation = await runner.cancel(runID: runID)
+        expect(cancellation == .requested, "forced cancellation is accepted")
+        let result = await task.value
+        expect(result.cancelled, "forced termination remains cancelled")
+        expect(ContinuousClock.now - started < .seconds(4), "signals escalate promptly")
+    }
+
+    private static func cancelledParentDoesNotLeaveDescendant() async {
+        let runner = CLIRunner()
+        let runID = UUID()
+        let parentMarker = temporaryMarker("tree-parent")
+        let childMarker = temporaryMarker("tree-child")
+        defer {
+            try? FileManager.default.removeItem(at: parentMarker)
+            try? FileManager.default.removeItem(at: childMarker)
+        }
+        let childProgram = """
+        import signal
+        import sys
+        import time
+
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        with open(sys.argv[1], "w", encoding="utf-8") as ready:
+            ready.write("ready")
+        time.sleep(30)
+        """
+        let parentProgram = """
+        import signal
+        import subprocess
+        import sys
+        import time
+
+        child = subprocess.Popen([sys.executable, "-c", sys.argv[1], sys.argv[3]])
+        with open(sys.argv[2], "w", encoding="utf-8") as marker:
+            marker.write(str(child.pid))
+
+        def handle_interrupt(_signal, _frame):
+            sys.exit(130)
+
+        signal.signal(signal.SIGINT, handle_interrupt)
+        time.sleep(30)
+        """
+        let task = Task {
+            await runner.run(
+                binary: "/usr/bin/python3",
+                arguments: ["-c", parentProgram, childProgram, parentMarker.path, childMarker.path],
+                mutation: false,
+                runID: runID
+            )
+        }
+        let parentStarted = await waitForFile(parentMarker)
+        let childStarted = await waitForFile(childMarker)
+        expect(parentStarted, "process-tree parent starts")
+        expect(childStarted, "process-tree descendant starts")
+        guard let childPID = try? String(contentsOf: parentMarker, encoding: .utf8),
+              let pid = pid_t(childPID.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            expect(false, "process-tree descendant PID is recorded")
+            return
+        }
+        defer { _ = Darwin.kill(pid, SIGKILL) }
+
+        let cancellation = await runner.cancel(runID: runID)
+        expect(cancellation == .requested, "process-tree cancellation is accepted")
+        let result = await task.value
+        expect(result.cancelled, "process-tree cancellation marks the parent result cancelled")
+        let childExited = await waitForProcessExit(pid)
+        expect(childExited, "process-tree escalation terminates the descendant")
+    }
+
+    private static func forkedReparentedGrandchildIsKilled() async {
+        let runner = CLIRunner()
+        let runID = UUID()
+        let workerMarker = temporaryMarker("race-worker")
+        let grandchildMarker = temporaryMarker("race-grandchild")
+        defer {
+            try? FileManager.default.removeItem(at: workerMarker)
+            try? FileManager.default.removeItem(at: grandchildMarker)
+        }
+        let grandchildProgram = """
+        import os
+        import signal
+        import sys
+        import time
+
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        with open(sys.argv[1], "w", encoding="utf-8") as marker:
+            marker.write(str(os.getpid()))
+        time.sleep(30)
+        """
+        let workerProgram = """
+        import signal
+        import subprocess
+        import sys
+        import time
+
+        def handle_interrupt(_signal, _frame):
+            subprocess.Popen([sys.executable, "-c", sys.argv[1], sys.argv[2]])
+            sys.exit(130)
+
+        signal.signal(signal.SIGINT, handle_interrupt)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        with open(sys.argv[3], "w", encoding="utf-8") as marker:
+            marker.write("ready")
+        time.sleep(30)
+        """
+        let rootProgram = """
+        import signal
+        import subprocess
+        import sys
+        import time
+
+        subprocess.Popen([sys.executable, "-c", sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]])
+        signal.signal(signal.SIGINT, lambda _signal, _frame: sys.exit(130))
+        time.sleep(30)
+        """
+        let task = Task {
+            await runner.run(
+                binary: "/usr/bin/python3",
+                arguments: [
+                    "-c",
+                    rootProgram,
+                    workerProgram,
+                    grandchildProgram,
+                    grandchildMarker.path,
+                    workerMarker.path,
+                ],
+                mutation: false,
+                runID: runID
+            )
+        }
+        let workerStarted = await waitForFile(workerMarker)
+        expect(workerStarted, "fork-race worker starts")
+        let cancellation = await runner.cancel(runID: runID)
+        expect(cancellation == .requested, "fork-race cancellation is accepted")
+        let result = await task.value
+        expect(result.cancelled, "fork-race result remains cancelled")
+        let grandchildStarted = await waitForFile(grandchildMarker)
+        expect(grandchildStarted, "signaled worker forks a grandchild before exiting")
+
+        guard let value = try? String(contentsOf: grandchildMarker, encoding: .utf8),
+              let grandchildPID = pid_t(value.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            expect(false, "fork-race grandchild PID is recorded")
+            return
+        }
+        defer { _ = Darwin.kill(grandchildPID, SIGKILL) }
+        let grandchildExited = await waitForProcessExit(grandchildPID, attempts: 180)
+        expect(grandchildExited, "process-group escalation terminates the reparented grandchild")
+    }
+
+    private static func closedOutputDoesNotBlockCancellation() async {
+        let runner = CLIRunner()
+        let runID = UUID()
+        let marker = temporaryMarker("closed-output")
+        defer { try? FileManager.default.removeItem(at: marker) }
+        let childProgram = """
+        import os
+        import signal
+        import sys
+        import time
+
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        signal.alarm(8)
+        os.close(1)
+        os.close(2)
+        with open(sys.argv[1], "w", encoding="utf-8") as ready:
+            ready.write("ready")
+        time.sleep(30)
+        """
+        let task = Task {
+            await runner.run(
+                binary: "/usr/bin/python3",
+                arguments: ["-c", childProgram, marker.path],
+                mutation: false,
+                runID: runID
+            )
+        }
+        let childStarted = await waitForFile(marker)
+        expect(childStarted, "closed-output child starts")
+        let cancellation = await runner.cancel(runID: runID)
+        expect(cancellation == .requested, "runner remains responsive after EOF")
+        let result = await task.value
+        expect(result.cancelled, "closed-output child is cancelled")
+    }
+
+    private static func inheritedPipeDoesNotHoldRunOpen() async {
+        let runner = CLIRunner()
+        let childProgram = """
+        import subprocess
+        import sys
+
+        subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(3)"],
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
+        print("direct-parent-exited", flush=True)
+        """
+        let started = ContinuousClock.now
+        let result = await runner.run(
+            binary: "/usr/bin/python3",
+            arguments: ["-c", childProgram],
+            mutation: false
+        )
+        expect(result.succeeded, "direct parent exit succeeds")
+        expect(result.output.contains("direct-parent-exited"), "direct parent output is retained")
+        expect(ContinuousClock.now - started < .seconds(2), "descendant-held pipe is bounded")
+    }
+
+    private static func standardInputIsWrittenAndClosed() async {
+        let runner = CLIRunner()
+        let result = await runner.run(
+            binary: "/usr/bin/python3",
+            arguments: ["-c", "import sys; print(sys.stdin.readline().strip()); print('eof' if not sys.stdin.read() else 'open')"],
+            standardInput: "y"
+        )
+        expect(result.succeeded, "stdin-backed command succeeds")
+        expect(result.output.contains("y\neof"), "stdin value is written and the pipe is closed")
+    }
+
+    private static func cancelledResultIsNotSuccessful() {
+        expect(!CLIResult(exitCode: 0, output: "", cancelled: true).succeeded,
+               "exit zero cannot override cancellation")
+    }
+
+    private static func temporaryMarker(_ name: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("defenseclaw-\(name)-\(UUID().uuidString)")
+    }
+
+    private static func waitForFile(_ url: URL, attempts: Int = 100) async -> Bool {
+        for _ in 0..<attempts {
+            if FileManager.default.fileExists(atPath: url.path) { return true }
+            try? await Task.sleep(for: .milliseconds(30))
+        }
+        return false
+    }
+
+    private static func waitForProcessExit(_ pid: pid_t, attempts: Int = 120) async -> Bool {
+        for _ in 0..<attempts {
+            if Darwin.kill(pid, 0) == -1, errno == ESRCH { return true }
+            try? await Task.sleep(for: .milliseconds(30))
+        }
+        return false
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        guard condition() else {
+            fputs("FAILED: \(message)\n", stderr)
+            exit(1)
+        }
+    }
+}

--- a/macos/DefenseClawMac/Tests/CatalogActionSafetyTests.swift
+++ b/macos/DefenseClawMac/Tests/CatalogActionSafetyTests.swift
@@ -1,0 +1,345 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Darwin
+import Foundation
+
+@main
+struct CatalogActionSafetyTests {
+    static func main() async {
+        CLIProcessGroupLauncher.execIfRequested()
+        scanActionsRemainOneClickButAreMutations()
+        informationalActionsRemainNonMutating()
+        auditCorruptionClassifierIsExact()
+        await malformedAuditUsesPrivateReadOnlyCatalog()
+        await genericFailuresDoNotUseIsolatedCatalog()
+        await binaryOverrideDoesNotCrossCatalogLoad()
+        await installationRebindInvalidatesCatalogLoad()
+        print("CatalogActionSafetyTests passed")
+    }
+
+    private static func scanActionsRemainOneClickButAreMutations() {
+        let skill = SkillItem(
+            key: "codex/example",
+            name: "example",
+            version: "1",
+            source: "/tmp/example",
+            enabled: true,
+            connector: "codex"
+        )
+        let mcp = MCPItem(
+            name: "example",
+            transport: "stdio",
+            endpoint: "example",
+            version: "1",
+            enabled: true,
+            connector: "codex"
+        )
+        let plugin = PluginItem(
+            name: "example",
+            version: "1",
+            category: "command",
+            enabled: true,
+            connector: "codex",
+            commandID: "example"
+        )
+
+        let checks: [(CatalogResourceAction, CatalogInvocation)] = [
+            actionAndInvocation(CatalogActions.skills(skill), skill: skill),
+            actionAndInvocation(CatalogActions.mcps(mcp), mcp: mcp),
+            actionAndInvocation(CatalogActions.plugins(plugin), plugin: plugin),
+        ]
+        for (action, invocation) in checks {
+            expect(action.readOnly, "scan remains a one-click action")
+            expect(action.changesState, "scan explicitly changes installation state")
+            expect(!invocation.requiresConfirmation, "scan does not gain an unrelated confirmation")
+            expect(invocation.changesState, "scan invocation reaches the mutation gate")
+        }
+    }
+
+    private static func informationalActionsRemainNonMutating() {
+        let skill = SkillItem(
+            key: "codex/example",
+            name: "example",
+            version: "1",
+            source: "/tmp/example",
+            enabled: true,
+            connector: "codex"
+        )
+        guard let info = CatalogActions.skills(skill).first(where: { $0.verb == "info" }) else {
+            fail("skill info action is missing")
+        }
+        let invocation = CatalogActions.invocation(info, skill: skill)
+        expect(info.readOnly, "info remains one-click")
+        expect(!info.changesState, "info remains non-mutating")
+        expect(!invocation.changesState, "info invocation bypasses only the mutation gate")
+    }
+
+    private static func auditCorruptionClassifierIsExact() {
+        expect(
+            CLIRunner.isAuditStoreCorruption(
+                "Failed to open audit store: database disk image is malformed\n"
+            ),
+            "the runtime's exact malformed-audit error enables degraded catalog mode"
+        )
+        expect(
+            !CLIRunner.isAuditStoreCorruption("database disk image is malformed"),
+            "an unattributed SQLite error cannot redirect catalog execution"
+        )
+        expect(
+            !CLIRunner.isAuditStoreCorruption(
+                "Failed to open audit store: database is locked"
+            ),
+            "busy and permission failures remain ordinary errors"
+        )
+        expect(
+            !CLIRunner.isAuditStoreCorruption(
+                "prefix Failed to open audit store: database disk image is malformed suffix"
+            ),
+            "the classifier requires a complete diagnostic line"
+        )
+    }
+
+    private static func malformedAuditUsesPrivateReadOnlyCatalog() async {
+        guard let fixture = try? CatalogFixture() else { fail("could not create catalog fixture") }
+        defer { fixture.cleanup() }
+        setenv("CATALOG_TEST_FAILURE", "corrupt", 1)
+        defer { unsetenv("CATALOG_TEST_FAILURE") }
+
+        let before = isolatedCatalogDirectories()
+        do {
+            let listing = try await CatalogCLI.plugins(using: CLIRunner(context: fixture.context))
+            expect(listing.auditHistoryUnavailable, "fallback is labeled as audit-history unavailable")
+            expect(listing.items.map(\.name) == ["example"], "fallback catalog JSON is parsed")
+        } catch {
+            fail("private read-only fallback failed: \(error)")
+        }
+        expect(
+            isolatedCatalogDirectories() == before,
+            "the private catalog workspace is removed after the command"
+        )
+    }
+
+    private static func genericFailuresDoNotUseIsolatedCatalog() async {
+        guard let fixture = try? CatalogFixture() else { fail("could not create catalog fixture") }
+        defer { fixture.cleanup() }
+        setenv("CATALOG_TEST_FAILURE", "generic", 1)
+        defer { unsetenv("CATALOG_TEST_FAILURE") }
+
+        let before = isolatedCatalogDirectories()
+        do {
+            _ = try await CatalogCLI.plugins(using: CLIRunner(context: fixture.context))
+            fail("a generic catalog failure must be surfaced")
+        } catch {
+            expect(
+                error.localizedDescription.contains("permission denied"),
+                "the original generic failure is preserved"
+            )
+        }
+        expect(
+            isolatedCatalogDirectories() == before,
+            "generic failures never create an isolated catalog workspace"
+        )
+    }
+
+    private static func installationRebindInvalidatesCatalogLoad() async {
+        guard let first = try? CatalogFixture(), let second = try? CatalogFixture() else {
+            fail("could not create rebind fixtures")
+        }
+        defer {
+            first.cleanup()
+            second.cleanup()
+        }
+        setenv("CATALOG_TEST_FAILURE", "rebind", 1)
+        defer { unsetenv("CATALOG_TEST_FAILURE") }
+        let runner = CLIRunner(context: first.context)
+
+        let load = Task { try await CatalogCLI.plugins(using: runner) }
+        try? await Task.sleep(for: .milliseconds(100))
+        await runner.rebind(to: second.context)
+        do {
+            _ = try await load.value
+            fail("a catalog load cannot cross installations")
+        } catch {
+            expect(
+                error.localizedDescription.contains("installation changed"),
+                "rebind returns a retryable installation-change failure"
+            )
+        }
+    }
+
+    private static func binaryOverrideDoesNotCrossCatalogLoad() async {
+        guard let first = try? CatalogFixture(), let second = try? CatalogFixture() else {
+            fail("could not create binary override fixtures")
+        }
+        defer {
+            first.cleanup()
+            second.cleanup()
+        }
+        let defaults = UserDefaults.standard
+        let previousOverride = defaults.string(forKey: CLIRunner.pathOverrideKey)
+        defaults.set(first.binaryURL.path, forKey: CLIRunner.pathOverrideKey)
+        defer {
+            if let previousOverride {
+                defaults.set(previousOverride, forKey: CLIRunner.pathOverrideKey)
+            } else {
+                defaults.removeObject(forKey: CLIRunner.pathOverrideKey)
+            }
+        }
+        setenv("CATALOG_TEST_FAILURE", "rebind", 1)
+        defer { unsetenv("CATALOG_TEST_FAILURE") }
+
+        let load = Task {
+            try await CatalogCLI.plugins(using: CLIRunner(context: first.context))
+        }
+        try? await Task.sleep(for: .milliseconds(100))
+        defaults.set(second.binaryURL.path, forKey: CLIRunner.pathOverrideKey)
+        do {
+            let listing = try await load.value
+            expect(listing.auditHistoryUnavailable, "the pinned binary completes degraded loading")
+            expect(
+                listing.selectedBinaryPath == first.binaryURL.path,
+                "catalog loading pins the binary selected before its first await"
+            )
+        } catch {
+            fail("binary override crossed an in-flight catalog load: \(error)")
+        }
+    }
+
+    private static func isolatedCatalogDirectories() -> Set<String> {
+        let prefix = "DefenseClaw-catalog-read-only-"
+        let values = (try? FileManager.default.contentsOfDirectory(
+            atPath: FileManager.default.temporaryDirectory.path
+        )) ?? []
+        return Set(values.filter { $0.hasPrefix(prefix) })
+    }
+
+    private static func actionAndInvocation(
+        _ actions: [CatalogResourceAction],
+        skill: SkillItem
+    ) -> (CatalogResourceAction, CatalogInvocation) {
+        guard let action = actions.first(where: { $0.verb == "scan" }) else {
+            fail("skill scan action is missing")
+        }
+        return (action, CatalogActions.invocation(action, skill: skill))
+    }
+
+    private static func actionAndInvocation(
+        _ actions: [CatalogResourceAction],
+        mcp: MCPItem
+    ) -> (CatalogResourceAction, CatalogInvocation) {
+        guard let action = actions.first(where: { $0.verb == "scan" }) else {
+            fail("MCP scan action is missing")
+        }
+        return (action, CatalogActions.invocation(action, mcp: mcp))
+    }
+
+    private static func actionAndInvocation(
+        _ actions: [CatalogResourceAction],
+        plugin: PluginItem
+    ) -> (CatalogResourceAction, CatalogInvocation) {
+        guard let action = actions.first(where: { $0.verb == "scan" }) else {
+            fail("plugin scan action is missing")
+        }
+        return (action, CatalogActions.invocation(action, plugin: plugin))
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        guard condition() else { fail(message) }
+    }
+
+    private static func fail(_ message: String) -> Never {
+        FileHandle.standardError.write(Data("FAIL: \(message)\n".utf8))
+        Foundation.exit(1)
+    }
+
+    private final class CatalogFixture {
+        let root: URL
+        let context: InstallationContext
+        let binaryURL: URL
+
+        init() throws {
+            root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "DefenseClaw-catalog-fixture-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            let home = root.appendingPathComponent("home", isDirectory: true)
+            let venv = root.appendingPathComponent("venv", isDirectory: true)
+            let bin = venv.appendingPathComponent("bin", isDirectory: true)
+            try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+            let config = home.appendingPathComponent("config.yaml", isDirectory: false)
+            try Data("config_version: 8\n".utf8).write(to: config)
+
+            let executable = bin.appendingPathComponent("defenseclaw", isDirectory: false)
+            binaryURL = executable
+            let script = """
+            #!/bin/sh
+            set -eu
+            if [ "$*" = "config show --source --format json" ]; then
+              printf '%s\\n' '{"config_version":8,"token":"SENTINEL_SECRET","gateway":{"token_env":"OPENCLAW_GATEWAY_TOKEN"}}'
+              exit 0
+            fi
+            if [ "$*" != "plugin list --json" ]; then
+              printf '%s\\n' 'unexpected command' >&2
+              exit 64
+            fi
+            if [ "${CATALOG_TEST_FAILURE:-}" = "generic" ]; then
+              printf '%s\\n' 'permission denied' >&2
+              exit 1
+            fi
+            if [ "$DEFENSECLAW_HOME" = "\(home.path)" ]; then
+              if [ "${CATALOG_TEST_FAILURE:-}" = "rebind" ]; then sleep 1; fi
+              printf '%s\\n' 'Failed to open audit store: database disk image is malformed' >&2
+              exit 1
+            fi
+            case "$DEFENSECLAW_CONFIG" in
+              "$DEFENSECLAW_HOME"/*) ;;
+              *) printf '%s\\n' 'config escaped isolated home' >&2; exit 65 ;;
+            esac
+            [ "$DEFENSECLAW_VENV" = "\(venv.path)" ]
+            [ "$(stat -f '%Lp' "$DEFENSECLAW_HOME")" = "700" ]
+            [ "$(stat -f '%Lp' "$DEFENSECLAW_CONFIG")" = "600" ]
+            ! grep -q 'SENTINEL_SECRET' "$DEFENSECLAW_CONFIG"
+            ! grep -q '"audit_db"' "$DEFENSECLAW_CONFIG"
+            printf '%s\\n' '[{"connector":"codex","plugins":[{"id":"example","name":"example","enabled":true}]}]'
+            """
+            try Data(script.utf8).write(to: executable)
+            guard chmod(executable.path, 0o755) == 0 else {
+                throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+            }
+
+            context = InstallationContext(
+                source: .userDefault,
+                accessMode: .unmanagedMutable,
+                homeRoot: home,
+                configURL: config,
+                dataDirectory: home,
+                auditDBURL: home.appendingPathComponent("audit.db"),
+                environmentURL: home.appendingPathComponent(".env"),
+                gatewayJSONLURL: home.appendingPathComponent("gateway.jsonl"),
+                gatewayLogURL: home.appendingPathComponent("gateway.log"),
+                gatewayErrorLogURL: nil,
+                watchdogLogURL: home.appendingPathComponent("watchdog.log"),
+                venvURL: venv
+            )
+        }
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: root)
+        }
+    }
+}

--- a/macos/DefenseClawMac/Tests/ConnectorOnboardingTests.swift
+++ b/macos/DefenseClawMac/Tests/ConnectorOnboardingTests.swift
@@ -151,7 +151,7 @@ struct ConnectorOnboardingTests {
 
     private static func multipleAdditiveSetupsRestartOnlyAfterTheFinalConnector() {
         let plan = makePlan(
-            detected: ["codex", "claudecode", "cursor", "hermes", "openclaw"],
+            detected: ["codex", "claudecode", "cursor", "openclaw"],
             registered: ["codex", "claudecode", "cursor"],
             action: [],
             profile: "observe"
@@ -167,8 +167,7 @@ struct ConnectorOnboardingTests {
             "final additive setup preserves connector order"
         )
         expect(!plan[2].contains("--no-restart"), "final additive setup performs the restart")
-        expect(!plan.contains { $0.contains("hermes") }, "unregistered hook connector stays absent")
-        expect(!plan.contains { $0.contains("openclaw") }, "proxy connector stays absent")
+        expect(!plan.contains { $0.contains("openclaw") }, "unregistered connector stays absent")
     }
 
     private static func subsetWithoutGatewayStartNeverRestarts() {

--- a/macos/DefenseClawMac/Tests/ConnectorOnboardingTests.swift
+++ b/macos/DefenseClawMac/Tests/ConnectorOnboardingTests.swift
@@ -151,7 +151,7 @@ struct ConnectorOnboardingTests {
 
     private static func multipleAdditiveSetupsRestartOnlyAfterTheFinalConnector() {
         let plan = makePlan(
-            detected: ["codex", "claudecode", "cursor", "openclaw"],
+            detected: ["codex", "claudecode", "cursor", "amp"],
             registered: ["codex", "claudecode", "cursor"],
             action: [],
             profile: "observe"
@@ -167,7 +167,7 @@ struct ConnectorOnboardingTests {
             "final additive setup preserves connector order"
         )
         expect(!plan[2].contains("--no-restart"), "final additive setup performs the restart")
-        expect(!plan.contains { $0.contains("openclaw") }, "unregistered connector stays absent")
+        expect(!plan.contains { $0.contains("amp") }, "unregistered connector stays absent")
     }
 
     private static func subsetWithoutGatewayStartNeverRestarts() {

--- a/macos/DefenseClawMac/Tests/DependencyLockValidatorTests.py
+++ b/macos/DefenseClawMac/Tests/DependencyLockValidatorTests.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "scripts" / "validate_dependency_lock.py"
+SCANNER_URL = (
+    "https://files.pythonhosted.org/packages/aa/bb/"
+    "cisco_ai_skill_scanner-2.0.4-py3-none-any.whl"
+    "#sha256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+)
+
+
+class DependencyLockValidatorTests(unittest.TestCase):
+    def validate(self, lock: str, source_url: str = SCANNER_URL) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            pyproject = root / "pyproject.toml"
+            lock_path = root / "requirements.lock"
+            pyproject.write_text(
+                '[project]\nname = "fixture"\nversion = "1.0.0"\n'
+                f'dependencies = ["cisco-ai-skill-scanner @ {source_url}"]\n',
+                encoding="utf-8",
+            )
+            lock_path.write_text(lock, encoding="utf-8")
+            return subprocess.run(
+                ["python3", str(VALIDATOR), str(pyproject), str(lock_path)],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+
+    def test_accepts_authenticated_hash_bound_pythonhosted_reference(self) -> None:
+        result = self.validate(
+            f"cisco-ai-skill-scanner @ {SCANNER_URL} \\\n"
+            "    --hash=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+            "click==8.3.3 \\\n"
+            "    --hash=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+
+    def test_rejects_changed_direct_reference(self) -> None:
+        changed = SCANNER_URL.replace("/aa/bb/", "/cc/dd/")
+        result = self.validate(
+            f"cisco-ai-skill-scanner @ {changed} \\\n"
+            "    --hash=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unauthenticated direct reference", result.stdout)
+
+    def test_rejects_local_paths(self) -> None:
+        result = self.validate(
+            "cisco-ai-skill-scanner @ file:///tmp/scanner.whl \\\n"
+            "    --hash=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unauthenticated direct reference", result.stdout)
+
+    def test_rejects_missing_distribution_hash(self) -> None:
+        result = self.validate(f"cisco-ai-skill-scanner @ {SCANNER_URL}\n")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("has no SHA-256 hash", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/macos/DefenseClawMac/Tests/InspectorLayoutPolicyTests.swift
+++ b/macos/DefenseClawMac/Tests/InspectorLayoutPolicyTests.swift
@@ -1,0 +1,41 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import CoreGraphics
+import Foundation
+
+@main
+struct InspectorLayoutPolicyTests {
+    static func main() {
+        expect(
+            InspectorLayoutPolicy.minimumWidth <= InspectorLayoutPolicy.idealWidth,
+            "minimum inspector width must not exceed ideal"
+        )
+        expect(
+            InspectorLayoutPolicy.idealWidth <= InspectorLayoutPolicy.maximumWidth,
+            "ideal inspector width must not exceed maximum"
+        )
+
+        print("InspectorLayoutPolicyTests passed")
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        guard condition() else {
+            fputs("FAILED: \(message)\n", stderr)
+            exit(1)
+        }
+    }
+}

--- a/macos/DefenseClawMac/Tests/InstallationContextTests.swift
+++ b/macos/DefenseClawMac/Tests/InstallationContextTests.swift
@@ -22,13 +22,17 @@ struct InstallationContextTests {
     private static let currentDirectory = URL(fileURLWithPath: "/work", isDirectory: true)
 
     static func main() async {
+        CLIProcessGroupLauncher.execIfRequested()
         sourcePrecedenceMatchesRuntime()
         managedLayoutAndCapabilitiesAreExact()
         explicitUnreadableAndRelativePathsFailClosed()
         configPathsAndVenvResolveIndependently()
+        emptyFlowCollectionsMatchRuntimeGeneratedConfig()
+        populatedFlowCollectionsMatchRuntimeGeneratedConfig()
         managedEvidenceMonotonicallyRemovesMutation()
         nestedAuditPathIsReadCorrectly()
         protectedEnvironmentCannotBeOverridden()
+        await redactionDefaultProfileMatchesRuntimeSchema()
         await configStoreRebindDropsThePreviousInstallation()
         await lowerLevelMutationGateSurvivesRebind()
         await gatewayPOSTGateFailsBeforeNetwork()
@@ -202,6 +206,231 @@ struct InstallationContextTests {
         )
     }
 
+    private static func emptyFlowCollectionsMatchRuntimeGeneratedConfig() {
+        let path = "/chosen/generated-empty-collections.yaml"
+        var context = resolve(
+            environment: ["DEFENSECLAW_CONFIG": path],
+            texts: [path: """
+            config_version: 8
+            deployment_mode: unmanaged_byod
+            observability: { } # no custom destinations
+            registries: [ ] # no external registries
+            """]
+        )
+        expect(!isInvalid(context), "runtime-generated empty mappings remain valid")
+        expect(
+            MiniYAML.parse("observability: {}\n")["observability"]?.mapping?.isEmpty == true,
+            "empty flow mapping retains its YAML type"
+        )
+        expect(
+            MiniYAML.parse("registries: []\n")["registries"]?.sequence?.isEmpty == true,
+            "empty flow sequence retains its YAML type"
+        )
+
+        let quotedPath = "/chosen/quoted-empty-mapping.yaml"
+        context = resolve(
+            environment: ["DEFENSECLAW_CONFIG": quotedPath],
+            texts: [quotedPath: """
+            config_version: 8
+            deployment_mode: unmanaged_byod
+            observability: "{}"
+            """]
+        )
+        expect(isInvalid(context), "quoted braces remain a scalar and fail closed")
+
+        let sequencePath = "/chosen/observability-sequence.yaml"
+        context = resolve(
+            environment: ["DEFENSECLAW_CONFIG": sequencePath],
+            texts: [sequencePath: """
+            config_version: 8
+            deployment_mode: unmanaged_byod
+            observability: []
+            """]
+        )
+        expect(isInvalid(context), "an observability sequence remains invalid")
+    }
+
+    private static func populatedFlowCollectionsMatchRuntimeGeneratedConfig() {
+        let path = "/chosen/generated-splunk-observability.yaml"
+        let generatedConfig = """
+        config_version: 8
+        deployment_mode: unmanaged_byod
+        observability: {destinations: [{enabled: true, endpoint: 'https://127.0.0.1:8088/services/collector/event', kind: splunk-hec, name: 'splunk, local', network_safety: {allow_private_networks: true}, tls: {insecure_skip_verify: true}, token_env: SPLUNK_HEC_TOKEN}]}
+        """
+        var context = resolve(
+            environment: ["DEFENSECLAW_CONFIG": path],
+            texts: [path: generatedConfig]
+        )
+        expect(!isInvalid(context), "runtime-generated Splunk flow mapping remains valid")
+
+        let observability = MiniYAML.parse(generatedConfig)["observability"]?.mapping
+        let destination = observability?["destinations"]?.sequence?.first?.mapping
+        expect(destination?["kind"]?.string == "splunk-hec", "flow destination kind is parsed")
+        expect(destination?["name"]?.string == "splunk, local", "quoted flow scalar preserves commas")
+        expect(
+            destination?["network_safety"]?.mapping?["allow_private_networks"]?.bool == true,
+            "nested flow mapping is parsed"
+        )
+        expect(
+            destination?["tls"]?.mapping?["insecure_skip_verify"]?.bool == true,
+            "second nested flow mapping is parsed"
+        )
+
+        let stringHeaders = MiniYAML.parse(
+            "observability: {headers: {inf: value, nan: value, Infinity: value, 1e2: value}}\n"
+        )["observability"]?.mapping?["headers"]?.mapping
+        expect(
+            stringHeaders?.count == 4,
+            "PyYAML string-like numeric header keys remain valid strings"
+        )
+
+        let localPath = "/chosen/generated-local-observability.yaml"
+        context = resolve(
+            environment: ["DEFENSECLAW_CONFIG": localPath],
+            texts: [localPath: """
+            config_version: 8
+            deployment_mode: unmanaged_byod
+            observability: {local: {path: /runtime/audit/compact.db}, destinations: []}
+            """]
+        )
+        expect(!isInvalid(context), "populated observability flow mapping remains valid")
+        expect(context.auditDBURL.path == "/runtime/audit/compact.db", "flow mapping audit path is read")
+
+        let wrappedPath = "/chosen/generated-wrapped-observability.yaml"
+        context = resolve(
+            environment: ["DEFENSECLAW_CONFIG": wrappedPath],
+            texts: [wrappedPath: """
+            config_version: 8
+            deployment_mode: unmanaged_byod
+            observability: {destinations: [{enabled: true,
+                kind: splunk-hec, name: splunk-local,
+                network_safety: {allow_private_networks: true}}],
+              local: {path: /runtime/audit/wrapped.db}}
+            """]
+        )
+        expect(!isInvalid(context), "wrapped runtime flow mapping remains valid")
+        expect(context.auditDBURL.path == "/runtime/audit/wrapped.db", "wrapped flow audit path is read")
+
+        let escapedPath = "/chosen/generated-escaped-observability.yaml"
+        context = resolve(
+            environment: ["DEFENSECLAW_CONFIG": escapedPath],
+            texts: [escapedPath: """
+            config_version: 8
+            deployment_mode: unmanaged_byod
+            observability: {"local":{"path":"/runtime/a\\u0075dit/escaped.db"}}
+            """]
+        )
+        expect(!isInvalid(context), "JSON-compatible flow mapping remains valid")
+        expect(context.auditDBURL.path == "/runtime/audit/escaped.db", "flow scalar escapes are decoded")
+
+        let embeddedHashPath = "/chosen/generated-embedded-hash-observability.yaml"
+        let embeddedHashConfig = """
+        config_version: 8
+        deployment_mode: unmanaged_byod
+        observability: {label: "a\\t \\\" # b", local: {path: /runtime/audit/hash.db}}
+        """
+        context = resolve(
+            environment: ["DEFENSECLAW_CONFIG": embeddedHashPath],
+            texts: [embeddedHashPath: embeddedHashConfig]
+        )
+        expect(!isInvalid(context), "hash inside an escaped flow scalar is not treated as a comment")
+        expect(context.auditDBURL.path == "/runtime/audit/hash.db", "content after escaped quote is retained")
+        expect(
+            MiniYAML.parse(embeddedHashConfig)["observability"]?.mapping?["label"]?.string == "a\t \" # b",
+            "escaped quote and hash decode like the runtime loader"
+        )
+
+        let missingSeparatorPath = "/chosen/missing-flow-separator.yaml"
+        context = resolve(
+            environment: ["DEFENSECLAW_CONFIG": missingSeparatorPath],
+            texts: [missingSeparatorPath: """
+            config_version: 8
+            deployment_mode: unmanaged_byod
+            observability: {local: {path:/runtime/wrong.db}}
+            """]
+        )
+        expect(isInvalid(context), "plain flow keys require a YAML value separator")
+
+        let duplicatePath = "/chosen/duplicate-flow-key.yaml"
+        context = resolve(
+            environment: ["DEFENSECLAW_CONFIG": duplicatePath],
+            texts: [duplicatePath: """
+            config_version: 8
+            deployment_mode: unmanaged_byod
+            observability: {local: {path: /runtime/first.db, path: /runtime/second.db}}
+            """]
+        )
+        expect(isInvalid(context), "duplicate flow keys fail closed like the runtime loader")
+
+        for invalidKey in ["true", "123", "2026-08-20", "<<"] {
+            let invalidKeyPath = "/chosen/non-string-flow-key-\(invalidKey).yaml"
+            context = resolve(
+                environment: ["DEFENSECLAW_CONFIG": invalidKeyPath],
+                texts: [invalidKeyPath: """
+                config_version: 8
+                deployment_mode: unmanaged_byod
+                observability: {\(invalidKey): ignored, local: {path: /runtime/audit.db}}
+                """]
+            )
+            expect(isInvalid(context), "non-string or merge flow key \(invalidKey) fails closed")
+        }
+
+        let quotedMergePath = "/chosen/quoted-merge-flow-key.yaml"
+        context = resolve(
+            environment: ["DEFENSECLAW_CONFIG": quotedMergePath],
+            texts: [quotedMergePath: """
+            config_version: 8
+            deployment_mode: unmanaged_byod
+            observability: {"<<": ignored, local: {path: /runtime/audit.db}}
+            """]
+        )
+        expect(isInvalid(context), "quoted merge keys fail closed like the runtime loader")
+
+        let multilineQuotedPath = "/chosen/multiline-quoted-flow-value.yaml"
+        let longLabel = String(repeating: "a", count: 4_100)
+        let multilineQuotedConfig = """
+        config_version: 8
+        deployment_mode: unmanaged_byod
+        observability: {label: "\(longLabel)\\
+          # retained inside the quoted value", local: {path: /runtime/audit/multiline.db}}
+        """
+        context = resolve(
+            environment: ["DEFENSECLAW_CONFIG": multilineQuotedPath],
+            texts: [multilineQuotedPath: multilineQuotedConfig]
+        )
+        expect(!isInvalid(context), "wrapped quoted flow scalars retain YAML line-continuation semantics")
+        expect(
+            context.auditDBURL.path == "/runtime/audit/multiline.db",
+            "content following a wrapped quoted scalar remains visible"
+        )
+        expect(
+            MiniYAML.parse(multilineQuotedConfig)["observability"]?.mapping?["label"]?.string
+                == longLabel + "# retained inside the quoted value",
+            "escaped quoted line breaks decode exactly like the runtime loader"
+        )
+
+        let oversizedPath = "/chosen/oversized-config.yaml"
+        context = resolve(
+            environment: ["DEFENSECLAW_CONFIG": oversizedPath],
+            texts: [
+                oversizedPath: "config_version: 8\n#"
+                    + String(repeating: "\u{00E9}", count: 2 * 1024 * 1024 + 1),
+            ]
+        )
+        expect(isInvalid(context), "multibyte configs over the runtime byte limit fail closed")
+
+        let malformedPath = "/chosen/malformed-flow-observability.yaml"
+        context = resolve(
+            environment: ["DEFENSECLAW_CONFIG": malformedPath],
+            texts: [malformedPath: """
+            config_version: 8
+            deployment_mode: unmanaged_byod
+            observability: {destinations: [{name: splunk-local}]
+            """]
+        )
+        expect(isInvalid(context), "truncated flow mapping still fails closed")
+    }
+
     private static func managedEvidenceMonotonicallyRemovesMutation() {
         let appPath = "/chosen/app.yaml"
         var context = resolve(
@@ -258,6 +487,60 @@ struct InstallationContextTests {
         expect(environment["DEFENSECLAW_CONFIG"] == context.configURL.path, "config env is pinned")
         expect(environment["DEFENSECLAW_HOME"] == context.homeRoot.path, "home env is pinned")
         expect(environment["PATH"]?.hasPrefix("/custom/bin") == true, "normal PATH inheritance remains")
+    }
+
+    private static func redactionDefaultProfileMatchesRuntimeSchema() async {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("defenseclaw-redaction-profile-\(UUID().uuidString)", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+            defer { try? FileManager.default.removeItem(at: directory) }
+
+            let configURL = directory.appendingPathComponent("config.yaml", isDirectory: false)
+            let context = InstallationContext.resolve(
+                environment: ["DEFENSECLAW_CONFIG": configURL.path],
+                appConfigOverride: nil,
+                userHome: directory
+            )
+            let store = ConfigStore(context: context)
+
+            try """
+            config_version: 8
+            deployment_mode: unmanaged_byod
+            privacy:
+              disable_redaction: true
+            """.write(to: configURL, atomically: true, encoding: .utf8)
+            var config = await store.reload()
+            expect(
+                config.redactionDefaultProfile.isEmpty,
+                "legacy privacy.disable_redaction no longer defines the v8 redaction profile"
+            )
+
+            try """
+            config_version: 8
+            deployment_mode: unmanaged_byod
+            observability:
+              defaults:
+                redaction_profile: none
+            """.write(to: configURL, atomically: true, encoding: .utf8)
+            config = await store.reload()
+            expect(
+                config.redactionDefaultProfile == "none",
+                "the permissive none profile remains distinct from an absent profile"
+            )
+
+            try """
+            config_version: 8
+            deployment_mode: unmanaged_byod
+            observability:
+              defaults:
+                redaction_profile: strict
+            """.write(to: configURL, atomically: true, encoding: .utf8)
+            config = await store.reload()
+            expect(config.redactionDefaultProfile == "strict", "v8 redaction profile is loaded")
+        } catch {
+            fail("redaction profile fixture failed: \(error)")
+        }
     }
 
     private static func lowerLevelMutationGateSurvivesRebind() async {

--- a/macos/DefenseClawMac/Tests/InventoryCapabilityWarningTests.swift
+++ b/macos/DefenseClawMac/Tests/InventoryCapabilityWarningTests.swift
@@ -1,0 +1,140 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+@main
+struct InventoryCapabilityWarningTests {
+    static func main() {
+        filtersCapabilityNotesAcrossConnectors()
+        preservesRealFailuresAndDiagnostics()
+        rejectsNearMatches()
+        supportsLegacySummaryCounts()
+        print("InventoryCapabilityWarningTests passed")
+    }
+
+    private static func filtersCapabilityNotesAcrossConnectors() {
+        let connectors = ["antigravity", "claudecode", "codex", "cursor", "opencode"]
+        let documents = connectors.map(capabilityDocument)
+        let warning = Array(
+            repeating: "Warning: 4 connector inventory command(s) failed",
+            count: connectors.count
+        ).joined(separator: "\n")
+
+        let data = try? JSONSerialization.data(withJSONObject: documents, options: [.sortedKeys])
+        let output = warning + "\n" + (data.flatMap { String(data: $0, encoding: .utf8) } ?? "")
+        guard let parsed = InventoryOutputParser.parse(output) else {
+            fail("multi-connector inventory output should parse")
+        }
+
+        expect(parsed.documents.count == connectors.count, "all connector documents are retained")
+        expect(
+            parsed.documents.allSatisfy { InventoryOutputParser.actionableErrorCount(in: $0) == 0 },
+            "expected connector capability notes are not counted as failures"
+        )
+        expect(
+            InventoryOutputParser.userFacingDiagnostics(from: parsed).isEmpty,
+            "capability-only aggregate warnings are removed"
+        )
+    }
+
+    private static func preservesRealFailuresAndDiagnostics() {
+        var document = capabilityDocument("codex")
+        var errors = document["errors"] as? [[String: Any]] ?? []
+        errors.append(["command": "codex:skills", "error": "permission denied"])
+        document["errors"] = errors
+
+        let result = InventoryOutputParseResult(
+            documents: [document],
+            diagnostics: "Warning: 5 connector inventory command(s) failed\nscanner cache is stale"
+        )
+        expect(
+            InventoryOutputParser.actionableErrorCount(in: document) == 1,
+            "real inventory failures remain actionable"
+        )
+        expect(
+            InventoryOutputParser.userFacingDiagnostics(from: result)
+                == "Warning: 1 connector inventory command(s) failed\nscanner cache is stale",
+            "real failures are deduplicated and unrelated diagnostics are preserved"
+        )
+    }
+
+    private static func rejectsNearMatches() {
+        var document = capabilityDocument("codex")
+        document["errors"] = [[
+            "command": "codex:skills",
+            "error": "agents are not a first-class concept on this connector",
+        ]]
+        expect(
+            InventoryOutputParser.actionableErrorCount(in: document) == 1,
+            "capability text under the wrong command remains actionable"
+        )
+
+        document["errors"] = [[
+            "command": "codex:agents",
+            "error": "agent inventory timed out",
+        ]]
+        expect(
+            InventoryOutputParser.actionableErrorCount(in: document) == 1,
+            "unknown errors remain actionable"
+        )
+    }
+
+    private static func supportsLegacySummaryCounts() {
+        let document: [String: Any] = [
+            "connector": "codex",
+            "summary": ["errors": 3],
+        ]
+        expect(
+            InventoryOutputParser.actionableErrorCount(in: document) == 3,
+            "legacy payloads without structured errors retain their summary count"
+        )
+    }
+
+    private static func capabilityDocument(_ connector: String) -> [String: Any] {
+        [
+            "connector": connector,
+            "errors": [
+                [
+                    "command": "\(connector):agents",
+                    "error": "agents are not a first-class concept on this connector",
+                ],
+                [
+                    "command": "\(connector):tools",
+                    "error": "tool registry is owned by each plugin's manifest",
+                ],
+                [
+                    "command": "\(connector):models",
+                    "error": "model providers are configured inside the framework",
+                ],
+                [
+                    "command": "\(connector):memory",
+                    "error": "memory backend is private to the framework",
+                ],
+            ],
+            "summary": ["errors": 4],
+        ]
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        guard condition() else { fail(message) }
+    }
+
+    private static func fail(_ message: String) -> Never {
+        fputs("FAILED: \(message)\n", stderr)
+        exit(1)
+    }
+}

--- a/macos/DefenseClawMac/Tests/LocalModelDiscoveryParityTests.swift
+++ b/macos/DefenseClawMac/Tests/LocalModelDiscoveryParityTests.swift
@@ -20,6 +20,7 @@ import Foundation
 struct LocalModelDiscoveryParityTests {
     static func main() {
         decodesLocalModelRuntimeAndEvidenceMetadata()
+        decodesProvenanceDiagnosticsAndClassificationMetadata()
         safelyCoercesUntrustedModelMetadata()
         groupsLocalModelsByModelIDAndSearchesModelNames()
         preservesStableCollisionSafeRowIdentity()
@@ -95,6 +96,87 @@ struct LocalModelDiscoveryParityTests {
         )
     }
 
+    private static func decodesProvenanceDiagnosticsAndClassificationMetadata() {
+        let signal = AISignalDecoding.decode([
+            "model": [
+                "id": "llama3:8b-q4",
+                "owner_application": "Ollama",
+                "relevance": "primary",
+                "discovery_confidence": 92,
+                "provenance": [
+                    "publisher": "Meta",
+                    "country_code": " us ",
+                    "base_models": ["Llama 3", "", 42] as [Any],
+                    "quantized": "yes",
+                    "quantization": "4-bit",
+                    "distilled": false,
+                    "source": "catalog",
+                    "confidence": "high",
+                ] as [String: Any],
+            ] as [String: Any],
+        ])
+
+        guard let model = signal.model, let provenance = model.provenance else {
+            fail("model provenance is decoded")
+        }
+        expect(model.ownerApplication == "Ollama", "model owner application")
+        expect(model.relevance == "primary", "model relevance")
+        expect(model.discoveryConfidence == 0.92, "percent model confidence is normalized")
+        expect(provenance.publisher == "Meta", "provenance publisher")
+        expect(provenance.countryCode == "US", "country code is normalized")
+        expect(provenance.countryDisplay == "US 🇺🇸", "country display includes its derived flag")
+        expect(provenance.baseModels == ["Llama 3"], "malformed and empty base models are discarded")
+        expect(provenance.rootDisplay == "ambiguous (1)", "ambiguous lineage is explicit")
+        expect(provenance.quantized == true, "string quantized flag is decoded")
+        expect(provenance.distilled == false, "boolean distilled flag is decoded")
+        expect(provenance.derivationDisplay == "quantized · 4-bit", "derivation fallback")
+        expect(provenance.source == "catalog", "provenance source")
+        expect(provenance.confidence == "high", "provenance confidence")
+        expect(
+            AIDiscoveryGrouping.modelDetail(model)
+                == "model: id=llama3:8b-q4 relevance=primary owner=Ollama discovery_confidence=92%",
+            "classification metadata appears in bounded inspector detail"
+        )
+
+        let diagnostics = AIDiscoveryDiagnostics.fromMapping([
+            "result": "partial",
+            "errors": NSNumber(value: 2),
+            "detector_errors": [
+                "ollama": "request timed out",
+                "empty": "   ",
+                "numeric": 42,
+            ] as [String: Any],
+        ])
+        expect(diagnostics.result == "partial", "diagnostic result")
+        expect(diagnostics.errors == 2, "diagnostic error count")
+        expect(
+            diagnostics.detectorErrors == ["ollama": "request timed out"],
+            "only nonempty string detector errors are retained"
+        )
+
+        var snapshot = AIUsageSnapshot()
+        snapshot.result = diagnostics.result
+        snapshot.errors = diagnostics.errors
+        snapshot.detectorErrors = diagnostics.detectorErrors
+        expect(snapshot.isPartial, "reported diagnostics mark a partial scan")
+        expect(snapshot.reportedDiscoveryErrorCount == 2, "reported count wins over detector map size")
+        expect(snapshot.discoveryIssueLabel == "2 errors", "diagnostic issue label")
+        expect(
+            snapshot.partialDiscoveryDescription == "2 errors occurred during discovery.",
+            "diagnostic description"
+        )
+
+        expect(AIConfidence.optionalNormalized(true) == nil, "boolean confidence is rejected")
+        expect(
+            AIConfidence.optionalNormalized(NSNumber(value: true)) == nil,
+            "bridged boolean confidence is rejected"
+        )
+        expect(AIConfidence.optionalNormalized(NSNumber(value: 0)) == 0, "numeric zero is preserved")
+        expect(AIConfidence.optionalNormalized(NSNumber(value: 1)) == 1, "numeric one is preserved")
+        expect(AIConfidence.optionalNormalized(Double.nan) == nil, "non-finite confidence is rejected")
+        expect(AIUsageModel.fromMapping([:]) == nil, "empty model mapping remains absent")
+    }
+
     private static func safelyCoercesUntrustedModelMetadata() {
         let invalid = AISignalDecoding.decode([
             "model": ["id": "private", "size_bytes": "not-a-number", "pinned": "false"],
@@ -115,9 +197,16 @@ struct LocalModelDiscoveryParityTests {
         expect(negative.model?.pinned == true, "true string is accepted")
 
         let boundary = AISignalDecoding.decode([
-            "model": ["id": "boundary", "size_bytes": Double(Int64.max)],
+            "model": [
+                "id": "boundary",
+                "size_bytes": Double(Int64.max),
+                "discovery_confidence": true,
+                "provenance": ["country_code": "USA"],
+            ] as [String: Any],
         ])
         expect(boundary.model?.sizeBytes == 0, "rounded Int64 boundary cannot trap")
+        expect(boundary.model?.discoveryConfidence == nil, "boolean confidence remains absent")
+        expect(boundary.model?.provenance?.countryCode.isEmpty == true, "invalid country code is discarded")
 
         var distant = makeSignal(id: "distant")
         distant.lastSeen = Date(timeIntervalSince1970: 1e22)
@@ -152,25 +241,21 @@ struct LocalModelDiscoveryParityTests {
             model: AIUsageModel(id: "Whisper-Tiny", status: "installed", format: "onnx")
         )
 
-        let signals = [whisper, installed, loaded]
-        let rows = AIDiscoveryGrouping.modelRows(from: signals)
+        let rows = AIDiscoveryGrouping.rows(from: [whisper, installed, loaded])
         expect(rows.count == 2, "distinct model ids remain separate")
-        expect(
-            AIDiscoveryGrouping.rows(from: signals).isEmpty,
-            "identified models leave the product table"
-        )
+        expect(AIDiscoveryGrouping.hasModels(in: rows), "model columns are enabled")
 
-        guard let qwen = rows.first(where: { $0.modelID == "Qwen3-0.6B-GGUF" }),
-              let whisperRow = rows.first(where: { $0.modelID == "Whisper-Tiny" }) else {
+        guard let qwen = rows.first(where: { $0.model == "Qwen3-0.6B-GGUF" }),
+              let whisperRow = rows.first(where: { $0.model == "Whisper-Tiny" }) else {
             fail("grouped model rows")
         }
         expect(qwen.count == 2, "installed and loaded signals group together")
-        expect(qwen.statuses == ["installed", "loaded"], "statuses retain first-seen order")
-        expect(qwen.formats == ["gguf"], "formats are deduplicated")
+        expect(qwen.modelStatuses == ["installed", "loaded"], "statuses retain first-seen order")
+        expect(qwen.modelFormats == ["gguf"], "formats are deduplicated")
         expect(qwen.id != whisperRow.id, "model id participates in stable row identity")
-        expect(qwen.matches("qwen3"), "model id is searchable")
-        expect(!whisperRow.matches("qwen3"), "search excludes other models")
-        expect(rows.map(\.modelID) == ["Qwen3-0.6B-GGUF", "Whisper-Tiny"], "model id breaks sort ties")
+        expect(AIDiscoveryGrouping.matches(qwen, query: "qwen3"), "model id is searchable")
+        expect(!AIDiscoveryGrouping.matches(whisperRow, query: "qwen3"), "search excludes other models")
+        expect(rows.map(\.model) == ["Qwen3-0.6B-GGUF", "Whisper-Tiny"], "model id breaks sort ties")
         expect(AIDiscoveryGrouping.detailSignalLimit == 50, "inspector detail is bounded")
     }
 
@@ -236,7 +321,7 @@ struct LocalModelDiscoveryParityTests {
         snapshot.lookupModelProvenanceOnline = true
         expect(
             snapshot.discoveryHeaderParts.last == "model-lookup=online",
-            "live model provenance lookup state appears in the compact header"
+            "online provenance lookup is visible in the discovery header"
         )
 
         var newAgent = makeSignal(id: "new", name: "New agent", category: "ai_cli", product: "New")

--- a/macos/DefenseClawMac/Tests/MainWindowLifecycleContractTests.swift
+++ b/macos/DefenseClawMac/Tests/MainWindowLifecycleContractTests.swift
@@ -1,0 +1,143 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+@main
+enum MainWindowLifecycleContractTests {
+    static func main() throws {
+        guard CommandLine.arguments.count == 2 else {
+            fputs("Usage: MainWindowLifecycleContractTests <repository-root>\n", stderr)
+            exit(2)
+        }
+
+        let root = URL(fileURLWithPath: CommandLine.arguments[1], isDirectory: true)
+        let appSource = try source(
+            at: root.appendingPathComponent("DefenseClawMac/App/DefenseClawApp.swift")
+        )
+        let popoverSource = try source(
+            at: root.appendingPathComponent("DefenseClawMac/Features/MenuBarPopover.swift")
+        )
+        let mainWindowSource = try source(
+            at: root.appendingPathComponent("DefenseClawMac/Features/MainWindow.swift")
+        )
+
+        expect(appSource.contains(#"Window("DefenseClaw", id: "main")"#),
+               "the primary dashboard must use a singleton Window scene")
+        expect(!appSource.contains(#"WindowGroup("DefenseClaw", id: "main")"#),
+               "the primary dashboard must not use a multi-instance WindowGroup")
+        expect(appSource.contains("CommandGroup(replacing: .newItem) { }"),
+               "the New Window command must remain disabled")
+
+        let helper = try functionBody(named: "openMainWindow", in: popoverSource)
+        expect(helper.contains("AppDelegate.prepareForMainWindowPresentation()"),
+               "the menu action must activate the app before presenting the dashboard")
+        expect(helper.components(separatedBy: #"openWindow(id: "main")"#).count - 1 == 1,
+               "the menu action must issue exactly one SwiftUI window request")
+        expect(!helper.contains("AppDelegate.openMainWindow()"),
+               "the menu action must not combine AppKit and SwiftUI open operations")
+
+        expect(mainWindowSource.contains("NavigationSplitView {"),
+               "the main window must retain its native sidebar/detail split")
+        expect(!mainWindowSource.contains("NavigationSplitView(columnVisibility:"),
+               "inspector presentation must not programmatically change split-view visibility")
+
+        let applicationSources = try swiftSources(
+            under: root.appendingPathComponent("DefenseClawMac", isDirectory: true)
+        )
+        for forbiddenSymbol in [
+            "detailInspectorPresented",
+            "reportsDetailInspector(",
+            "inspectorCollapsedSidebar",
+            "shouldCollapseSidebar(",
+        ] {
+            expect(!applicationSources.contains(forbiddenSymbol),
+                   "legacy inspector/sidebar coupling returned: \(forbiddenSymbol)")
+        }
+
+        for relativePath in [
+            "DefenseClawMac/Features/ActivityView.swift",
+            "DefenseClawMac/Features/AlertsView.swift",
+            "DefenseClawMac/Features/AuditView.swift",
+            "DefenseClawMac/Features/LogsView.swift",
+        ] {
+            let featureSource = try source(at: root.appendingPathComponent(relativePath))
+            expect(featureSource.contains(".inspector(isPresented:"),
+                   "\(relativePath) must retain its native inspector")
+            expect(featureSource.contains(".dcInspectorColumnWidth()"),
+                   "\(relativePath) must retain bounded inspector sizing")
+        }
+
+        print("MainWindowLifecycleContractTests passed")
+    }
+
+    private static func source(at url: URL) throws -> String {
+        try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private static func swiftSources(under directory: URL) throws -> String {
+        guard let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            throw TestError("could not enumerate \(directory.path)")
+        }
+
+        var contents: [String] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            contents.append(try source(at: url))
+        }
+        return contents.joined(separator: "\n")
+    }
+
+    private static func functionBody(named name: String, in source: String) throws -> String {
+        guard let start = source.range(of: "private func \(name)() {") else {
+            throw TestError("could not find \(name) helper")
+        }
+
+        var depth = 1
+        var index = start.upperBound
+        while index < source.endIndex {
+            switch source[index] {
+            case "{": depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 {
+                    return String(source[start.upperBound..<index])
+                }
+            default: break
+            }
+            index = source.index(after: index)
+        }
+        throw TestError("could not parse \(name) helper")
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        guard condition() else {
+            fputs("FAILED: \(message)\n", stderr)
+            exit(1)
+        }
+    }
+
+    private struct TestError: Error, CustomStringConvertible {
+        let description: String
+
+        init(_ description: String) {
+            self.description = description
+        }
+    }
+}

--- a/macos/DefenseClawMac/Tests/OutputSafetyTests.swift
+++ b/macos/DefenseClawMac/Tests/OutputSafetyTests.swift
@@ -36,54 +36,36 @@ actor StreamedLineRecorder {
 @main
 struct OutputSafetyTests {
     static func main() async {
+        CLIProcessGroupLauncher.execIfRequested()
         await capturesNormalOutput()
-        await capturesStandardInput()
         await truncatesANewlineLessLine()
         await capsTotalOutputAndReportsFailure()
         await taskCancellationInterruptsChildAndDrainsPipe()
-        await explicitRunIDCancellationInterruptsChild()
-        await pendingCancellationIsHonoredAndConsumed()
-        await ignoredSignalsEscalateToForcedTermination()
-        await groupCancellationStopsLongLivedDescendant()
-        await closedOutputDoesNotBlockCancellation()
-        await inheritedPipeDoesNotHoldRunOpen()
-        await continuouslyWritingDescendantDoesNotHoldRunOpen()
-        await notFoundCancellationStaysActiveForResult()
-        cancelledResultIsNotSuccessful()
+        resolvesRuntimePythonAdjacentToSelectedCLI()
         parsesBoundedInventoryDocuments()
+        normalizesInventoryCapabilityNotes()
         rejectsOversizedAndAdversarialInventoryOutput()
         print("CLI output and inventory parser safety tests passed")
     }
 
     private static func capturesNormalOutput() async {
-        let result = await makeTestRunner().run(
+        let result = await CLIRunner().run(
             binary: "/usr/bin/python3",
-            arguments: ["-c", "import sys; sys.stdout.write('alpha\\nbeta')"]
+            arguments: ["-c", "import sys; sys.stdout.write('alpha\\nbeta')"],
+            mutation: false
         )
-        expect(
-            result.succeeded,
-            "normal command succeeds (exit \(result.exitCode), output: \(result.output))"
-        )
+        expect(result.succeeded, "normal command succeeds")
         expect(!result.outputTruncated, "normal command is not truncated")
         expect(result.output == "alpha\nbeta\n", "normal output is preserved")
-    }
-
-    private static func capturesStandardInput() async {
-        let result = await makeTestRunner().run(
-            binary: "/usr/bin/python3",
-            arguments: ["-c", "import sys; print(sys.stdin.readline().strip())"],
-            standardInput: "stdin-preserved"
-        )
-        expect(result.succeeded, "standard-input command succeeds")
-        expect(result.output == "stdin-preserved\n", "standard input reaches the isolated process")
     }
 
     private static func truncatesANewlineLessLine() async {
         let count = CLIOutputLimits.maximumLineBytes + 4_096
         let recorder = StreamedLineRecorder()
-        let result = await makeTestRunner().run(
+        let result = await CLIRunner().run(
             binary: "/usr/bin/python3",
-            arguments: ["-c", "import sys; sys.stdout.write('x' * \(count))"]
+            arguments: ["-c", "import sys; sys.stdout.write('x' * \(count))"],
+            mutation: false
         ) { line in
             await recorder.append(line)
         }
@@ -109,12 +91,13 @@ struct OutputSafetyTests {
 
     private static func capsTotalOutputAndReportsFailure() async {
         let count = CLIOutputLimits.maximumOutputBytes + 1_024 * 1_024
-        let result = await makeTestRunner().run(
+        let result = await CLIRunner().run(
             binary: "/usr/bin/python3",
             arguments: [
                 "-c",
                 "import sys; sys.stdout.write(('y' * 80 + '\\n') * (\(count) // 81 + 1))",
-            ]
+            ],
+            mutation: false
         )
         expect(result.exitCode == 0, "large-output child is fully drained")
         expect(result.outputTruncated, "total output cap sets truncation state")
@@ -127,7 +110,7 @@ struct OutputSafetyTests {
     }
 
     private static func taskCancellationInterruptsChildAndDrainsPipe() async {
-        let runner = makeTestRunner()
+        let runner = CLIRunner()
         let recorder = StreamedLineRecorder()
         let interruptionSentinel = "sigint-handler-output-drained"
         let childProgram = """
@@ -147,12 +130,20 @@ struct OutputSafetyTests {
         let task = Task {
             await runner.run(
                 binary: "/usr/bin/python3",
-                arguments: ["-c", childProgram]
+                arguments: ["-c", childProgram],
+                mutation: false
             ) { line in
                 await recorder.append(line)
             }
         }
-        let childStarted = await waitForLine("ready", in: recorder)
+        var childStarted = false
+        for _ in 0..<100 {
+            if (await recorder.snapshot()).contains("ready") {
+                childStarted = true
+                break
+            }
+            try? await Task.sleep(nanoseconds: 30_000_000)
+        }
         expect(childStarted, "child starts before the cancellation check")
         task.cancel()
         let result = await task.value
@@ -164,359 +155,26 @@ struct OutputSafetyTests {
         )
     }
 
-    private static func explicitRunIDCancellationInterruptsChild() async {
-        let runner = makeTestRunner()
-        let recorder = StreamedLineRecorder()
-        let runID = UUID()
-        let interruptionSentinel = "explicit-run-id-sigint-drained"
-        let childProgram = """
-        import signal
-        import sys
-        import time
+    private static func resolvesRuntimePythonAdjacentToSelectedCLI() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("defenseclaw-python-resolution-\(UUID().uuidString)")
+        let bin = root.appendingPathComponent("venv/bin", isDirectory: true)
+        let cli = bin.appendingPathComponent("defenseclaw")
+        let linkedCLI = root.appendingPathComponent("defenseclaw-link")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try? FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: cli.path, contents: Data())
+        try? FileManager.default.createSymbolicLink(at: linkedCLI, withDestinationURL: cli)
 
-        def handle_interrupt(_signal, _frame):
-            print("\(interruptionSentinel)", flush=True)
-            sys.exit(130)
-
-        signal.signal(signal.SIGINT, handle_interrupt)
-        signal.alarm(8)
-        print("ready", flush=True)
-        time.sleep(30)
-        """
-        let task = Task {
-            await runner.run(
-                binary: "/usr/bin/python3",
-                arguments: ["-c", childProgram],
-                runID: runID
-            ) { line in
-                await recorder.append(line)
-            }
-        }
-        let childStarted = await waitForLine("ready", in: recorder)
-        expect(childStarted, "explicit run-ID child starts before cancellation")
-        let disposition = await runner.cancel(runID: runID)
-        expect(disposition == .requested, "explicit run-ID cancellation is accepted")
-        let result = await task.value
-        expect(result.cancelled, "explicit run-ID cancellation is reflected in the result")
-        expect(!result.succeeded, "an explicitly cancelled command is not successful")
+        let candidates = CLIRunner.runtimePythonCandidates(
+            contextPythonPath: root.appendingPathComponent("home-venv/bin/python").path,
+            selectedCLIPath: linkedCLI.path
+        )
+        expect(candidates.count == 2, "selected CLI contributes a runtime interpreter candidate")
         expect(
-            result.output.contains(interruptionSentinel),
-            "explicit cancellation drains output from the SIGINT handler"
+            candidates[1] == bin.appendingPathComponent("python").path,
+            "selected CLI symlink resolves to its sibling Python"
         )
-    }
-
-    private static func pendingCancellationIsHonoredAndConsumed() async {
-        let runner = makeTestRunner()
-        let runID = UUID()
-        let reserved = await runner.reserve(runID: runID)
-        expect(reserved, "Activity run ID can be reserved before publication")
-        let disposition = await runner.cancel(runID: runID)
-        expect(disposition == .requested, "cancellation against a reservation is retained")
-
-        let cancelled = await runner.run(
-            binary: "/usr/bin/python3",
-            arguments: ["-c", "print('must-not-launch')"],
-            runID: runID
-        )
-        expect(cancelled.cancelled, "reserved cancellation prevents process launch")
-        expect(!cancelled.output.contains("must-not-launch"), "cancelled reservation does not execute the child")
-
-        let reused = await runner.run(
-            binary: "/usr/bin/python3",
-            arguments: ["-c", "print('run-id-reused')"],
-            runID: runID
-        )
-        expect(reused.succeeded, "pre-launch cancellation is consumed after one run")
-        expect(reused.output.contains("run-id-reused"), "a consumed run ID can be reused safely")
-    }
-
-    private static func ignoredSignalsEscalateToForcedTermination() async {
-        let runner = makeTestRunner()
-        let recorder = StreamedLineRecorder()
-        let runID = UUID()
-        let childProgram = """
-        import signal
-        import time
-
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        signal.alarm(8)
-        print("ready", flush=True)
-        time.sleep(30)
-        """
-        let task = Task {
-            await runner.run(
-                binary: "/usr/bin/python3",
-                arguments: ["-c", childProgram],
-                runID: runID
-            ) { line in
-                await recorder.append(line)
-            }
-        }
-        let childStarted = await waitForLine("ready", in: recorder)
-        expect(childStarted, "signal-ignoring child starts before cancellation")
-        let started = ContinuousClock.now
-        let disposition = await runner.cancel(runID: runID)
-        expect(disposition == .requested, "signal-ignoring child accepts cancellation")
-        let result = await task.value
-        let elapsed = ContinuousClock.now - started
-        expect(result.cancelled, "forced termination remains a cancelled result")
-        expect(elapsed < .seconds(4), "ignored signals escalate to forced termination promptly")
-    }
-
-    private static func groupCancellationStopsLongLivedDescendant() async {
-        let runner = makeTestRunner()
-        let recorder = StreamedLineRecorder()
-        let runID = UUID()
-        let marker = FileManager.default.temporaryDirectory
-            .appendingPathComponent("defenseclaw-descendant-pid-\(UUID().uuidString)")
-        var descendantPID: pid_t = 0
-        defer {
-            if descendantPID > 0 {
-                _ = Darwin.kill(descendantPID, SIGKILL)
-            }
-            try? FileManager.default.removeItem(at: marker)
-        }
-
-        let descendantProgram = """
-        import signal
-        import time
-
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        signal.alarm(8)
-        print("descendant-ready", flush=True)
-        time.sleep(30)
-        """
-        let parentProgram = """
-        import signal
-        import subprocess
-        import sys
-        import time
-
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        signal.alarm(8)
-        descendant = subprocess.Popen(
-            [sys.executable, "-c", sys.argv[2]],
-            stdout=sys.stdout,
-            stderr=sys.stderr,
-        )
-        with open(sys.argv[1], "w", encoding="utf-8") as marker:
-            marker.write(str(descendant.pid))
-        print("parent-ready", flush=True)
-        time.sleep(30)
-        """
-        let task = Task {
-            await runner.run(
-                binary: "/usr/bin/python3",
-                arguments: ["-c", parentProgram, marker.path, descendantProgram],
-                runID: runID
-            ) { line in
-                await recorder.append(line)
-            }
-        }
-        let parentStarted = await waitForLine("parent-ready", in: recorder)
-        let descendantStarted = await waitForLine("descendant-ready", in: recorder)
-        let markerWritten = await waitForFile(marker)
-        expect(parentStarted, "process-group parent starts before cancellation")
-        expect(descendantStarted, "long-lived descendant starts before cancellation")
-        expect(markerWritten, "long-lived descendant publishes its PID")
-        if let pidText = try? String(contentsOf: marker, encoding: .utf8),
-           let parsedPID = pid_t(pidText.trimmingCharacters(in: .whitespacesAndNewlines)) {
-            descendantPID = parsedPID
-        }
-        expect(descendantPID > 0, "long-lived descendant PID is readable")
-
-        let disposition = await runner.cancel(runID: runID)
-        expect(disposition == .requested, "process-group cancellation is accepted")
-        let result = await task.value
-        let descendantStopped = await waitForProcessExit(descendantPID)
-        expect(result.cancelled, "process-group cancellation marks the result cancelled")
-        expect(
-            descendantStopped,
-            "SIGINT/SIGTERM/SIGKILL escalation stops the long-lived descendant"
-        )
-    }
-
-    private static func closedOutputDoesNotBlockCancellation() async {
-        let runner = makeTestRunner()
-        let runID = UUID()
-        let marker = FileManager.default.temporaryDirectory
-            .appendingPathComponent("defenseclaw-closed-output-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: marker) }
-        let childProgram = """
-        import os
-        import signal
-        import sys
-        import time
-
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        signal.alarm(8)
-        print("ready", flush=True)
-        os.close(1)
-        os.close(2)
-        with open(sys.argv[1], "w", encoding="utf-8") as marker:
-            marker.write("output-closed")
-        time.sleep(30)
-        """
-        let task = Task {
-            await runner.run(
-                binary: "/usr/bin/python3",
-                arguments: ["-c", childProgram, marker.path],
-                runID: runID
-            )
-        }
-        let outputClosed = await waitForFile(marker)
-        expect(outputClosed, "child closes output before cancellation is requested")
-        let started = ContinuousClock.now
-        let disposition = await runner.cancel(runID: runID)
-        expect(disposition == .requested, "runner actor remains available after output closes")
-        let result = await task.value
-        let elapsed = ContinuousClock.now - started
-        expect(result.cancelled, "closed-output child is cancelled")
-        expect(elapsed < .seconds(4), "closed output cannot block cancellation on waitUntilExit")
-    }
-
-    private static func inheritedPipeDoesNotHoldRunOpen() async {
-        let runner = makeTestRunner()
-        let childProgram = """
-        import subprocess
-        import sys
-
-        subprocess.Popen(
-            [sys.executable, "-c", "import time; time.sleep(3)"],
-            stdout=sys.stdout,
-            stderr=sys.stderr,
-        )
-        print("direct-parent-exited", flush=True)
-        """
-        let started = ContinuousClock.now
-        let result = await runner.run(
-            binary: "/usr/bin/python3",
-            arguments: ["-c", childProgram]
-        )
-        let elapsed = ContinuousClock.now - started
-        expect(result.succeeded, "direct parent exit remains successful")
-        expect(result.output.contains("direct-parent-exited"), "direct parent output is drained")
-        expect(elapsed < .seconds(2), "descendant-held pipe does not hold the direct run open")
-    }
-
-    private static func continuouslyWritingDescendantDoesNotHoldRunOpen() async {
-        let runner = makeTestRunner()
-        let childProgram = """
-        import subprocess
-        import sys
-
-        writer = (
-            "import time\\n"
-            "end = time.monotonic() + 3\\n"
-            "while time.monotonic() < end:\\n"
-            " print('descendant-output', flush=True)\\n"
-            " time.sleep(0.005)"
-        )
-        subprocess.Popen(
-            [sys.executable, "-c", writer],
-            stdout=sys.stdout,
-            stderr=sys.stderr,
-        )
-        print("continuous-parent-exited", flush=True)
-        """
-        let started = ContinuousClock.now
-        let result = await runner.run(
-            binary: "/usr/bin/python3",
-            arguments: ["-c", childProgram]
-        )
-        let elapsed = ContinuousClock.now - started
-        expect(result.succeeded, "continuously writing descendant does not change the parent result")
-        expect(result.output.contains("continuous-parent-exited"), "direct parent output survives bounded drain")
-        expect(elapsed < .seconds(2), "post-exit drain has a hard ceiling under continuous output")
-    }
-
-    private static func notFoundCancellationStaysActiveForResult() async {
-        await MainActor.run {
-            let runID = UUID()
-            let store = CommandActivityStore(runner: makeTestRunner())
-            store.entries = [
-                CommandActivityEntry(
-                    id: runID,
-                    title: "Race",
-                    command: "true",
-                    category: "test",
-                    origin: "OutputSafetyTests",
-                    startedAt: Date(),
-                    status: .cancelling,
-                    output: "",
-                    sideEffects: [],
-                    suggestedNextAction: ""
-                ),
-            ]
-
-            store.applyCancellationDisposition(.notFound, to: runID)
-            expect(
-                store.entries.first?.status == .finishing,
-                "a cancellation notFound race waits for the actual result"
-            )
-            store.clearCompleted()
-            expect(
-                store.entries.first?.id == runID,
-                "a cancellation notFound race cannot be cleared before finalization"
-            )
-
-            // The real run continuation remains the sole owner of terminal
-            // status. Once it applies that result, normal clearing resumes.
-            store.entries[0].status = .succeeded
-            store.clearCompleted()
-            expect(store.entries.isEmpty, "the actual terminal result is clearable")
-        }
-    }
-
-    private static func cancelledResultIsNotSuccessful() {
-        let result = CLIResult(exitCode: 0, output: "", cancelled: true)
-        expect(!result.succeeded, "exit zero cannot override a cancelled result")
-    }
-
-    private static func makeTestRunner() -> CLIRunner {
-        let testHome = FileManager.default.temporaryDirectory
-            .appendingPathComponent("defenseclaw-output-test-\(UUID().uuidString)", isDirectory: true)
-        let context = InstallationContext.resolve(
-            environment: [:],
-            appConfigOverride: nil,
-            userHome: testHome,
-            fileExists: { _ in false },
-            readText: { _ in nil }
-        )
-        return CLIRunner(context: context)
-    }
-
-    private static func waitForLine(
-        _ expected: String,
-        in recorder: StreamedLineRecorder,
-        attempts: Int = 100
-    ) async -> Bool {
-        for _ in 0..<attempts {
-            if (await recorder.snapshot()).contains(expected) { return true }
-            try? await Task.sleep(nanoseconds: 30_000_000)
-        }
-        return false
-    }
-
-    private static func waitForFile(_ url: URL, attempts: Int = 100) async -> Bool {
-        for _ in 0..<attempts {
-            if FileManager.default.fileExists(atPath: url.path) { return true }
-            try? await Task.sleep(nanoseconds: 30_000_000)
-        }
-        return false
-    }
-
-    private static func waitForProcessExit(_ pid: pid_t, attempts: Int = 100) async -> Bool {
-        guard pid > 0 else { return false }
-        for _ in 0..<attempts {
-            if Darwin.kill(pid, 0) == -1, errno == ESRCH { return true }
-            try? await Task.sleep(nanoseconds: 30_000_000)
-        }
-        return false
     }
 
     private static func parsesBoundedInventoryDocuments() {
@@ -549,6 +207,105 @@ struct OutputSafetyTests {
         expect(
             InventoryOutputParser.firstJSONArrayData(in: unmatchedArrayOpeners) != nil,
             "array parser finds valid JSON after unmatched openers without rescanning"
+        )
+    }
+
+    private static func normalizesInventoryCapabilityNotes() {
+        let capabilityNotes: [[String: Any]] = [
+            [
+                "command": "codex:agents",
+                "error": "agents are not a first-class concept on this connector",
+            ],
+            [
+                "command": "codex:tools",
+                "error": "tool registry is owned by each plugin's manifest",
+            ],
+            [
+                "command": "codex:models",
+                "error": "model providers are configured inside the framework",
+            ],
+            [
+                "command": "codex:memory",
+                "error": "memory backend is private to the framework",
+            ],
+        ]
+        let capabilityOnly: [String: Any] = [
+            "connector": "codex",
+            "errors": capabilityNotes,
+            "summary": ["errors": 4],
+        ]
+        expect(
+            InventoryOutputParser.actionableErrorCount(in: capabilityOnly) == 0,
+            "expected connector capability notes are not counted as failures"
+        )
+
+        let repeatedWarning = Array(
+            repeating: "Warning: 4 connector inventory command(s) failed",
+            count: 5
+        ).joined(separator: "\n")
+        let capabilityResult = InventoryOutputParseResult(
+            documents: Array(repeating: capabilityOnly, count: 5),
+            diagnostics: repeatedWarning
+        )
+        expect(
+            InventoryOutputParser.userFacingDiagnostics(from: capabilityResult).isEmpty,
+            "aggregate warnings disappear when every reported error is a capability note"
+        )
+
+        let encodedDocuments = try? JSONSerialization.data(
+            withJSONObject: capabilityResult.documents,
+            options: [.sortedKeys]
+        )
+        let mixedOutput = repeatedWarning + "\n"
+            + (encodedDocuments.flatMap { String(data: $0, encoding: .utf8) } ?? "")
+        let parsedCapabilityOutput = InventoryOutputParser.parse(mixedOutput)
+        expect(
+            parsedCapabilityOutput?.documents.count == 5,
+            "multi-connector capability payload parses with runtime diagnostics"
+        )
+        if let parsedCapabilityOutput {
+            expect(
+                InventoryOutputParser.userFacingDiagnostics(from: parsedCapabilityOutput).isEmpty,
+                "parsed runtime capability warnings are suppressed"
+            )
+        }
+
+        var mixed = capabilityOnly
+        mixed["errors"] = capabilityNotes + [[
+            "command": "codex:skills",
+            "error": "permission denied",
+        ]]
+        let mixedResult = InventoryOutputParseResult(
+            documents: [mixed],
+            diagnostics: repeatedWarning + "\nscanner cache is stale"
+        )
+        expect(
+            InventoryOutputParser.actionableErrorCount(in: mixed) == 1,
+            "real inventory failures remain actionable"
+        )
+        expect(
+            InventoryOutputParser.userFacingDiagnostics(from: mixedResult)
+                == "Warning: 1 connector inventory command(s) failed\nscanner cache is stale",
+            "warnings are deduplicated and unrelated diagnostics are preserved"
+        )
+
+        var wrongCategory = capabilityOnly
+        wrongCategory["errors"] = [[
+            "command": "codex:skills",
+            "error": "agents are not a first-class concept on this connector",
+        ]]
+        expect(
+            InventoryOutputParser.actionableErrorCount(in: wrongCategory) == 1,
+            "capability text under the wrong command remains actionable"
+        )
+
+        let legacy: [String: Any] = [
+            "connector": "codex",
+            "summary": ["errors": 3],
+        ]
+        expect(
+            InventoryOutputParser.actionableErrorCount(in: legacy) == 3,
+            "legacy summaries without structured errors retain their count"
         )
     }
 

--- a/macos/DefenseClawMac/Tests/OverviewReadOnlyGuidanceContractTests.swift
+++ b/macos/DefenseClawMac/Tests/OverviewReadOnlyGuidanceContractTests.swift
@@ -1,0 +1,65 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+@main
+enum OverviewReadOnlyGuidanceContractTests {
+    static func main() throws {
+        guard CommandLine.arguments.count == 2 else {
+            fputs("Usage: OverviewReadOnlyGuidanceContractTests <repository-root>\n", stderr)
+            exit(2)
+        }
+
+        let root = URL(fileURLWithPath: CommandLine.arguments[1], isDirectory: true)
+        let overview = try source(root, "DefenseClawMac/Features/OverviewView.swift")
+        let settings = try source(root, "DefenseClawMac/Features/AppSettingsView.swift")
+        let state = try source(root, "DefenseClawMac/App/AppState.swift")
+
+        expect(overview.contains("if let reason = appState.installationReadOnlyReason"),
+               "Quick Actions must render the installation lock reason")
+        expect(overview.contains("Label(\"State-changing actions disabled: \\(reason)\", systemImage: \"lock.shield\")"),
+               "Quick Actions must identify the read-only state")
+        expect(overview.contains("Button(\"Review Installation\")"),
+               "Quick Actions must provide a visible recovery action")
+        expect(overview.contains("appState.selectedSettingsTab = .connection\n                            openSettings()"),
+               "Review Installation must open the Connection settings tab")
+        expect(overview.contains(".disabled(!appState.installationMutationsAllowed)"),
+               "mutation safety gates must remain in place")
+        expect(overview.contains(".disabled(doctorRunning || !appState.installationMutationsAllowed)"),
+               "Doctor must retain its mutation safety gate")
+
+        expect(state.contains("var selectedSettingsTab: AppSettingsTab = .general"),
+               "shared app state must own settings routing")
+        expect(settings.contains("TabView(selection: $state.selectedSettingsTab)"),
+               "Settings must bind its selected tab")
+        expect(settings.contains(".tag(AppSettingsTab.connection)"),
+               "Connection settings must have a selectable tag")
+
+        print("OverviewReadOnlyGuidanceContractTests passed")
+    }
+
+    private static func source(_ root: URL, _ path: String) throws -> String {
+        try String(contentsOf: root.appendingPathComponent(path), encoding: .utf8)
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        guard condition() else {
+            fputs("FAILED: \(message)\n", stderr)
+            exit(1)
+        }
+    }
+}

--- a/macos/DefenseClawMac/Tests/ResourceBoundaryTests.swift
+++ b/macos/DefenseClawMac/Tests/ResourceBoundaryTests.swift
@@ -1,0 +1,428 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+private final class StubGatewayURLProtocol: URLProtocol {
+    static var body = Data()
+    static var headers: [String: String] = [:]
+    static var statusCode = 200
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: Self.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: Self.headers
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+@main
+struct ResourceBoundaryTests {
+    static func main() async throws {
+        try registryAcceptsLegitimateIndex()
+        try registryRejectsOversizedDeepAndEntryHeavyIndexes()
+        try registryEnforcesAggregateMaterializationLimit()
+        try await eventReaderRejectsOversizedRecords()
+        try await eventReaderEnforcesAggregateRetainedByteLimit()
+        try await gatewayAcceptsLegitimateResponse()
+        try await gatewayDecodesOptionalAIDiscoveryMetadata()
+        try await gatewayRejectsDeclaredOversizedResponse()
+        try await gatewayStopsUnknownLengthOversizedResponse()
+        print("Resource boundary tests passed")
+    }
+
+    private static func registryAcceptsLegitimateIndex() throws {
+        let document: [String: Any] = [
+            "schema_version": 1,
+            "publisher": "Example {{publisher}}",
+            "verdicts": [[
+                "type": "skill",
+                "name": "safe-skill",
+                "status": "clean",
+                "args": ["--safe"],
+            ]],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: document)
+        let index = try RegistryStore.decodeIndex(
+            data: data,
+            sourceID: "trusted",
+            limits: testRegistryLimits()
+        )
+        expect(index.entries.count == 1, "normal registry entry is retained")
+        expect(index.publisher == "Example {{publisher}}", "braces inside strings do not count as nesting")
+    }
+
+    private static func registryRejectsOversizedDeepAndEntryHeavyIndexes() throws {
+        var limits = testRegistryLimits()
+        limits.maximumIndexBytes = 64
+        expectThrows("oversized registry index") {
+            _ = try RegistryStore.decodeIndex(
+                data: Data(repeating: 0x20, count: 65),
+                sourceID: "oversized",
+                limits: limits
+            )
+        }
+
+        limits = testRegistryLimits()
+        limits.maximumJSONNestingDepth = 3
+        let deeplyNested = Data(#"{"verdicts":[],"extra":[[[[0]]]]}"#.utf8)
+        expectThrows("deep registry JSON") {
+            _ = try RegistryStore.decodeIndex(
+                data: deeplyNested,
+                sourceID: "nested",
+                limits: limits
+            )
+        }
+
+        limits = testRegistryLimits()
+        limits.maximumEntriesPerIndex = 2
+        let entryHeavy = try JSONSerialization.data(withJSONObject: [
+            "verdicts": [
+                ["name": "one"],
+                ["name": "two"],
+                ["name": "three"],
+            ],
+        ])
+        expectThrows("entry-heavy registry index") {
+            _ = try RegistryStore.decodeIndex(
+                data: entryHeavy,
+                sourceID: "entries",
+                limits: limits
+            )
+        }
+    }
+
+    private static func registryEnforcesAggregateMaterializationLimit() throws {
+        let root = temporaryDirectory("registry")
+        defer { try? FileManager.default.removeItem(at: root) }
+        var indexSizes: [Int] = []
+
+        for sourceID in ["alpha", "beta"] {
+            let directory = root
+                .appendingPathComponent("registries", isDirectory: true)
+                .appendingPathComponent(sourceID, isDirectory: true)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let data = try JSONSerialization.data(withJSONObject: [
+                "verdicts": [["type": "skill", "name": sourceID, "status": "clean"]],
+            ])
+            try data.write(to: directory.appendingPathComponent("index.json"))
+            indexSizes.append(data.count)
+        }
+
+        var limits = testRegistryLimits()
+        limits.maximumAggregateEntries = 1
+        let snapshot = RegistryStore.load(
+            sources: [registrySource("alpha"), registrySource("beta")],
+            dataDirectory: root,
+            limits: limits
+        )
+        expect(snapshot.entries.count == 1, "aggregate entry limit prevents a second source from materializing")
+        expect(
+            snapshot.sources.first(where: { $0.id == "beta" })?.indexError?.contains("aggregate entries") == true,
+            "aggregate rejection is surfaced on the affected source"
+        )
+
+        limits = testRegistryLimits()
+        limits.maximumAggregateIndexBytes = indexSizes.max()! + 1
+        let byteLimited = RegistryStore.load(
+            sources: [registrySource("alpha"), registrySource("beta")],
+            dataDirectory: root,
+            limits: limits
+        )
+        expect(byteLimited.entries.count == 1, "aggregate index-byte limit prevents a second source from materializing")
+        expect(
+            byteLimited.sources.first(where: { $0.id == "beta" })?.indexError?.contains("aggregate index bytes") == true,
+            "aggregate index-byte rejection is surfaced on the affected source"
+        )
+    }
+
+    private static func eventReaderRejectsOversizedRecords() async throws {
+        let root = temporaryDirectory("event-record")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let jsonl = root.appendingPathComponent("gateway.jsonl")
+        let gateway = root.appendingPathComponent("gateway.log")
+        let watchdog = root.appendingPathComponent("watchdog.log")
+        try Data().write(to: watchdog)
+        let oversized = String(repeating: "x", count: 512)
+        try Data("\(oversized)\n12:00:00.000 [gateway] allowed-record\n".utf8).write(to: gateway)
+        let oversizedEvent: [String: Any] = [
+            "event_type": "scan_finding",
+            "severity": "HIGH",
+            "scan_finding": [
+                "scan_id": "oversized",
+                "scanner": "test",
+                "target": "target",
+                "title": "oversized",
+                "description": oversized,
+            ],
+        ]
+        let allowedEvent: [String: Any] = [
+            "event_type": "scan_finding",
+            "severity": "INFO",
+            "scan_finding": [
+                "scan_id": "allowed",
+                "scanner": "test",
+                "target": "target",
+                "title": "allowed",
+                "description": "normal",
+            ],
+        ]
+        let oversizedData = try JSONSerialization.data(withJSONObject: oversizedEvent)
+        let allowedData = try JSONSerialization.data(withJSONObject: allowedEvent)
+        var jsonlData = Data()
+        jsonlData.append(oversizedData)
+        jsonlData.append(0x0A)
+        jsonlData.append(allowedData)
+        jsonlData.append(0x0A)
+        try jsonlData.write(to: jsonl)
+
+        let reader = EventStreamReader(
+            url: jsonl,
+            gatewayLogURL: gateway,
+            watchdogLogURL: watchdog,
+            maximumRecordBytes: 256,
+            maximumRetainedBytes: 1_024
+        )
+        let delta = await reader.poll()
+        let rows = await reader.logBuffers[.gateway] ?? []
+        expect(delta.findings.count == 1, "oversized structured record is excluded from the live delta")
+        expect(delta.findings[0].title == "allowed", "normal structured record remains visible")
+        expect(
+            delta.logRows.filter { $0.eventType == "oversized_record" }.count == 2,
+            "oversized structured and plain records produce bounded visible notices"
+        )
+        expect(rows.count == 2, "plain-log buffer retains a notice and the normal record")
+        expect(
+            rows.contains(where: { $0.eventType == "oversized_record" }),
+            "oversized plain log record is replaced by an explicit omission notice"
+        )
+        expect(
+            rows.contains(where: { $0.message.contains("allowed-record") }),
+            "normal log record remains visible"
+        )
+    }
+
+    private static func eventReaderEnforcesAggregateRetainedByteLimit() async throws {
+        let root = temporaryDirectory("event-aggregate")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let jsonl = root.appendingPathComponent("gateway.jsonl")
+        let gateway = root.appendingPathComponent("gateway.log")
+        let watchdog = root.appendingPathComponent("watchdog.log")
+        try Data().write(to: jsonl)
+
+        let gatewayLines = (0..<6).map {
+            String(format: "12:00:%02d.000 [gateway] gateway-%02d-payload", $0, $0)
+        }.joined(separator: "\n") + "\n"
+        let watchdogLines = (0..<6).map {
+            String(format: "12:01:%02d.000 [watchdog] watchdog-%02d-payload", $0, $0)
+        }.joined(separator: "\n") + "\n"
+        try Data(gatewayLines.utf8).write(to: gateway)
+        try Data(watchdogLines.utf8).write(to: watchdog)
+
+        let reader = EventStreamReader(
+            url: jsonl,
+            gatewayLogURL: gateway,
+            watchdogLogURL: watchdog,
+            maximumRecordBytes: 256,
+            maximumRetainedBytes: 420
+        )
+        _ = await reader.poll()
+        let retainedBytes = await reader.retainedBufferBytes
+        let gatewayRows = await reader.logBuffers[.gateway] ?? []
+        let watchdogRows = await reader.logBuffers[.watchdog] ?? []
+        expect(retainedBytes <= 420, "aggregate retained bytes stay within the configured budget")
+        expect(gatewayRows.count + watchdogRows.count < 12, "oldest records are evicted across stream buffers")
+        expect(watchdogRows.last?.message.contains("watchdog-05") == true, "newest normal record remains visible")
+    }
+
+    private static func gatewayAcceptsLegitimateResponse() async throws {
+        StubGatewayURLProtocol.body = Data(#"{"state":"running","version":"test"}"#.utf8)
+        StubGatewayURLProtocol.headers = [
+            "Content-Type": "application/json",
+            "Content-Length": String(StubGatewayURLProtocol.body.count),
+        ]
+        let client = gatewayClient(maximumResponseBytes: 256)
+        let health = try await client.health()
+        expect(health.state == "running", "normal bounded gateway JSON is parsed")
+    }
+
+    private static func gatewayDecodesOptionalAIDiscoveryMetadata() async throws {
+        StubGatewayURLProtocol.body = Data(#"""
+        {
+            "enabled": true,
+            "lookup_model_provenance_online": true,
+            "summary": {
+                "active_signals": 1,
+                "files_scanned": 3,
+                "result": "partial",
+                "errors": 2,
+                "detector_errors": {
+                    "ollama": "request timed out",
+                    "empty": "",
+                    "numeric": 42
+                }
+            },
+            "signals": [{
+                "signal_id": "ollama-model",
+                "category": "local_model",
+                "model": {
+                    "id": "llama3:8b",
+                    "owner_application": "Ollama",
+                    "relevance": "primary",
+                    "discovery_confidence": 86,
+                    "provenance": {
+                        "publisher": "Meta",
+                        "country_code": "us",
+                        "root_model": "Llama 3",
+                        "quantized": true,
+                        "quantization": "Q4_K_M"
+                    }
+                }
+            }]
+        }
+        """#.utf8)
+        StubGatewayURLProtocol.headers = [
+            "Content-Type": "application/json",
+            "Content-Length": String(StubGatewayURLProtocol.body.count),
+        ]
+        let client = gatewayClient(maximumResponseBytes: 4_096)
+        let snapshot = try await client.aiUsage()
+        expect(snapshot.lookupModelProvenanceOnline, "online provenance lookup is decoded")
+        expect(snapshot.result == "partial", "discovery result is decoded")
+        expect(snapshot.errors == 2, "discovery error count is decoded")
+        expect(
+            snapshot.detectorErrors == ["ollama": "request timed out"],
+            "malformed detector errors are discarded"
+        )
+        expect(snapshot.signals.count == 1, "bounded response retains its signal")
+        expect(snapshot.signals[0].model?.ownerApplication == "Ollama", "model owner is decoded")
+        expect(snapshot.signals[0].model?.relevance == "primary", "model relevance is decoded")
+        expect(snapshot.signals[0].model?.discoveryConfidence == 0.86, "confidence is normalized")
+        expect(snapshot.signals[0].model?.provenance?.publisher == "Meta", "provenance is decoded")
+        expect(snapshot.signals[0].model?.provenance?.countryCode == "US", "country is normalized")
+
+        StubGatewayURLProtocol.body = Data(#"{"summary":{},"signals":[]}"#.utf8)
+        StubGatewayURLProtocol.headers = [
+            "Content-Type": "application/json",
+            "Content-Length": String(StubGatewayURLProtocol.body.count),
+        ]
+        let legacySnapshot = try await client.aiUsage()
+        expect(!legacySnapshot.lookupModelProvenanceOnline, "missing lookup mode defaults offline")
+        expect(legacySnapshot.result.isEmpty, "missing diagnostics remain absent")
+        expect(legacySnapshot.errors == 0, "missing diagnostic count defaults safely")
+        expect(legacySnapshot.detectorErrors.isEmpty, "missing detector errors default safely")
+    }
+
+    private static func gatewayStopsUnknownLengthOversizedResponse() async throws {
+        StubGatewayURLProtocol.body = Data(repeating: 0x78, count: 257)
+        StubGatewayURLProtocol.headers = ["Content-Type": "application/json"]
+        let client = gatewayClient(maximumResponseBytes: 256)
+        do {
+            _ = try await client.health()
+            fail("unknown-length oversized gateway response was accepted")
+        } catch GatewayError.badResponse(let detail) {
+            expect(detail.contains("256-byte limit"), "oversized gateway response reports its byte limit")
+        } catch {
+            fail("unexpected oversized gateway response error: \(error)")
+        }
+    }
+
+    private static func gatewayRejectsDeclaredOversizedResponse() async throws {
+        StubGatewayURLProtocol.body = Data(#"{"state":"running"}"#.utf8)
+        StubGatewayURLProtocol.headers = [
+            "Content-Type": "application/json",
+            "Content-Length": "257",
+        ]
+        let client = gatewayClient(maximumResponseBytes: 256)
+        do {
+            _ = try await client.health()
+            fail("declared oversized gateway response was accepted")
+        } catch GatewayError.badResponse(let detail) {
+            expect(detail.contains("256-byte limit"), "declared oversized response reports its byte limit")
+        } catch {
+            fail("unexpected declared-size gateway response error: \(error)")
+        }
+    }
+
+    private static func gatewayClient(maximumResponseBytes: Int) -> GatewayClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubGatewayURLProtocol.self]
+        return GatewayClient(
+            maximumResponseBytes: maximumResponseBytes,
+            session: URLSession(configuration: configuration)
+        )
+    }
+
+    private static func testRegistryLimits() -> RegistryStore.Limits {
+        RegistryStore.Limits(
+            maximumIndexBytes: 4_096,
+            maximumEntriesPerIndex: 10,
+            maximumAggregateIndexBytes: 8_192,
+            maximumAggregateEntries: 10,
+            maximumJSONNestingDepth: 8
+        )
+    }
+
+    private static func registrySource(_ id: String) -> DefenseClawConfig.RegistrySourceConfig {
+        DefenseClawConfig.RegistrySourceConfig(
+            id: id,
+            kind: "local",
+            content: "skills",
+            url: "",
+            authEnv: "",
+            enabled: true,
+            autoSync: false,
+            syncIntervalHours: 24,
+            lastSync: "",
+            lastStatus: ""
+        )
+    }
+
+    private static func temporaryDirectory(_ label: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("defenseclaw-\(label)-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    private static func expectThrows(_ label: String, _ operation: () throws -> Void) {
+        do {
+            try operation()
+            fail("\(label) was accepted")
+        } catch {
+            return
+        }
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ label: String) {
+        guard condition() else { fail(label) }
+    }
+
+    private static func fail(_ message: String) -> Never {
+        fputs("FAILED: \(message)\n", stderr)
+        exit(1)
+    }
+}

--- a/macos/DefenseClawMac/Tests/RuntimeCompatibilityAuditTests.py
+++ b/macos/DefenseClawMac/Tests/RuntimeCompatibilityAuditTests.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = (
+    ROOT
+    / ".codex"
+    / "skills"
+    / "defenseclaw-runtime-compat"
+    / "scripts"
+    / "audit_compatibility.py"
+)
+SPEC = importlib.util.spec_from_file_location("audit_compatibility", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+AUDIT = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(AUDIT)
+
+
+class RuntimeCompatibilityAuditTests(unittest.TestCase):
+    def test_protected_wheel_decode_is_not_a_legacy_assignment(self) -> None:
+        source = 'DECODED_WHEEL="$RUNTIME_DIR/defenseclaw-${RUNTIME_VERSION}-py3-none-any.whl"\n'
+        value = '"$RUNTIME_DIR/defenseclaw-${RUNTIME_VERSION}-py3-none-any.whl"'
+
+        self.assertFalse(AUDIT.has_shell_assignment(source, "WHEEL", value))
+
+    def test_legacy_wheel_assignment_is_detected(self) -> None:
+        source = '  export WHEEL = "$RUNTIME_DIR/defenseclaw-${RUNTIME_VERSION}-py3-none-any.whl" # old\n'
+        value = '"$RUNTIME_DIR/defenseclaw-${RUNTIME_VERSION}-py3-none-any.whl"'
+
+        self.assertTrue(AUDIT.has_shell_assignment(source, "WHEEL", value))
+
+    def test_version_skew_uses_installed_package_requirements(self) -> None:
+        self.assertEqual(AUDIT.dependency_probe_mode("0.8.10", "0.8.6"), "installed")
+        self.assertEqual(AUDIT.dependency_probe_mode("0.8.10", "0.8.10"), "upstream")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/macos/DefenseClawMac/Tests/RuntimeContractSurfaceTests.swift
+++ b/macos/DefenseClawMac/Tests/RuntimeContractSurfaceTests.swift
@@ -1,0 +1,83 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+@main
+enum RuntimeContractSurfaceTests {
+    static func main() {
+        precondition(CommandRegistry.sourceCount == 232, "unexpected upstream command count")
+        precondition(CommandRegistry.all.count == CommandRegistry.sourceCount, "registry count mismatch")
+
+        let titles = CommandRegistry.all.map(\.title)
+        precondition(Set(titles).count == titles.count, "command titles must be unique")
+        precondition(titles.contains("setup amp"), "Amp setup command is missing")
+        precondition(titles.contains("setup omnigent"), "OmniGent setup command is missing")
+        precondition(titles.contains("setup galileo"), "Galileo setup command is missing")
+        precondition(titles.contains("config show effective observability"), "effective observability command is missing")
+        precondition(titles.contains("observability plan"), "observability plan command is missing")
+        precondition(!titles.contains("setup observability migrate-splunk"), "retired migrate-splunk command remains")
+        precondition(!titles.contains("setup redaction"), "retired setup redaction command remains")
+
+        let bundledTitles = CommandRegistry.paletteCommands(supportedSetupCommands: []).map(\.title)
+        precondition(!bundledTitles.contains("setup amp"), "runtime 0.8.10 must not expose setup amp")
+        let futureTitles = CommandRegistry.paletteCommands(supportedSetupCommands: ["amp"]).map(\.title)
+        precondition(futureTitles.contains("setup amp"), "runtimes reporting Amp may expose setup amp")
+        let setupCommands = CommandRegistry.setupCommands(from: """
+        Usage: defenseclaw setup [OPTIONS] [COMMAND] [ARGS]...
+
+        Commands:
+          amp          Configure Amp.
+          omnigent     Configure OmniGent.
+                       Wrapped description text must not become a command.
+        """)
+        precondition(setupCommands == ["amp", "omnigent"], "setup help capabilities must parse exactly")
+
+        let galileo = command(titled: "setup galileo")
+        precondition(galileo.requiresTerminal, "interactive Galileo setup must be terminal-only")
+
+        let keysSet = command(titled: "keys set")
+        precondition(keysSet.acceptsSecretInput, "keys set must use hidden stdin")
+        let secret = "credential-value-that-must-not-enter-argv"
+        let invocation = try! keysSet.invocation(
+            extraArguments: ["GALILEO_API_KEY"],
+            secretInput: secret
+        )
+        precondition(invocation.arguments == ["keys", "set", "GALILEO_API_KEY"])
+        precondition(invocation.standardInput == secret)
+        precondition(!invocation.arguments.contains(secret), "credential leaked into argv")
+
+        let alertInvocation = try! command(titled: "alerts acknowledge").invocation(
+            extraArguments: ["--severity", "HIGH"],
+            secretInput: ""
+        )
+        precondition(alertInvocation.standardInput == AlertDispositionCommand.confirmationInput)
+        precondition(alertInvocation.arguments == ["alerts", "acknowledge", "--severity", "HIGH"])
+
+        let directAlertInvocation = AlertDispositionCommand.acknowledge(severity: "HIGH")
+        precondition(directAlertInvocation.arguments == alertInvocation.arguments)
+        precondition(directAlertInvocation.standardInput == "y")
+
+        print("Runtime contract surface tests passed")
+    }
+
+    private static func command(titled title: String) -> CommandDefinition {
+        guard let result = CommandRegistry.all.first(where: { $0.title == title }) else {
+            preconditionFailure("missing command: \(title)")
+        }
+        return result
+    }
+}

--- a/macos/DefenseClawMac/Tests/RuntimeProtectedArtifactTests.swift
+++ b/macos/DefenseClawMac/Tests/RuntimeProtectedArtifactTests.swift
@@ -1,0 +1,278 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import CryptoKit
+import Darwin
+import Foundation
+
+@main
+struct RuntimeProtectedArtifactTests {
+    static func main() throws {
+        try decodesProtectedWheel()
+        try rejectsInvalidEnvelope()
+        try rejectsEmptyPayload()
+        try rejectsChecksumDrift()
+        validatesVersionBoundFilename()
+        validatesProtectedArtifactSizeLimit()
+        validatesUpgradeResolverSanitizesAmbientVersion()
+        try validatesAuditRecoveryCommandTargetsInstallation()
+        print("RuntimeProtectedArtifactTests passed")
+    }
+
+    private static func decodesProtectedWheel() throws {
+        let fixture = try Fixture(payload: Data([0x50, 0x4b, 0x03, 0x04, 0x01, 0x02]))
+        defer { fixture.cleanup() }
+
+        try RuntimePayload.decodeProtectedArtifact(
+            from: fixture.source,
+            to: fixture.destination,
+            expectedEncodedSHA256: fixture.encodedSHA256
+        )
+
+        expect(
+            try Data(contentsOf: fixture.destination) == fixture.payload,
+            "protected wheel bytes decode exactly"
+        )
+        let attributes = try FileManager.default.attributesOfItem(atPath: fixture.destination.path)
+        let permissions = (attributes[.posixPermissions] as? NSNumber)?.intValue
+        expect(permissions == 0o600, "decoded wheel is owner-readable and owner-writable only")
+    }
+
+    private static func rejectsInvalidEnvelope() throws {
+        let fixture = try Fixture(payload: Data([0x50, 0x4b]))
+        defer { fixture.cleanup() }
+        try Data(
+            repeating: 0x78,
+            count: RuntimePayload.protectedArtifactMagic.count + 1
+        ).write(to: fixture.source)
+
+        expectThrows(.invalidEnvelope, "invalid protected header is rejected") {
+            try RuntimePayload.decodeProtectedArtifact(
+                from: fixture.source,
+                to: fixture.destination,
+                expectedEncodedSHA256: RuntimePayload.sha256(of: fixture.source) ?? ""
+            )
+        }
+        expect(!FileManager.default.fileExists(atPath: fixture.destination.path), "failed output is removed")
+    }
+
+    private static func rejectsEmptyPayload() throws {
+        let fixture = try Fixture(payload: Data([0x50]))
+        defer { fixture.cleanup() }
+        try RuntimePayload.protectedArtifactMagic.write(to: fixture.source)
+
+        expectThrows(.emptyPayload, "empty protected payload is rejected") {
+            try RuntimePayload.decodeProtectedArtifact(
+                from: fixture.source,
+                to: fixture.destination,
+                expectedEncodedSHA256: RuntimePayload.sha256(of: fixture.source) ?? ""
+            )
+        }
+    }
+
+    private static func rejectsChecksumDrift() throws {
+        let fixture = try Fixture(payload: Data([0x50, 0x4b, 0x03, 0x04]))
+        defer { fixture.cleanup() }
+
+        expectThrows(.checksumMismatch, "encoded checksum is revalidated during decode") {
+            try RuntimePayload.decodeProtectedArtifact(
+                from: fixture.source,
+                to: fixture.destination,
+                expectedEncodedSHA256: String(repeating: "0", count: 64)
+            )
+        }
+        expect(!FileManager.default.fileExists(atPath: fixture.destination.path), "checksum failure removes output")
+    }
+
+    private static func validatesVersionBoundFilename() {
+        expect(
+            RuntimePayload.expectedProtectedWheelFilename(version: "0.8.6")
+                == "defenseclaw-0.8.6-2-py3-none-any.dcwheel",
+            "schema-2 protected wheel name is version-bound"
+        )
+    }
+
+    private static func validatesProtectedArtifactSizeLimit() {
+        let minimum = Int64(RuntimePayload.protectedArtifactMagic.count + 1)
+        expect(
+            RuntimePayload.protectedArtifactSizeIsAllowed(minimum),
+            "a nonempty protected payload is allowed"
+        )
+        expect(
+            !RuntimePayload.protectedArtifactSizeIsAllowed(0),
+            "an undersized protected artifact is rejected"
+        )
+        expect(
+            !RuntimePayload.protectedArtifactSizeIsAllowed(
+                RuntimePayload.maximumProtectedArtifactBytes + 1
+            ),
+            "oversized protected payload is rejected before decoding"
+        )
+    }
+
+    private static func validatesUpgradeResolverSanitizesAmbientVersion() {
+        guard let command = RuntimeUpgradeResolverCommand.authenticated(releaseTag: "0.8.10") else {
+            fail("a valid runtime release tag should produce an authenticated resolver")
+        }
+        expect(
+            command.contains("set -eu\n  unset VERSION\n  umask 077"),
+            "the resolver must clear ambient VERSION before selecting the requested release"
+        )
+        expect(
+            !command.contains(" --version "),
+            "latest-mode resolution must not inject a version override"
+        )
+        expect(
+            RuntimeUpgradeResolverCommand.authenticated(releaseTag: "latest; touch /tmp/unsafe") == nil,
+            "the resolver rejects non-SemVer release tags"
+        )
+    }
+
+    private static func validatesAuditRecoveryCommandTargetsInstallation() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "DefenseClaw-recovery-fixture-'quoted'-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+        let venv = root.appendingPathComponent("venv", isDirectory: true)
+        let bin = venv.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        let cli = bin.appendingPathComponent("defenseclaw", isDirectory: false)
+        try Data("#!/bin/sh\n".utf8).write(to: cli)
+        guard chmod(cli.path, 0o755) == 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        let target = RuntimeAuditRecoveryTarget(
+            homeRoot: root,
+            configURL: root.appendingPathComponent("config.yaml"),
+            venvURL: venv,
+            runtimeCLIURL: cli,
+            installedVersion: "0.8.10",
+            permitsMutation: true
+        )
+
+        guard let command = RuntimeAuditRecoveryCommand.command(for: target) else {
+            fail("a writable installation with an executable CLI should produce a recovery command")
+        }
+        expect(
+            command.contains("upgrade --yes --version '0.8.10' --recover-corrupt-audit"),
+            "recovery uses the runtime's authenticated pre-config delegation"
+        )
+        expect(
+            !command.contains("upgrade --yes --recover-corrupt-audit"),
+            "recovery never silently selects the latest runtime"
+        )
+        expect(command.contains("DEFENSECLAW_HOME="), "recovery pins the selected home")
+        expect(command.contains("DEFENSECLAW_CONFIG="), "recovery pins the selected config")
+        expect(command.contains("DEFENSECLAW_VENV="), "recovery pins the selected venv")
+        expect(command.contains("'\"'\"'"), "single quotes in installation paths are shell-escaped")
+        expect(
+            command.contains("/venv/bin/defenseclaw' upgrade"),
+            "recovery executes the selected installation's CLI"
+        )
+        expect(!command.contains("curl "), "release authentication remains inside the runtime")
+        expect(
+            RuntimeAuditRecoveryCommand.command(
+                for: RuntimeAuditRecoveryTarget(
+                    homeRoot: target.homeRoot,
+                    configURL: target.configURL,
+                    venvURL: target.venvURL,
+                    runtimeCLIURL: target.runtimeCLIURL,
+                    installedVersion: target.installedVersion,
+                    permitsMutation: false
+                )
+            ) == nil,
+            "read-only installations cannot produce a repair command"
+        )
+        expect(
+            RuntimeAuditRecoveryCommand.command(
+                for: RuntimeAuditRecoveryTarget(
+                    homeRoot: target.homeRoot,
+                    configURL: target.configURL,
+                    venvURL: target.venvURL,
+                    runtimeCLIURL: target.runtimeCLIURL,
+                    installedVersion: "latest; touch /tmp/unsafe",
+                    permitsMutation: true
+                )
+            ) == nil,
+            "recovery rejects non-SemVer version input"
+        )
+    }
+
+    private static func expectThrows(
+        _ expected: ProtectedArtifactError,
+        _ message: String,
+        operation: () throws -> Void
+    ) {
+        do {
+            try operation()
+            fail(message)
+        } catch let error as ProtectedArtifactError {
+            expect(error == expected, message)
+        } catch {
+            fail("\(message): unexpected error \(error)")
+        }
+    }
+
+    private static func expect(_ condition: @autoclosure () throws -> Bool, _ message: String) {
+        do {
+            guard try condition() else { fail(message) }
+        } catch {
+            fail("\(message): \(error)")
+        }
+    }
+
+    private static func fail(_ message: String) -> Never {
+        fputs("FAILED: \(message)\n", stderr)
+        exit(1)
+    }
+
+    private struct Fixture {
+        let directory: URL
+        let source: URL
+        let destination: URL
+        let payload: Data
+        let encodedSHA256: String
+
+        init(payload: Data) throws {
+            self.payload = payload
+            directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "DefenseClaw-protected-artifact-tests-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            source = directory.appendingPathComponent("runtime.dcwheel")
+            destination = directory.appendingPathComponent("runtime.whl")
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+
+            var encodedPayload = payload
+            encodedPayload.withUnsafeMutableBytes { bytes in
+                for index in bytes.indices {
+                    bytes[index] ^= RuntimePayload.protectedArtifactXORByte
+                }
+            }
+            var artifact = RuntimePayload.protectedArtifactMagic
+            artifact.append(encodedPayload)
+            try artifact.write(to: source)
+            encodedSHA256 = SHA256.hash(data: artifact)
+                .map { String(format: "%02x", $0) }
+                .joined()
+        }
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: directory)
+        }
+    }
+}

--- a/macos/DefenseClawMac/Tests/RuntimeUICompatibilityContractTests.swift
+++ b/macos/DefenseClawMac/Tests/RuntimeUICompatibilityContractTests.swift
@@ -1,0 +1,66 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+@main
+enum RuntimeUICompatibilityContractTests {
+    static func main() throws {
+        guard CommandLine.arguments.count == 2 else {
+            fputs("Usage: RuntimeUICompatibilityContractTests <repository-root>\n", stderr)
+            exit(2)
+        }
+
+        let root = URL(fileURLWithPath: CommandLine.arguments[1], isDirectory: true)
+        let configEditorSource = try source(
+            at: root.appendingPathComponent("DefenseClawMac/Features/ConfigEditorDefinitions.swift")
+        )
+        let logsSource = try source(
+            at: root.appendingPathComponent("DefenseClawMac/Features/LogsView.swift")
+        )
+
+        expect(!configEditorSource.contains("privacy.disable_redaction"),
+               "the config editor must not expose the removed privacy.disable_redaction key")
+
+        for unsupportedSurface in [
+            "setup redaction",
+            "RedactionToggleSheet",
+            "showRedactionToggle",
+            "redactionButton",
+        ] {
+            expect(!logsSource.contains(unsupportedSurface),
+                   "the Logs UI must not expose the unsupported runtime 0.8.10 surface: \(unsupportedSurface)")
+        }
+
+        expect(logsSource.contains(".inspector(isPresented:"),
+               "the Logs view must retain the native inspector crash hotfix")
+        expect(logsSource.contains(".dcInspectorColumnWidth()"),
+               "the Logs inspector must retain its bounded column width")
+
+        print("RuntimeUICompatibilityContractTests passed")
+    }
+
+    private static func source(at url: URL) throws -> String {
+        try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        guard condition() else {
+            fputs("FAILED: \(message)\n", stderr)
+            exit(1)
+        }
+    }
+}

--- a/macos/DefenseClawMac/Tests/SetupDefinitionsParityTests.swift
+++ b/macos/DefenseClawMac/Tests/SetupDefinitionsParityTests.swift
@@ -115,6 +115,8 @@ struct SetupDefinitionsParityTests {
         customProviderBuilderDropsStaleFamilyOptions()
         customProviderValidationCatchesUnsafeInputs()
         observabilityBuilderCoversPresetSpecificInputs()
+        splunkHECDefaultsToVerifiedTLS()
+        secureSetupSecretsUseChildEnvironment()
         webhookBuilderCoversCurrentNotifierOptions()
         webhookValidationRequiresProviderCredentials()
         print("Setup definition parity tests passed")
@@ -533,6 +535,94 @@ struct SetupDefinitionsParityTests {
             "enabled": "yes",
         ], false)[0]
         expect(value(after: "--signals", in: galileo) == "traces", "Galileo emits traces only")
+    }
+
+    private static func splunkHECDefaultsToVerifiedTLS() {
+        guard let wizard = TUIWizards.all.first(where: { $0.id == "observability" }),
+              let field = wizard.fields.first(where: { $0.key == "verify-tls-hec" }) else {
+            expect(false, "Splunk HEC TLS field exists")
+            return
+        }
+        expect(field.defaultValue == "yes", "Splunk HEC verifies TLS by default")
+
+        let omittedToggle = TUIWizards.observabilityCommands([
+            "action": "add",
+            "preset": "splunk-hec",
+        ], false)[0]
+        expect(omittedToggle.contains("--verify-tls"), "omitted HEC TLS setting fails secure")
+        expect(!omittedToggle.contains("--no-verify-tls"), "omitted HEC TLS setting never disables verification")
+
+        let explicitOptOut = TUIWizards.observabilityCommands([
+            "action": "add",
+            "preset": "splunk-hec",
+            "host": "splunk.example",
+            "verify-tls-hec": "no",
+        ], false)[0]
+        expect(!explicitOptOut.contains("--no-verify-tls"), "remote HEC cannot disable TLS verification")
+        expect(explicitOptOut.contains("--verify-tls"), "remote HEC is forced to verify TLS")
+        expect(
+            TUIWizards.observabilityValidation([
+                "action": "add",
+                "preset": "splunk-hec",
+                "host": "splunk.example",
+                "port": "8088",
+                "verify-tls-hec": "no",
+            ]) != nil,
+            "remote HEC TLS opt-out shows a validation error"
+        )
+
+        for host in ["localhost", "collector.localhost", "127.0.0.1", "127.42.7.9", "::1", "[::1]"] {
+            let values = [
+                "action": "add",
+                "preset": "splunk-hec",
+                "host": host,
+                "port": "8088",
+                "verify-tls-hec": "no",
+            ]
+            expect(TUIWizards.observabilityValidation(values) == nil, "\(host) permits local TLS opt-out")
+            expect(
+                TUIWizards.observabilityCommands(values, false)[0].contains("--no-verify-tls"),
+                "\(host) emits the explicit local TLS opt-out"
+            )
+        }
+    }
+
+    private static func secureSetupSecretsUseChildEnvironment() {
+        let cases: [(id: String, field: String, environmentKey: String, values: [String: String])] = [
+            ("splunk", "access-token", "SPLUNK_ACCESS_TOKEN", ["mode": "splunk-o11y", "access-token": "private-value"]),
+            ("splunk", "hec-token", "DEFENSECLAW_SPLUNK_HEC_TOKEN", ["mode": "splunk-enterprise", "hec-token": "private-value"]),
+            ("observability", "token", "DEFENSECLAW_SETUP_OBSERVABILITY_TOKEN", ["action": "add", "preset": "datadog", "token": "private-value"]),
+            ("splunk-dashboards", "o11y-api-token", "SFX_AUTH_TOKEN", ["action": "apply", "o11y-api-token": "private-value"]),
+        ]
+
+        for item in cases {
+            guard let wizard = TUIWizards.all.first(where: { $0.id == item.id }),
+                  let field = wizard.fields.first(where: { $0.key == item.field }) else {
+                expect(false, "\(item.id) secure field exists")
+                continue
+            }
+            let message = SetupSecretTransportPolicy.validationMessage(
+                wizard: wizard,
+                values: item.values,
+                visibleFields: [field]
+            )
+            expect(message == nil, "\(item.id) accepts its child-environment secret transport")
+            let environment = wizard.secretEnvironment?(item.values) ?? [:]
+            expect(environment[item.environmentKey] == "private-value", "\(item.id) exports its documented child environment key")
+            let arguments = wizard.commandBuilder?(item.values, false).flatMap { $0 } ?? []
+            expect(!arguments.contains("private-value"), "\(item.id) secret never enters argv")
+
+            var withoutSecret = item.values
+            withoutSecret[item.field] = ""
+            expect(
+                SetupSecretTransportPolicy.validationMessage(
+                    wizard: wizard,
+                    values: withoutSecret,
+                    visibleFields: [field]
+                ) == nil,
+                "\(item.id) preserves non-secret setup operations"
+            )
+        }
     }
 
     private static func webhookBuilderCoversCurrentNotifierOptions() {

--- a/macos/DefenseClawMac/Tests/StructuredDetailParserTests.swift
+++ b/macos/DefenseClawMac/Tests/StructuredDetailParserTests.swift
@@ -1,0 +1,82 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+@main
+struct StructuredDetailParserTests {
+    static func main() {
+        leadingRedactionFallsBackToRawDetails()
+        safeMetadataSkipsRedactionAttributes()
+        redactedValueRemainsOneField()
+        quotedValuesRemainIntact()
+        prettyJSONStillFormatsStructuredPayloads()
+        print("StructuredDetailParserTests passed")
+    }
+
+    private static func leadingRedactionFallsBackToRawDetails() {
+        let details = reportedDriftDetails
+        expect(StructuredDetailParser.pairs(details).isEmpty,
+               "a leading redaction placeholder must not become a key/value grid")
+    }
+
+    private static func safeMetadataSkipsRedactionAttributes() {
+        let metadata = StructuredDetailParser.safeMetadataPairs(reportedDriftDetails)
+        expect(metadata.count == 1, "only allowlisted top-level metadata is extracted")
+        expect(metadata.first?.0 == "Rule IDs", "rule_ids receives a readable label")
+        expect(metadata.first?.1 == "SRC-CHILD-PROC,STRUCT-SCRIPT,JSON-SEC-GENERIC",
+               "rule identifiers are preserved")
+        expect(!metadata.contains { $0.0 == "Len" || $0.0 == "Sha" },
+               "redaction attributes never become metadata rows")
+    }
+
+    private static func redactedValueRemainsOneField() {
+        let pairs = StructuredDetailParser.pairs(
+            "payload=<redacted len=174 sha=7d7f6a97> connector=codex reason=\"policy denied command\""
+        )
+        expect(pairs.count == 3, "redacted and quoted values stay grouped")
+        expect(pairs[0].0 == "Payload", "payload key is parsed")
+        expect(pairs[0].1 == "redacted · 174 bytes · sha:7d7f6a97",
+               "redaction placeholder is summarized without losing its boundary")
+        expect(pairs[1].1 == "codex", "following fields remain parseable")
+        expect(pairs[2].1 == "policy denied command", "quoted spaces remain in one value")
+    }
+
+    private static func quotedValuesRemainIntact() {
+        let pairs = StructuredDetailParser.pairs("action=block message='unsafe command detected'")
+        expect(pairs.count == 2, "quoted record parses completely")
+        expect(pairs[1].1 == "unsafe command detected", "single-quoted values retain spaces")
+    }
+
+    private static func prettyJSONStillFormatsStructuredPayloads() {
+        let formatted = StructuredDetailParser.prettyJSON("{\"b\":2,\"a\":1}")
+        expect(formatted.contains("\n"), "JSON is pretty printed")
+        expect(formatted.range(of: "\"a\"")?.lowerBound ?? formatted.endIndex
+               < formatted.range(of: "\"b\"")?.lowerBound ?? formatted.endIndex,
+               "JSON keys are sorted")
+    }
+
+    private static let reportedDriftDetails = """
+    <redacted len=13291 sha=20e286f0> rule_ids=SRC-CHILD-PROC,STRUCT-SCRIPT,JSON-SEC-GENERIC <redacted len=76 sha=757a90e1> <redacted len=174 sha=7d7f6a97>
+    """
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        guard condition() else {
+            fputs("FAILED: \(message)\n", stderr)
+            exit(1)
+        }
+    }
+}

--- a/macos/DefenseClawMac/Tests/ToolbarHelpContractTests.swift
+++ b/macos/DefenseClawMac/Tests/ToolbarHelpContractTests.swift
@@ -1,0 +1,140 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+@main
+enum ToolbarHelpContractTests {
+    private struct Expectation {
+        let file: String
+        let action: String
+        let help: String
+    }
+
+    static func main() throws {
+        guard CommandLine.arguments.count == 2 else {
+            fputs("Usage: ToolbarHelpContractTests <repository-root>\n", stderr)
+            exit(2)
+        }
+
+        let root = URL(fileURLWithPath: CommandLine.arguments[1], isDirectory: true)
+        let expectations = [
+            Expectation(file: "ActivityView.swift", action: #"Label("Run Command", systemImage: "play.circle")"#, help: #".dcQuickHelp("Open Command Palette")"#),
+            Expectation(file: "ActivityView.swift", action: #"Label("Clear Completed", systemImage: "trash")"#, help: #".dcQuickHelp("Clear completed commands")"#),
+            Expectation(file: "ActivityView.swift", action: #"Label("Refresh", systemImage: "arrow.clockwise")"#, help: #".dcQuickHelp("Refresh mutations")"#),
+            Expectation(file: "AlertsView.swift", action: #"Label("Acknowledge Selection", systemImage: "checkmark.circle")"#, help: #".dcQuickHelp("Acknowledge selected alerts")"#),
+            Expectation(file: "AlertsView.swift", action: #"Label("Refresh", systemImage: "arrow.clockwise")"#, help: #".dcQuickHelp("Refresh alerts")"#),
+            Expectation(file: "AuditView.swift", action: #"Label("Export JSON", systemImage: "square.and.arrow.up")"#, help: #".dcQuickHelp("Export audit events as JSON")"#),
+            Expectation(file: "AuditView.swift", action: #"Label("Refresh", systemImage: "arrow.clockwise")"#, help: #".dcQuickHelp("Refresh audit events")"#),
+            Expectation(file: "LogsView.swift", action: #"Label("Auto-scroll", systemImage: "arrow.down.to.line")"#, help: #".dcQuickHelp("Follow new log lines")"#),
+            Expectation(file: "LogsView.swift", action: #"Label("Reload from disk", systemImage: "arrow.clockwise")"#, help: #".dcQuickHelp("Reload logs from disk")"#),
+            Expectation(file: "OverviewView.swift", action: #"Label("Run Health Check", systemImage: "stethoscope")"#, help: #".dcQuickHelp("Run DefenseClaw Doctor")"#),
+            Expectation(file: "OverviewView.swift", action: #"Label("Refresh", systemImage: "arrow.clockwise")"#, help: #".dcQuickHelp("Refresh overview")"#),
+            Expectation(file: "DiscoverViews.swift", action: #"Label("Rescan All", systemImage: "arrow.triangle.2.circlepath")"#, help: #".dcQuickHelp("Rescan connector inventories")"#),
+            Expectation(file: "DiscoverViews.swift", action: #"Label(primaryAction.label, systemImage: primaryAction.systemImage)"#, help: #".dcQuickHelp(primaryAction.label)"#),
+            Expectation(file: "DiscoverViews.swift", action: #"Label("Refresh", systemImage: "arrow.clockwise")"#, help: #".dcQuickHelp("Refresh AI Discovery results")"#),
+            Expectation(file: "DiscoverViews.swift", action: #"Label("Add Source", systemImage: "plus")"#, help: #".dcQuickHelp("Add Registry Source")"#),
+            Expectation(file: "DiscoverViews.swift", action: #"Label("Remove Source", systemImage: "trash")"#, help: #".dcQuickHelp("Remove Selected Source")"#),
+            Expectation(file: "DiscoverViews.swift", action: #"Label("Approve", systemImage: "checkmark.seal")"#, help: #".dcQuickHelp("Approve selected registry entry")"#),
+            Expectation(file: "DiscoverViews.swift", action: #"Label("Reject", systemImage: "xmark.seal")"#, help: #".dcQuickHelp("Reject selected registry entry")"#),
+            Expectation(file: "DiscoverViews.swift", action: #"Label(requirementActionLabel, systemImage: "lock.shield")"#, help: #".dcQuickHelp(requirementActionLabel)"#),
+            Expectation(file: "DiscoverViews.swift", action: #"Label("Sync Selected", systemImage: "arrow.triangle.2.circlepath")"#, help: #".dcQuickHelp("Sync selected registry source")"#),
+            Expectation(file: "DiscoverViews.swift", action: #"Label("Sync All", systemImage: "arrow.triangle.2.circlepath.circle")"#, help: #".dcQuickHelp("Sync all registry sources")"#),
+            Expectation(file: "DiscoverViews.swift", action: #"Label("Refresh", systemImage: "arrow.clockwise")"#, help: #".dcQuickHelp("Refresh registries")"#),
+            Expectation(file: "CatalogViews.swift", action: #"Label("Install Skill", systemImage: "square.and.arrow.down")"#, help: #".dcQuickHelp("Install a skill")"#),
+            Expectation(file: "CatalogViews.swift", action: #"Label("Set MCP Server", systemImage: "plus")"#, help: #".dcQuickHelp("Scan and add or update an MCP server")"#),
+            Expectation(file: "CatalogViews.swift", action: #"Label("Install Plugin", systemImage: "square.and.arrow.down")"#, help: #".dcQuickHelp("Install a plugin")"#),
+            Expectation(file: "CatalogViews.swift", action: #"Label("Refresh", systemImage: "arrow.clockwise")"#, help: #".dcQuickHelp("Refresh catalog")"#),
+            Expectation(file: "MainWindow.swift", action: #"Label("Command Palette", systemImage: "command")"#, help: #".dcQuickHelp("Command Palette (Command-Shift-P)")"#),
+        ]
+
+        var sourceCache: [String: String] = [:]
+        for expectation in expectations {
+            let source = try sourceCache[expectation.file] ?? {
+                let url = root
+                    .appendingPathComponent("DefenseClawMac/Features")
+                    .appendingPathComponent(expectation.file)
+                return try String(contentsOf: url, encoding: .utf8)
+            }()
+            sourceCache[expectation.file] = source
+            expectHelp(expectation, in: source)
+        }
+
+        try expectQuickHelpImplementation(at: root)
+        try expectStableOverviewToolbarItems(at: root)
+        print("ToolbarHelpContractTests passed")
+    }
+
+    private static func expectHelp(_ expectation: Expectation, in source: String) {
+        guard let helpRange = source.range(of: expectation.help) else {
+            fail("\(expectation.file) is missing \(expectation.help)")
+        }
+        let available = source.distance(from: source.startIndex, to: helpRange.lowerBound)
+        let lowerBound = source.index(
+            helpRange.lowerBound,
+            offsetBy: -min(700, available)
+        )
+        let nearbySource = source[lowerBound..<helpRange.upperBound]
+        guard nearbySource.contains(expectation.action) else {
+            fail("\(expectation.file) does not attach \(expectation.help) to \(expectation.action)")
+        }
+    }
+
+    private static func expectQuickHelpImplementation(at root: URL) throws {
+        let url = root.appendingPathComponent("DefenseClawMac/DesignSystem/QuickHoverHelp.swift")
+        let source = try String(contentsOf: url, encoding: .utf8)
+        let requirements = [
+            "static let displayDelay: TimeInterval = 0.15",
+            "NSEvent.addLocalMonitorForEvents",
+            "toolbar.visibleItems",
+            "window.acceptsMouseMovedEvents = true",
+            "popover.animates = false",
+            "accessibilityHint(Text(text))",
+        ]
+        for requirement in requirements where !source.contains(requirement) {
+            fail("QuickHoverHelp.swift is missing \(requirement)")
+        }
+
+        let appURL = root.appendingPathComponent("DefenseClawMac/App/DefenseClawApp.swift")
+        let appSource = try String(contentsOf: appURL, encoding: .utf8)
+        guard appSource.contains("DCToolbarQuickHelpMonitor.shared.start()") else {
+            fail("AppDelegate does not start the toolbar quick-help monitor")
+        }
+    }
+
+    private static func expectStableOverviewToolbarItems(at root: URL) throws {
+        let url = root.appendingPathComponent("DefenseClawMac/Features/OverviewView.swift")
+        let source = try String(contentsOf: url, encoding: .utf8)
+        guard let toolbarStart = source.range(of: ".toolbar {"),
+              let toolbarEnd = source.range(of: ".task { refresh() }", range: toolbarStart.upperBound..<source.endIndex)
+        else {
+            fail("Overview toolbar source could not be located")
+        }
+        let toolbar = String(source[toolbarStart.lowerBound..<toolbarEnd.lowerBound])
+        let separateItemCount = toolbar.components(separatedBy: "ToolbarItem {").count - 1
+        guard separateItemCount == 2,
+              toolbar.contains("runDoctor()"),
+              toolbar.contains("refresh()")
+        else {
+            fail("Overview Doctor and Refresh controls must use separate ToolbarItems")
+        }
+    }
+
+    private static func fail(_ message: String) -> Never {
+        fputs("FAILED: \(message)\n", stderr)
+        exit(1)
+    }
+}

--- a/macos/DefenseClawMac/Tests/UpdateCheckerVerificationTests.swift
+++ b/macos/DefenseClawMac/Tests/UpdateCheckerVerificationTests.swift
@@ -25,13 +25,37 @@ enum RuntimePayload {
 @main
 struct UpdateCheckerVerificationTests {
     static func main() {
+        pinsExpectedPublisherRequirement()
         rejectsUnverifiedSelfUpdateAssets()
         selectsVerifiedSelfUpdateAsset()
         rejectsQualifiedAndMismatchedSelfUpdateAssets()
         rejectsNonAppZipAssets()
         allowsRuntimeReleaseWithoutSelfUpdateAsset()
         returnsPopulatedReleaseInfoForAppSelfUpdate()
+        selectsDigestBoundRuntimeInstallerAsset()
+        rejectsMutableOrUnverifiableRuntimeInstallerAssets()
         print("Update checker verification tests passed")
+    }
+
+    private static func pinsExpectedPublisherRequirement() {
+        expect(
+            UpdateChecker.expectedBundleIdentifier == "com.cisco.defenseclaw.macos",
+            "self-update pins the production bundle identifier"
+        )
+        expect(
+            UpdateChecker.expectedCodeRequirement.contains(#"identifier "com.cisco.defenseclaw.macos""#),
+            "self-update pins the Cisco bundle identifier in the publisher requirement"
+        )
+        let requirement = UpdateChecker.expectedCodeRequirement
+        expect(requirement.contains("anchor apple generic"), "publisher requirement uses Apple's trust anchor")
+        expect(
+            requirement.contains(#"identifier "com.cisco.defenseclaw.macos""#),
+            "publisher requirement binds the bundle identifier"
+        )
+        expect(
+            requirement.contains(#"identifier "com.cisco.defenseclaw.macos""#),
+            "publisher requirement binds the Cisco bundle identifier"
+        )
     }
 
     private static func rejectsUnverifiedSelfUpdateAssets() {
@@ -140,6 +164,55 @@ struct UpdateCheckerVerificationTests {
         expect(release?.assetName == "DefenseClawMac-1.2.3-macos-arm64.zip", "app release asset name is preserved")
         expect(release?.assetURL == "https://example.test/verified.zip", "app release asset URL is preserved")
         expect(release?.assetSHA256 == "def", "app release digest prefix is stripped")
+    }
+
+    private static func selectsDigestBoundRuntimeInstallerAsset() {
+        let digest = String(repeating: "a", count: 64)
+        let release = UpdateChecker.runtimeInstallerInfo(
+            from: [
+                "html_url": "https://github.com/cisco-ai-defense/defenseclaw/releases/tag/0.8.10",
+                "assets": [[
+                    "name": "install.sh",
+                    "browser_download_url": "https://github.com/cisco-ai-defense/defenseclaw/releases/download/0.8.10/install.sh",
+                    "digest": "sha256:\(digest)",
+                ]],
+            ],
+            tag: "0.8.10"
+        )
+        expect(release?.tag == "0.8.10", "runtime installer retains the immutable release tag")
+        expect(release?.assetSHA256 == digest, "runtime installer retains its release digest")
+    }
+
+    private static func rejectsMutableOrUnverifiableRuntimeInstallerAssets() {
+        let digest = String(repeating: "b", count: 64)
+        let mutable = UpdateChecker.runtimeInstallerInfo(
+            from: ["assets": [[
+                "name": "install.sh",
+                "browser_download_url": "https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh",
+                "digest": "sha256:\(digest)",
+            ]]],
+            tag: "0.8.10"
+        )
+        expect(mutable == nil, "mutable main-branch installer URL is rejected")
+
+        let missingDigest = UpdateChecker.runtimeInstallerInfo(
+            from: ["assets": [[
+                "name": "install.sh",
+                "browser_download_url": "https://github.com/cisco-ai-defense/defenseclaw/releases/download/0.8.10/install.sh",
+            ]]],
+            tag: "0.8.10"
+        )
+        expect(missingDigest == nil, "runtime installer without a SHA-256 digest is rejected")
+
+        let wrongTag = UpdateChecker.runtimeInstallerInfo(
+            from: ["assets": [[
+                "name": "install.sh",
+                "browser_download_url": "https://github.com/cisco-ai-defense/defenseclaw/releases/download/0.8.9/install.sh",
+                "digest": "sha256:\(digest)",
+            ]]],
+            tag: "0.8.10"
+        )
+        expect(wrongTag == nil, "runtime installer URL must match the selected release tag")
     }
 
     private static func expect(_ condition: @autoclosure () -> Bool, _ label: String) {

--- a/macos/DefenseClawMac/UPSTREAM.md
+++ b/macos/DefenseClawMac/UPSTREAM.md
@@ -20,10 +20,10 @@ SPDX-License-Identifier: Apache-2.0
 
 The macOS app was imported from [`keitheobrien/defenseclaw_mac`](https://github.com/keitheobrien/defenseclaw_mac) at:
 
-- Stable release: `v1.1.5`
-- Commit: `c3b7681b082eefb8d8e21dc9347270b7bf803b0e`
-- Commit title: `Release DefenseClawMac 1.1.5`
-- Imported: 2026-07-10
+- Stable release: `v1.1.19`
+- Commit: `8bb84f18c5c29b99edf3c93175ddbc259e9ff7a9`
+- Commit title: `Merge pull request #18 from keitheobrien/kobrien/splunk-flow-yaml-compatibility`
+- Imported: 2026-09-03
 
 The import includes the Xcode project, Swift sources, tests, developer build/test scripts, icon-generation tool, asset catalog, and README images. It intentionally excludes the upstream repository's Git metadata, `.codex` configuration, personal signing identities, duplicate license file, and standalone release wrapper. The upstream `scripts/build_unified_dmg.sh` behavior is adapted into the monorepo's `scripts/build-macos-app-release.sh` so the unified DMG is built from the same unpublished commit as the backend release rather than downloading an already-published runtime.
 

--- a/macos/DefenseClawMac/upstream.lock.toml
+++ b/macos/DefenseClawMac/upstream.lock.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 repository = "keitheobrien/defenseclaw_mac"
-tag = "v1.1.5"
-commit = "c3b7681b082eefb8d8e21dc9347270b7bf803b0e"
-source_version = "1.1.5"
-imported_at = "2026-07-10"
+tag = "v1.1.19"
+commit = "8bb84f18c5c29b99edf3c93175ddbc259e9ff7a9"
+source_version = "1.1.19"
+imported_at = "2026-09-03"


### PR DESCRIPTION
> Stacked on #830. Review/merge that PR first; this PR's base is the stack parent, not `main`.

## Problem

The weekly freshness check found the checked-in macOS companion app still pinned at standalone `v1.1.5`. Operators and the in-app updater were not shipping the current stable upstream release (`v1.1.19`).

## Current Situation

`macos/DefenseClawMac/upstream.lock.toml` recorded `v1.1.5` / `c3b7681b082eefb8d8e21dc9347270b7bf803b0e`. The official updater (`scripts/update-macos-app.sh v1.1.19`) three-way-merges Cisco overlay onto that lock as the base and the requested tag as theirs. The first run left 36 conflicted files in `build/macos-upstream-sync-v1.1.19`; those are resolved in this import.

## Solution

Import `keitheobrien/defenseclaw_mac` `v1.1.19` (`8bb84f18c5c29b99edf3c93175ddbc259e9ff7a9`) through the maintained paths only. Keep Cisco identity and release integration:

- Bundle ID `com.cisco.defenseclaw.macos`, empty development team, `MARKETING_VERSION` aligned with repo `VERSION` (`0.8.10`)
- `UpdateChecker` stays on `cisco-ai-defense/defenseclaw` and verified `DefenseClawMac-*-macos-arm64.zip` only
- RuntimePayload / authenticated upgrade-resolver commands preserved
- First-run connector allow-list remains the Cisco overlay set
- License headers reapplied; offline lock check passes

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `macos/DefenseClawMac/upstream.lock.toml` | Pin `v1.1.19@8bb84f18c5c2`, imported 2026-09-03 |
| `macos/DefenseClawMac/UPSTREAM.md` | Provenance for the new tag/commit |
| `macos/DefenseClawMac/DefenseClawMac/**` | Upstream product/API updates plus Cisco overlay |
| `macos/DefenseClawMac/Tests/**` | New contract tests shipped with v1.1.19 |
| `macos/DefenseClawMac.xcodeproj/project.pbxproj` | Release `--timestamp`; still Cisco bundle ID / no team |

## Breaking Changes

None for CLI/gateway APIs. The macOS app UI picks up upstream Discover/Alerts/setup changes from v1.1.6–v1.1.19.

## Open Issues / Follow-ups

None

## Test Plan

```
/opt/homebrew/bin/python3 scripts/check-macos-upstream.py --offline
python3 scripts/macos_license_headers.py
make check-version-sync
```

Observed:
- Offline lock: `v1.1.19@8bb84f18c5c2 (offline)`
- License headers OK
- Version sync: `0.8.10 (source epoch 2, runtime 8)`
- `make macos-app-test` was **not** run here: this machine has Command Line Tools only, not full Xcode. `defenseclaw-macos` SSH timed out during the import. CI `macos-app-test` / a full Xcode host should compile before merge.

Fixes #778