### PR TITLE
fix(actionfacts): bind plaintext HTTP-after-CONNECT metadata to its proxy

### DIFF
--- a/internal/actionfacts/curl_http_after_connect.go
+++ b/internal/actionfacts/curl_http_after_connect.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package actionfacts
+
+// staticCurlHTTPAfterCONNECTRequestComponents rebinds already-proved origin
+// HTTP path, query, ordinary headers, and origin authentication onto the
+// explicit HTTP(S) proxy that observes those bytes after CONNECT. HTTPS
+// origin request bytes stay excluded: they are encrypted inside the tunnel.
+func staticCurlHTTPAfterCONNECTRequestComponents(
+	command CommandFact,
+) []TransmittedRequestComponent {
+	proxy, parsed, ok := staticCurlProxyDestination(command)
+	if !ok || proxy.Scheme != "http" && proxy.Scheme != "https" ||
+		len(parsed.Targets) == 0 {
+		return nil
+	}
+	group := parsed.Targets[0].Group
+	if !curlProxyTunnelEnabled(parsed, group) ||
+		!staticCurlHostnameFirstWireSetupValid(command, parsed, group) {
+		return nil
+	}
+
+	var proxiedHTTP []NetworkFact
+	for _, target := range parsed.Targets {
+		if target.Group != group || !curlTargetUsesExplicitProxy(parsed, target) {
+			continue
+		}
+		targetFact, valid := webTargetFact(
+			command.ID, target.Value, NetworkDownload,
+		)
+		if valid && targetFact.Scheme == "http" {
+			proxiedHTTP = append(proxiedHTTP, targetFact)
+		}
+	}
+	if len(proxiedHTTP) == 0 {
+		return nil
+	}
+
+	origin := StaticCurlTransmittedMetadata(command)
+	component := func(value string) TransmittedRequestComponent {
+		return TransmittedRequestComponent{
+			Value: value, Scheme: proxy.Scheme,
+			Host: proxy.Host, Port: proxy.Port,
+		}
+	}
+	var components []TransmittedRequestComponent
+	appendComponent := func(value string) {
+		if value == "" {
+			return
+		}
+		candidate := component(value)
+		for _, existing := range components {
+			if existing == candidate {
+				return
+			}
+		}
+		components = append(components, candidate)
+	}
+	for _, value := range origin.Headers {
+		appendComponent(value)
+	}
+	for _, value := range origin.HTTPOriginCredentials {
+		appendComponent(value)
+	}
+	for _, value := range origin.HTTPBearerTokens {
+		appendComponent(value)
+	}
+	appendTargetBound := func(candidates []TransmittedRequestComponent) {
+		for _, candidate := range candidates {
+			for _, target := range proxiedHTTP {
+				if candidate.Scheme == target.Scheme &&
+					candidate.Host == target.Host && candidate.Port == target.Port {
+					appendComponent(candidate.Value)
+					break
+				}
+			}
+		}
+	}
+	appendTargetBound(origin.HTTPRequestComponents)
+	appendTargetBound(origin.HTTPOriginCredentialComponents)
+	return components
+}
+
+func appendUniqueTransmittedRequestComponents(
+	dst []TransmittedRequestComponent,
+	src []TransmittedRequestComponent,
+) []TransmittedRequestComponent {
+	for _, candidate := range src {
+		found := false
+		for _, existing := range dst {
+			if existing == candidate {
+				found = true
+				break
+			}
+		}
+		if !found {
+			dst = append(dst, candidate)
+		}
+	}
+	return dst
+}

--- a/internal/actionfacts/curl_http_after_connect.go
+++ b/internal/actionfacts/curl_http_after_connect.go
@@ -18,14 +18,22 @@ package actionfacts
 
 // staticCurlHTTPAfterCONNECTRequestComponents rebinds already-proved origin
 // HTTP path, query, ordinary headers, and origin authentication onto the
-// explicit HTTP(S) proxy that observes those bytes after CONNECT. HTTPS
-// origin request bytes stay excluded: they are encrypted inside the tunnel.
+// explicit HTTP proxy that observes those bytes after CONNECT. HTTPS origin
+// request bytes stay excluded: they are encrypted inside the tunnel. HTTPS
+// proxies are excluded: https-proxy is a separate libcurl capability, and
+// this lane has no executable capability fact.
 func staticCurlHTTPAfterCONNECTRequestComponents(
 	command CommandFact,
 ) []TransmittedRequestComponent {
 	proxy, parsed, ok := staticCurlProxyDestination(command)
+	if !ok {
+		proxy, parsed, ok = staticCurlHTTPProxyChainDestination(command)
+	}
 	if !ok || proxy.Scheme != "http" && proxy.Scheme != "https" ||
 		len(parsed.Targets) == 0 {
+		return nil
+	}
+	if proxy.Scheme == "https" {
 		return nil
 	}
 	group := parsed.Targets[0].Group

--- a/internal/actionfacts/curl_http_after_connect.go
+++ b/internal/actionfacts/curl_http_after_connect.go
@@ -102,22 +102,3 @@ func staticCurlHTTPAfterCONNECTRequestComponents(
 	appendTargetBound(origin.HTTPOriginCredentialComponents)
 	return components
 }
-
-func appendUniqueTransmittedRequestComponents(
-	dst []TransmittedRequestComponent,
-	src []TransmittedRequestComponent,
-) []TransmittedRequestComponent {
-	for _, candidate := range src {
-		found := false
-		for _, existing := range dst {
-			if existing == candidate {
-				found = true
-				break
-			}
-		}
-		if !found {
-			dst = append(dst, candidate)
-		}
-	}
-	return dst
-}

--- a/internal/actionfacts/curl_http_after_connect_test.go
+++ b/internal/actionfacts/curl_http_after_connect_test.go
@@ -36,16 +36,43 @@ func TestStaticCurlHTTPAfterCONNECTRequestComponents(t *testing.T) {
 			wantAuthoritative: true,
 		},
 		{
-			name: "HTTPS proxy observes tunneled HTTP header",
+			name: "HTTPS proxy does not project after-CONNECT without https-proxy",
 			argv: []string{
 				"curl", "-p", "--proxy", "https://proxy.example",
 				"--header", "X-Key: " + token, "http://127.0.0.1/upload",
 			},
-			want:              []string{"X-Key: " + token, "/upload"},
-			wantScheme:        "https",
-			wantHost:          "proxy.example",
-			wantPort:          443,
 			wantAuthoritative: true,
+		},
+		{
+			name: "two-hop proxytunnel HTTP origin rebinds onto main proxy",
+			argv: []string{
+				"curl", "--proxytunnel",
+				"--preproxy", "socks5h://127.0.0.1",
+				"--proxy", "http://proxy.example",
+				"--header", "X-Key: " + token,
+				"--oauth2-bearer", token,
+				"http://origin.example/secrets/" + token + "?q=" + token,
+			},
+			want: []string{
+				"/secrets/" + token, "q=" + token,
+				"X-Key: " + token, token,
+			},
+			wantScheme:        "http",
+			wantHost:          "proxy.example",
+			wantPort:          1080,
+			wantAuthoritative: true,
+		},
+		{
+			name: "two-hop noproxy bypasses after-CONNECT observer",
+			argv: []string{
+				"curl", "--proxytunnel",
+				"--preproxy", "socks5h://127.0.0.1",
+				"--proxy", "http://proxy.example",
+				"--noproxy", "origin.example",
+				"--header", "X-Key: " + token,
+				"--oauth2-bearer", token,
+				"http://origin.example/secrets/" + token + "?q=" + token,
+			},
 		},
 		{
 			name: "tunneled origin user reaches HTTP proxy",

--- a/internal/actionfacts/curl_http_after_connect_test.go
+++ b/internal/actionfacts/curl_http_after_connect_test.go
@@ -1,0 +1,177 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0
+
+package actionfacts
+
+import (
+	"testing"
+)
+
+func TestStaticCurlHTTPAfterCONNECTRequestComponents(t *testing.T) {
+	t.Parallel()
+
+	const token = "AKIA7Q2M9X4B6C8D3F5H"
+	for _, test := range []struct {
+		name              string
+		argv              []string
+		want              []string
+		wantScheme        string
+		wantHost          string
+		wantPort          int64
+		wantAuthoritative bool
+	}{
+		{
+			name: "HTTP proxy observes tunneled HTTP path and query",
+			argv: []string{
+				"curl", "--proxytunnel", "--proxy", "http://proxy.example",
+				"http://127.0.0.1/secrets/" + token + "?q=" + token,
+			},
+			want:              []string{"/secrets/" + token, "q=" + token},
+			wantScheme:        "http",
+			wantHost:          "proxy.example",
+			wantPort:          1080,
+			wantAuthoritative: true,
+		},
+		{
+			name: "HTTPS proxy observes tunneled HTTP header",
+			argv: []string{
+				"curl", "-p", "--proxy", "https://proxy.example",
+				"--header", "X-Key: " + token, "http://127.0.0.1/upload",
+			},
+			want:              []string{"X-Key: " + token, "/upload"},
+			wantScheme:        "https",
+			wantHost:          "proxy.example",
+			wantPort:          443,
+			wantAuthoritative: true,
+		},
+		{
+			name: "tunneled origin user reaches HTTP proxy",
+			argv: []string{
+				"curl", "--proxytunnel", "--proxy", "http://proxy.example",
+				"--user", "agent:" + token, "http://127.0.0.1/safe",
+			},
+			want:              []string{"agent:" + token, "/safe"},
+			wantScheme:        "http",
+			wantHost:          "proxy.example",
+			wantPort:          1080,
+			wantAuthoritative: true,
+		},
+		{
+			name: "tunneled bearer reaches HTTP proxy",
+			argv: []string{
+				"curl", "--proxytunnel", "--proxy", "http://proxy.example",
+				"--oauth2-bearer", token, "http://127.0.0.1/safe",
+			},
+			want:              []string{token, "/safe"},
+			wantScheme:        "http",
+			wantHost:          "proxy.example",
+			wantPort:          1080,
+			wantAuthoritative: true,
+		},
+		{
+			name: "custom Host remains visible after CONNECT",
+			argv: []string{
+				"curl", "--proxytunnel", "--proxy", "http://proxy.example",
+				"--header", "Host: " + token + ".example",
+				"http://127.0.0.1/safe",
+			},
+			want:              []string{"Host: " + token + ".example", "/safe"},
+			wantScheme:        "http",
+			wantHost:          "proxy.example",
+			wantPort:          1080,
+			wantAuthoritative: true,
+		},
+		{
+			name: "separate proxy-header does not hide ordinary tunneled header",
+			argv: []string{
+				"curl", "--proxytunnel", "--proxy", "http://proxy.example",
+				"--proxy-header", "X-Proxy: safe", "--header",
+				"X-Key: " + token, "http://127.0.0.1/upload",
+			},
+			want:              []string{"X-Key: " + token, "/upload"},
+			wantScheme:        "http",
+			wantHost:          "proxy.example",
+			wantPort:          1080,
+			wantAuthoritative: true,
+		},
+		{
+			name: "HTTPS origin request stays inside TLS after CONNECT",
+			argv: []string{
+				"curl", "--proxytunnel", "--proxy", "http://proxy.example",
+				"--header", "X-Key: " + token, "https://127.0.0.1/secrets",
+			},
+			wantAuthoritative: true,
+		},
+		{
+			name: "matching noproxy bypasses after-CONNECT observer",
+			argv: []string{
+				"curl", "--proxytunnel", "--proxy", "http://proxy.example",
+				"--noproxy", "127.0.0.1", "--header", "X-Key: " + token,
+				"http://127.0.0.1/upload",
+			},
+		},
+		{
+			name: "mixed later transfer group closes after-CONNECT observer",
+			argv: []string{
+				"curl", "--proxytunnel", "--proxy", "http://proxy.example",
+				"--header", "X-Key: " + token, "http://127.0.0.1/upload",
+				"--next", "https://two.example/",
+			},
+		},
+		{
+			name: "header file is a pre-connect failure",
+			argv: []string{
+				"curl", "--proxytunnel", "--proxy", "http://proxy.example",
+				"--header", "@/missing", "--user", "agent:" + token,
+				"http://127.0.0.1/safe",
+			},
+		},
+		{
+			name: "config remains opaque",
+			argv: []string{
+				"curl", "--config", "curlrc", "--proxytunnel",
+				"--proxy", "http://proxy.example", "--header",
+				"X-Key: " + token, "http://127.0.0.1/upload",
+			},
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			facts := Analyze(Input{Tool: "exec", Argv: test.argv})
+			if facts.Authoritative() != test.wantAuthoritative {
+				t.Fatalf("Authoritative() = %t, want %t status=%s issues=%v",
+					facts.Authoritative(), test.wantAuthoritative,
+					facts.Parse.Status, facts.Parse.Issues)
+			}
+			if len(facts.Commands) != 1 {
+				t.Fatalf("commands = %#v", facts.Commands)
+			}
+			got := staticCurlHTTPAfterCONNECTRequestComponents(facts.Commands[0])
+			if len(test.want) == 0 {
+				if len(got) != 0 {
+					t.Fatalf("after-CONNECT components = %#v, want none", got)
+				}
+				return
+			}
+			seen := map[string]bool{}
+			for _, component := range got {
+				if component.Scheme != test.wantScheme ||
+					component.Host != test.wantHost ||
+					component.Port != test.wantPort {
+					t.Fatalf("component = %#v, want %s %s:%d",
+						component, test.wantScheme, test.wantHost, test.wantPort)
+				}
+				seen[component.Value] = true
+			}
+			for _, value := range test.want {
+				if !seen[value] {
+					t.Fatalf("missing %q in %#v", value, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/actionfacts/curl_proxy_metadata_test.go
+++ b/internal/actionfacts/curl_proxy_metadata_test.go
@@ -205,10 +205,13 @@ func TestStaticCurlProxyTransmittedMetadata(t *testing.T) {
 			wantAuthoritative: true,
 		},
 		{
-			name: "proxy tunnel hides HTTP origin query", argv: []string{
+			name: "proxy tunnel exposes HTTP origin query after CONNECT", argv: []string{
 				"curl", "-p", "--proxy", "http://proxy.example",
 				"--url-query", "key=" + token, "http://127.0.0.1/",
 			},
+			want: components(
+				"http", "proxy.example", 1080, "/", "key="+token,
+			),
 			wantAuthoritative: true,
 		},
 		{
@@ -283,7 +286,9 @@ func TestStaticCurlProxyTransmittedMetadata(t *testing.T) {
 				"curl", "-p", "--proxy", "http://proxy.example", "--proxy-header",
 				"Host: " + token, "http://origin.example",
 			},
-			want:              components("http", "proxy.example", 1080, "Host: "+token),
+			want: components(
+				"http", "proxy.example", 1080, "Host: "+token, "/",
+			),
 			wantAuthoritative: true,
 		},
 		{

--- a/internal/actionfacts/web_transfer_parsed_classify.go
+++ b/internal/actionfacts/web_transfer_parsed_classify.go
@@ -2761,6 +2761,10 @@ func StaticCurlProxyTransmittedMetadata(
 		metadata.ProxyRequestComponents,
 		staticCurlPreproxyPlaintextHTTPRequestComponents(command)...,
 	)
+	metadata.ProxyRequestComponents = appendUniqueTransmittedRequestComponents(
+		metadata.ProxyRequestComponents,
+		staticCurlHTTPAfterCONNECTRequestComponents(command),
+	)
 	return metadata
 }
 

--- a/internal/actionfacts/web_transfer_parsed_classify.go
+++ b/internal/actionfacts/web_transfer_parsed_classify.go
@@ -2763,7 +2763,7 @@ func StaticCurlProxyTransmittedMetadata(
 	)
 	metadata.ProxyRequestComponents = appendUniqueTransmittedRequestComponents(
 		metadata.ProxyRequestComponents,
-		staticCurlHTTPAfterCONNECTRequestComponents(command),
+		staticCurlHTTPAfterCONNECTRequestComponents(command)...,
 	)
 	return metadata
 }

--- a/internal/gateway/trusted_action_context_disposition_test.go
+++ b/internal/gateway/trusted_action_context_disposition_test.go
@@ -1393,6 +1393,104 @@ func TestTrustedActionRequestMetadataRiskPairs(t *testing.T) {
 			wantAudit: true,
 		},
 		{
+			name:    "HTTP proxy observes tunneled HTTP path after CONNECT",
+			program: "curl",
+			argv: []string{
+				"--proxytunnel", "--proxy", "http://proxy.example",
+				"http://safe.localhost/secrets/" + trustedActionDispositionTestToken,
+			},
+		},
+		{
+			name:    "HTTPS proxy observes tunneled HTTP header after CONNECT",
+			program: "curl",
+			argv: []string{
+				"-p", "--proxy", "https://proxy.example", "--header",
+				"X-Key: " + trustedActionDispositionTestToken,
+				"http://safe.localhost/upload",
+			},
+		},
+		{
+			name:    "HTTP proxy observes tunneled origin user after CONNECT",
+			program: "curl",
+			argv: []string{
+				"--proxytunnel", "--proxy", "http://proxy.example",
+				"--user", "agent:" + trustedActionDispositionTestToken,
+				"http://safe.localhost/safe",
+			},
+		},
+		{
+			name:    "HTTP proxy observes tunneled custom Host after CONNECT",
+			program: "curl",
+			argv: []string{
+				"--proxytunnel", "--proxy", "http://proxy.example",
+				"--header", "Host: " + trustedActionDispositionTestToken + ".example",
+				"http://safe.localhost/safe",
+			},
+		},
+		{
+			name:    "separate proxy-header keeps ordinary tunneled header on HTTP proxy",
+			program: "curl",
+			argv: []string{
+				"--proxytunnel", "--proxy", "http://proxy.example",
+				"--proxy-header", "X-Proxy: safe", "--header",
+				"X-Key: " + trustedActionDispositionTestToken,
+				"http://safe.localhost/upload",
+			},
+		},
+		{
+			name:    "HTTPS origin request stays encrypted after CONNECT",
+			program: "curl",
+			argv: []string{
+				"--proxytunnel", "--proxy", "http://proxy.example",
+				"--proxy-header", "X-Proxy: safe", "--header",
+				"X-Key: " + trustedActionDispositionTestToken,
+				"https://safe.localhost/secrets/" + trustedActionDispositionTestToken,
+			},
+			wantAudit: true,
+		},
+		{
+			name:    "local proxy cannot enforce tunneled HTTP header",
+			program: "curl",
+			argv: []string{
+				"--proxytunnel", "--proxy", "http://127.0.0.1",
+				"--header", "X-Key: " + trustedActionDispositionTestToken,
+				"http://safe.localhost/upload",
+			},
+			wantAudit: true,
+		},
+		{
+			name:    "matching noproxy bypasses after-CONNECT observer",
+			program: "curl",
+			argv: []string{
+				"--proxytunnel", "--proxy", "http://proxy.example",
+				"--noproxy", "safe.localhost", "--header",
+				"X-Key: " + trustedActionDispositionTestToken,
+				"http://safe.localhost/upload",
+			},
+			wantAudit: true,
+		},
+		{
+			name:    "mixed later transfer group closes after-CONNECT observer",
+			program: "curl",
+			argv: []string{
+				"--proxytunnel", "--proxy", "http://proxy.example",
+				"--header", "X-Key: " + trustedActionDispositionTestToken,
+				"http://safe.localhost/upload", "--next", "https://two.example/",
+			},
+			wantAudit: true,
+		},
+		{
+			name:    "header file preempts after-CONNECT observer",
+			program: "curl",
+			argv: []string{
+				"--proxytunnel", "--proxy", "http://proxy.example",
+				"--header", "@/missing", "--user",
+				"agent:" + trustedActionDispositionTestToken,
+				"http://safe.localhost/safe",
+			},
+			wantAudit: true,
+		},
+		{
 			name: "external Wget HTTPS destination hostname", program: "wget",
 			argv: []string{
 				"--no-config",


### PR DESCRIPTION
Stacked on top of #843 (`fix/curl-http-proxy-chain`). Review/merge that PR first; this PR's base is the stack parent, not `main`.

Fixes #774.

## Problem

For an explicit HTTP(S) proxy with curl `--proxytunnel` and a plaintext `http://` origin, the proxy receives CONNECT and then observes the plaintext HTTP request inside that tunnel. CONNECT hostname and inline bodies were already proxy-bound, but path, query, ordinary headers, and origin authentication stayed on the origin fact. A local origin through an external proxy therefore left those exact proxy-observed values detection-only.

## Current Situation

PR #755 binds CONNECT hostnames and inline proxy bodies. `staticCurlHTTPProxyTransmittedMetadata` returns early on `--proxytunnel` before path/query/auth are copied. Ordinary `--header` values are also omitted from the proxy when a separate `--proxy-header` list is present, even though those headers still travel in plaintext after CONNECT.

## Solution

Rebind already-proved origin HTTP path, query, ordinary headers, and origin authentication onto the exact HTTP(S) proxy used by that `--proxytunnel` target.

- Applies only to plaintext `http://` traffic after CONNECT.
- HTTPS origin request bytes stay excluded.
- `--proxy-header` versus ordinary-header ownership is preserved; CONNECT-phase headers are not duplicated.
- Matching `--noproxy`, mixed `--next` groups, local proxies, header-file setup failures, and config/env-derived routes stay detection-only.

```
curl -p --proxy http://proxy.example --header "X-Key: SECRET" http://127.0.0.1/path
        │
        ├─ origin NetworkDownload 127.0.0.1 (loopback)
        └─ proxy NetworkConnect proxy.example
             path/header/auth bind here → action-mode block
```

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `internal/actionfacts/curl_http_after_connect.go` | After-CONNECT projector and unique component merge |
| `internal/actionfacts/curl_http_after_connect_test.go` | HTTP/HTTPS proxy, path/query/header/auth, Host, noproxy, mixed-group |
| `internal/actionfacts/web_transfer_parsed_classify.go` | Append after-CONNECT components to proxy metadata |
| `internal/actionfacts/curl_proxy_metadata_test.go` | Tunneled query and CONNECT Host now include after-CONNECT path |
| `internal/gateway/trusted_action_context_disposition_test.go` | Same-rule enforce/audit pairs for the proxy observer |

## Breaking Changes

Authoritative action-mode now blocks `--proxytunnel` HTTP origins that send proved secrets through an external proxy after CONNECT. Previously those commands were detection-only when the origin itself was local.

## Open Issues / Follow-ups

- #770 - curl executable capability facts for HTTPS-proxy hostname and build-gated flags

## Test Plan

```
go test ./internal/actionfacts/ -count=1 -timeout 180s \
  -run 'TestStaticCurlHTTPAfterCONNECT|TestStaticCurlProxyTransmittedMetadata$'
```

Observed: `ok`

```
go test ./internal/gateway/ -count=1 -timeout 180s \
  -run 'TestTrustedActionRequestMetadataRiskPairs|TestTrustedActionCurlProxyMetadataEgress'
```

Observed: `ok`