### PR TITLE
docs(windows): record managed rotation adapter Phase 1 decision

### DIFF
--- a/cli/defenseclaw/rotate_token_guardian.py
+++ b/cli/defenseclaw/rotate_token_guardian.py
@@ -190,16 +190,19 @@ def is_managed_enterprise(cfg: Any) -> bool:
     return str(getattr(cfg, "deployment_mode", "") or "").strip().lower() == "managed_enterprise"
 
 
+WINDOWS_MANAGED_ROTATION_UNAVAILABLE = (
+    "Managed-enterprise token rotation on Windows requires the native "
+    "guardian adapter; the general Linux/macOS guardian cannot join."
+)
+
+
 def require_guardian_participant(cfg: Any) -> bool:
-    """Windows managed targets join only through the native adapter (#736)."""
+    """Join Linux/macOS guardians only. Windows waits for spec 007 / #736."""
 
     if not is_managed_enterprise(cfg):
         return False
     if os.name == "nt":
-        raise click.ClickException(
-            "Managed-enterprise token rotation on Windows requires the native "
-            "guardian adapter; the general Linux/macOS guardian cannot join."
-        )
+        raise click.ClickException(WINDOWS_MANAGED_ROTATION_UNAVAILABLE)
     return True
 
 

--- a/cli/tests/test_rotate_token_guardian.py
+++ b/cli/tests/test_rotate_token_guardian.py
@@ -14,6 +14,7 @@ import click
 from defenseclaw.rotate_token_guardian import (
     GUARDIAN_AUTH_DIR_ENV,
     GUARDIAN_MANIFEST_ENV,
+    WINDOWS_MANAGED_ROTATION_UNAVAILABLE,
     GuardianRotationPlan,
     GuardianRotationTarget,
     assert_current_attestations,
@@ -149,7 +150,9 @@ class RequireGuardianParticipantBehaviorTests(RequireGuardianParticipantTests):
         with mock.patch("defenseclaw.rotate_token_guardian.os.name", "nt"):
             with self.assertRaises(click.ClickException) as raised:
                 require_guardian_participant(SimpleNamespace(deployment_mode="managed_enterprise"))
-        self.assertIn("native guardian adapter", str(raised.exception))
+        self.assertEqual(str(raised.exception), WINDOWS_MANAGED_ROTATION_UNAVAILABLE)
+        self.assertNotIn("rotate-prepare", str(raised.exception))
+        self.assertNotIn("rotate-commit", str(raised.exception))
 
     @unittest.skipIf(os.name == "nt", "POSIX managed participant")
     def test_posix_managed_joins(self) -> None:

--- a/docs-site/content/docs/setup/enterprise-deployment.mdx
+++ b/docs-site/content/docs/setup/enterprise-deployment.mdx
@@ -1683,6 +1683,22 @@ Expected evidence:
 
 Treat this evidence as a release gate for the managed endpoint image. Run destructive tamper scenarios only in a dedicated validation environment with an independent administrator recovery channel.
 
+## Scoped token rotation platform boundary
+
+Linux and macOS managed-enterprise rotation coordinates the gateway service
+with the POSIX guardian participant. Windows does not join that protocol.
+
+On Windows `managed_enterprise`, `defenseclaw setup rotate-token` fail-closes
+before it stops the service or publishes replacement credentials. The shipped
+`DefenseClawHookGuardian` LocalSystem service continues to install and repair
+hooks; it is not a token-rotation participant until a native prepare, commit,
+and rollback adapter is certified. Unmanaged Windows rotation is unchanged.
+
+Do not route Windows through `enterprise hooks rotate-prepare`,
+`rotate-commit`, or `rotate-rollback`. That would claim Linux/macOS parity at
+a privileged credential boundary. See spec 007 for the approved topology,
+identity, DACL, and certification requirements.
+
 ## Production checklist
 
 - [ ] AI agent users are standard users without passwordless sudo/admin rights.

--- a/docs/specs/007-windows-managed-rotation-adapter/README.md
+++ b/docs/specs/007-windows-managed-rotation-adapter/README.md
@@ -1,0 +1,33 @@
+# Spec 007 — Windows managed token-rotation adapter
+
+Parent issues: #704, #736. Depends on the Linux/macOS participant and
+coordinator in #733–#735. This document records the required Phase 1 product
+decision. Phase 2 implementation must not start from a different topology.
+
+## Phase 1 decision (reviewable)
+
+Windows managed-enterprise scoped-token rotation is **unavailable** until a
+Windows-native participant exists. The Linux/macOS `enterprise hooks
+rotate-prepare|rotate-commit|rotate-rollback` journal protocol must not be
+used on Windows.
+
+| Question | Decision |
+| --- | --- |
+| Topology | Future work uses the already shipped `DefenseClawHookGuardian` LocalSystem service. Closed draft PR #658 is not a product contract and must not be treated as landed support. |
+| Coordinator | `defenseclaw setup rotate-token` fail-closes on Windows `managed_enterprise` before stopping service A or changing credentials. Unmanaged Windows rotation is unchanged. |
+| POSIX guardian | Forbidden as a Windows participant. Routing Windows through that protocol would claim false parity at a privileged credential boundary. |
+| Qualified connectors | Only families that already pass the native Windows managed-hook filter. Today that is the certified Claude/Codex managed set; Cursor machine-wide enterprise remains spec 006 and is not a rotation target. |
+| Service identity | Guardian mutations run as LocalSystem. Per-user footprint writes require the exact active non-elevated token for the manifest-pinned SID. Split-token administrators and standard users cannot mint, prepare, commit, or roll back rotation state. |
+| Path invariants | Windows-native fixed-volume, no-reparse, single-link, owner, and protected-DACL primitives. Do not emulate POSIX ownership checks. |
+| Offline / no session | Preflight fails closed when a required interactive session or impersonation token is missing. |
+| Prerequisite failure | Rotation remains unavailable. #704 stays open for Windows until Phase 2 plus certification land. |
+| Certification | Native Windows CI plus the approved disposable-host enterprise harness. Cross-compilation or Linux/macOS guardian tests are not Windows coverage. |
+
+## Phase 2 (not started)
+
+After this decision is approved, implement prepare/commit/rollback with the
+same generation-bound attestation contract as #733/#735, using Windows handles
+and DACLs rather than the POSIX journal. Public state may carry only opaque
+operation/generation IDs and non-secret fingerprints. Raw A/B credentials must
+never appear in argv, environment snapshots, PowerShell transcripts, SCM
+configuration, event logs, audit records, or test diagnostics.


### PR DESCRIPTION
Stacked on top of #838 (`fix/guardian-rotation-coordinator`). Review/merge that PR first; this PR's base is the stack parent, not `main`.

Records the required #736 Phase 1 product decision. Does not close #736; Phase 2 (native prepare/commit/rollback) remains on that issue.

## Problem

#736 forbids routing Windows managed-enterprise rotation through the Linux/macOS guardian without an explicit, reviewable topology decision. Shipping the coordinator without that decision would either claim false Windows parity or leave operators without a recorded product boundary.

## Current Situation

`setup rotate-token` already fail-closes on Windows `managed_enterprise` and refuses the POSIX `rotate-prepare|commit|rollback` journal. Closed draft PR #658 is not a merged contract. The shipped `DefenseClawHookGuardian` LocalSystem service installs and repairs hooks; it is not a rotation participant. #704 stays open for Windows until a certified native adapter lands.

## Solution

Record the Phase 1 decision in spec 007 and the enterprise deployment guide, and pin the existing fail-closed coordinator message as the approved contract.

- Future Windows rotation uses the shipped LocalSystem guardian topology, not the POSIX journal and not #658.
- Qualified connectors are only families that already pass the native Windows managed-hook filter.
- Per-user writes require the exact active non-elevated token for the manifest-pinned SID.
- Missing session, untrusted DACL, or reparse/hard-link conditions fail closed.
- Certification requires native Windows CI plus the disposable-host harness. Cross-compilation is not coverage.

## Architecture Diagram

```
Linux/macOS managed_enterprise
  setup rotate-token ──▶ POSIX guardian rotate-prepare/commit/rollback

Windows managed_enterprise (this PR)
  setup rotate-token ──▶ fail closed (spec 007)
  DefenseClawHookGuardian ──▶ hook install/repair only
       │
       └── Phase 2 (still #736): native rotate-prepare/commit/rollback
           with SID/DACL/no-reparse handles + current attestations
```

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `docs/specs/007-windows-managed-rotation-adapter/README.md` | Phase 1 topology, identity, connector, and certification decision |
| `docs-site/content/docs/setup/enterprise-deployment.mdx` | Operator-facing rotation platform boundary |
| `cli/defenseclaw/rotate_token_guardian.py` | Exported fail-closed message bound to spec 007 |
| `cli/tests/test_rotate_token_guardian.py` | Exact-message pin; no POSIX rotate-* leak |

## Breaking Changes

None. Windows managed rotation was already refused. This records why and how a later adapter may join.

## Open Issues / Follow-ups

- #736 — Phase 2 native Windows prepare/commit/rollback adapter and certification
- #704 — remains open until #736 Phase 2 lands
- #473 — remains open pending live `INCOMING REQUEST` + block evidence

## Test Plan

```
PYTHONPATH=cli python -m unittest \
  cli.tests.test_rotate_token_guardian.RequireGuardianParticipantBehaviorTests
```

Observed: 3 tests OK.