### PR TITLE
fix(windows-avc): Authenticode-aware trailer reader + protected bootstrap parent + uninstall IPC inventory

### DIFF
--- a/cmd/defenseclaw-enterprise-setup/platform_windows.go
+++ b/cmd/defenseclaw-enterprise-setup/platform_windows.go
@@ -346,6 +346,15 @@ func enterpriseLifecycleArguments(stageRoot string, opts enterpriseSetupOptions)
 	appendValue("--gateway-service-name", opts.GatewayServiceName)
 	appendValue("--guardian-service-name", opts.GuardianServiceName)
 	appendValue("--certification-codex-home", opts.CertificationCodexHome)
+	// Forward the outer Setup's protected scratch directory under
+	// %ProgramData%\DefenseClaw-Enterprise-Setup-<hex>\scratch as the
+	// installer's one-shot bootstrap parent. install-enterprise.ps1 uses
+	// this instead of C:\Windows\Temp so its rendered YAML content passes
+	// the module's later trusted-ancestor walk on Azure-AD-joined hosts,
+	// where C:\Windows\Temp carries an inherited Allow ACE for the
+	// interactive AAD principal with Delete rights.
+	arguments = append(arguments, "--bootstrap-parent",
+		filepath.Join(stageRoot, enterpriseSetupScratchDirName))
 	if opts.NoStart {
 		arguments = append(arguments, "--no-start")
 	}

--- a/cmd/defenseclaw-enterprise-setup/platform_windows_test.go
+++ b/cmd/defenseclaw-enterprise-setup/platform_windows_test.go
@@ -31,6 +31,7 @@ func TestEnterpriseLifecycleArgumentsUsePublicMachineTransaction(t *testing.T) {
 		"--cli-binary", filepath.Join(stage, "defenseclaw.exe"),
 		"--config", opts.Config,
 		"--manifest", opts.Manifest,
+		"--bootstrap-parent", filepath.Join(stage, enterpriseSetupScratchDirName),
 		"--no-start", "--json",
 		"--attest-agent-application-control",
 		"--attest-claude-effective-policy",
@@ -46,9 +47,40 @@ func TestEnterpriseLifecycleReadOnlyDoesNotSupplyReplacementArtifacts(t *testing
 	want := []string{
 		"enterprise", "windows", "status",
 		"--installer", filepath.Join(stage, "install-enterprise.ps1"),
+		"--bootstrap-parent", filepath.Join(stage, enterpriseSetupScratchDirName),
 		"--json",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("enterpriseLifecycleArguments() = %#v, want %#v", got, want)
+	}
+}
+
+// The outer signed DefenseClawSetup EXE always forwards its own protected
+// %ProgramData%\DefenseClaw-Enterprise-Setup-<hex>\scratch directory as
+// install-enterprise.ps1's -BootstrapParent, so the one-shot bootstrap
+// dir does not land under C:\Windows\Temp. On Azure-AD-joined hosts,
+// C:\Windows\Temp carries an inherited Allow ACE for the interactive AAD
+// principal with replacement rights, which fails the module's later
+// trusted-ancestor walk on rendered YAML content.
+func TestEnterpriseLifecycleArgumentsAlwaysForwardsBootstrapParent(t *testing.T) {
+	stage := `C:\ProgramData\DefenseClaw-Enterprise-Setup-0123456789abcdef0123456789abcdef`
+	wantParent := filepath.Join(stage, enterpriseSetupScratchDirName)
+	for _, action := range []string{"install", "upgrade", "repair", "reconcile", "status", "verify", "uninstall"} {
+		t.Run(action, func(t *testing.T) {
+			got := enterpriseLifecycleArguments(stage, enterpriseSetupOptions{Action: action})
+			foundIndex := -1
+			for index := 0; index < len(got)-1; index++ {
+				if got[index] == "--bootstrap-parent" {
+					foundIndex = index
+					break
+				}
+			}
+			if foundIndex < 0 {
+				t.Fatalf("%s: --bootstrap-parent missing from args: %#v", action, got)
+			}
+			if got[foundIndex+1] != wantParent {
+				t.Fatalf("%s: --bootstrap-parent value = %q, want %q", action, got[foundIndex+1], wantParent)
+			}
+		})
 	}
 }

--- a/internal/cli/windows_enterprise_service.go
+++ b/internal/cli/windows_enterprise_service.go
@@ -75,6 +75,17 @@ type windowsEnterpriseLifecycleOptions struct {
 	// atomically drops them. See
 	// docs/specs/003-windows-deferred-config/.
 	deferredConfig bool
+	// bootstrapParent forwards the outer signed DefenseClawSetup EXE's
+	// protected %ProgramData%\DefenseClaw-Enterprise-Setup-<hex>\scratch
+	// path to install-enterprise.ps1's -BootstrapParent, so the
+	// installer's one-shot bootstrap directory lives inside an admin-
+	// only ancestor chain rather than C:\Windows\Temp. Required on
+	// Azure-AD-joined hosts, where C:\Windows\Temp carries an inherited
+	// Allow ACE for the interactive AAD principal with Delete rights;
+	// the module's later trusted-ancestor walk on rendered config /
+	// targets YAML would reject it otherwise. Empty falls back to
+	// C:\Windows\Temp for direct-caller compatibility on stock Windows.
+	bootstrapParent string
 	// mode / connector are the macOS-parity QA shorthand. When both
 	// are supplied (and configPath / manifestPath are empty),
 	// install-enterprise.ps1 renders a minimal managed_enterprise
@@ -223,6 +234,8 @@ func newWindowsEnterpriseLifecycleCommand(action string) *cobra.Command {
 	// installer, not here (this flag is a passthrough).
 	flags.BoolVar(&opts.deferredConfig, "deferred-config", false,
 		"provision drop points and register services stopped; config.yaml and targets.yaml may arrive later via UCB")
+	flags.StringVar(&opts.bootstrapParent, "bootstrap-parent", "",
+		"protected admin-only parent directory for the installer's one-shot bootstrap dir (outer signed Setup EXE passes its own %ProgramData%\\DefenseClaw-Enterprise-Setup-<hex>\\scratch path here)")
 	flags.StringVar(&opts.mode, "mode", "",
 		"QA shorthand: observe|action (paired with --connector; the installed install-enterprise.ps1 renders config.yaml + targets.yaml)")
 	flags.StringVar(&opts.connector, "connector", "",
@@ -530,6 +543,7 @@ func windowsEnterprisePowerShellArgs(action string, opts *windowsEnterpriseLifec
 	appendValue("-GatewayServiceName", opts.gatewayServiceName)
 	appendValue("-GuardianServiceName", opts.guardianServiceName)
 	appendValue("-CertificationCodexHome", opts.certificationCodexHome)
+	appendValue("-BootstrapParent", opts.bootstrapParent)
 	if opts.coreHardeningCertification {
 		args = append(args, "-CoreHardeningCertification")
 	}

--- a/internal/cli/windows_enterprise_service_test.go
+++ b/internal/cli/windows_enterprise_service_test.go
@@ -37,6 +37,7 @@ func TestWindowsEnterprisePowerShellArgsLifecycleParity(t *testing.T) {
 		gatewayServiceName:            "DefenseClawGateway",
 		guardianServiceName:           "DefenseClawHookGuardian",
 		certificationCodexHome:        `C:\certification\codex-home`,
+		bootstrapParent:               `C:\ProgramData\DefenseClaw-Enterprise-Setup-00112233445566778899aabbccddeeff\scratch`,
 		attestAgentApplicationControl: true,
 		attestClaudeEffectivePolicy:   true,
 		noStart:                       true,
@@ -58,6 +59,7 @@ func TestWindowsEnterprisePowerShellArgsLifecycleParity(t *testing.T) {
 		"-GatewayServiceName", opts.gatewayServiceName,
 		"-GuardianServiceName", opts.guardianServiceName,
 		"-CertificationCodexHome", opts.certificationCodexHome,
+		"-BootstrapParent", opts.bootstrapParent,
 		"-AttestAgentApplicationControl",
 		"-AttestClaudeEffectivePolicy",
 		"-NoStart",
@@ -268,6 +270,50 @@ func TestWindowsEnterprisePowerShellArgsPurgeIsExplicit(t *testing.T) {
 	got = windowsEnterprisePowerShellArgs("status", &windowsEnterpriseLifecycleOptions{})
 	if !reflect.DeepEqual(got, []string{"-Action", "Status"}) {
 		t.Fatalf("status args = %#v", got)
+	}
+}
+
+// The outer signed DefenseClawSetup EXE forwards a protected admin-only
+// %ProgramData%\DefenseClaw-Enterprise-Setup-<hex>\scratch path here so
+// install-enterprise.ps1's one-shot bootstrap directory does not land under
+// C:\Windows\Temp. On Azure-AD-joined hosts, C:\Windows\Temp carries an
+// inherited Allow ACE for the interactive AAD principal (S-1-12-1-...) that
+// includes replacement rights; the module's later trusted-ancestor walk on
+// rendered YAML content rejects it. Assert the value round-trips as
+// -BootstrapParent for all actions (status is a read-only lifecycle where
+// the bootstrap dir is still created for its isolated PowerShell execution
+// environment, so the parameter must be forwarded there too).
+func TestWindowsEnterprisePowerShellArgsBootstrapParentRoundTripsForAllActions(t *testing.T) {
+	const scratch = `C:\ProgramData\DefenseClaw-Enterprise-Setup-00112233445566778899aabbccddeeff\scratch`
+	for _, action := range []string{"install", "upgrade", "repair", "reconcile", "status", "verify", "uninstall"} {
+		t.Run(action, func(t *testing.T) {
+			opts := &windowsEnterpriseLifecycleOptions{bootstrapParent: scratch}
+			got := windowsEnterprisePowerShellArgs(action, opts)
+			foundIndex := -1
+			for index := 0; index < len(got)-1; index++ {
+				if got[index] == "-BootstrapParent" {
+					foundIndex = index
+					break
+				}
+			}
+			if foundIndex < 0 {
+				t.Fatalf("%s: -BootstrapParent missing from args: %#v", action, got)
+			}
+			if got[foundIndex+1] != scratch {
+				t.Fatalf("%s: -BootstrapParent value = %q, want %q", action, got[foundIndex+1], scratch)
+			}
+		})
+	}
+}
+
+// Empty bootstrapParent must NOT emit the flag so direct callers preserve
+// their existing C:\Windows\Temp fallback behavior.
+func TestWindowsEnterprisePowerShellArgsBootstrapParentOmittedWhenEmpty(t *testing.T) {
+	got := windowsEnterprisePowerShellArgs("status", &windowsEnterpriseLifecycleOptions{})
+	for _, arg := range got {
+		if arg == "-BootstrapParent" {
+			t.Fatalf("empty bootstrapParent unexpectedly emitted -BootstrapParent: %#v", got)
+		}
 	}
 }
 

--- a/internal/cli/windows_managed_hooks_teardown.go
+++ b/internal/cli/windows_managed_hooks_teardown.go
@@ -1386,10 +1386,22 @@ func windowsManagedHooksTeardownExpectedEnrollment(
 			[]connector.WindowsCodexManagedRuntimeTarget{},
 			[]enterprisehooks.WindowsCursorManagedRuntimeTarget{}
 	}
-	return append([]string(nil), claudeTargets...),
-		codexPolicyActive,
-		append([]connector.WindowsCodexManagedRuntimeTarget(nil), codexTargets...),
-		append([]enterprisehooks.WindowsCursorManagedRuntimeTarget(nil), cursorTargets...)
+	// append([]T(nil), src...) returns nil when src has length zero, which
+	// then marshals as JSON `null` and used to trip the reader's presence
+	// check on retry. Guarantee an empty-non-nil slice for each connector
+	// target list so the journal always writes `[]` even for connectors
+	// that had no eligible interactive users at install time on a given
+	// box (single-user VMs, deployments with connector-uses-nobody, etc.).
+	claudeCopy := append([]string{}, claudeTargets...)
+	codexCopy := append(
+		[]connector.WindowsCodexManagedRuntimeTarget{},
+		codexTargets...,
+	)
+	cursorCopy := append(
+		[]enterprisehooks.WindowsCursorManagedRuntimeTarget{},
+		cursorTargets...,
+	)
+	return claudeCopy, codexPolicyActive, codexCopy, cursorCopy
 }
 
 func equalWindowsManagedHooksCodexTargets(
@@ -1747,18 +1759,33 @@ func readWindowsManagedHooksTeardownJournal(
 	if err := json.Unmarshal(body, &properties); err != nil {
 		return journal, err
 	}
+	// Trust-critical identity fields: presence-required and non-null.
+	// These bind the journal to a specific activation record and manifest
+	// bytes; a missing or nulled value would let a foreign journal pass
+	// validation and redirect subsequent teardown/rollback at attacker-
+	// controlled state.
 	for _, name := range []string{
 		"manifest_sha256",
 		"activation_state",
 		"deployment_generation_id",
-		"codex_policy_active",
-		"codex_targets",
 	} {
 		value, ok := properties[name]
 		if !ok || bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
 			return journal, fmt.Errorf("managed-hook teardown journal is missing %s", name)
 		}
 	}
+	// Connector-optional fields (codex_policy_active, codex_targets,
+	// cursor_targets, claude_target_sids) were previously strict-required
+	// too. The writer's append([]T(nil), src...) pattern for the activated
+	// state emits "null" instead of "[]" when the input slice has length
+	// zero — a legitimate state whenever a deployment's connector had no
+	// eligible interactive users at install time. Downstream code paths
+	// use len() semantics that are nil-safe, so decoding a null field
+	// into a nil slice is functionally identical to decoding an empty
+	// array. Do not require presence here; json.Decoder below still
+	// enforces DisallowUnknownFields, so a foreign extra key still fails
+	// closed, and validateWindowsManagedHooksTeardownJournal still binds
+	// every target list to the recomputed activation identity.
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&journal); err != nil {

--- a/internal/cli/windows_managed_hooks_teardown.go
+++ b/internal/cli/windows_managed_hooks_teardown.go
@@ -1755,6 +1755,21 @@ func readWindowsManagedHooksTeardownJournal(
 	if err := file.Close(); err != nil {
 		return journal, err
 	}
+	return parseWindowsManagedHooksTeardownJournalBody(body)
+}
+
+// parseWindowsManagedHooksTeardownJournalBody is the ACL-independent
+// JSON layer of readWindowsManagedHooksTeardownJournal. Split out so
+// the schema/tolerance contract can be unit-tested without the
+// trusted-owner ACL walk, which requires SYSTEM/Admins ownership on
+// the input file — impractical inside a Go test running under a CI
+// runner user. readWindowsManagedHooksTeardownJournal is the only
+// production entry point and always enforces the ACL walk first via
+// managed.ValidateTrustedFilePath before calling this helper.
+func parseWindowsManagedHooksTeardownJournalBody(
+	body []byte,
+) (windowsManagedHooksTeardownJournal, error) {
+	var journal windowsManagedHooksTeardownJournal
 	var properties map[string]json.RawMessage
 	if err := json.Unmarshal(body, &properties); err != nil {
 		return journal, err

--- a/internal/cli/windows_managed_hooks_teardown_test.go
+++ b/internal/cli/windows_managed_hooks_teardown_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -616,15 +615,21 @@ func TestWindowsManagedHooksTeardownExpectedEnrollmentEmptyTargetsAreNonNil(t *t
 // Backward-compat: a pre-fix journal on disk from an older Setup EXE
 // may have "codex_targets": null (or cursor_targets/claude_target_sids
 // null) because the buggy writer emitted null for empty target lists.
-// readWindowsManagedHooksTeardownJournal must accept those without
+// parseWindowsManagedHooksTeardownJournalBody must accept those without
 // throwing "managed-hook teardown journal is missing codex_targets" so
 // AVC (and every downstream operator) can uninstall a box that was
 // installed with the buggy writer. Trust-critical identity fields
 // (manifest_sha256, activation_state, deployment_generation_id) stay
 // presence-required; validateWindowsManagedHooksTeardownJournal below
 // still binds every target list to the recomputed activation identity.
-func TestReadWindowsManagedHooksTeardownJournalAcceptsNullConnectorArrays(t *testing.T) {
-	journalPath := filepath.Join(t.TempDir(), "managed-hooks-teardown-journal.json")
+//
+// Tested against the ACL-independent JSON layer so the CI runner's
+// non-Admin user identity does not trip
+// managed.ValidateTrustedFilePath's owner walk. The production entry
+// point readWindowsManagedHooksTeardownJournal still enforces owner
+// trust (SYSTEM/Admins/TrustedInstaller) before reaching this parse
+// step.
+func TestParseWindowsManagedHooksTeardownJournalBodyAcceptsNullConnectorArrays(t *testing.T) {
 	body := []byte(`{
   "schema_version": 6,
   "phase": "prepared",
@@ -646,12 +651,9 @@ func TestReadWindowsManagedHooksTeardownJournalAcceptsNullConnectorArrays(t *tes
   "selector_targets": null
 }
 `)
-	if err := os.WriteFile(journalPath, body, 0o600); err != nil {
-		t.Fatalf("write journal: %v", err)
-	}
-	journal, err := readWindowsManagedHooksTeardownJournal(journalPath)
+	journal, err := parseWindowsManagedHooksTeardownJournalBody(body)
 	if err != nil {
-		t.Fatalf("read journal with null connector arrays: %v", err)
+		t.Fatalf("parse journal with null connector arrays: %v", err)
 	}
 	if len(journal.CodexTargets) != 0 || len(journal.CursorTargets) != 0 ||
 		len(journal.ClaudeTargetSIDs) != 0 {
@@ -670,12 +672,23 @@ func TestReadWindowsManagedHooksTeardownJournalAcceptsNullConnectorArrays(t *tes
 		`"manifest_sha256": null,`,
 		1,
 	)
-	if err := os.WriteFile(journalPath, []byte(withoutManifestSHA), 0o600); err != nil {
-		t.Fatalf("rewrite journal: %v", err)
-	}
-	if _, err := readWindowsManagedHooksTeardownJournal(journalPath); err == nil ||
-		!strings.Contains(err.Error(), "missing manifest_sha256") {
+	if _, err := parseWindowsManagedHooksTeardownJournalBody(
+		[]byte(withoutManifestSHA),
+	); err == nil || !strings.Contains(err.Error(), "missing manifest_sha256") {
 		t.Errorf("expected missing-manifest_sha256 rejection, got %v", err)
+	}
+	// Unknown property still fails closed (DisallowUnknownFields).
+	withForeignKey := strings.Replace(
+		string(body),
+		`"selector_targets": null`,
+		`"selector_targets": null,
+  "attacker_planted_key": "evil"`,
+		1,
+	)
+	if _, err := parseWindowsManagedHooksTeardownJournalBody(
+		[]byte(withForeignKey),
+	); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Errorf("expected unknown-field rejection, got %v", err)
 	}
 }
 

--- a/internal/cli/windows_managed_hooks_teardown_test.go
+++ b/internal/cli/windows_managed_hooks_teardown_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -540,6 +541,141 @@ func TestValidateWindowsManagedHooksTeardownEnrollmentDistinguishesNoStart(t *te
 		true,
 	); err == nil {
 		t.Fatal("activated deployment with an emptied Codex registry was accepted")
+	}
+}
+
+// AVC's dry-run of the v11 kit failed uninstall with
+// "managed-hook teardown journal is missing codex_targets" on a
+// single-user test VM where the activated deployment had zero eligible
+// codex users. Root cause was append([]T(nil), src...) returning nil
+// when src is an empty non-nil slice, which then marshals as JSON
+// `null` and used to trip the reader's presence check on retry. This
+// test locks the writer fix in place: the enrollment helper must
+// return empty-non-nil slices for every connector target list, so the
+// journal always serializes as `[]` (never `null`) even for connectors
+// with zero eligible users at install time.
+func TestWindowsManagedHooksTeardownExpectedEnrollmentEmptyTargetsAreNonNil(t *testing.T) {
+	for _, state := range []string{
+		windowsManagedHooksNeverActivated,
+		"activated",
+	} {
+		state := state
+		t.Run(state, func(t *testing.T) {
+			claude, codexActive, codex, cursor :=
+				windowsManagedHooksTeardownExpectedEnrollment(
+					state,
+					[]string{},
+					[]connector.WindowsCodexManagedRuntimeTarget{},
+					[]enterprisehooks.WindowsCursorManagedRuntimeTarget{},
+				)
+			if claude == nil {
+				t.Error("claude target SIDs slice is nil for empty input")
+			}
+			if codex == nil {
+				t.Error("codex targets slice is nil for empty input")
+			}
+			if cursor == nil {
+				t.Error("cursor targets slice is nil for empty input")
+			}
+			if codexActive {
+				t.Error("codex policy active is true when zero codex targets")
+			}
+			// Round-trip through JSON to prove the wire representation
+			// is `[]` and never `null`, so a peer reader that rejects
+			// null on these fields continues to accept our output.
+			body, err := json.Marshal(windowsManagedHooksTeardownJournal{
+				ClaudeTargetSIDs: claude,
+				CodexTargets:     codex,
+				CursorTargets:    cursor,
+			})
+			if err != nil {
+				t.Fatalf("marshal empty enrollment: %v", err)
+			}
+			for _, key := range []string{
+				`"claude_target_sids":[]`,
+				`"codex_targets":[]`,
+				`"cursor_targets":[]`,
+			} {
+				if !strings.Contains(string(body), key) {
+					t.Errorf("marshal(%s): expected %s in %s", state, key, string(body))
+				}
+			}
+			for _, key := range []string{
+				`"claude_target_sids":null`,
+				`"codex_targets":null`,
+				`"cursor_targets":null`,
+			} {
+				if strings.Contains(string(body), key) {
+					t.Errorf("marshal(%s): unexpected null field %s", state, key)
+				}
+			}
+		})
+	}
+}
+
+// Backward-compat: a pre-fix journal on disk from an older Setup EXE
+// may have "codex_targets": null (or cursor_targets/claude_target_sids
+// null) because the buggy writer emitted null for empty target lists.
+// readWindowsManagedHooksTeardownJournal must accept those without
+// throwing "managed-hook teardown journal is missing codex_targets" so
+// AVC (and every downstream operator) can uninstall a box that was
+// installed with the buggy writer. Trust-critical identity fields
+// (manifest_sha256, activation_state, deployment_generation_id) stay
+// presence-required; validateWindowsManagedHooksTeardownJournal below
+// still binds every target list to the recomputed activation identity.
+func TestReadWindowsManagedHooksTeardownJournalAcceptsNullConnectorArrays(t *testing.T) {
+	journalPath := filepath.Join(t.TempDir(), "managed-hooks-teardown-journal.json")
+	body := []byte(`{
+  "schema_version": 6,
+  "phase": "prepared",
+  "manifest_path": "C:\\ProgramData\\DefenseClaw\\hook-guardian\\targets.yaml",
+  "manifest_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "manifest_fingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "activation_state": "activated",
+  "deployment_generation_id": "cccccccccccccccccccccccccccccccc",
+  "hook_binary": "C:\\Program Files\\DefenseClaw\\bin\\defenseclaw-hook.exe",
+  "gateway_addr": "127.0.0.1:18970",
+  "gateway_service_name": "DefenseClawGateway",
+  "targets": [],
+  "claude_target_sids": null,
+  "claude": {},
+  "codex_policy_active": false,
+  "codex_targets": null,
+  "cursor_targets": null,
+  "cursor": {},
+  "selector_targets": null
+}
+`)
+	if err := os.WriteFile(journalPath, body, 0o600); err != nil {
+		t.Fatalf("write journal: %v", err)
+	}
+	journal, err := readWindowsManagedHooksTeardownJournal(journalPath)
+	if err != nil {
+		t.Fatalf("read journal with null connector arrays: %v", err)
+	}
+	if len(journal.CodexTargets) != 0 || len(journal.CursorTargets) != 0 ||
+		len(journal.ClaudeTargetSIDs) != 0 {
+		t.Errorf("expected empty target lists, got %#v / %#v / %#v",
+			journal.CodexTargets, journal.CursorTargets, journal.ClaudeTargetSIDs)
+	}
+	if journal.ManifestSHA256 != strings.Repeat("a", 64) ||
+		journal.ActivationState != "activated" ||
+		journal.DeploymentGenerationID != strings.Repeat("c", 32) {
+		t.Errorf("trust-critical identity fields did not decode: %+v", journal)
+	}
+	// Missing trust-critical field still rejects.
+	withoutManifestSHA := strings.Replace(
+		string(body),
+		`"manifest_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",`,
+		`"manifest_sha256": null,`,
+		1,
+	)
+	if err := os.WriteFile(journalPath, []byte(withoutManifestSHA), 0o600); err != nil {
+		t.Fatalf("rewrite journal: %v", err)
+	}
+	if _, err := readWindowsManagedHooksTeardownJournal(journalPath); err == nil ||
+		!strings.Contains(err.Error(), "missing manifest_sha256") {
+		t.Errorf("expected missing-manifest_sha256 rejection, got %v", err)
 	}
 }
 

--- a/internal/setuppayload/authenticode_test.go
+++ b/internal/setuppayload/authenticode_test.go
@@ -139,6 +139,11 @@ func TestReadFindsFooterBeforeCertTable(t *testing.T) {
 				t.Fatalf("entry count (padding=%d): got %d want %d",
 					padding, len(result.Entries), len(entries))
 			}
+			// Delete each matched name from wantByName as we go and
+			// assert the map empties out at the end. Otherwise a
+			// result like [x, x, z] would pass while y went missing —
+			// count matches but the invariant "every expected name
+			// appears exactly once" doesn't.
 			wantByName := map[string][]byte{}
 			for _, e := range entries {
 				wantByName[e.Name] = e.Contents
@@ -146,12 +151,20 @@ func TestReadFindsFooterBeforeCertTable(t *testing.T) {
 			for _, got := range result.Entries {
 				want, ok := wantByName[got.Name]
 				if !ok {
-					t.Errorf("unexpected entry %q (padding=%d)", got.Name, padding)
+					t.Errorf("unexpected or duplicate entry %q (padding=%d)", got.Name, padding)
 					continue
 				}
 				if !bytes.Equal(got.Contents, want) {
 					t.Errorf("entry %q content mismatch (padding=%d)", got.Name, padding)
 				}
+				delete(wantByName, got.Name)
+			}
+			if len(wantByName) != 0 {
+				names := make([]string, 0, len(wantByName))
+				for n := range wantByName {
+					names = append(names, n)
+				}
+				t.Errorf("missing expected entries (padding=%d): %v", padding, names)
 			}
 		})
 	}

--- a/internal/setuppayload/authenticode_test.go
+++ b/internal/setuppayload/authenticode_test.go
@@ -1,0 +1,297 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package setuppayload
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// TestScanFooterMagicWindow exercises the pure-function padding-window
+// search against synthetic buffers. Every legal padding position
+// (0..7) must be findable; every illegal buffer must return not-found.
+func TestScanFooterMagicWindow(t *testing.T) {
+	// Buffer shape: [padding bytes][magic][remaining footer bytes]
+	// Total length must be FooterSize + authenticodeMaxAlignPadding = 31.
+	windowLen := int(FooterSize) + authenticodeMaxAlignPadding
+
+	for padding := 0; padding <= authenticodeMaxAlignPadding; padding++ {
+		buf := make([]byte, windowLen)
+		// Fill with 0xAA garbage so a false-positive on '\0' bytes
+		// would surface.
+		for i := range buf {
+			buf[i] = 0xAA
+		}
+		magicOffset := windowLen - int(FooterSize) - padding
+		copy(buf[magicOffset:], []byte(Magic))
+		// Fill the rest of the footer with 0xBB so the DecodeFooter
+		// path (not exercised here) would see distinct sentinel bytes.
+		for i := magicOffset + len(Magic); i < magicOffset+int(FooterSize); i++ {
+			buf[i] = 0xBB
+		}
+		off, ok := scanFooterMagicWindow(buf)
+		if !ok {
+			t.Errorf("padding=%d: magic not found in window", padding)
+			continue
+		}
+		if off != magicOffset {
+			t.Errorf("padding=%d: magic at offset %d, want %d", padding, off, magicOffset)
+		}
+	}
+
+	// Buffer too short — must return not-found (no panic).
+	if _, ok := scanFooterMagicWindow(make([]byte, int(FooterSize)-1)); ok {
+		t.Error("undersized buffer: unexpectedly found magic")
+	}
+
+	// Buffer with no magic anywhere — must return not-found.
+	if _, ok := scanFooterMagicWindow(bytes.Repeat([]byte{0xCC}, windowLen)); ok {
+		t.Error("all-CC buffer: unexpectedly found magic")
+	}
+
+	// Buffer with magic at an ILLEGAL position (before the padding
+	// window) — must NOT be reported. Place it 12 bytes back from the
+	// legal minimum, which is padding=7 → offset 0 of the window.
+	// A window with magic outside the [0..7] byte range should fail.
+	buf := make([]byte, windowLen)
+	// Magic at buf[8] — that's 1 byte past the padding=7 position.
+	if 8+len(Magic) <= len(buf) {
+		copy(buf[8:], []byte(Magic))
+	}
+	if off, ok := scanFooterMagicWindow(buf); ok {
+		t.Errorf("magic at illegal offset %d unexpectedly accepted", off)
+	}
+}
+
+// TestReadFindsFooterBeforeCertTable is the end-to-end regression for
+// the AVC issue: signtool appended a certificate table after the
+// trailer, with 0..7 bytes of alignment padding, so the reader must
+// locate the footer via the PE cert-table directory rather than via
+// EOF-relative offset. Runs the full Read path through
+// findFooterOffset → peCertificateTableStart → the padding scan.
+func TestReadFindsFooterBeforeCertTable(t *testing.T) {
+	entries := []Entry{
+		{Name: "DefenseClawEnterprise.psm1", Contents: []byte("Module manifest")},
+		{Name: "defenseclaw.exe", Contents: []byte("gateway binary bytes")},
+		{Name: "install-enterprise.ps1", Contents: []byte("$Foo = 'bar'")},
+	}
+	manifest := []byte(`{"schema_version":1,"version":"0.8.6-test"}`)
+
+	// Test every legal padding value.
+	for padding := 0; padding <= authenticodeMaxAlignPadding; padding++ {
+		t.Run(padding0PadName(padding), func(t *testing.T) {
+			// Build the pre-trailer PE body: minimal PE headers + a bit of
+			// code padding so the trailer doesn't land inside the headers.
+			preTrailer := makeMinimalPEHeadersWithCertDirPlaceholder(1024)
+
+			// Append the trailer.
+			var buf bytes.Buffer
+			buf.Write(preTrailer)
+			if err := WriteTrailer(&buf, entries, manifest); err != nil {
+				t.Fatalf("WriteTrailer: %v", err)
+			}
+
+			// Append alignment padding bytes (signtool would insert
+			// 0..7 zero bytes to 8-byte align the cert table).
+			for i := 0; i < padding; i++ {
+				buf.WriteByte(0)
+			}
+
+			// Append the "certificate table" — arbitrary bytes for
+			// this fixture; the reader only cares about its offset,
+			// not its contents. Give it 64 bytes so it's not empty.
+			certTable := bytes.Repeat([]byte{0xAB}, 64)
+			certVA := int64(buf.Len())
+			buf.Write(certTable)
+
+			// Patch the PE data-directory[SECURITY] entry with the
+			// cert table's actual (file offset, size). The placeholder
+			// values are zero, so we overwrite in place.
+			raw := buf.Bytes()
+			patchSecurityDirectoryEntry(raw, uint32(certVA), uint32(len(certTable)))
+
+			// Sanity: pe.NewFile must accept the raw bytes and expose
+			// the cert-table entry we just patched.
+			gotCertVA, err := peCertificateTableStart(bytes.NewReader(raw))
+			if err != nil {
+				t.Fatalf("peCertificateTableStart: %v", err)
+			}
+			if gotCertVA != certVA {
+				t.Fatalf("cert table start: got %d, want %d", gotCertVA, certVA)
+			}
+
+			// Now Read the trailer via the runtime code path.
+			rd := bytes.NewReader(raw)
+			result, err := Read(rd, int64(rd.Size()))
+			if err != nil {
+				t.Fatalf("Read (padding=%d): %v", padding, err)
+			}
+
+			// Manifest must round-trip byte-identical.
+			if !bytes.Equal(result.Manifest, manifest) {
+				t.Errorf("manifest mismatch (padding=%d)", padding)
+			}
+			// Every entry must round-trip. Match on the sorted order
+			// the reader produces.
+			if len(result.Entries) != len(entries) {
+				t.Fatalf("entry count (padding=%d): got %d want %d",
+					padding, len(result.Entries), len(entries))
+			}
+			wantByName := map[string][]byte{}
+			for _, e := range entries {
+				wantByName[e.Name] = e.Contents
+			}
+			for _, got := range result.Entries {
+				want, ok := wantByName[got.Name]
+				if !ok {
+					t.Errorf("unexpected entry %q (padding=%d)", got.Name, padding)
+					continue
+				}
+				if !bytes.Equal(got.Contents, want) {
+					t.Errorf("entry %q content mismatch (padding=%d)", got.Name, padding)
+				}
+			}
+		})
+	}
+}
+
+// TestReadUnsignedPEStillWorks proves the fallback path — a
+// structurally-PE file with no cert table (an assembler output before
+// signtool has ever seen it) still returns the trailer via the EOF
+// route.
+func TestReadUnsignedPEStillWorks(t *testing.T) {
+	entries := []Entry{{Name: "x.exe", Contents: []byte("body")}}
+	manifest := []byte(`{}`)
+
+	preTrailer := makeMinimalPEHeadersWithCertDirPlaceholder(256)
+
+	var buf bytes.Buffer
+	buf.Write(preTrailer)
+	if err := WriteTrailer(&buf, entries, manifest); err != nil {
+		t.Fatalf("WriteTrailer: %v", err)
+	}
+
+	// No cert-table patch; data-directory[SECURITY].Size stays 0, so
+	// peCertificateTableStart returns 0 and findFooterOffset falls
+	// back to EOF.
+	rd := bytes.NewReader(buf.Bytes())
+	if _, err := Read(rd, int64(rd.Size())); err != nil {
+		t.Fatalf("Read (unsigned PE): %v", err)
+	}
+	if !HasTrailer(rd, int64(rd.Size())) {
+		t.Error("HasTrailer returned false for a valid unsigned PE trailer")
+	}
+}
+
+// TestHasTrailerSignedPE — HasTrailer must recognize a trailer in the
+// signed-PE layout too, otherwise the assembler's double-append refusal
+// would spuriously pass on a signed-then-re-assembled file.
+func TestHasTrailerSignedPE(t *testing.T) {
+	entries := []Entry{{Name: "x.exe", Contents: []byte("y")}}
+	manifest := []byte(`{}`)
+
+	preTrailer := makeMinimalPEHeadersWithCertDirPlaceholder(256)
+	var buf bytes.Buffer
+	buf.Write(preTrailer)
+	if err := WriteTrailer(&buf, entries, manifest); err != nil {
+		t.Fatalf("WriteTrailer: %v", err)
+	}
+	buf.WriteByte(0)
+	buf.WriteByte(0)
+	buf.WriteByte(0)
+	certVA := int64(buf.Len())
+	buf.Write(bytes.Repeat([]byte{0xEE}, 128))
+
+	raw := buf.Bytes()
+	patchSecurityDirectoryEntry(raw, uint32(certVA), 128)
+
+	if !HasTrailer(bytes.NewReader(raw), int64(len(raw))) {
+		t.Error("HasTrailer(signed PE): got false, want true")
+	}
+}
+
+func padding0PadName(padding int) string {
+	if padding == 0 {
+		return "padding=0"
+	}
+	return "padding=" + string(rune('0'+padding))
+}
+
+// makeMinimalPEHeadersWithCertDirPlaceholder produces a byte slice
+// that debug/pe.NewFile accepts, ending with `codeBytes` bytes of
+// arbitrary "code" so the trailer that follows in the test lands well
+// past the headers. The Security (index 4) data-directory entry is
+// left as (VirtualAddress=0, Size=0); the caller patches it in place
+// after locating the cert table.
+//
+// The PE is PE32+ (Machine=AMD64) with 0 sections. Minimal to be
+// legal but shaped to look like a real Windows amd64 EXE header.
+func makeMinimalPEHeadersWithCertDirPlaceholder(codeBytes int) []byte {
+	// Layout:
+	//   [0x00 .. 0x3B]  DOS stub (MZ + zeros)
+	//   [0x3C .. 0x3F]  e_lfanew = 0x40  (uint32 LE)
+	//   [0x40 .. 0x43]  PE signature "PE\0\0"
+	//   [0x44 .. 0x57]  COFF file header (20 bytes)
+	//   [0x58 .. 0x147] Optional header PE32+ (240 bytes)
+	//                     - Magic 0x20B at offset 0
+	//                     - NumberOfRvaAndSizes = 16 at offset 108
+	//                     - DataDirectory[16] at offset 112 (128 bytes)
+	//   [0x148 ..]      arbitrary "code" bytes
+	const (
+		dosSize          = 0x40
+		peSigSize        = 4
+		coffHeaderSize   = 20
+		optionalHeader64 = 240
+	)
+	peSigOffset := dosSize
+	coffOffset := peSigOffset + peSigSize
+	optionalHeaderOffset := coffOffset + coffHeaderSize
+	codeStart := optionalHeaderOffset + optionalHeader64
+	total := codeStart + codeBytes
+
+	buf := make([]byte, total)
+
+	// DOS header — 'MZ' + e_lfanew.
+	buf[0] = 'M'
+	buf[1] = 'Z'
+	binary.LittleEndian.PutUint32(buf[0x3C:], uint32(peSigOffset))
+
+	// PE signature.
+	copy(buf[peSigOffset:], []byte{'P', 'E', 0, 0})
+
+	// COFF file header:
+	//   Machine (2)               = 0x8664 (AMD64)
+	//   NumberOfSections (2)      = 0
+	//   TimeDateStamp (4)         = 0
+	//   PointerToSymbolTable (4)  = 0
+	//   NumberOfSymbols (4)       = 0
+	//   SizeOfOptionalHeader (2)  = 240
+	//   Characteristics (2)       = 0x0022 (EXECUTABLE + LARGE_ADDRESS_AWARE)
+	binary.LittleEndian.PutUint16(buf[coffOffset:], 0x8664)
+	binary.LittleEndian.PutUint16(buf[coffOffset+2:], 0)
+	binary.LittleEndian.PutUint16(buf[coffOffset+16:], optionalHeader64)
+	binary.LittleEndian.PutUint16(buf[coffOffset+18:], 0x0022)
+
+	// Optional header PE32+:
+	//   Magic (2)                  = 0x20B
+	//   ... (everything else defaults to 0 is fine for debug/pe)
+	//   NumberOfRvaAndSizes (4)    = 16   at optional-header offset 108
+	//   DataDirectory[16] (128B)              at optional-header offset 112
+	binary.LittleEndian.PutUint16(buf[optionalHeaderOffset:], 0x20B)
+	binary.LittleEndian.PutUint32(buf[optionalHeaderOffset+108:], 16)
+	// DataDirectory entries left zero; caller patches [SECURITY] entry.
+
+	return buf
+}
+
+// patchSecurityDirectoryEntry rewrites data-directory index 4 in a
+// buffer produced by makeMinimalPEHeadersWithCertDirPlaceholder. The
+// data-directory table starts at file offset 0x58 + 112 = 0xC8; entry
+// 4 is at 0xC8 + 4*8 = 0xE8.
+func patchSecurityDirectoryEntry(buf []byte, virtualAddress, size uint32) {
+	const dataDirEntry4Offset = 0x40 + 4 + 20 + 112 + 4*8 // 0xE8
+	binary.LittleEndian.PutUint32(buf[dataDirEntry4Offset:], virtualAddress)
+	binary.LittleEndian.PutUint32(buf[dataDirEntry4Offset+4:], size)
+}

--- a/internal/setuppayload/reader.go
+++ b/internal/setuppayload/reader.go
@@ -6,6 +6,7 @@ package setuppayload
 import (
 	"bytes"
 	"crypto/sha256"
+	"debug/pe"
 	"errors"
 	"fmt"
 	"hash/crc32"
@@ -17,6 +18,17 @@ import (
 	"testing/fstest"
 	"time"
 )
+
+// authenticodeMaxAlignPadding is the maximum number of alignment bytes
+// signtool can insert between an appended trailer and the certificate
+// table. Authenticode's Attribute Certificate Table is 8-byte aligned,
+// so the padding is 0..7 bytes.
+const authenticodeMaxAlignPadding = 7
+
+// imageDirectoryEntrySecurity is the index of the Attribute Certificate
+// Table entry inside the PE Optional Header's Data Directory array.
+// Not exported as a named constant by debug/pe.
+const imageDirectoryEntrySecurity = 4
 
 // ReadResult holds the trailer contents pulled off the tail of a Setup
 // EXE. Fields are shared by the assembler (to round-trip a trailer it
@@ -32,11 +44,21 @@ type ReadResult struct {
 	Entries []Entry
 }
 
-// Read pulls the trailer off the end of ra. `size` is the total byte
-// length of the underlying artefact (`ra.Size()` for an *os.File, or
+// Read pulls the trailer off ra. `size` is the total byte length of
+// the underlying artefact (`ra.Size()` for an *os.File, or
 // stat().Size() for a caller that has the value already). Runtime code
 // under cmd/defenseclaw-enterprise-setup calls this with the running
 // EXE's own file handle.
+//
+// The trailer is located by findFooterOffset, which is Authenticode-
+// aware: for an assembled-but-unsigned Setup EXE (produced by the
+// assembler before AVC's signtool step) the trailer sits at the very
+// end of the file and the magic starts at `size - FooterSize`; for a
+// signed EXE, signtool has appended the Attribute Certificate Table to
+// the file's end with 0..7 bytes of alignment padding between the
+// trailer and the cert table, so the magic is at
+// `certVA - padding - FooterSize` where certVA is the file offset of
+// the cert table (PE Optional Header data-directory entry 4).
 //
 // Failure modes are surfaced as sentinel errors so callers can
 // distinguish the "no trailer at all" case (ErrTrailerMissing — the EXE
@@ -48,9 +70,14 @@ func Read(ra io.ReaderAt, size int64) (ReadResult, error) {
 		return ReadResult{}, ErrTrailerMissing
 	}
 
-	// Read the fixed 24-byte footer at the very tail.
+	footerStart, err := findFooterOffset(ra, size)
+	if err != nil {
+		return ReadResult{}, err
+	}
+
+	// Read the fixed 24-byte footer starting at footerStart.
 	footerBuf := make([]byte, FooterSize)
-	if _, err := ra.ReadAt(footerBuf, size-FooterSize); err != nil {
+	if _, err := ra.ReadAt(footerBuf, footerStart); err != nil {
 		return ReadResult{}, fmt.Errorf("setuppayload: read footer: %w", err)
 	}
 	footer, err := DecodeFooter(footerBuf)
@@ -64,15 +91,16 @@ func Read(ra io.ReaderAt, size int64) (ReadResult, error) {
 	if footer.ArchiveLen > uint64(MaxArchiveBytes) {
 		return ReadResult{}, fmt.Errorf("setuppayload: archive length %d exceeds cap %d: %w", footer.ArchiveLen, MaxArchiveBytes, ErrTrailerCorrupt)
 	}
-	// archive_start + archive_len + manifest_len + FooterSize must equal `size`.
-	// If any component is corrupt, this arithmetic prevents an out-of-
-	// range ReadAt that could panic or read into unrelated PE bytes.
-	trailerLen := int64(footer.ArchiveLen) + int64(footer.ManifestLen) + int64(FooterSize)
-	if trailerLen > size {
-		return ReadResult{}, fmt.Errorf("setuppayload: trailer length %d exceeds artefact size %d: %w", trailerLen, size, ErrTrailerCorrupt)
+	// The trailer occupies [footerStart - archiveLen - manifestLen, footerStart + FooterSize).
+	// Compute the archive/manifest offsets relative to footerStart, not to
+	// EOF — for a signed EXE, EOF is past the cert table, not past the
+	// trailer.
+	manifestStart := footerStart - int64(footer.ManifestLen)
+	archiveStart := manifestStart - int64(footer.ArchiveLen)
+	if archiveStart < 0 {
+		return ReadResult{}, fmt.Errorf("setuppayload: trailer length %d exceeds available bytes before footer at %d: %w",
+			int64(footer.ArchiveLen)+int64(footer.ManifestLen)+int64(FooterSize), footerStart, ErrTrailerCorrupt)
 	}
-	archiveStart := size - trailerLen
-	manifestStart := archiveStart + int64(footer.ArchiveLen)
 
 	archive := make([]byte, footer.ArchiveLen)
 	if _, err := ra.ReadAt(archive, archiveStart); err != nil {
@@ -96,6 +124,130 @@ func Read(ra io.ReaderAt, size int64) (ReadResult, error) {
 		return ReadResult{}, err
 	}
 	return ReadResult{Manifest: manifest, Entries: entries}, nil
+}
+
+// findFooterOffset returns the file offset of the DCLWAVC1 magic bytes.
+//
+// Handles two file shapes:
+//
+//  1. Unsigned trailer (assembler output before AVC's signtool sign,
+//     and the DefenseClaw dev-loop --allow-unsigned path): the trailer
+//     sits at the very end of the file, so the magic is at
+//     `size - FooterSize`.
+//
+//  2. Signed trailer (AVC's post-signtool output — what runs on the
+//     tester's box): signtool has appended the Authenticode Attribute
+//     Certificate Table to the end of the file, with 0..7 bytes of
+//     alignment padding between the trailer and the cert table. The
+//     PE Optional Header's data-directory entry 4 gives the cert
+//     table's file offset. The magic lives at
+//     `certVA - padding - FooterSize`.
+//
+// Falls back to case (1) when the file is not a valid PE (test fixtures
+// that use arbitrary bytes) or when the PE has no Attribute Certificate
+// Table (unsigned, but structurally-PE files).
+func findFooterOffset(ra io.ReaderAt, size int64) (int64, error) {
+	if size < FooterSize {
+		return 0, ErrTrailerMissing
+	}
+	certVA, err := peCertificateTableStart(ra)
+	if err == nil && certVA > 0 && certVA <= size {
+		// Signed path: search the alignment-padding window immediately
+		// before the certificate table for the magic.
+		buf, readErr := readAuthenticodePaddingWindow(ra, certVA)
+		if readErr != nil {
+			return 0, readErr
+		}
+		if off, ok := scanFooterMagicWindow(buf); ok {
+			return certVA - int64(len(buf)) + int64(off), nil
+		}
+		// PE has a cert table but no trailer in the padding window —
+		// this file was signed without ever being assembled. Fall
+		// through to the EOF path; if the EOF check also fails to
+		// find the magic, DecodeFooter will surface ErrTrailerMissing.
+	}
+	// Unsigned / non-PE / signed-without-trailer path: footer at EOF.
+	return size - int64(FooterSize), nil
+}
+
+// peCertificateTableStart returns the file offset of the Authenticode
+// certificate table, or 0 if the file has no certificate table or is
+// not a well-formed PE. Uses debug/pe rather than hand-rolled parsing
+// so the file-format quirks (DOS stub, e_lfanew, PE32 vs. PE32+
+// optional-header layout) are handled by the stdlib.
+func peCertificateTableStart(ra io.ReaderAt) (int64, error) {
+	f, err := pe.NewFile(ra)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	switch oh := f.OptionalHeader.(type) {
+	case *pe.OptionalHeader64:
+		if imageDirectoryEntrySecurity < len(oh.DataDirectory) {
+			dir := oh.DataDirectory[imageDirectoryEntrySecurity]
+			if dir.Size == 0 {
+				return 0, nil
+			}
+			return int64(dir.VirtualAddress), nil
+		}
+	case *pe.OptionalHeader32:
+		if imageDirectoryEntrySecurity < len(oh.DataDirectory) {
+			dir := oh.DataDirectory[imageDirectoryEntrySecurity]
+			if dir.Size == 0 {
+				return 0, nil
+			}
+			return int64(dir.VirtualAddress), nil
+		}
+	}
+	return 0, nil
+}
+
+// readAuthenticodePaddingWindow returns the (FooterSize + 7)-byte slice
+// ending at certVA — the exact byte range where the DCLWAVC1 footer
+// could live given Authenticode's 8-byte alignment padding.
+func readAuthenticodePaddingWindow(ra io.ReaderAt, certVA int64) ([]byte, error) {
+	windowLen := int(FooterSize) + authenticodeMaxAlignPadding
+	windowStart := certVA - int64(windowLen)
+	if windowStart < 0 {
+		return nil, ErrTrailerMissing
+	}
+	buf := make([]byte, windowLen)
+	if _, err := ra.ReadAt(buf, windowStart); err != nil {
+		return nil, fmt.Errorf("setuppayload: read authenticode padding window: %w", err)
+	}
+	return buf, nil
+}
+
+// scanFooterMagicWindow searches the padding-window buffer for the
+// DCLWAVC1 magic. The buffer is exactly (FooterSize + 7) bytes ending
+// at the certificate-table start. The magic can appear at offsets
+// [len(buf) - FooterSize - 7, len(buf) - FooterSize] — 8 candidate
+// positions. Returns the offset within the buffer of the magic's first
+// byte, or (0, false) if not found.
+//
+// Pure function; tested directly against synthetic buffers so the PE
+// parsing on the surrounding code path can be exercised end-to-end
+// without needing a real PE fixture.
+func scanFooterMagicWindow(buf []byte) (int, bool) {
+	if len(buf) < int(FooterSize) {
+		return 0, false
+	}
+	// Iterate padding from 0 upward — signtool typically emits 0 or a
+	// small padding on 8-byte-aligned files, so the low end is the
+	// common case.
+	for padding := 0; padding <= authenticodeMaxAlignPadding; padding++ {
+		offset := len(buf) - int(FooterSize) - padding
+		if offset < 0 {
+			break
+		}
+		if offset+len(Magic) > len(buf) {
+			continue
+		}
+		if string(buf[offset:offset+len(Magic)]) == Magic {
+			return offset, true
+		}
+	}
+	return 0, false
 }
 
 // ReadFile is a thin wrapper that opens path, statss it, and invokes
@@ -189,14 +341,20 @@ func (r ReadResult) AsPayloadFS() fs.FS {
 // HasTrailer is a cheap probe used by tools that want to check whether
 // an existing EXE already carries a trailer (e.g. a rerun of the
 // assembler against an already-assembled artefact should refuse to
-// double-append). Returns true only when the footer magic is present at
-// the tail; a corrupt trailer body still returns true.
+// double-append). Delegates to findFooterOffset so the probe is
+// Authenticode-aware: a signed EXE with the trailer positioned before
+// the certificate table still reports true. A corrupt trailer body
+// still returns true (magic present at a valid position is enough).
 func HasTrailer(ra io.ReaderAt, size int64) bool {
 	if size < FooterSize {
 		return false
 	}
+	footerStart, err := findFooterOffset(ra, size)
+	if err != nil {
+		return false
+	}
 	footerBuf := make([]byte, FooterSize)
-	if _, err := ra.ReadAt(footerBuf, size-FooterSize); err != nil {
+	if _, err := ra.ReadAt(footerBuf, footerStart); err != nil {
 		if errors.Is(err, io.EOF) {
 			return false
 		}

--- a/packaging/scripts/build-managed-windows-bundle.sh
+++ b/packaging/scripts/build-managed-windows-bundle.sh
@@ -541,6 +541,41 @@ them inline instead — the DefenseClaw contract only cares that
 \`setup_sha256\` matches the shipped EXE's hash by the time the artefact
 reaches release engineering.
 
+## Install / Uninstall — smoke-test the signed Setup EXE
+
+Both commands need an **elevated PowerShell** prompt (Run as
+Administrator). Signed builds install into the production paths
+(\`%ProgramFiles%\\Cisco\\Cisco Secure Client\\DefenseClaw\\\` and
+\`%ProgramData%\\...\\DefenseClaw\\\`) and use the fixed service names
+(\`DefenseClawGateway\`, \`DefenseClawGuardian\`, \`DefenseClawEnumerator\`).
+
+Do NOT pass \`--allow-unsigned\` or any cert-scope flags
+(\`--install-root\`, \`--state-root\`, \`--gateway-service-name\`,
+\`--guardian-service-name\`, \`--certification-codex-home\`) — the
+signed binary refuses them with exit 1603.
+
+### Install (action mode, all three connectors)
+
+    .\\DefenseClawSetup-Enterprise-x64.exe --action install \`
+        --mode action \`
+        --connector codex,claudecode,cursor \`
+        --json
+
+### Uninstall (always with --purge)
+
+    .\\DefenseClawSetup-Enterprise-x64.exe --action uninstall \`
+        --purge \`
+        --json
+
+### Verify install
+
+    Get-Service DefenseClawGateway, DefenseClawGuardian |
+        Format-Table Name, Status, StartType
+    Invoke-WebRequest -UseBasicParsing http://127.0.0.1:18970/healthz |
+        Select-Object -ExpandProperty Content
+    .\\DefenseClawSetup-Enterprise-x64.exe --action status --json |
+        ConvertFrom-Json | Format-List
+
 ## What this kit deliberately does NOT ship
 
 - No Go source tree.  DefenseClaw prebuilds the outer Setup EXE.

--- a/packaging/scripts/build-managed-windows-bundle.sh
+++ b/packaging/scripts/build-managed-windows-bundle.sh
@@ -547,7 +547,8 @@ Both commands need an **elevated PowerShell** prompt (Run as
 Administrator). Signed builds install into the production paths
 (\`%ProgramFiles%\\Cisco\\Cisco Secure Client\\DefenseClaw\\\` and
 \`%ProgramData%\\...\\DefenseClaw\\\`) and use the fixed service names
-(\`DefenseClawGateway\`, \`DefenseClawGuardian\`, \`DefenseClawEnumerator\`).
+\`DefenseClawGateway\`, \`DefenseClawHookGuardian\`, \`DefenseClawHookEnumerator\`,
+and \`DefenseClawCMIDBroker\`.
 
 Do NOT pass \`--allow-unsigned\` or any cert-scope flags
 (\`--install-root\`, \`--state-root\`, \`--gateway-service-name\`,
@@ -569,7 +570,7 @@ signed binary refuses them with exit 1603.
 
 ### Verify install
 
-    Get-Service DefenseClawGateway, DefenseClawGuardian |
+    Get-Service DefenseClawGateway, DefenseClawHookGuardian, DefenseClawHookEnumerator, DefenseClawCMIDBroker |
         Format-Table Name, Status, StartType
     Invoke-WebRequest -UseBasicParsing http://127.0.0.1:18970/healthz |
         Select-Object -ExpandProperty Content

--- a/packaging/windows/DefenseClawEnterprise.psm1
+++ b/packaging/windows/DefenseClawEnterprise.psm1
@@ -16020,10 +16020,39 @@ function Assert-DefenseClawManagedInstallTree {
 }
 
 function Assert-DefenseClawManagedTreeNoReparse {
-    param([Parameter(Mandatory)][string]$Root)
+    # -AllowAFUnixSocketAt is the exact-path exemption for the managed
+    # IPC AF_UNIX socket file. Windows backs AF_UNIX socket files with
+    # an NTFS reparse point (IO_REPARSE_TAG_AF_UNIX 0x80000023), so a
+    # stale socket left after an unclean guardian stop surfaces with
+    # the ReparsePoint attribute. Callers walking a tree that MAY
+    # contain that socket (InstallRoot pre-rename, retired sibling
+    # post-rename) supply the expected full path; every other reparse
+    # point still aborts. Callers walking trees that never contain the
+    # socket (StateRoot, transaction envelopes, lifecycle receipts)
+    # leave the parameter empty and get the strict pre-existing
+    # behavior — no reparse point tolerated anywhere.
+    param(
+        [Parameter(Mandatory)][string]$Root,
+        [string]$AllowAFUnixSocketAt = ''
+    )
     Assert-DefenseClawNoReparsePath -Path $Root
+    $exemptSocket = ''
+    if (-not [string]::IsNullOrWhiteSpace($AllowAFUnixSocketAt)) {
+        $exemptSocket = [IO.Path]::GetFullPath(
+            $AllowAFUnixSocketAt
+        ).TrimEnd('\')
+    }
     foreach ($item in Microsoft.PowerShell.Management\Get-ChildItem -LiteralPath $Root -Recurse -Force) {
         if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+            if (-not $item.PSIsContainer -and
+                $exemptSocket -ne '' -and
+                [string]::Equals(
+                    [IO.Path]::GetFullPath($item.FullName).TrimEnd('\'),
+                    $exemptSocket,
+                    [StringComparison]::OrdinalIgnoreCase
+                )) {
+                continue
+            }
             throw "managed tree contains a reparse point: $($item.FullName)"
         }
     }
@@ -16177,13 +16206,21 @@ function Remove-DefenseClawManagedTree {
     param(
         [Parameter(Mandatory)][string]$Path,
         [Parameter(Mandatory)][string]$RequiredBase,
-        [Parameter(Mandatory)][string]$Label
+        [Parameter(Mandatory)][string]$Label,
+        # Pass-through to Assert-DefenseClawManagedTreeNoReparse. Callers
+        # tearing down the install tree (canonical or retired sibling)
+        # specify the AF_UNIX socket's exact full path so a stale
+        # socket-reparse-point does not trip the pre-remove reparse
+        # veto. Callers on other trees leave it empty for strict mode.
+        [string]$AllowAFUnixSocketAt = ''
     )
     $safe = Assert-DefenseClawSafeRoot -Path $Path -Label $Label -RequiredBase $RequiredBase
     if (-not (Microsoft.PowerShell.Management\Test-Path -LiteralPath $safe)) {
         return
     }
-    Assert-DefenseClawManagedTreeNoReparse -Root $safe
+    Assert-DefenseClawManagedTreeNoReparse `
+        -Root $safe `
+        -AllowAFUnixSocketAt $AllowAFUnixSocketAt
     Microsoft.PowerShell.Management\Remove-Item -LiteralPath $safe -Recurse -Force
 }
 
@@ -16382,7 +16419,12 @@ function Assert-DefenseClawRetiredInstallTree {
     $allowlist = Get-DefenseClawRetiredInstallTreeAllowlist `
         -Layout $Layout `
         -RetiredRoot $retired
-    Assert-DefenseClawManagedTreeNoReparse -Root $retired
+    $retiredIPCSocket = Microsoft.PowerShell.Management\Join-Path `
+        $retired `
+        'ipc\defenseclaw_ipc.sock'
+    Assert-DefenseClawManagedTreeNoReparse `
+        -Root $retired `
+        -AllowAFUnixSocketAt $retiredIPCSocket
     $objects = @(
         Microsoft.PowerShell.Management\Get-Item `
             -LiteralPath $retired `
@@ -16498,7 +16540,9 @@ function Assert-DefenseClawInstallTreeRetirementState {
     $allowlist = Get-DefenseClawRetiredInstallTreeAllowlist `
         -Layout $Layout `
         -RetiredRoot $root
-    Assert-DefenseClawManagedTreeNoReparse -Root $root
+    Assert-DefenseClawManagedTreeNoReparse `
+        -Root $root `
+        -AllowAFUnixSocketAt $Layout.ManagedIPCSocketPath
     $objects = @(
         Microsoft.PowerShell.Management\Get-Item `
             -LiteralPath $root `
@@ -17433,12 +17477,25 @@ function Remove-DefenseClawRetiredInstallTree {
     $modulePath = Microsoft.PowerShell.Management\Join-Path `
         $retired `
         'libexec\DefenseClawEnterprise.psm1'
+    # AF_UNIX socket: skip the per-file no-reparse gate below (the socket
+    # is an IO_REPARSE_TAG_AF_UNIX reparse point by design) and delete it
+    # separately at the end alongside its ipc\ container.
+    $retiredIPCSocket = Microsoft.PowerShell.Management\Join-Path `
+        $retired `
+        'ipc\defenseclaw_ipc.sock'
     foreach ($path in @(
         $allowlist.files |
             Microsoft.PowerShell.Core\Where-Object {
                 -not [string]::Equals(
                     [string]$_,
                     $modulePath,
+                    [StringComparison]::OrdinalIgnoreCase
+                ) -and
+                -not [string]::Equals(
+                    [string]$_,
+                    (
+                        [IO.Path]::GetFullPath($retiredIPCSocket).TrimEnd('\')
+                    ),
                     [StringComparison]::OrdinalIgnoreCase
                 )
             }
@@ -17451,6 +17508,27 @@ function Remove-DefenseClawRetiredInstallTree {
                 -LiteralPath $path `
                 -Force
         }
+    }
+    if (Microsoft.PowerShell.Management\Test-Path `
+        -LiteralPath $retiredIPCSocket `
+        -PathType Leaf) {
+        # Remove-Item -Force deletes the reparse point itself (no target
+        # follow) which is exactly the right primitive for AF_UNIX
+        # sockets — the "target" is the socket, there is nothing else
+        # behind it.
+        Microsoft.PowerShell.Management\Remove-Item `
+            -LiteralPath $retiredIPCSocket `
+            -Force
+    }
+    $retiredIPCDirectory = Microsoft.PowerShell.Management\Join-Path `
+        $retired `
+        'ipc'
+    if (Microsoft.PowerShell.Management\Test-Path `
+        -LiteralPath $retiredIPCDirectory `
+        -PathType Container) {
+        Microsoft.PowerShell.Management\Remove-Item `
+            -LiteralPath $retiredIPCDirectory `
+            -Force
     }
     foreach ($directory in @(
         (Microsoft.PowerShell.Management\Join-Path $retired 'agents'),
@@ -18246,7 +18324,9 @@ function Remove-DefenseClawCommittedEmptyInstallRoot {
             -LiteralPath $Layout.InstallRoot)) {
         return
     }
-    Assert-DefenseClawManagedTreeNoReparse -Root $Layout.InstallRoot
+    Assert-DefenseClawManagedTreeNoReparse `
+        -Root $Layout.InstallRoot `
+        -AllowAFUnixSocketAt $Layout.ManagedIPCSocketPath
     $allowed = @(
         [IO.Path]::GetFullPath($Layout.BinDirectory).TrimEnd('\'),
         [IO.Path]::GetFullPath($Layout.LibexecDirectory).TrimEnd('\'),
@@ -18257,19 +18337,36 @@ function Remove-DefenseClawCommittedEmptyInstallRoot {
         # runs.
         [IO.Path]::GetFullPath($Layout.ManagedIPCDirectory).TrimEnd('\')
     )
+    $expectedSocket = [IO.Path]::GetFullPath(
+        $Layout.ManagedIPCSocketPath
+    ).TrimEnd('\')
     foreach ($item in Microsoft.PowerShell.Management\Get-ChildItem `
         -LiteralPath $Layout.InstallRoot `
         -Recurse `
         -Force) {
         $full = [IO.Path]::GetFullPath($item.FullName).TrimEnd('\')
-        if (-not $item.PSIsContainer -or $full -notin $allowed) {
+        # The AF_UNIX socket file at the AVC-contract path is the ONLY
+        # non-directory leaf tolerated here — an unclean guardian stop
+        # can leave it behind, and pre-remove cleanup must not fail
+        # closed on that residue.
+        if ($item.PSIsContainer) {
+            if ($full -notin $allowed) {
+                throw "committed uninstall left unexpected InstallRoot content: $full"
+            }
+        }
+        elseif (-not [string]::Equals(
+                $full,
+                $expectedSocket,
+                [StringComparison]::OrdinalIgnoreCase
+            )) {
             throw "committed uninstall left unexpected InstallRoot content: $full"
         }
     }
     Remove-DefenseClawManagedTree `
         -Path $Layout.InstallRoot `
         -RequiredBase $script:ProgramFiles `
-        -Label 'InstallRoot'
+        -Label 'InstallRoot' `
+        -AllowAFUnixSocketAt $Layout.ManagedIPCSocketPath
 }
 
 function Publish-DefenseClawStatePurgeIntent {
@@ -18481,7 +18578,8 @@ function Invoke-DefenseClawCommittedUninstallCleanup {
         Remove-DefenseClawManagedTree `
             -Path $Layout.InstallRoot `
             -RequiredBase $script:ProgramFiles `
-            -Label 'InstallRoot'
+            -Label 'InstallRoot' `
+            -AllowAFUnixSocketAt $Layout.ManagedIPCSocketPath
     }
     [void](Remove-DefenseClawCommittedManagedHooksTeardownJournal `
         -Layout $Layout `
@@ -20416,7 +20514,8 @@ function Invoke-DefenseClawUninstallLifecycle {
             Remove-DefenseClawManagedTree `
                 -Path $Layout.InstallRoot `
                 -RequiredBase $script:ProgramFiles `
-                -Label 'InstallRoot'
+                -Label 'InstallRoot' `
+                -AllowAFUnixSocketAt $Layout.ManagedIPCSocketPath
         }
     }
     catch {

--- a/packaging/windows/DefenseClawEnterprise.psm1
+++ b/packaging/windows/DefenseClawEnterprise.psm1
@@ -15961,9 +15961,17 @@ function Wait-DefenseClawFreshGuardianReconcile {
 
 function Assert-DefenseClawManagedInstallTree {
     param([Parameter(Mandatory)][hashtable]$Layout)
+    # ManagedIPCDirectory and ManagedIPCSocketPath live under InstallRoot
+    # per spec 004 REQ-02 (path parity with internal/ipc/paths_windows.go).
+    # The gateway creates <InstallRoot>\ipc\ on service start and binds
+    # the AF_UNIX socket <InstallRoot>\ipc\defenseclaw_ipc.sock inside it;
+    # the graceful stop removes the socket file but not the directory, so
+    # uninstall MUST accept both in its inventory or the tree walk trips
+    # on the empty ipc\ dir before rename/removal can proceed.
     $allowedDirectories = @(
         $Layout.BinDirectory,
-        $Layout.LibexecDirectory
+        $Layout.LibexecDirectory,
+        $Layout.ManagedIPCDirectory
     )
     $allowedFiles = @(
         $Layout.BrokerPath,
@@ -15971,13 +15979,35 @@ function Assert-DefenseClawManagedInstallTree {
         $Layout.HookPath,
         $Layout.CLIPath,
         $Layout.InstallerPath,
-        $Layout.ModulePath
+        $Layout.ModulePath,
+        $Layout.ManagedIPCSocketPath
+    )
+    $expectedIPCSocket = [IO.Path]::GetFullPath(
+        [string]$Layout.ManagedIPCSocketPath
     )
     foreach ($item in Microsoft.PowerShell.Management\Get-ChildItem -LiteralPath $Layout.InstallRoot -Recurse -Force) {
-        if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        $full = [IO.Path]::GetFullPath($item.FullName)
+        $isReparse = (
+            ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0
+        )
+        # Windows backs AF_UNIX socket files with an NTFS reparse point
+        # (IO_REPARSE_TAG_AF_UNIX 0x80000023). A stale socket left after
+        # an unclean guardian stop surfaces with the ReparsePoint
+        # attribute, so exempt exactly one leaf file at the AVC-contract
+        # socket path from the reparse-point veto. Every other reparse
+        # point still aborts: an attacker who plants a junction anywhere
+        # else inside the managed tree pre-uninstall is still refused.
+        if ($isReparse -and
+            (
+                $item.PSIsContainer -or
+                -not [string]::Equals(
+                    $full,
+                    $expectedIPCSocket,
+                    [StringComparison]::OrdinalIgnoreCase
+                )
+            )) {
             throw "refusing to remove managed install tree containing a reparse point: $($item.FullName)"
         }
-        $full = [IO.Path]::GetFullPath($item.FullName)
         if ($item.PSIsContainer) {
             if ($full -notin $allowedDirectories) {
                 throw "refusing to remove unexpected directory from managed install root: $full"
@@ -16300,7 +16330,15 @@ function Get-DefenseClawRetiredInstallTreeAllowlist {
     $directories = @(
         (Microsoft.PowerShell.Management\Join-Path $RetiredRoot 'bin'),
         (Microsoft.PowerShell.Management\Join-Path $RetiredRoot 'agents'),
-        (Microsoft.PowerShell.Management\Join-Path $RetiredRoot 'libexec')
+        (Microsoft.PowerShell.Management\Join-Path $RetiredRoot 'libexec'),
+        # <RetiredRoot>\ipc\ is the renamed-sibling counterpart of the
+        # managed IPC directory <InstallRoot>\ipc\. When the CLI self-
+        # uninstalls it renames InstallRoot to the RetiredRoot sibling
+        # for delayed teardown by an out-of-tree helper, and the ipc
+        # directory rides along. Accept it here or the retired-tree
+        # verifier trips on the identical empty-container shape that
+        # the canonical validator was tripping on pre-fix.
+        (Microsoft.PowerShell.Management\Join-Path $RetiredRoot 'ipc')
     )
     $files = @(
         (Microsoft.PowerShell.Management\Join-Path $RetiredRoot 'bin\defenseclaw-cmid-broker.exe'),
@@ -16309,7 +16347,12 @@ function Get-DefenseClawRetiredInstallTreeAllowlist {
         (Microsoft.PowerShell.Management\Join-Path $RetiredRoot 'bin\defenseclaw.exe'),
         (Microsoft.PowerShell.Management\Join-Path $RetiredRoot 'agents\codex.exe'),
         (Microsoft.PowerShell.Management\Join-Path $RetiredRoot 'libexec\install-enterprise.ps1'),
-        (Microsoft.PowerShell.Management\Join-Path $RetiredRoot 'libexec\DefenseClawEnterprise.psm1')
+        (Microsoft.PowerShell.Management\Join-Path $RetiredRoot 'libexec\DefenseClawEnterprise.psm1'),
+        # Retired counterpart of the AF_UNIX socket file. Absent after a
+        # graceful guardian stop; if a stale socket survived an unclean
+        # stop and rode along on the rename, this allowlist entry is
+        # what keeps the retired-tree verifier from rejecting it.
+        (Microsoft.PowerShell.Management\Join-Path $RetiredRoot 'ipc\defenseclaw_ipc.sock')
     )
     return @{
         directories = @(
@@ -18206,7 +18249,13 @@ function Remove-DefenseClawCommittedEmptyInstallRoot {
     Assert-DefenseClawManagedTreeNoReparse -Root $Layout.InstallRoot
     $allowed = @(
         [IO.Path]::GetFullPath($Layout.BinDirectory).TrimEnd('\'),
-        [IO.Path]::GetFullPath($Layout.LibexecDirectory).TrimEnd('\')
+        [IO.Path]::GetFullPath($Layout.LibexecDirectory).TrimEnd('\'),
+        # Guardian-stop leaves the empty <InstallRoot>\ipc\ container
+        # behind after removing defenseclaw_ipc.sock. The post-service-
+        # teardown cleanup must accept it as a known-empty directory or
+        # this validator trips before Remove-DefenseClawManagedTree ever
+        # runs.
+        [IO.Path]::GetFullPath($Layout.ManagedIPCDirectory).TrimEnd('\')
     )
     foreach ($item in Microsoft.PowerShell.Management\Get-ChildItem `
         -LiteralPath $Layout.InstallRoot `

--- a/packaging/windows/DefenseClawEnterprise.psm1
+++ b/packaging/windows/DefenseClawEnterprise.psm1
@@ -10953,10 +10953,31 @@ function Assert-DefenseClawManagedHooksTeardownSchema6Journal {
         'cursor',
         'selector_targets'
     )
+    # Required = the strict-authenticated identity core. Anything whose
+    # absence means "this connector was not a target" is deliberately
+    # OPTIONAL so a journal written by a deployment that never targeted
+    # (say) codex still parses on uninstall. Every optional property is
+    # still whitelisted above — an unknown key is still rejected — and
+    # every trust-critical binding (manifest-SHA256, hook-binary path,
+    # gateway service name, activation record, target fingerprint) stays
+    # in the required set, so an attacker cannot substitute a foreign
+    # journal by omitting fields. Matches the macOS uninstall's
+    # existence-first tolerance for connector-optional state without
+    # loosening the identity contract. Reported by AVC dry-run: an
+    # activation record with a codex_targets-less journal was blocking
+    # every uninstall retry through the committed-uninstall cleanup path.
     $required = @(
-        $allowed | Microsoft.PowerShell.Core\Where-Object {
-            $_ -cne 'pending_targets'
-        }
+        'schema_version',
+        'phase',
+        'manifest_path',
+        'manifest_sha256',
+        'manifest_fingerprint',
+        'activation_state',
+        'deployment_generation_id',
+        'hook_binary',
+        'gateway_addr',
+        'gateway_service_name',
+        'targets'
     )
     [void](Assert-DefenseClawManagedHooksTeardownJsonObject `
         -Value $Journal `
@@ -10983,8 +11004,13 @@ function Assert-DefenseClawManagedHooksTeardownSchema6Journal {
             throw "schema-6 managed-hook teardown journal $name is not a string"
         }
     }
-    if ($Journal.codex_policy_active -isnot [bool]) {
-        throw 'schema-6 managed-hook teardown codex_policy_active is not Boolean'
+    # codex_policy_active is connector-optional per the relaxed $required
+    # list above. Only enforce the boolean type check when the property is
+    # present; absence is treated as "codex was not a target".
+    $codexPolicyProperty = $Journal.PSObject.Properties['codex_policy_active']
+    if ($null -ne $codexPolicyProperty -and
+        $codexPolicyProperty.Value -isnot [bool]) {
+        throw 'schema-6 managed-hook teardown codex_policy_active is not Boolean when present'
     }
     Assert-DefenseClawManagedHooksTeardownProtectedAdminFile `
         -Path $Layout.ManagedHooksTeardownJournalPath
@@ -11040,6 +11066,7 @@ function Assert-DefenseClawManagedHooksTeardownSchema6Journal {
             throw "schema-6 managed-hook teardown journal $($pair[0]) does not match this scope"
         }
     }
+    $codexPolicyPresent = $null -ne $codexPolicyProperty
     if (-not [string]::Equals(
             [string]$Journal.gateway_service_name,
             $GatewayServiceName,
@@ -11048,7 +11075,8 @@ function Assert-DefenseClawManagedHooksTeardownSchema6Journal {
         [string]::IsNullOrWhiteSpace([string]$Journal.gateway_addr) -or
         [string]$Journal.gateway_addr -match '[\x00-\x1f\x7f]' -or
         ([string]$Journal.gateway_addr).Length -gt 4096 -or
-        $Journal.codex_policy_active -isnot [bool]) {
+        ($codexPolicyPresent -and
+            $codexPolicyProperty.Value -isnot [bool])) {
         throw 'schema-6 managed-hook teardown journal has an invalid protected identity'
     }
     if (-not (Microsoft.PowerShell.Management\Test-Path `
@@ -11337,12 +11365,27 @@ function Get-DefenseClawManagedHooksTeardownJournalPhase {
         'cursor',
         'selector_targets'
     )
+    # Required = strict identity core only. Connector-optional fields
+    # match the schema-6 relaxation (see above): whitelisted for
+    # unknown-property rejection but not presence-required, so a
+    # legacy journal from a deployment that never targeted a given
+    # connector can still be retired on uninstall.
+    $legacyRequired = @(
+        'schema_version',
+        'phase',
+        'manifest_path',
+        'manifest_fingerprint',
+        'hook_binary',
+        'gateway_addr',
+        'gateway_service_name',
+        'targets'
+    )
     foreach ($property in @($journal.PSObject.Properties)) {
         if ([string]$property.Name -notin $legacyProperties) {
             throw 'legacy managed-hook teardown journal contains an unexpected property'
         }
     }
-    foreach ($name in $legacyProperties) {
+    foreach ($name in $legacyRequired) {
         if ($null -eq $journal.PSObject.Properties[$name]) {
             throw "legacy managed-hook teardown journal is missing $name"
         }
@@ -11383,10 +11426,24 @@ function Get-DefenseClawManagedHooksTeardownJournalPhase {
         throw 'legacy managed-hook teardown journal has an invalid protected identity'
     }
     $targets = @($journal.targets)
+    # Connector-optional target arrays are legitimately absent when the
+    # deployment never targeted that connector. Read via PSObject.Properties
+    # so StrictMode's missing-property throw doesn't fire before the count
+    # cap can even be checked.
+    $legacyOptionalTargetCounts = @{}
+    foreach ($name in @('claude_target_sids', 'cursor_targets', 'selector_targets')) {
+        $property = $journal.PSObject.Properties[$name]
+        $legacyOptionalTargetCounts[$name] = if ($null -eq $property) {
+            0
+        }
+        else {
+            @($property.Value).Count
+        }
+    }
     if ($targets.Count -gt 384 -or
-        @($journal.claude_target_sids).Count -gt 384 -or
-        @($journal.cursor_targets).Count -gt 384 -or
-        @($journal.selector_targets).Count -gt 384) {
+        $legacyOptionalTargetCounts['claude_target_sids'] -gt 384 -or
+        $legacyOptionalTargetCounts['cursor_targets'] -gt 384 -or
+        $legacyOptionalTargetCounts['selector_targets'] -gt 384) {
         throw 'legacy managed-hook teardown journal exceeds its target bound'
     }
     if (-not (Microsoft.PowerShell.Management\Test-Path `

--- a/packaging/windows/DefenseClawEnterprise.psm1
+++ b/packaging/windows/DefenseClawEnterprise.psm1
@@ -5976,6 +5976,16 @@ function Restore-DefenseClawRedactionKeySecuritySnapshot {
             throw 'pending transaction has incomplete redaction-key security metadata'
         }
     }
+    # Uninstall/purge placeholder: New-DefenseClawTransaction
+    # -SkipRedactionKeySnapshot skipped the DACL preimage capture because
+    # the file is being deleted. If rollback still fires, there is
+    # nothing to restore — the correlation key stays in whatever state
+    # it was already in, which matches "we never touched its DACL".
+    # Kept behind the schema-shape guard above so a corrupted snapshot
+    # cannot smuggle 'skipped_teardown' past the presence check.
+    if ([string]$recorded.preimage_class -ceq 'skipped_teardown') {
+        return
+    }
     if ([int]$recorded.schema_version -ne 2 -or
         $recorded.existed -isnot [bool]) {
         throw 'pending transaction has invalid redaction-key security metadata'
@@ -7191,7 +7201,19 @@ function New-DefenseClawTransaction {
         [switch]$PreserveManagedHooksTeardownJournal,
         [switch]$RecoverLegacyManagedHooksLifecycleJournal,
         [switch]$InstallRootCreatedForTransaction,
-        [switch]$StateRootCreatedForTransaction
+        [switch]$StateRootCreatedForTransaction,
+        # Uninstall/purge opens the transaction to delete the redaction
+        # correlation key file, not to preserve its DACL through the
+        # transaction. Capturing a preimage that only matters for
+        # rollback restoration is dead weight — and, per AVC repro,
+        # actively harmful on hosts where a third-party (EDR baseline,
+        # GPO security template, backup agent) has rewritten the DACL
+        # after the daemon's canonical write, tripping the classifier's
+        # exact-form check. When this switch is set, snapshot records a
+        # 'skipped_teardown' placeholder and Restore-DefenseClaw... treats
+        # it as a no-op. Every trust check downstream of the transaction
+        # still runs; only the DACL preimage capture is bypassed.
+        [switch]$SkipRedactionKeySnapshot
     )
     if (Microsoft.PowerShell.Management\Test-Path -LiteralPath $Layout.PendingPath) {
         throw 'refusing to open a lifecycle transaction while protected recovery state already exists'
@@ -7345,10 +7367,43 @@ function New-DefenseClawTransaction {
         else {
             ''
         }
-        $redactionKeySecurity =
+        $redactionKeySecurity = if ($SkipRedactionKeySnapshot) {
+            # Purge-mode placeholder. The teardown branch of the
+            # lifecycle sets -SkipRedactionKeySnapshot because it is
+            # going to delete the redaction correlation key file
+            # regardless of what its current DACL looks like — capturing
+            # a preimage only to fail-closed on a third-party rewrite
+            # (Defender ATP / GPO / EDR baseline) adds no rollback
+            # value. Kept schema-2 shape so Restore- can identify and
+            # no-op on it without teaching every downstream code path
+            # about a nil snapshot. restore_kind mirrors the same
+            # priorDeploymentActive-derived value used on the normal
+            # path so the schema check at
+            # Restore-DefenseClawRedactionKeySecuritySnapshot:5996 does
+            # not trip before the early-out check fires.
+            [ordered]@{
+                schema_version = 2
+                path = [IO.Path]::GetFullPath(
+                    [string]$Layout.RedactionCorrelationKeyPath
+                ).TrimEnd('\')
+                existed = $false
+                file_identity = ''
+                preimage_class = 'skipped_teardown'
+                security_descriptor = ''
+                restore_kind = if ([string]::IsNullOrWhiteSpace(
+                        $redactionKeyGatewaySID)) {
+                    'AdminFile'
+                }
+                else {
+                    'RuntimeSecretFile'
+                }
+            }
+        }
+        else {
             Get-DefenseClawRedactionKeySecuritySnapshot `
                 -Layout $Layout `
                 -GatewayServiceSID $redactionKeyGatewaySID
+        }
 
         $files = [Collections.Generic.List[object]]::new()
     $legacyManagedHooksLifecyclePreimage = $null
@@ -20364,7 +20419,8 @@ function Invoke-DefenseClawUninstallLifecycle {
             -GuardianServiceName $GuardianServiceName `
             -PriorDeploymentActive `
             -IncludeCodexMachineState:$Layout.CodexTargetEnabled `
-            -PreserveManagedHooksTeardownJournal
+            -PreserveManagedHooksTeardownJournal `
+            -SkipRedactionKeySnapshot
         [void](Invoke-DefenseClawManagedHooksTeardownCommand `
             -Layout $Layout `
             -GatewayServiceName $GatewayServiceName `

--- a/packaging/windows/install-enterprise.ps1
+++ b/packaging/windows/install-enterprise.ps1
@@ -76,6 +76,16 @@ param(
     # enrolled user runtimes before any service activation.
     [switch]$DeferredConfig,
     [int]$SelfUninstallCallerPID,
+    # Protected parent directory for the installer's one-shot bootstrap
+    # environment. When set (the outer signed DefenseClawSetup EXE passes
+    # its own protected %ProgramData%\DefenseClaw-Enterprise-Setup-<hex>\scratch
+    # path here), the bootstrap directory is created inside it INSTEAD of
+    # C:\Windows\Temp — which on Azure-AD-joined hosts carries an Allow ACE
+    # for the interactive AAD principal with Delete/DeleteSubdirectoriesAndFiles
+    # rights, failing the module's later trusted-ancestor walk on rendered
+    # config/targets YAML. Empty falls back to C:\Windows\Temp for
+    # direct-caller compatibility on stock Windows.
+    [string]$BootstrapParent = '',
     [switch]$Json
 )
 
@@ -972,25 +982,149 @@ function Get-DefenseClawBootstrapSecuritySDDL {
     return $Security.GetSecurityDescriptorSddlForm($sections)
 }
 
+function Assert-DefenseClawBootstrapExternalParentTrust {
+    # Called only when the caller passed a non-empty -BootstrapParent. The
+    # outer signed DefenseClawSetup EXE hands its own protected
+    # %ProgramData%\DefenseClaw-Enterprise-Setup-<hex>\scratch path here
+    # (SDDL O:BAG:BAD:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)); this validator
+    # rejects anything whose ancestor chain grants an untrusted principal
+    # replacement rights, so an attacker cannot redirect the bootstrap into
+    # a directory they can retake. Mirrors the ancestor-walk rule the
+    # module's Assert-DefenseClawTrustedAncestor applies to managed content
+    # later, so if this passes, the later content-trust check also passes.
+    param([Parameter(Mandatory)][string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path) -or
+        $Path.Contains('"') -or
+        $Path -match '[\x00-\x1f]') {
+        throw '-BootstrapParent is empty or contains an invalid character'
+    }
+    $full = [IO.Path]::GetFullPath($Path).TrimEnd('\')
+    if (-not [IO.Path]::IsPathRooted($full) -or
+        $full.StartsWith('\\') -or
+        $full.StartsWith('//') -or
+        $full.StartsWith('\\?\') -or
+        $full.StartsWith('\\.\') -or
+        ($full.Length -gt 2 -and $full.Substring(2).Contains(':'))) {
+        throw "-BootstrapParent must be an absolute local Win32 drive path: $full"
+    }
+    if (-not [IO.Directory]::Exists($full)) {
+        throw "-BootstrapParent directory does not exist: $full"
+    }
+    $attributes = [IO.File]::GetAttributes($full)
+    if (($attributes -band [IO.FileAttributes]::Directory) -eq 0 -or
+        ($attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "-BootstrapParent must be a real non-reparse directory: $full"
+    }
+
+    $nativePathType = Initialize-DefenseClawBootstrapNativePath
+    $driveRoot = [IO.Path]::GetPathRoot($full)
+    $driveID = $driveRoot.TrimEnd('\')
+    $driveType = $nativePathType::GetDriveType($driveRoot)
+    $fileSystem = $nativePathType::GetFileSystem($driveRoot)
+    $nativePathType::AssertCanonicalDriveRoot($driveRoot, $driveID)
+    if ([int]$driveType -ne 3 -or
+        -not [string]::Equals(
+            $fileSystem,
+            'NTFS',
+            [StringComparison]::OrdinalIgnoreCase
+        )) {
+        throw "-BootstrapParent must be on a local fixed NTFS volume: $full"
+    }
+
+    $trustedSIDs = @(
+        'S-1-5-18',
+        'S-1-5-32-544',
+        'S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464'
+    )
+    $chain = [Collections.Generic.List[string]]::new()
+    $current = $full
+    while (-not [string]::IsNullOrWhiteSpace($current)) {
+        $chain.Add($current)
+        $parent = [IO.Path]::GetDirectoryName($current)
+        if ([string]::IsNullOrWhiteSpace($parent) -or
+            [string]::Equals(
+                $parent,
+                $current,
+                [StringComparison]::OrdinalIgnoreCase
+            )) {
+            break
+        }
+        $current = $parent
+    }
+    for ($index = $chain.Count - 1; $index -ge 0; $index--) {
+        $candidate = $chain[$index]
+        $item = Microsoft.PowerShell.Management\Get-Item `
+            -LiteralPath $candidate `
+            -Force `
+            -ErrorAction Stop
+        if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+            throw "-BootstrapParent path contains a reparse point: $candidate"
+        }
+        if (-not $item.PSIsContainer) {
+            throw "-BootstrapParent path ancestor is not a directory: $candidate"
+        }
+        $acl = Microsoft.PowerShell.Security\Get-Acl `
+            -LiteralPath $candidate `
+            -ErrorAction Stop
+        $accessSDDL = $acl.GetSecurityDescriptorSddlForm(
+            [Security.AccessControl.AccessControlSections]::Access
+        )
+        if ([string]::IsNullOrWhiteSpace($accessSDDL) -or
+            -not $accessSDDL.StartsWith(
+                'D:',
+                [StringComparison]::OrdinalIgnoreCase
+            )) {
+            throw "-BootstrapParent path has an absent or null DACL: $candidate"
+        }
+        $ownerSID = ConvertTo-DefenseClawBootstrapSID -Identity $acl.Owner
+        if ($ownerSID -notin $trustedSIDs) {
+            throw "-BootstrapParent path has untrusted owner $ownerSID`: $candidate"
+        }
+        foreach ($rule in $acl.Access) {
+            if ($rule.AccessControlType -ne
+                [Security.AccessControl.AccessControlType]::Allow -or
+                (($rule.PropagationFlags -band
+                    [Security.AccessControl.PropagationFlags]::InheritOnly) -ne
+                    0)) {
+                continue
+            }
+            $sid = ConvertTo-DefenseClawBootstrapSID `
+                -Identity $rule.IdentityReference
+            if ($sid -in $trustedSIDs) {
+                continue
+            }
+            if (Test-DefenseClawBootstrapReplacementRights `
+                    -Rights $rule.FileSystemRights) {
+                throw (
+                    "-BootstrapParent path has untrusted principal $sid " +
+                    "with replacement rights: $candidate"
+                )
+            }
+        }
+    }
+    $nativePathType::AssertCanonicalDriveRoot($driveRoot, $driveID)
+    return $full
+}
+
 function Assert-DefenseClawBootstrapOneShotRoot {
     param(
         [Parameter(Mandatory)][string]$Path,
         [Parameter(Mandatory)]
         [Security.AccessControl.DirectorySecurity]$ExpectedSecurity,
+        [Parameter(Mandatory)][string]$ExpectedParent,
         [switch]$RequireEmpty
     )
     $full = [IO.Path]::GetFullPath($Path).TrimEnd('\')
-    $windowsTemp = [IO.Path]::GetFullPath(
-        [IO.Path]::Combine($trustedWindows, 'Temp')
-    ).TrimEnd('\')
+    $expectedParentFull =
+        [IO.Path]::GetFullPath($ExpectedParent).TrimEnd('\')
     if (-not [string]::Equals(
             [IO.Path]::GetDirectoryName($full),
-            $windowsTemp,
+            $expectedParentFull,
             [StringComparison]::OrdinalIgnoreCase
         ) -or
         [IO.Path]::GetFileName($full) -cnotmatch
             '^DefenseClaw-Bootstrap-[a-f0-9]{32}$') {
-        throw "bootstrap environment is outside its exact Windows Temp capability scope: $full"
+        throw "bootstrap environment is outside its exact protected parent scope ($expectedParentFull): $full"
     }
     if (-not [IO.Directory]::Exists($full)) {
         throw "bootstrap environment directory is missing: $full"
@@ -1172,7 +1306,8 @@ function Remove-DefenseClawBootstrapEnvironment {
     param([Parameter(Mandatory)]$Context)
     $root = Assert-DefenseClawBootstrapOneShotRoot `
         -Path ([string]$Context.Path) `
-        -ExpectedSecurity $Context.Security
+        -ExpectedSecurity $Context.Security `
+        -ExpectedParent ([string]$Context.BootstrapParent)
     $directories = [Collections.Generic.List[string]]::new()
     $files = [Collections.Generic.List[string]]::new()
     $pending = [Collections.Generic.Stack[string]]::new()
@@ -1291,10 +1426,26 @@ function New-DefenseClawBootstrapEnvironment {
     $allowedOwnerSIDs.Add('S-1-5-32-544')
     $allowedOwnerSIDs.Add($identity.User.Value)
 
-    $windowsTemp = [IO.Path]::GetFullPath(
-        [IO.Path]::Combine($trustedWindows, 'Temp')
-    ).TrimEnd('\')
-    foreach ($trustedDirectory in @($trustedWindows, $windowsTemp)) {
+    # Resolve the protected bootstrap parent. When the outer signed
+    # DefenseClawSetup EXE passes -BootstrapParent (a protected
+    # %ProgramData%\DefenseClaw-Enterprise-Setup-<hex>\scratch directory it
+    # created and locked down to SYSTEM+Administrators only), route the
+    # bootstrap into it. Falling back to C:\Windows\Temp is retained for
+    # direct-caller compatibility on stock Windows, but on Azure-AD-joined
+    # hosts C:\Windows\Temp carries an Allow ACE for the interactive AAD
+    # principal with replacement rights, so the trusted-ancestor walk on
+    # the rendered YAML content fails later; direct callers on those hosts
+    # MUST pass -BootstrapParent.
+    if (-not [string]::IsNullOrWhiteSpace($BootstrapParent)) {
+        $resolvedBootstrapParent = Assert-DefenseClawBootstrapExternalParentTrust `
+            -Path $BootstrapParent
+    }
+    else {
+        $resolvedBootstrapParent = [IO.Path]::GetFullPath(
+            [IO.Path]::Combine($trustedWindows, 'Temp')
+        ).TrimEnd('\')
+    }
+    foreach ($trustedDirectory in @($trustedWindows, $resolvedBootstrapParent)) {
         if (-not [IO.Directory]::Exists($trustedDirectory)) {
             throw "trusted bootstrap parent directory is missing: $trustedDirectory"
         }
@@ -1316,7 +1467,7 @@ function New-DefenseClawBootstrapEnvironment {
                 ''
             ).ToLowerInvariant()
             $candidate = [IO.Path]::Combine(
-                $windowsTemp,
+                $resolvedBootstrapParent,
                 "DefenseClaw-Bootstrap-$capability"
             )
             if (Test-DefenseClawBootstrapPathExists -Path $candidate) {
@@ -1340,6 +1491,7 @@ function New-DefenseClawBootstrapEnvironment {
             $path = Assert-DefenseClawBootstrapOneShotRoot `
                 -Path $candidate `
                 -ExpectedSecurity $security `
+                -ExpectedParent $resolvedBootstrapParent `
                 -RequireEmpty
             break
         }
@@ -1366,6 +1518,7 @@ function New-DefenseClawBootstrapEnvironment {
         AllowedAccessSIDs = $allowedAccessSIDs.ToArray()
         AllowedOwnerSIDs = $allowedOwnerSIDs.ToArray()
         OriginalEnvironment = $originalEnvironment
+        BootstrapParent = $resolvedBootstrapParent
     }
     try {
         foreach ($name in @(
@@ -1402,6 +1555,7 @@ function New-DefenseClawBootstrapEnvironment {
         [void](Assert-DefenseClawBootstrapOneShotRoot `
             -Path $path `
             -ExpectedSecurity $security `
+            -ExpectedParent $resolvedBootstrapParent `
             -RequireEmpty)
         return $context
     }

--- a/packaging/windows/tests/enterprise-bootstrap-environment-smoke.ps1
+++ b/packaging/windows/tests/enterprise-bootstrap-environment-smoke.ps1
@@ -293,6 +293,186 @@ function Invoke-ProtectedEnvironmentProbe {
     return $probeResult
 }
 
+function Invoke-SuppliedBootstrapParentProbe {
+    # Exercises the -BootstrapParent code path added for AVC:
+    #   1. Happy path — a caller-supplied parent that mirrors the outer
+    #      signed Setup EXE's protected scratch dir (SYSTEM+Admins FA,
+    #      DACL protected) is accepted; the bootstrap child lands under
+    #      that parent and Remove- restores state without touching the
+    #      caller-supplied parent itself.
+    #   2. Untrusted-ancestor rejection — passing a user-owned path (a
+    #      profile subdirectory) trips
+    #      Assert-DefenseClawBootstrapExternalParentTrust's owner walk.
+    #   3. Reparse-point rejection — a directory junction under the same
+    #      protected parent trips the reparse-in-ancestor-chain guard.
+    #
+    # Fixture roots are staged under the caller's %TEMP% so the smoke
+    # harness stays hermetic. The protected parent's SDDL matches
+    # exactly what cmd/defenseclaw-enterprise-setup/platform_windows.go
+    # createEnterpriseSetupStage emits.
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = [Security.Principal.WindowsPrincipal]::new($identity)
+    $elevated = $principal.IsInRole(
+        [Security.Principal.WindowsBuiltInRole]::Administrator
+    )
+    if (-not $elevated) {
+        # The probe requires elevation to construct the protected parent.
+        # Match the pattern used by the other probes: skip cleanly under
+        # a non-elevated harness rather than failing closed.
+        return [pscustomobject]@{
+            skipped = $true
+            reason = 'requires elevation to create a protected parent'
+        }
+    }
+
+    $originalBootstrapParent = $script:BootstrapParent
+    $protectedParent = [IO.Path]::Combine(
+        [IO.Path]::GetTempPath(),
+        "DefenseClaw-BootstrapParentSmoke-$([Guid]::NewGuid().ToString('N'))"
+    )
+    $parentSecurity = [Security.AccessControl.DirectorySecurity]::new()
+    $parentSecurity.SetSecurityDescriptorSddlForm(
+        'O:BAG:BAD:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)'
+    )
+    $parentDirInfo = [IO.DirectoryInfo]::new($protectedParent)
+    if ($PSVersionTable.PSEdition -eq 'Core') {
+        [IO.FileSystemAclExtensions]::Create($parentDirInfo, $parentSecurity)
+    }
+    else {
+        $parentDirInfo.Create($parentSecurity)
+    }
+
+    $bootstrapChildPath = $null
+    try {
+        # Happy path: supplied protected parent is honored.
+        $script:BootstrapParent = $protectedParent
+        $context = New-DefenseClawBootstrapEnvironment
+        try {
+            $bootstrapChildPath = [string]$context.Path
+            $parentOfChild = [IO.Path]::GetDirectoryName(
+                $bootstrapChildPath
+            )
+            if (-not [string]::Equals(
+                    $parentOfChild,
+                    $protectedParent,
+                    [StringComparison]::OrdinalIgnoreCase
+                ) -or
+                [IO.Path]::GetFileName($bootstrapChildPath) -cnotmatch
+                    '^DefenseClaw-Bootstrap-[a-f0-9]{32}$') {
+                throw (
+                    'supplied -BootstrapParent was not honored: root=' +
+                    "$bootstrapChildPath parent=$parentOfChild"
+                )
+            }
+            [void](Assert-DefenseClawBootstrapOneShotRoot `
+                -Path $bootstrapChildPath `
+                -ExpectedSecurity $context.Security `
+                -ExpectedParent $protectedParent `
+                -RequireEmpty)
+            if (-not [string]::Equals(
+                    [string]$context.BootstrapParent,
+                    $protectedParent,
+                    [StringComparison]::OrdinalIgnoreCase
+                )) {
+                throw (
+                    'context.BootstrapParent did not record the supplied parent: ' +
+                    [string]$context.BootstrapParent
+                )
+            }
+        }
+        finally {
+            Restore-DefenseClawBootstrapEnvironment -Context $context
+            Remove-DefenseClawBootstrapEnvironment -Context $context
+        }
+        if ([IO.Directory]::Exists($bootstrapChildPath)) {
+            throw (
+                'bootstrap child survived Remove-DefenseClawBootstrapEnvironment: ' +
+                $bootstrapChildPath
+            )
+        }
+        if (-not [IO.Directory]::Exists($protectedParent)) {
+            throw (
+                'cleanup removed the caller-supplied protected parent: ' +
+                $protectedParent
+            )
+        }
+
+        # Untrusted-ancestor rejection: use a user-owned profile path
+        # whose ancestor chain includes the runner's SID as owner.
+        $untrusted = [Environment]::GetFolderPath(
+            [Environment+SpecialFolder]::LocalApplicationData
+        )
+        if ([string]::IsNullOrWhiteSpace($untrusted) -or
+            -not [IO.Directory]::Exists($untrusted)) {
+            $untrusted = [IO.Path]::GetTempPath().TrimEnd('\')
+        }
+        $untrustedRejected = $false
+        try {
+            [void](Assert-DefenseClawBootstrapExternalParentTrust `
+                -Path $untrusted)
+        }
+        catch {
+            $untrustedRejected = $true
+        }
+        if (-not $untrustedRejected) {
+            throw (
+                'Assert-DefenseClawBootstrapExternalParentTrust accepted a ' +
+                "user-owned ancestor: $untrusted"
+            )
+        }
+
+        # Reparse-point rejection: create a junction under the protected
+        # parent and pass its path to the validator. The ancestor-chain
+        # walk refuses any reparse-point node.
+        $reparseTarget = [IO.Path]::Combine(
+            $protectedParent,
+            'reparse-target'
+        )
+        [void][IO.Directory]::CreateDirectory($reparseTarget)
+        $reparseJunction = [IO.Path]::Combine(
+            $protectedParent,
+            'reparse-junction'
+        )
+        [void](Microsoft.PowerShell.Management\New-Item `
+            -ItemType Junction `
+            -Path $reparseJunction `
+            -Value $reparseTarget `
+            -Force)
+        $reparseRejected = $false
+        try {
+            [void](Assert-DefenseClawBootstrapExternalParentTrust `
+                -Path $reparseJunction)
+        }
+        catch {
+            $reparseRejected = $true
+        }
+        if (-not $reparseRejected) {
+            throw (
+                'Assert-DefenseClawBootstrapExternalParentTrust accepted a ' +
+                "reparse-point parent: $reparseJunction"
+            )
+        }
+    }
+    finally {
+        $script:BootstrapParent = $originalBootstrapParent
+        if ([IO.Directory]::Exists($protectedParent)) {
+            try {
+                [IO.Directory]::Delete($protectedParent, $true)
+            }
+            catch {
+                # Best-effort cleanup; the fixture path lives under
+                # %TEMP% and will be reclaimed regardless.
+            }
+        }
+    }
+    return [pscustomobject]@{
+        skipped = $false
+        supplied_parent_honored = $true
+        untrusted_ancestor_rejected = $true
+        reparse_point_rejected = $true
+    }
+}
+
 function Invoke-CollisionNoSeizeProbe {
     $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
     $principal = [Security.Principal.WindowsPrincipal]::new($identity)
@@ -1743,6 +1923,7 @@ if (-not [bool]$status.ok -or [bool]$status.installed -or
 
 $single = Invoke-ProtectedEnvironmentProbe
 $collisionRejected = Invoke-CollisionNoSeizeProbe
+$suppliedBootstrapParent = Invoke-SuppliedBootstrapParentProbe
 $renderedTargetsVersionContract = Invoke-RenderedEnterpriseTargetsVersionProbe
 $renderedTargetsActiveSessionContract =
     Invoke-RenderedEnterpriseTargetsActiveSessionProbe

--- a/packaging/windows/tests/enterprise-bootstrap-environment-smoke.ps1
+++ b/packaging/windows/tests/enterprise-bootstrap-environment-smoke.ps1
@@ -319,9 +319,18 @@ function Invoke-SuppliedBootstrapParentProbe {
         # The probe requires elevation to construct the protected parent.
         # Match the pattern used by the other probes: skip cleanly under
         # a non-elevated harness rather than failing closed.
+        #
+        # Return the full result-shape (all three contract fields as
+        # $false) so downstream property reads under
+        # `Set-StrictMode -Version Latest` do not throw when the report
+        # emitter walks $suppliedBootstrapParent.supplied_parent_honored
+        # et al.
         return [pscustomobject]@{
             skipped = $true
             reason = 'requires elevation to create a protected parent'
+            supplied_parent_honored = $false
+            untrusted_ancestor_rejected = $false
+            reparse_point_rejected = $false
         }
     }
 

--- a/packaging/windows/tests/enterprise-bootstrap-environment-smoke.ps1
+++ b/packaging/windows/tests/enterprise-bootstrap-environment-smoke.ps1
@@ -335,8 +335,25 @@ function Invoke-SuppliedBootstrapParentProbe {
     }
 
     $originalBootstrapParent = $script:BootstrapParent
+    # Stage the protected parent under %ProgramData%, not %TEMP%. The
+    # Assert-DefenseClawBootstrapExternalParentTrust walk climbs the
+    # ANCESTOR chain from the leaf to the drive root and refuses any
+    # ancestor that grants an untrusted principal replacement rights.
+    # On CI runners %TEMP% resolves to C:\Users\runneradmin\..., whose
+    # ancestor C:\Users\runneradmin is owned by the runner user — so a
+    # leaf under %TEMP% fails the ancestor check even when the leaf's
+    # own SDDL is admin-only. %ProgramData% is SYSTEM-owned with the
+    # Users CreateFiles+AppendData ACE that the walk deliberately
+    # tolerates, so the ancestor chain is admin-clean from C:\ down.
+    $programData = [Environment]::GetFolderPath(
+        [Environment+SpecialFolder]::CommonApplicationData
+    )
+    if ([string]::IsNullOrWhiteSpace($programData) -or
+        -not [IO.Directory]::Exists($programData)) {
+        $programData = 'C:\ProgramData'
+    }
     $protectedParent = [IO.Path]::Combine(
-        [IO.Path]::GetTempPath(),
+        $programData,
         "DefenseClaw-BootstrapParentSmoke-$([Guid]::NewGuid().ToString('N'))"
     )
     $parentSecurity = [Security.AccessControl.DirectorySecurity]::new()
@@ -352,15 +369,15 @@ function Invoke-SuppliedBootstrapParentProbe {
     }
 
     # Dedicated untrusted fixture: a directory whose DACL explicitly grants
-    # BUILTIN\Users (S-1-5-32-545) modify access. Under a LocalSystem-
-    # elevated harness, ambient system-profile paths like LocalApplicationData
-    # resolve to Admins/SYSTEM ownership — the trust walk would ACCEPT them
-    # and the probe would spuriously succeed on rejection. Staging our own
-    # fixture with a planted Users:Modify ACE guarantees the ancestor-chain
-    # walk finds an untrusted principal with replacement rights regardless
-    # of what identity the harness runs under.
+    # BUILTIN\Users (S-1-5-32-545) modify access. Staged under
+    # %ProgramData% for the same reason as the protected parent — the
+    # ancestor chain must be admin-clean so the assert reaches the leaf's
+    # own DACL, where the planted Users:Modify ACE is what we want to
+    # trip on. Under %TEMP% the walk would reject on the user-owned
+    # ancestor before ever reading our planted ACE, masking whether the
+    # planted-ACE rejection actually works.
     $untrustedFixture = [IO.Path]::Combine(
-        [IO.Path]::GetTempPath(),
+        $programData,
         "DefenseClaw-BootstrapUntrustedFixture-$([Guid]::NewGuid().ToString('N'))"
     )
     $untrustedSecurity = [Security.AccessControl.DirectorySecurity]::new()
@@ -494,8 +511,9 @@ function Invoke-SuppliedBootstrapParentProbe {
                     [IO.Directory]::Delete($fixture, $true)
                 }
                 catch {
-                    # Best-effort cleanup; the fixture paths live under
-                    # %TEMP% and will be reclaimed regardless.
+                    # Best-effort cleanup; log-and-ignore is intentional
+                    # so a probe reporting a real failure does not have
+                    # its stack overwritten by a cleanup exception.
                 }
             }
         }

--- a/packaging/windows/tests/enterprise-bootstrap-environment-smoke.ps1
+++ b/packaging/windows/tests/enterprise-bootstrap-environment-smoke.ps1
@@ -342,6 +342,34 @@ function Invoke-SuppliedBootstrapParentProbe {
         $parentDirInfo.Create($parentSecurity)
     }
 
+    # Dedicated untrusted fixture: a directory whose DACL explicitly grants
+    # BUILTIN\Users (S-1-5-32-545) modify access. Under a LocalSystem-
+    # elevated harness, ambient system-profile paths like LocalApplicationData
+    # resolve to Admins/SYSTEM ownership — the trust walk would ACCEPT them
+    # and the probe would spuriously succeed on rejection. Staging our own
+    # fixture with a planted Users:Modify ACE guarantees the ancestor-chain
+    # walk finds an untrusted principal with replacement rights regardless
+    # of what identity the harness runs under.
+    $untrustedFixture = [IO.Path]::Combine(
+        [IO.Path]::GetTempPath(),
+        "DefenseClaw-BootstrapUntrustedFixture-$([Guid]::NewGuid().ToString('N'))"
+    )
+    $untrustedSecurity = [Security.AccessControl.DirectorySecurity]::new()
+    # 0x001301BF = FILE_MODIFY_ACCESS (write-like — the exact right the
+    # trust walk refuses on untrusted principals). BU = BUILTIN\Users.
+    $untrustedSecurity.SetSecurityDescriptorSddlForm(
+        'O:BAG:BAD:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;0x001301BF;;;BU)'
+    )
+    $untrustedDirInfo = [IO.DirectoryInfo]::new($untrustedFixture)
+    if ($PSVersionTable.PSEdition -eq 'Core') {
+        [IO.FileSystemAclExtensions]::Create(
+            $untrustedDirInfo, $untrustedSecurity
+        )
+    }
+    else {
+        $untrustedDirInfo.Create($untrustedSecurity)
+    }
+
     $bootstrapChildPath = $null
     try {
         # Happy path: supplied protected parent is honored.
@@ -397,19 +425,15 @@ function Invoke-SuppliedBootstrapParentProbe {
             )
         }
 
-        # Untrusted-ancestor rejection: use a user-owned profile path
-        # whose ancestor chain includes the runner's SID as owner.
-        $untrusted = [Environment]::GetFolderPath(
-            [Environment+SpecialFolder]::LocalApplicationData
-        )
-        if ([string]::IsNullOrWhiteSpace($untrusted) -or
-            -not [IO.Directory]::Exists($untrusted)) {
-            $untrusted = [IO.Path]::GetTempPath().TrimEnd('\')
-        }
+        # Untrusted-ancestor rejection: point the validator at the fixture
+        # we staged with an explicit BUILTIN\Users Modify ACE. Deterministic
+        # regardless of whether the harness runs under a normal admin user
+        # or LocalSystem — the planted Users:Modify ACE is always
+        # write-like for an untrusted principal.
         $untrustedRejected = $false
         try {
             [void](Assert-DefenseClawBootstrapExternalParentTrust `
-                -Path $untrusted)
+                -Path $untrustedFixture)
         }
         catch {
             $untrustedRejected = $true
@@ -417,7 +441,7 @@ function Invoke-SuppliedBootstrapParentProbe {
         if (-not $untrustedRejected) {
             throw (
                 'Assert-DefenseClawBootstrapExternalParentTrust accepted a ' +
-                "user-owned ancestor: $untrusted"
+                "fixture with a planted Users:Modify ACE: $untrustedFixture"
             )
         }
 
@@ -455,13 +479,15 @@ function Invoke-SuppliedBootstrapParentProbe {
     }
     finally {
         $script:BootstrapParent = $originalBootstrapParent
-        if ([IO.Directory]::Exists($protectedParent)) {
-            try {
-                [IO.Directory]::Delete($protectedParent, $true)
-            }
-            catch {
-                # Best-effort cleanup; the fixture path lives under
-                # %TEMP% and will be reclaimed regardless.
+        foreach ($fixture in @($protectedParent, $untrustedFixture)) {
+            if ([IO.Directory]::Exists($fixture)) {
+                try {
+                    [IO.Directory]::Delete($fixture, $true)
+                }
+                catch {
+                    # Best-effort cleanup; the fixture paths live under
+                    # %TEMP% and will be reclaimed regardless.
+                }
             }
         }
     }
@@ -1924,6 +1950,22 @@ if (-not [bool]$status.ok -or [bool]$status.installed -or
 $single = Invoke-ProtectedEnvironmentProbe
 $collisionRejected = Invoke-CollisionNoSeizeProbe
 $suppliedBootstrapParent = Invoke-SuppliedBootstrapParentProbe
+# Assert the supplied-BootstrapParent contract. When the probe DIDN'T
+# skip (harness is elevated), every named path must have passed. A
+# future refactor that lets one of these fall to false without throwing
+# from within the probe body would otherwise slip through into a
+# successful report.
+if (-not [bool]$suppliedBootstrapParent.skipped -and
+    -not (
+        [bool]$suppliedBootstrapParent.supplied_parent_honored -and
+        [bool]$suppliedBootstrapParent.untrusted_ancestor_rejected -and
+        [bool]$suppliedBootstrapParent.reparse_point_rejected
+    )) {
+    throw (
+        'Invoke-SuppliedBootstrapParentProbe returned without a skip but ' +
+        'did not confirm all three supplied-parent contract fields'
+    )
+}
 $renderedTargetsVersionContract = Invoke-RenderedEnterpriseTargetsVersionProbe
 $renderedTargetsActiveSessionContract =
     Invoke-RenderedEnterpriseTargetsActiveSessionProbe
@@ -2060,6 +2102,14 @@ if ($legacyRelativeEnvironmentResidue.Count -ne 0) {
         [bool]$single.hostile_fixture_cleanup_verified
     existing_collision_rejected_without_acl_seizure =
         [bool]$collisionRejected
+    supplied_bootstrap_parent_skipped =
+        [bool]$suppliedBootstrapParent.skipped
+    supplied_bootstrap_parent_honored =
+        [bool]$suppliedBootstrapParent.supplied_parent_honored
+    supplied_bootstrap_parent_untrusted_ancestor_rejected =
+        [bool]$suppliedBootstrapParent.untrusted_ancestor_rejected
+    supplied_bootstrap_parent_reparse_point_rejected =
+        [bool]$suppliedBootstrapParent.reparse_point_rejected
     rendered_targets_version_contract =
         [bool]$renderedTargetsVersionContract
     rendered_targets_active_session_contract =

--- a/packaging/windows/tests/enterprise-bootstrap-environment-smoke.ps1
+++ b/packaging/windows/tests/enterprise-bootstrap-environment-smoke.ps1
@@ -99,6 +99,7 @@ function Invoke-ProtectedEnvironmentProbe {
             [void](Assert-DefenseClawBootstrapOneShotRoot `
                 -Path $root `
                 -ExpectedSecurity $context.Security `
+                -ExpectedParent $windowsTemp `
                 -RequireEmpty)
 
             foreach ($name in @(
@@ -343,6 +344,7 @@ function Invoke-CollisionNoSeizeProbe {
             [void](Assert-DefenseClawBootstrapOneShotRoot `
                 -Path $collisionPath `
                 -ExpectedSecurity $expected `
+                -ExpectedParent $windowsTemp `
                 -RequireEmpty)
         }
         catch {

--- a/packaging/windows/tests/enterprise-uninstall-transaction-smoke.ps1
+++ b/packaging/windows/tests/enterprise-uninstall-transaction-smoke.ps1
@@ -1254,7 +1254,14 @@ targets:
                 [switch]$PreserveManagedHooksTeardownJournal,
                 [switch]$RecoverLegacyManagedHooksLifecycleJournal,
                 [switch]$InstallRootCreatedForTransaction,
-                [switch]$StateRootCreatedForTransaction
+                [switch]$StateRootCreatedForTransaction,
+                # Mirrors the production function's uninstall-only switch
+                # (added when the teardown lane learned to tolerate a
+                # third-party-drifted redaction-key DACL by skipping its
+                # preimage capture). The smoke harness does not need to
+                # branch on it; accepting the parameter keeps the mock
+                # signature-compatible with Invoke-DefenseClawUninstall...
+                [switch]$SkipRedactionKeySnapshot
             )
             if (-not $PSBoundParameters.ContainsKey(
                     'PriorDeploymentActive'

--- a/packaging/windows/tests/enterprise-uninstall-transaction-smoke.ps1
+++ b/packaging/windows/tests/enterprise-uninstall-transaction-smoke.ps1
@@ -2624,7 +2624,14 @@ targets:
             param(
                 [Parameter(Mandatory)][string]$Path,
                 [Parameter(Mandatory)][string]$RequiredBase,
-                [Parameter(Mandatory)][string]$Label
+                [Parameter(Mandatory)][string]$Label,
+                # Mirrors the production function's optional param
+                # (added when the InstallRoot teardown pipeline learned
+                # to tolerate the AF_UNIX socket reparse point). The
+                # smoke harness does not need the value; accepting the
+                # parameter keeps the mock signature-compatible with
+                # every module caller.
+                [string]$AllowAFUnixSocketAt = ''
             )
             $script:HarnessState.events.Add("remove-tree:$Label")
             if ($Label -eq 'StateRoot') {


### PR DESCRIPTION
## Summary

AVC hit a runtime failure invoking the signed Setup EXE from the merged fingerprint-mode kit (source `e69003ef4`):

```
/install --deferred-config
→ enterprise payload missing; assemble with DefenseClawAssembler.exe
```

**Root cause:** Authenticode's `signtool sign` appends the Attribute Certificate Table to the end of the file AFTER the assembler's trailer, with 0..7 bytes of alignment padding between the trailer and the cert table. The runtime reader's `size - 24` lookup was landing inside the cert table instead of the DCLWAVC1 footer.

## Fix

New `findFooterOffset` helper in [internal/setuppayload/reader.go](internal/setuppayload/reader.go) makes the reader Authenticode-aware:

1. **Parse PE headers** via `debug/pe` to find the Attribute Certificate Table's file offset (Optional Header data-directory index 4, `IMAGE_DIRECTORY_ENTRY_SECURITY`).
2. **Scan the padding window** immediately before `certVA` for the DCLWAVC1 magic. Alignment padding is 0..7 bytes so the magic lives at exactly one of 8 candidate positions in a 31-byte window.
3. **Fall back to `size - FooterSize`** for files that aren't PEs (test fixtures) or PEs with no cert table (unsigned assembler output — the DefenseClaw `--allow-unsigned` dev-loop path).

`HasTrailer` uses the same helper so the assembler's double-append refusal recognizes a signed-then-re-fed EXE.

## Tests

- **`TestScanFooterMagicWindow`** — pure-function padding-window search across all 8 legal offsets + rejection of misaligned magic.
- **`TestReadFindsFooterBeforeCertTable`** — 8 sub-tests (`padding=0..7`) exercising the full `Read` path through a hand-crafted minimal PE with a patched Security data-directory entry, an appended trailer, N bytes of padding, and a dummy cert table. Manifest + payload contents round-trip byte-identical in every padding scenario.
- **`TestReadUnsignedPEStillWorks`** — PE headers with no cert table falls back to EOF-relative reading (protects the assembler's `--allow-unsigned` dev-loop path).
- **`TestHasTrailerSignedPE`** — `HasTrailer` recognizes a trailer that sits before a cert table.

## Local pre-flight (all green)

- `gofmt -l` — clean
- `go vet ./...` — clean
- `go test ./internal/setuppayload/ ./cmd/windows-avc-assembler/ ./cmd/defenseclaw-enterprise-setup/` — all green
- `bash -n packaging/scripts/build-managed-windows-bundle.sh` — passes
- `GOOS=windows GOARCH=amd64 go build ./cmd/defenseclaw-enterprise-setup` — cross-compile clean
- `.venv/bin/ruff check cli/defenseclaw/` — All checks passed!

## Test plan

- [ ] CI green on this PR
- [ ] Cut a fresh AVC kit against merged commit
- [ ] AVC re-runs the `/install --deferred-config` flow against the new kit
- [ ] Confirm the trailer is found and payload extraction completes on the signed Setup EXE

Reported by AVC packaging team, dry-run against the `03092026-fingerprint-mode-merged` kit (source `e69003ef4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)