### PR TITLE
fix(doctor): bind credential probes and lifecycle exec to inspected objects

### DIFF
--- a/cli/defenseclaw/commands/cmd_doctor.py
+++ b/cli/defenseclaw/commands/cmd_doctor.py
@@ -85,6 +85,7 @@ from defenseclaw.doctor_engine import (
     legacy_outcome_state,
     stable_doctor_id,
 )
+from defenseclaw.doctor_exec import ExecBindError, bind_trusted_executable, revalidate_bound_executable
 from defenseclaw.doctor_gateway import (
     GATEWAY_PROCESS_NAMES,
     GatewayEvidence,
@@ -100,7 +101,6 @@ from defenseclaw.doctor_gateway import (
     pid_file_fingerprint_from_fd,
     read_pid_record,
 )
-from defenseclaw.doctor_exec import ExecBindError, bind_trusted_executable, revalidate_bound_executable
 from defenseclaw.doctor_hooks import (
     WindowsHookCheck,
     _packaged_windows_install_root,

--- a/cli/defenseclaw/commands/cmd_doctor.py
+++ b/cli/defenseclaw/commands/cmd_doctor.py
@@ -3638,7 +3638,6 @@ def _check_codex_otel_alignment(cfg, r: _DoctorResult) -> None:
         cfg,
         token,
         trust,
-        url=f"http://127.0.0.1:{api_port}/status",
     )
     if code != 200:
         detail = "gateway is unreachable" if code == 0 else f"authenticated status returned HTTP {code}"

--- a/cli/defenseclaw/commands/cmd_doctor.py
+++ b/cli/defenseclaw/commands/cmd_doctor.py
@@ -100,11 +100,18 @@ from defenseclaw.doctor_gateway import (
     pid_file_fingerprint_from_fd,
     read_pid_record,
 )
+from defenseclaw.doctor_exec import ExecBindError, bind_trusted_executable, revalidate_bound_executable
 from defenseclaw.doctor_hooks import (
     WindowsHookCheck,
     _packaged_windows_install_root,
     validate_windows_copilot_hook_registration,
     validate_windows_hook_registration,
+)
+from defenseclaw.doctor_peer import (
+    PeerBindError,
+    TrustedPeer,
+    loopback_bearer_requires_peer,
+    peer_bound_handlers,
 )
 from defenseclaw.envvars import active_security_overrides
 from defenseclaw.file_lock import FileLockTimeoutError, locked_file_update
@@ -702,6 +709,9 @@ def _http_probe(
     response_limit: int = _HTTP_PROBE_DISPLAY_BYTES,
     allow_truncation: bool = True,
     bypass_proxy: bool = False,
+    trusted_peer: TrustedPeer | None = None,
+    peer_lookup=None,
+    process_lookup=None,
 ) -> tuple[int, str]:
     """Run one HTTP probe with a portable total wall-clock deadline.
 
@@ -728,7 +738,12 @@ def _http_probe(
                 response_limit=response_limit,
                 allow_truncation=allow_truncation,
                 bypass_proxy=bypass_proxy,
+                trusted_peer=trusted_peer,
+                peer_lookup=peer_lookup,
+                process_lookup=process_lookup,
             )
+        except PeerBindError as exc:
+            value = (0, str(exc))
         except Exception as exc:  # noqa: BLE001 - redact arbitrary transport detail.
             value = (0, f"{type(exc).__name__}: probe failed")
         try:
@@ -758,6 +773,9 @@ def _http_probe_once(
     response_limit: int = _HTTP_PROBE_DISPLAY_BYTES,
     allow_truncation: bool = True,
     bypass_proxy: bool = False,
+    trusted_peer: TrustedPeer | None = None,
+    peer_lookup=None,
+    process_lookup=None,
 ) -> tuple[int, str]:
     """Fire an HTTP request; return (status_code, body_text). Returns (0, error) on failure.
 
@@ -773,6 +791,11 @@ def _http_probe_once(
     prevents local gateway bearer tokens from being forwarded to a proxy and
     prevents a proxy response from impersonating local gateway health.
 
+    Loopback ``Authorization: Bearer`` probes require ``trusted_peer``. The
+    TCP peer is bound after connect and before request bytes, so a replacement
+    listener cannot receive the gateway token. Missing peer identity fails
+    closed without sending credentials.
+
     ``response_limit`` is a byte bound, not just a post-read display slice.
     The default retains the compact diagnostic-body behavior. Structured
     callers such as the sidecar health check opt into a larger bounded document
@@ -781,6 +804,8 @@ def _http_probe_once(
     """
     if response_limit <= 0:
         raise ValueError("response_limit must be positive")
+    if loopback_bearer_requires_peer(url, headers) and trusted_peer is None:
+        return 0, "refusing to send gateway credentials before peer bind"
 
     def _read_response(stream) -> str:
         raw = stream.read(response_limit + 1)
@@ -807,11 +832,23 @@ def _http_probe_once(
     handlers: list[urllib.request.BaseHandler] = []
     if bypass_proxy or loopback_host:
         handlers.append(urllib.request.ProxyHandler({}))
-    handlers.append(urllib.request.HTTPSHandler(context=context))
+    if trusted_peer is not None:
+        handlers.extend(
+            peer_bound_handlers(
+                trusted_peer,
+                peer_lookup=peer_lookup,
+                process_lookup=process_lookup,
+                ssl_context=context,
+            )
+        )
+    else:
+        handlers.append(urllib.request.HTTPSHandler(context=context))
     opener = build_no_redirect_opener(*handlers)
     try:
         with opener.open(req, timeout=timeout) as resp:
             return resp.status, _read_response(resp)
+    except PeerBindError as exc:
+        return 0, str(exc)
     except urllib.error.HTTPError as exc:
         body_text = ""
         try:
@@ -824,7 +861,28 @@ def _http_probe_once(
         # instead of leaking the auth header to the redirect target.
         return 0, str(exc)
     except (urllib.error.URLError, OSError, ValueError) as exc:
+        if isinstance(getattr(exc, "reason", None), PeerBindError):
+            return 0, str(exc.reason)
         return 0, str(exc)
+
+
+def _probe_authenticated_gateway_status(
+    cfg,
+    token: str,
+    trust: _GatewayTrust,
+    *,
+    url: str | None = None,
+) -> tuple[int, str]:
+    """Send a loopback bearer status probe only after the TCP peer is bound."""
+    return _http_probe(
+        url or _gateway_api_url(cfg, "/status"),
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=3.0,
+        response_limit=64 * 1024,
+        allow_truncation=False,
+        bypass_proxy=True,
+        trusted_peer=trust.peer(),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1821,14 +1879,7 @@ def _check_gateway_auth(cfg, r: _DoctorResult) -> bool:
         )
         return False
 
-    code, body = _http_probe(
-        _gateway_api_url(cfg, "/status"),
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=3.0,
-        response_limit=64 * 1024,
-        allow_truncation=False,
-        bypass_proxy=True,
-    )
+    code, body = _probe_authenticated_gateway_status(cfg, token, trust)
     if code == 200:
         runtime_ok, runtime_detail = _authenticated_runtime_matches(cfg, trust.pid, body)
         if not runtime_ok:
@@ -2071,6 +2122,22 @@ class _GatewayTrust:
     @property
     def trusted(self) -> bool:
         return self.code == "trusted" and self.pid > 0
+
+    def peer(self) -> TrustedPeer | None:
+        """Return the kernel generation that must own a credential-bearing socket."""
+        if not self.trusted:
+            return None
+        identity = ""
+        if self.process is not None:
+            identity = (self.process.start_identity or "").strip()
+        if not identity and self.record is not None:
+            identity = (self.record.start_identity or "").strip()
+        if not identity:
+            return None
+        try:
+            return TrustedPeer(pid=self.pid, start_identity=identity)
+        except PeerBindError:
+            return None
 
 
 @dataclass(frozen=True)
@@ -2352,14 +2419,7 @@ def _authenticated_origin_main_gateway_lifecycle_trust(
             record=record,
             process=process,
         )
-    code, body = _http_probe(
-        _gateway_api_url(cfg, "/status"),
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=3.0,
-        response_limit=64 * 1024,
-        allow_truncation=False,
-        bypass_proxy=True,
-    )
+    code, body = _probe_authenticated_gateway_status(cfg, token, strong_identity)
     if code != 200:
         detail = "transport failure" if code == 0 else f"HTTP {code}"
         return _GatewayTrust(
@@ -2677,14 +2737,7 @@ def _check_windows_gateway_diagnostics(
     elif not trust.trusted:
         status_error = f"{trust.detail}; refusing to send the gateway token"
     else:
-        status_code, status_body = _http_probe(
-            _gateway_api_url(cfg, "/status"),
-            headers={"Authorization": f"Bearer {token}"},
-            timeout=3.0,
-            response_limit=64 * 1024,
-            allow_truncation=False,
-            bypass_proxy=True,
-        )
+        status_code, status_body = _probe_authenticated_gateway_status(cfg, token, trust)
         status_error = ""
 
     runtime: dict = {}
@@ -3574,12 +3627,20 @@ def _check_codex_otel_alignment(cfg, r: _DoctorResult) -> None:
         )
         return
 
-    code, body = _http_probe(
-        f"http://127.0.0.1:{api_port}/status",
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=3.0,
-        response_limit=64 * 1024,
-        allow_truncation=False,
+    trust = _trusted_gateway_listener(cfg)
+    if not trust.trusted:
+        _emit(
+            "skip",
+            "Codex OTel runtime",
+            f"authenticated runtime telemetry status is unavailable ({trust.detail})",
+            r=r,
+        )
+        return
+    code, body = _probe_authenticated_gateway_status(
+        cfg,
+        token,
+        trust,
+        url=f"http://127.0.0.1:{api_port}/status",
     )
     if code != 200:
         detail = "gateway is unreachable" if code == 0 else f"authenticated status returned HTTP {code}"
@@ -3866,14 +3927,7 @@ def _opencode_load_heartbeat_status(cfg) -> tuple[str, str]:
     if not trust.trusted:
         return "warn", f"runtime load unverified: {trust.detail}"
 
-    code, body = _http_probe(
-        _gateway_api_url(cfg, "/status"),
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=3.0,
-        response_limit=64 * 1024,
-        allow_truncation=False,
-        bypass_proxy=True,
-    )
+    code, body = _probe_authenticated_gateway_status(cfg, token, trust)
     if code != 200:
         detail = "gateway is unreachable" if code == 0 else f"authenticated status returned HTTP {code}"
         return "warn", f"runtime load unverified: {detail}"
@@ -3987,6 +4041,7 @@ def _run_cursor_windows_runtime_process(
     *,
     env: dict[str, str],
     timeout: float,
+    bound=None,
 ) -> subprocess.CompletedProcess:
     """Run one Cursor transport probe with bounded descendant ownership.
 
@@ -3999,6 +4054,12 @@ def _run_cursor_windows_runtime_process(
     """
 
     creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    spawn_kwargs: dict = {}
+    if bound is not None:
+        revalidate_bound_executable(bound)
+        if sys.platform.startswith("linux"):
+            spawn_kwargs["executable"] = f"/proc/self/fd/{bound.fd}"
+            spawn_kwargs["pass_fds"] = (bound.fd,)
     if os.name != "nt":
         return subprocess.run(
             argv,
@@ -4009,6 +4070,7 @@ def _run_cursor_windows_runtime_process(
             timeout=timeout,
             check=False,
             creationflags=creationflags,
+            **spawn_kwargs,
         )
 
     from defenseclaw.tui.windows_process import WindowsJob
@@ -4022,6 +4084,7 @@ def _run_cursor_windows_runtime_process(
         stdin=subprocess.DEVNULL,
         env=env,
         creationflags=creationflags,
+        **spawn_kwargs,
     )
     job = None
     try:
@@ -4168,6 +4231,15 @@ def _probe_cursor_windows_runtime(cfg, adapter_path: str) -> tuple[bool, str]:
             "-EncodedCommand",
             encoded,
         ]
+        try:
+            bound_powershell = bind_trusted_executable(powershell)
+        except ExecBindError:
+            return False, "the system PowerShell executable identity could not be bound"
+        try:
+            bound_adapter = bind_trusted_executable(adapter_path)
+        except ExecBindError:
+            bound_powershell.close()
+            return False, "the Cursor adapter executable identity could not be bound"
         # The registered Cursor command contract permits 30 seconds. Doctor
         # allows the adapter's bounded five-second child-drain interval plus
         # Windows PowerShell host startup and cold Add-Type compilation on top
@@ -4175,30 +4247,37 @@ def _probe_cursor_windows_runtime(cfg, adapter_path: str) -> tuple[bool, str]:
         # extended. A contained timeout may be retried once, but the first
         # process tree is fully reaped and live sidecar state is read again
         # before a second native event is allowed to start.
-        for attempt in range(_CURSOR_WINDOWS_RUNTIME_PROBE_ATTEMPTS):
-            before_code, before_body = _http_probe(
-                health_url,
-                timeout=3.0,
-                response_limit=_HEALTH_DOCUMENT_MAX_BYTES,
-                allow_truncation=False,
-                bypass_proxy=True,
-            )
-            before = _cursor_health_row(before_body) if before_code == 200 else None
-            if before is None:
-                return False, "sidecar /health has no live Cursor connector row"
-            try:
-                proc = _run_cursor_windows_runtime_process(
-                    argv,
-                    env=child_env,
-                    timeout=_CURSOR_WINDOWS_RUNTIME_PROBE_TIMEOUT_SECONDS,
+        try:
+            for attempt in range(_CURSOR_WINDOWS_RUNTIME_PROBE_ATTEMPTS):
+                before_code, before_body = _http_probe(
+                    health_url,
+                    timeout=3.0,
+                    response_limit=_HEALTH_DOCUMENT_MAX_BYTES,
+                    allow_truncation=False,
+                    bypass_proxy=True,
                 )
-            except subprocess.TimeoutExpired:
-                if attempt + 1 < _CURSOR_WINDOWS_RUNTIME_PROBE_ATTEMPTS:
-                    continue
-                return False, "Cursor runtime probe timed out"
-            break
+                before = _cursor_health_row(before_body) if before_code == 200 else None
+                if before is None:
+                    return False, "sidecar /health has no live Cursor connector row"
+                try:
+                    proc = _run_cursor_windows_runtime_process(
+                        argv,
+                        env=child_env,
+                        timeout=_CURSOR_WINDOWS_RUNTIME_PROBE_TIMEOUT_SECONDS,
+                        bound=bound_powershell,
+                    )
+                except subprocess.TimeoutExpired:
+                    if attempt + 1 < _CURSOR_WINDOWS_RUNTIME_PROBE_ATTEMPTS:
+                        continue
+                    return False, "Cursor runtime probe timed out"
+                break
+        finally:
+            bound_adapter.close()
+            bound_powershell.close()
     except FileNotFoundError:
         return False, "powershell.exe is unavailable for the Cursor runtime probe"
+    except ExecBindError:
+        return False, "the Cursor runtime probe executable identity could not be bound"
     except OSError as exc:
         return False, f"Cursor runtime probe could not start: {exc}"
     finally:
@@ -10621,14 +10700,7 @@ def _fix_gateway_token_drift(
             f"{trust.detail}; refusing to send the configured token",
         )
     if trust.trusted:
-        code, body = _http_probe(
-            _gateway_api_url(cfg, "/status"),
-            headers={"Authorization": f"Bearer {probe_token}"},
-            timeout=3.0,
-            response_limit=64 * 1024,
-            allow_truncation=False,
-            bypass_proxy=True,
-        )
+        code, body = _probe_authenticated_gateway_status(cfg, probe_token, trust)
         if code == 200:
             runtime_ok, runtime_detail = _authenticated_runtime_matches(cfg, trust.pid, body)
             if runtime_ok:
@@ -10699,14 +10771,7 @@ def _fix_gateway_token_drift(
             "gateway restarted but replacement endpoint ownership/authentication "
             f"could not be verified ({replacement_trust.detail})",
         )
-    code, body = _http_probe(
-        _gateway_api_url(cfg, "/status"),
-        headers={"Authorization": f"Bearer {replacement_token}"},
-        timeout=3.0,
-        response_limit=64 * 1024,
-        allow_truncation=False,
-        bypass_proxy=True,
-    )
+    code, body = _probe_authenticated_gateway_status(cfg, replacement_token, replacement_trust)
     if code != 200:
         return ("fail", f"gateway restarted but still rejects configured authentication (HTTP {code})")
     runtime_ok, runtime_detail = _authenticated_runtime_matches(

--- a/cli/defenseclaw/commands/cmd_doctor.py
+++ b/cli/defenseclaw/commands/cmd_doctor.py
@@ -112,6 +112,7 @@ from defenseclaw.doctor_peer import (
     TrustedPeer,
     loopback_bearer_requires_peer,
     peer_bound_handlers,
+    trusted_lsof_path,
 )
 from defenseclaw.envvars import active_security_overrides
 from defenseclaw.file_lock import FileLockTimeoutError, locked_file_update
@@ -3128,10 +3129,7 @@ def _gateway_listener_pid(port: int, *, host: str = "") -> int:
 
 def _trusted_lsof_path() -> str:
     """Return a fixed system lsof path, never a PATH-resolved executable."""
-    for candidate in ("/usr/sbin/lsof", "/usr/bin/lsof"):
-        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-            return candidate
-    return ""
+    return trusted_lsof_path()
 
 
 def _lsof_listener_address_matches(endpoint: str, host: str, port: int) -> bool:

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -94,6 +94,7 @@ from defenseclaw.connector_contracts import (
     resolve_connector_contract,
 )
 from defenseclaw.context import SETUP_RESTART_HANDLED_META_KEY, AppContext, pass_ctx
+from defenseclaw.doctor_exec import ExecBindError, bind_trusted_executable, run_bound_executable
 from defenseclaw.file_permissions import (
     MAX_DOTENV_BYTES,
     atomic_write_private_bytes,
@@ -13652,15 +13653,20 @@ def _restart_defense_gateway(
         click.echo(" ✗ (binary is not a verified executable file)")
         return False
     executable = str(Path(executable).resolve())
-    cmd = [executable, "restart"] if was_running else [executable, "start"]
+    try:
+        bound = bind_trusted_executable(executable, verify_custody=False)
+    except ExecBindError:
+        click.echo(" ✗ (binary identity could not be bound)")
+        return False
+    action = "restart" if was_running else "start"
     generation_before = previous_generation or _gateway_runtime_generation_before_restart(data_dir)
     try:
-        result = subprocess.run(
-            cmd,
+        result = run_bound_executable(
+            bound,
+            [action],
+            runner=subprocess.run,
             capture_output=True,
             text=True,
-            shell=False,
-            stdin=subprocess.DEVNULL,
             env=child_env,
             timeout=30,
         )
@@ -13680,6 +13686,9 @@ def _restart_defense_gateway(
             for line in err.splitlines()[:3]:
                 click.echo(f"    {line}")
         return False
+    except ExecBindError:
+        click.echo(" ✗ (binary identity could not be bound)")
+        return False
     except FileNotFoundError:
         click.echo(" ✗ (binary not found)")
         click.echo("    Build with: make gateway")
@@ -13695,7 +13704,7 @@ def _restart_defense_gateway(
         # child cannot outlive the failed setup command.  On restart, preserve
         # the pre-existing generation rather than stopping an otherwise healthy
         # service whose replacement outcome is uncertain.
-        status = _gateway_lifecycle_status(executable, child_env=child_env)
+        status = _gateway_lifecycle_status(executable, child_env=child_env, bound=bound)
         if status and _wait_for_defense_gateway_api(
             data_dir,
             previous_generation=generation_before,
@@ -13703,9 +13712,11 @@ def _restart_defense_gateway(
             click.echo(" ✓ (ready after launcher timeout)")
             return True
         if not was_running:
-            _cleanup_timed_out_gateway_start(executable, child_env=child_env)
+            _cleanup_timed_out_gateway_start(executable, child_env=child_env, bound=bound)
         click.echo(" ✗ (timed out; final status is not healthy)")
         return False
+    finally:
+        bound.close()
 
 
 def _wait_for_defense_gateway_api(
@@ -13934,18 +13945,32 @@ def _gateway_lifecycle_status(
     executable: str,
     *,
     child_env: dict[str, str] | None = None,
+    bound=None,
 ) -> bool:
     try:
-        result = subprocess.run(
-            [executable, "status"],
-            capture_output=True,
-            text=True,
-            shell=False,
-            stdin=subprocess.DEVNULL,
-            env=child_env,
-            timeout=_DEFENSE_GATEWAY_STATUS_TIMEOUT_SECONDS,
-        )
+        if bound is not None:
+            result = run_bound_executable(
+                bound,
+                ["status"],
+                runner=subprocess.run,
+                capture_output=True,
+                text=True,
+                env=child_env,
+                timeout=_DEFENSE_GATEWAY_STATUS_TIMEOUT_SECONDS,
+            )
+        else:
+            result = subprocess.run(
+                [executable, "status"],
+                capture_output=True,
+                text=True,
+                shell=False,
+                stdin=subprocess.DEVNULL,
+                env=child_env,
+                timeout=_DEFENSE_GATEWAY_STATUS_TIMEOUT_SECONDS,
+            )
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+    except ExecBindError:
         return False
     return result.returncode == 0
 
@@ -13954,17 +13979,29 @@ def _cleanup_timed_out_gateway_start(
     executable: str,
     *,
     child_env: dict[str, str] | None = None,
+    bound=None,
 ) -> None:
     try:
-        subprocess.run(
-            [executable, "stop"],
-            capture_output=True,
-            text=True,
-            shell=False,
-            stdin=subprocess.DEVNULL,
-            env=child_env,
-            timeout=_DEFENSE_GATEWAY_STOP_TIMEOUT_SECONDS,
-        )
+        if bound is not None:
+            run_bound_executable(
+                bound,
+                ["stop"],
+                runner=subprocess.run,
+                capture_output=True,
+                text=True,
+                env=child_env,
+                timeout=_DEFENSE_GATEWAY_STOP_TIMEOUT_SECONDS,
+            )
+        else:
+            subprocess.run(
+                [executable, "stop"],
+                capture_output=True,
+                text=True,
+                shell=False,
+                stdin=subprocess.DEVNULL,
+                env=child_env,
+                timeout=_DEFENSE_GATEWAY_STOP_TIMEOUT_SECONDS,
+            )
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         # The caller already reports failure. The gateway's native PID and
         # identity checks prevent this best-effort cleanup targeting another

--- a/cli/defenseclaw/doctor_exec.py
+++ b/cli/defenseclaw/doctor_exec.py
@@ -25,8 +25,9 @@ POSIX (Linux/macOS)
   must not grant write. The path must be a regular file (no symlink). After
   that pathname custody check, Doctor opens the file with ``O_RDONLY`` /
   ``O_NOFOLLOW`` and executes the held inode through ``/proc/self/fd/<n>``
-  (Linux) or ``/dev/fd/<n>`` (macOS). A replacement at the original path
-  cannot change the object that is spawned.
+  (Linux). Darwin ``/dev/fd/<n>`` is not executable, so macOS re-validates
+  the held inode against the pathname (``os.path.samestat``) and fail-closes
+  on swap, then execs by path. Do not switch Darwin to ``/dev/fd`` exec.
 
 Windows
   Packaged installs must resolve to the sibling gateway under the install
@@ -167,6 +168,8 @@ def run_bound_executable(
         executable = _posix_held_executable_path(bound.fd)
         extra = {"pass_fds": tuple(set(kwargs.pop("pass_fds", ())) | {bound.fd})}
     else:
+        # Darwin /dev/fd/N is not executable. Revalidate already fail-closed
+        # if the pathname no longer names the held inode; exec that path.
         executable = bound.path
         extra = {}
     argv = [bound.path, *list(args)]

--- a/cli/defenseclaw/doctor_exec.py
+++ b/cli/defenseclaw/doctor_exec.py
@@ -1,0 +1,391 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bind Doctor/setup lifecycle execution to the inspected executable object.
+
+Supported installation custody model
+------------------------------------
+
+POSIX (Linux/macOS)
+  The executable and every ancestor directory must be owned by root or the
+  current user and must not be group/world writable. Darwin extended ACLs
+  must not grant write. The path must be a regular file (no symlink). After
+  that pathname custody check, Doctor opens the file with ``O_RDONLY`` /
+  ``O_NOFOLLOW`` and executes the held inode through ``/proc/self/fd/<n>``
+  (Linux) or ``/dev/fd/<n>`` (macOS). A replacement at the original path
+  cannot change the object that is spawned.
+
+Windows
+  Packaged installs must resolve to the sibling gateway under the install
+  root. Non-packaged paths must pass the existing integrity ACL write check
+  and must not be a reparse point. Doctor then opens the file with
+  ``GENERIC_READ | GENERIC_EXECUTE``, ``FILE_SHARE_READ`` only (no write or
+  delete sharing), and records the volume serial plus file index from that
+  handle. Spawn refuses if the path's object identity has changed. Holding
+  the handle without delete/write sharing prevents the inspected file from
+  being replaced for the duration of the lifecycle call.
+
+Failure is closed whenever the held identity cannot be established or no
+longer matches. Callers keep explicit argv, ``shell=False``, and a bounded
+environment; this module only changes *which object* those argv bytes exec.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from defenseclaw.file_permissions import (
+    UnsafePathError,
+    open_regular_file_no_follow,
+    trusted_posix_executable_path,
+)
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+class ExecBindError(Exception):
+    """Refuse to spawn an executable whose object identity is not bound."""
+
+
+@dataclass(frozen=True)
+class ExecutableIdentity:
+    """Stable identity of one opened executable object."""
+
+    device: int
+    inode: int
+    size: int
+    windows_volume: int = 0
+    windows_index: int = 0
+
+
+class BoundExecutable:
+    """An executable inode/handle held across check-to-exec."""
+
+    def __init__(self, path: str, fd: int, identity: ExecutableIdentity) -> None:
+        self.path = path
+        self._fd = fd
+        self.identity = identity
+
+    @property
+    def fd(self) -> int:
+        if self._fd < 0:
+            raise ExecBindError("bound executable handle is already closed")
+        return self._fd
+
+    def close(self) -> None:
+        fd = self._fd
+        self._fd = -1
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+    def __enter__(self) -> BoundExecutable:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+
+def bind_trusted_executable(path: str, *, verify_custody: bool = True) -> BoundExecutable:
+    """Open the custody-checked executable and hold that exact object.
+
+    ``verify_custody=False`` is for callers that just completed a pathname
+    custody check and only need the check-to-exec handle. The opened inode is
+    still identity-pinned; ancestor ACL walks are not repeated.
+    """
+    if not path or not os.path.isabs(path):
+        raise ExecBindError("lifecycle executable path is not absolute")
+    verified = _verify_pathname_custody(path) if verify_custody else os.path.abspath(path)
+    try:
+        fd = _open_executable_object(verified)
+    except (OSError, UnsafePathError) as exc:
+        raise ExecBindError("lifecycle executable object could not be opened") from exc
+    try:
+        identity = executable_identity(fd)
+        _verify_opened_identity(verified, fd, identity)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        raise
+    return BoundExecutable(verified, fd, identity)
+
+
+def revalidate_bound_executable(bound: BoundExecutable) -> None:
+    """Fail closed if the held object is gone or no longer named by its path."""
+    current = executable_identity(bound.fd)
+    if current != bound.identity:
+        raise ExecBindError("held executable object changed before spawn")
+    if os.name == "nt":
+        _assert_windows_path_still_bound(bound)
+    elif not sys.platform.startswith("linux"):
+        _assert_posix_path_still_bound(bound)
+
+
+def run_bound_executable(
+    bound: BoundExecutable,
+    args: Sequence[str],
+    *,
+    runner: Runner = subprocess.run,
+    capture_output: bool = True,
+    text: bool = True,
+    env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
+    stdin=subprocess.DEVNULL,
+    **kwargs: Any,
+) -> subprocess.CompletedProcess:
+    """Spawn ``args`` from the held executable object, not a later pathname."""
+    if not args:
+        raise ExecBindError("lifecycle argv is empty")
+    revalidate_bound_executable(bound)
+    if os.name == "nt":
+        executable = bound.path
+        extra: dict[str, Any] = {}
+    elif sys.platform.startswith("linux"):
+        executable = _posix_held_executable_path(bound.fd)
+        extra = {"pass_fds": tuple(set(kwargs.pop("pass_fds", ())) | {bound.fd})}
+    else:
+        executable = bound.path
+        extra = {}
+    argv = [bound.path, *list(args)]
+    return runner(
+        argv,
+        executable=executable,
+        capture_output=capture_output,
+        text=text,
+        shell=False,
+        stdin=stdin,
+        env=dict(env) if env is not None else None,
+        timeout=timeout,
+        **extra,
+        **kwargs,
+    )
+
+
+def executable_identity(fd: int) -> ExecutableIdentity:
+    """Return the identity of an already-open executable descriptor."""
+    try:
+        opened = os.fstat(fd)
+    except OSError as exc:
+        raise ExecBindError("lifecycle executable identity could not be read") from exc
+    if not stat.S_ISREG(opened.st_mode):
+        raise ExecBindError("lifecycle executable is not a regular file")
+    volume = 0
+    index = 0
+    if os.name == "nt":
+        volume, index = _windows_file_id(fd)
+    return ExecutableIdentity(
+        device=int(opened.st_dev),
+        inode=int(opened.st_ino),
+        size=int(opened.st_size),
+        windows_volume=volume,
+        windows_index=index,
+    )
+
+
+def _verify_pathname_custody(path: str) -> str:
+    if os.name != "nt":
+        try:
+            return trusted_posix_executable_path(path)
+        except (OSError, UnsafePathError) as exc:
+            raise ExecBindError("lifecycle executable custody could not be verified") from exc
+    from defenseclaw.file_permissions import windows_acl_write_error
+    from defenseclaw.gateway import packaged_windows_gateway_path
+
+    resolved = os.path.abspath(path)
+    packaged = packaged_windows_gateway_path()
+    if packaged:
+        try:
+            if os.path.samefile(resolved, packaged):
+                return os.path.abspath(packaged)
+        except OSError as exc:
+            raise ExecBindError("packaged lifecycle executable could not be verified") from exc
+    for candidate in (resolved, os.path.dirname(resolved)):
+        if windows_acl_write_error(candidate) is not None:
+            raise ExecBindError("lifecycle executable custody could not be verified")
+    if not os.path.isfile(resolved):
+        raise ExecBindError("lifecycle executable is not a regular file")
+    return resolved
+
+
+def _open_executable_object(path: str) -> int:
+    if os.name == "nt":
+        return _open_windows_executable(path)
+    return open_regular_file_no_follow(path)
+
+
+def _verify_opened_identity(path: str, fd: int, identity: ExecutableIdentity) -> None:
+    try:
+        path_stat = os.stat(path)
+    except OSError as exc:
+        raise ExecBindError("lifecycle executable path changed while opening") from exc
+    if not stat.S_ISREG(path_stat.st_mode):
+        raise ExecBindError("lifecycle executable is not a regular file")
+    if os.name != "nt":
+        if (int(path_stat.st_dev), int(path_stat.st_ino)) != (identity.device, identity.inode):
+            raise ExecBindError("lifecycle executable path no longer names the opened object")
+        return
+    volume, index = _windows_path_file_id(path)
+    if (volume, index) != (identity.windows_volume, identity.windows_index):
+        raise ExecBindError("lifecycle executable path no longer names the opened object")
+
+
+def _posix_held_executable_path(fd: int) -> str:
+    held = f"/proc/self/fd/{fd}"
+    if not os.path.exists(held):
+        raise ExecBindError("handle-bound executable path is unavailable")
+    return held
+
+
+def _assert_posix_path_still_bound(bound: BoundExecutable) -> None:
+    try:
+        opened = os.fstat(bound.fd)
+        current = os.stat(bound.path)
+    except OSError as exc:
+        raise ExecBindError("lifecycle executable path could not be revalidated") from exc
+    if not os.path.samestat(opened, current):
+        raise ExecBindError("lifecycle executable was replaced after it was bound")
+
+
+def _assert_windows_path_still_bound(bound: BoundExecutable) -> None:
+    volume, index = _windows_path_file_id(bound.path)
+    if (volume, index) != (bound.identity.windows_volume, bound.identity.windows_index):
+        raise ExecBindError("lifecycle executable was replaced after it was bound")
+
+
+def _open_windows_executable(path: str) -> int:  # pragma: no cover - native Windows
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    from defenseclaw.file_permissions import UnsafePathError, reject_reparse_path
+
+    try:
+        reject_reparse_path(path)
+    except (OSError, UnsafePathError) as exc:
+        raise ExecBindError("lifecycle executable is a reparse point") from exc
+
+    generic_read = 0x80000000
+    generic_execute = 0x20000000
+    file_share_read = 0x00000001
+    open_existing = 3
+    file_flag_open_reparse_point = 0x00200000
+    invalid_handle = ctypes.c_void_p(-1).value
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+
+    handle = create_file(
+        _windows_extended_path(path),
+        generic_read | generic_execute,
+        file_share_read,
+        None,
+        open_existing,
+        file_flag_open_reparse_point,
+        None,
+    )
+    if handle == invalid_handle:
+        raise ExecBindError("lifecycle executable handle could not be opened")
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOINHERIT", 0)
+    try:
+        return msvcrt.open_osfhandle(handle, flags)
+    except BaseException:
+        close_handle(handle)
+        raise
+
+
+def _windows_file_id(fd: int) -> tuple[int, int]:
+    if os.name != "nt":
+        return 0, 0
+    return _windows_handle_file_id(_osfhandle(fd))
+
+
+def _windows_path_file_id(path: str) -> tuple[int, int]:
+    if os.name != "nt":
+        return 0, 0
+    fd = _open_windows_executable(path)
+    try:
+        return _windows_file_id(fd)
+    finally:
+        os.close(fd)
+
+
+def _osfhandle(fd: int) -> int:
+    import msvcrt
+
+    return int(msvcrt.get_osfhandle(fd))
+
+
+def _windows_extended_path(path: str) -> str:
+    value = os.path.abspath(path)
+    if value.startswith(("\\\\?\\", "\\\\.\\")):
+        return value
+    if value.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + value[2:]
+    return "\\\\?\\" + value
+
+
+def _windows_handle_file_id(handle: int) -> tuple[int, int]:  # pragma: no cover - native Windows
+    import ctypes
+    from ctypes import wintypes
+
+    class _FileTime(ctypes.Structure):
+        _fields_ = [("low", wintypes.DWORD), ("high", wintypes.DWORD)]
+
+    class _Info(ctypes.Structure):
+        _fields_ = [
+            ("file_attributes", wintypes.DWORD),
+            ("creation_time", _FileTime),
+            ("last_access_time", _FileTime),
+            ("last_write_time", _FileTime),
+            ("volume_serial_number", wintypes.DWORD),
+            ("file_size_high", wintypes.DWORD),
+            ("file_size_low", wintypes.DWORD),
+            ("number_of_links", wintypes.DWORD),
+            ("file_index_high", wintypes.DWORD),
+            ("file_index_low", wintypes.DWORD),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    get_info = kernel32.GetFileInformationByHandle
+    get_info.argtypes = [wintypes.HANDLE, ctypes.POINTER(_Info)]
+    get_info.restype = wintypes.BOOL
+    info = _Info()
+    if not get_info(handle, ctypes.byref(info)):
+        raise ExecBindError("lifecycle executable file identity could not be read")
+    index = (int(info.file_index_high) << 32) | int(info.file_index_low)
+    return int(info.volume_serial_number), index

--- a/cli/defenseclaw/doctor_exec.py
+++ b/cli/defenseclaw/doctor_exec.py
@@ -31,8 +31,11 @@ POSIX (Linux/macOS)
 
 Windows
   Packaged installs must resolve to the sibling gateway under the install
-  root. Non-packaged paths must pass the existing integrity ACL write check
-  and must not be a reparse point. Doctor then opens the file with
+  root. Non-packaged paths must pass executable custody
+  (``windows_acl_custody_write_error``), not the private-file current-user
+  owner check. That admits TrustedInstaller, Administrators, LocalSystem, and
+  the current user so system PowerShell and user-owned adapters can both bind.
+  The path must not be a reparse point. Doctor then opens the file with
   ``GENERIC_READ | GENERIC_EXECUTE``, ``FILE_SHARE_READ`` only (no write or
   delete sharing), and records the volume serial plus file index from that
   handle. Spawn refuses if the path's object identity has changed. Holding
@@ -58,6 +61,7 @@ from defenseclaw.file_permissions import (
     UnsafePathError,
     open_regular_file_no_follow,
     trusted_posix_executable_path,
+    windows_acl_custody_write_error,
 )
 
 Runner = Callable[..., subprocess.CompletedProcess]
@@ -214,7 +218,6 @@ def _verify_pathname_custody(path: str) -> str:
             return trusted_posix_executable_path(path)
         except (OSError, UnsafePathError) as exc:
             raise ExecBindError("lifecycle executable custody could not be verified") from exc
-    from defenseclaw.file_permissions import windows_acl_write_error
     from defenseclaw.gateway import packaged_windows_gateway_path
 
     resolved = os.path.abspath(path)
@@ -226,7 +229,9 @@ def _verify_pathname_custody(path: str) -> str:
         except OSError as exc:
             raise ExecBindError("packaged lifecycle executable could not be verified") from exc
     for candidate in (resolved, os.path.dirname(resolved)):
-        if windows_acl_write_error(candidate) is not None:
+        # Executables may be owned by Windows itself. The private-file
+        # current-user owner check would refuse System32 PowerShell.
+        if windows_acl_custody_write_error(candidate, allow_current_user=True) is not None:
             raise ExecBindError("lifecycle executable custody could not be verified")
     if not os.path.isfile(resolved):
         raise ExecBindError("lifecycle executable is not a regular file")

--- a/cli/defenseclaw/doctor_peer.py
+++ b/cli/defenseclaw/doctor_peer.py
@@ -489,11 +489,14 @@ def _linux_established_peer_pid(sock: socket.socket) -> int:
     )
 
 
+_LinuxEndpoint = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+
 def _linux_established_row(
     row: str,
     *,
     ipv6: bool,
-) -> tuple[ipaddress.IPv4Address | ipaddress.IPv6Address, int, ipaddress.IPv4Address | ipaddress.IPv6Address, int, str] | None:
+) -> tuple[_LinuxEndpoint, int, _LinuxEndpoint, int, str] | None:
     fields = row.split()
     if len(fields) < 10 or fields[3] != _LINUX_TCP_ESTABLISHED:
         return None

--- a/cli/defenseclaw/doctor_peer.py
+++ b/cli/defenseclaw/doctor_peer.py
@@ -1,0 +1,742 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bind Doctor credential-bearing HTTP probes to the verified gateway peer.
+
+Listener inspection plus a later urllib connect leaves an inspect-to-send
+interval: a replacement process can accept the TCP connection and receive the
+gateway bearer before authenticated runtime metadata rejects the response.
+
+This module binds after TCP connect and before any request bytes are written.
+The connected ESTABLISHED peer must be the inspected PID and start identity.
+Failure is closed; the socket is dropped without an HTTP request.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import http.client
+import ipaddress
+import os
+import socket
+import subprocess
+import sys
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from defenseclaw.doctor_gateway import GatewayEvidence
+from defenseclaw.file_permissions import trusted_system_subprocess_env
+
+PeerLookup = Callable[[socket.socket], int]
+ProcessLookup = Callable[[int], str]
+
+_LINUX_TCP_ESTABLISHED = "01"
+_WINDOWS_TCP_TABLE_OWNER_PID_CONNECTIONS = 4
+_WINDOWS_MIB_TCP_STATE_ESTAB = 5
+_MAX_PLATFORM_PID = 2_147_483_647
+
+
+class PeerBindError(Exception):
+    """Refuse to send credentials to a peer that is not the verified gateway."""
+
+
+@dataclass(frozen=True)
+class TrustedPeer:
+    """Inspected gateway generation that must own the connected socket."""
+
+    pid: int
+    start_identity: str
+
+    def __post_init__(self) -> None:
+        if type(self.pid) is not int or self.pid <= 0 or self.pid > _MAX_PLATFORM_PID:
+            raise PeerBindError("trusted gateway peer PID is invalid")
+        identity = self.start_identity.strip()
+        if not identity:
+            raise PeerBindError("trusted gateway peer start identity is unavailable")
+        object.__setattr__(self, "start_identity", identity)
+
+
+def loopback_bearer_requires_peer(url: str, headers: dict | None) -> bool:
+    """Return whether this request would send a loopback bearer credential."""
+    if not _authorization_is_bearer(headers):
+        return False
+    try:
+        host = (urllib.parse.urlsplit(url).hostname or "").lower()
+    except ValueError:
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return host == "localhost"
+
+
+def bind_connected_peer(
+    sock: socket.socket,
+    trusted: TrustedPeer,
+    *,
+    peer_lookup: PeerLookup | None = None,
+    process_lookup: ProcessLookup | None = None,
+) -> None:
+    """Fail closed unless ``sock`` is owned by ``trusted`` right now."""
+    if sock is None:
+        raise PeerBindError("refusing to send credentials before the TCP peer exists")
+    lookup = peer_lookup or connected_peer_pid
+    try:
+        peer_pid = lookup(sock)
+    except PeerBindError:
+        raise
+    except OSError as exc:
+        raise PeerBindError("connected gateway peer could not be identified") from exc
+    if type(peer_pid) is not int or peer_pid <= 0 or peer_pid > _MAX_PLATFORM_PID:
+        raise PeerBindError("connected gateway peer PID is invalid")
+    if peer_pid != trusted.pid:
+        raise PeerBindError("connected peer is not the verified gateway process")
+    identity_lookup = process_lookup or process_start_identity
+    try:
+        start_identity = identity_lookup(peer_pid)
+    except PeerBindError:
+        raise
+    except OSError as exc:
+        raise PeerBindError("connected gateway peer start identity could not be queried") from exc
+    if not isinstance(start_identity, str) or not start_identity.strip():
+        raise PeerBindError("connected gateway peer start identity is unavailable")
+    if start_identity.strip() != trusted.start_identity:
+        raise PeerBindError("connected peer is not the verified gateway generation")
+
+
+def connected_peer_pid(sock: socket.socket) -> int:
+    """Return the PID that owns the ESTABLISHED remote endpoint of ``sock``."""
+    platform_name = "win32" if os.name == "nt" else sys.platform
+    if platform_name == "win32":
+        return _windows_established_peer_pid(sock)
+    if platform_name.startswith("linux"):
+        return _linux_established_peer_pid(sock)
+    return _lsof_established_peer_pid(sock)
+
+
+def process_start_identity(pid: int) -> str:
+    """Read the live start identity for one connected peer PID."""
+    platform_name = "win32" if os.name == "nt" else sys.platform
+    evidence = GatewayEvidence(platform_name=platform_name).process(pid)
+    if evidence.status != "ok" or not evidence.start_identity.strip():
+        raise PeerBindError("connected gateway peer start identity is unavailable")
+    return evidence.start_identity.strip()
+
+
+def socket_endpoints(
+    sock: socket.socket,
+) -> tuple[ipaddress.IPv4Address | ipaddress.IPv6Address, int, ipaddress.IPv4Address | ipaddress.IPv6Address, int]:
+    """Return canonical (local_ip, local_port, remote_ip, remote_port)."""
+    try:
+        local = sock.getsockname()
+        remote = sock.getpeername()
+    except OSError as exc:
+        raise PeerBindError("connected socket endpoints are unavailable") from exc
+    return (
+        _canonical_ip(local[0]),
+        int(local[1]),
+        _canonical_ip(remote[0]),
+        int(remote[1]),
+    )
+
+
+def linux_established_peer_pid_from_proc(
+    local_ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    local_port: int,
+    remote_ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    remote_port: int,
+    *,
+    proc_root: str,
+) -> int:
+    """Resolve an ESTABLISHED Linux peer from a (possibly fake) proc tree."""
+    matching_inodes: set[str] = set()
+    table_found = False
+    for table_name in ("tcp", "tcp6"):
+        table_path = os.path.join(proc_root, "net", table_name)
+        try:
+            with open(table_path, encoding="ascii") as table:
+                rows = table.readlines()[1:]
+            table_found = True
+        except FileNotFoundError:
+            continue
+        except (OSError, UnicodeError) as exc:
+            raise PeerBindError("Linux connection table could not be read") from exc
+        for row in rows:
+            parsed = _linux_established_row(row, ipv6=table_name == "tcp6")
+            if parsed is None:
+                continue
+            row_local_ip, row_local_port, row_remote_ip, row_remote_port, inode = parsed
+            if (
+                row_local_port == remote_port
+                and row_remote_port == local_port
+                and row_local_ip == remote_ip
+                and row_remote_ip == local_ip
+            ):
+                matching_inodes.add(inode)
+    if not table_found:
+        raise PeerBindError("Linux connection tables are unavailable")
+    if not matching_inodes:
+        raise PeerBindError("connected gateway peer is not present in the ESTABLISHED table")
+    return _linux_socket_inode_owner(matching_inodes, proc_root=proc_root)
+
+
+def windows_established_peer_pid_from_rows(
+    rows: list[tuple[int, str, int, str, int, int]],
+    local_ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    local_port: int,
+    remote_ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    remote_port: int,
+) -> int:
+    """Resolve an ESTABLISHED Windows peer from already-decoded table rows.
+
+    Each row is ``(state, local_addr, local_port, remote_addr, remote_port, pid)``.
+    """
+    matching: set[int] = set()
+    for state, row_local_addr, row_local_port, row_remote_addr, row_remote_port, pid in rows:
+        if state != _WINDOWS_MIB_TCP_STATE_ESTAB:
+            continue
+        if type(pid) is not int or pid <= 0 or pid > _MAX_PLATFORM_PID:
+            continue
+        try:
+            row_local_ip = ipaddress.ip_address(row_local_addr)
+            row_remote_ip = ipaddress.ip_address(row_remote_addr)
+        except ValueError:
+            continue
+        if (
+            row_local_port == remote_port
+            and row_remote_port == local_port
+            and row_local_ip == remote_ip
+            and row_remote_ip == local_ip
+        ):
+            matching.add(pid)
+    if len(matching) != 1:
+        raise PeerBindError("connected gateway peer could not be uniquely identified")
+    return next(iter(matching))
+
+
+def lsof_established_peer_pid_from_output(
+    stdout: str,
+    local_ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    local_port: int,
+    remote_ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    remote_port: int,
+) -> int:
+    """Resolve an ESTABLISHED macOS/lsof peer from machine-readable output."""
+    matching: set[int] = set()
+    current_pid = 0
+    for raw_line in stdout.splitlines():
+        if raw_line.startswith("p"):
+            try:
+                current_pid = int(raw_line[1:])
+            except ValueError:
+                current_pid = 0
+            continue
+        if not raw_line.startswith("n") or current_pid <= 0:
+            continue
+        if _lsof_established_name_matches(
+            raw_line[1:],
+            local_ip,
+            local_port,
+            remote_ip,
+            remote_port,
+        ):
+            matching.add(current_pid)
+    if len(matching) != 1:
+        raise PeerBindError("connected gateway peer could not be uniquely identified")
+    return next(iter(matching))
+
+
+class PeerBoundHTTPConnection(http.client.HTTPConnection):
+    """HTTP connection that binds the TCP peer before writing a request."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int | None = None,
+        timeout: float = socket._GLOBAL_DEFAULT_TIMEOUT,
+        source_address: tuple[str, int] | None = None,
+        blocksize: int = 8192,
+        *,
+        trusted_peer: TrustedPeer,
+        peer_lookup: PeerLookup | None = None,
+        process_lookup: ProcessLookup | None = None,
+    ) -> None:
+        super().__init__(
+            host,
+            port,
+            timeout=timeout,
+            source_address=source_address,
+            blocksize=blocksize,
+        )
+        self._trusted_peer = trusted_peer
+        self._peer_lookup = peer_lookup
+        self._process_lookup = process_lookup
+        self._peer_bound = False
+
+    def connect(self) -> None:
+        super().connect()
+        try:
+            bind_connected_peer(
+                self.sock,
+                self._trusted_peer,
+                peer_lookup=self._peer_lookup,
+                process_lookup=self._process_lookup,
+            )
+        except Exception:
+            self._close_unbound_socket()
+            raise
+        self._peer_bound = True
+
+    def send(self, data) -> None:
+        if self.sock is None:
+            self.connect()
+        if not self._peer_bound:
+            self._close_unbound_socket()
+            raise PeerBindError("refusing to send credentials before peer bind")
+        super().send(data)
+
+    def _close_unbound_socket(self) -> None:
+        sock = self.sock
+        self.sock = None
+        self._peer_bound = False
+        if sock is None:
+            return
+        try:
+            sock.close()
+        except OSError:
+            pass
+
+
+class PeerBoundHTTPSConnection(http.client.HTTPSConnection):
+    """HTTPS connection that binds the TCP peer before request bytes."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int | None = None,
+        timeout: float = socket._GLOBAL_DEFAULT_TIMEOUT,
+        source_address: tuple[str, int] | None = None,
+        context=None,
+        blocksize: int = 8192,
+        *,
+        trusted_peer: TrustedPeer,
+        peer_lookup: PeerLookup | None = None,
+        process_lookup: ProcessLookup | None = None,
+    ) -> None:
+        super().__init__(
+            host,
+            port,
+            timeout=timeout,
+            source_address=source_address,
+            context=context,
+            blocksize=blocksize,
+        )
+        self._trusted_peer = trusted_peer
+        self._peer_lookup = peer_lookup
+        self._process_lookup = process_lookup
+        self._peer_bound = False
+
+    def connect(self) -> None:
+        super().connect()
+        try:
+            bind_connected_peer(
+                self.sock,
+                self._trusted_peer,
+                peer_lookup=self._peer_lookup,
+                process_lookup=self._process_lookup,
+            )
+        except Exception:
+            self._close_unbound_socket()
+            raise
+        self._peer_bound = True
+
+    def send(self, data) -> None:
+        if self.sock is None:
+            self.connect()
+        if not self._peer_bound:
+            self._close_unbound_socket()
+            raise PeerBindError("refusing to send credentials before peer bind")
+        super().send(data)
+
+    def _close_unbound_socket(self) -> None:
+        sock = self.sock
+        self.sock = None
+        self._peer_bound = False
+        if sock is None:
+            return
+        try:
+            sock.close()
+        except OSError:
+            pass
+
+
+class _PeerBoundHTTPHandler(urllib.request.HTTPHandler):
+    def __init__(
+        self,
+        trusted_peer: TrustedPeer,
+        *,
+        peer_lookup: PeerLookup | None = None,
+        process_lookup: ProcessLookup | None = None,
+    ) -> None:
+        super().__init__()
+        self._trusted_peer = trusted_peer
+        self._peer_lookup = peer_lookup
+        self._process_lookup = process_lookup
+
+    def http_open(self, req):
+        return self.do_open(self._connection, req)
+
+    def _connection(self, *args, **kwargs):
+        return PeerBoundHTTPConnection(
+            *args,
+            **kwargs,
+            trusted_peer=self._trusted_peer,
+            peer_lookup=self._peer_lookup,
+            process_lookup=self._process_lookup,
+        )
+
+
+class _PeerBoundHTTPSHandler(urllib.request.HTTPSHandler):
+    def __init__(
+        self,
+        trusted_peer: TrustedPeer,
+        *,
+        peer_lookup: PeerLookup | None = None,
+        process_lookup: ProcessLookup | None = None,
+        context=None,
+    ) -> None:
+        super().__init__(context=context)
+        self._trusted_peer = trusted_peer
+        self._peer_lookup = peer_lookup
+        self._process_lookup = process_lookup
+
+    def https_open(self, req):
+        return self.do_open(self._connection, req)
+
+    def _connection(self, *args, **kwargs):
+        return PeerBoundHTTPSConnection(
+            *args,
+            **kwargs,
+            trusted_peer=self._trusted_peer,
+            peer_lookup=self._peer_lookup,
+            process_lookup=self._process_lookup,
+        )
+
+
+def peer_bound_handlers(
+    trusted_peer: TrustedPeer,
+    *,
+    peer_lookup: PeerLookup | None = None,
+    process_lookup: ProcessLookup | None = None,
+    ssl_context=None,
+) -> list[urllib.request.BaseHandler]:
+    """Return HTTP/HTTPS handlers that bind before writing credentials."""
+    return [
+        _PeerBoundHTTPHandler(
+            trusted_peer,
+            peer_lookup=peer_lookup,
+            process_lookup=process_lookup,
+        ),
+        _PeerBoundHTTPSHandler(
+            trusted_peer,
+            peer_lookup=peer_lookup,
+            process_lookup=process_lookup,
+            context=ssl_context,
+        ),
+    ]
+
+
+def _authorization_is_bearer(headers: dict | None) -> bool:
+    for key, value in (headers or {}).items():
+        if str(key).lower() == "authorization" and str(value).lower().startswith("bearer "):
+            return True
+    return False
+
+
+def _canonical_ip(value: object) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+    try:
+        parsed = ipaddress.ip_address(value)
+    except ValueError as exc:
+        raise PeerBindError("connected socket address is not an IP literal") from exc
+    if parsed.version == 6 and parsed.ipv4_mapped is not None:
+        return parsed.ipv4_mapped
+    return parsed
+
+
+def _linux_established_peer_pid(sock: socket.socket) -> int:
+    local_ip, local_port, remote_ip, remote_port = socket_endpoints(sock)
+    return linux_established_peer_pid_from_proc(
+        local_ip,
+        local_port,
+        remote_ip,
+        remote_port,
+        proc_root="/proc",
+    )
+
+
+def _linux_established_row(
+    row: str,
+    *,
+    ipv6: bool,
+) -> tuple[ipaddress.IPv4Address | ipaddress.IPv6Address, int, ipaddress.IPv4Address | ipaddress.IPv6Address, int, str] | None:
+    fields = row.split()
+    if len(fields) < 10 or fields[3] != _LINUX_TCP_ESTABLISHED:
+        return None
+    try:
+        local_ip, local_port = _linux_hex_endpoint(fields[1], ipv6=ipv6)
+        remote_ip, remote_port = _linux_hex_endpoint(fields[2], ipv6=ipv6)
+    except ValueError:
+        return None
+    inode = fields[9]
+    if not inode.isdigit():
+        return None
+    return local_ip, local_port, remote_ip, remote_port, inode
+
+
+def _linux_hex_endpoint(
+    field: str,
+    *,
+    ipv6: bool,
+) -> tuple[ipaddress.IPv4Address | ipaddress.IPv6Address, int]:
+    raw_address, separator, raw_port = field.rpartition(":")
+    if not separator:
+        raise ValueError("missing address/port separator")
+    port = int(raw_port, 16)
+    packed = bytes.fromhex(raw_address)
+    if ipv6:
+        network_bytes = b"".join(packed[index : index + 4][::-1] for index in range(0, len(packed), 4))
+        return ipaddress.ip_address(network_bytes), port
+    return ipaddress.ip_address(packed[::-1]), port
+
+
+def _linux_socket_inode_owner(inodes: set[str], *, proc_root: str) -> int:
+    owners_by_inode: dict[str, set[int]] = {inode: set() for inode in inodes}
+    try:
+        process_entries = list(os.scandir(proc_root))
+    except OSError as exc:
+        raise PeerBindError("Linux process descriptors could not be enumerated") from exc
+    for process_entry in process_entries:
+        if not process_entry.name.isdigit():
+            continue
+        pid = int(process_entry.name)
+        if not 0 < pid <= _MAX_PLATFORM_PID:
+            continue
+        try:
+            descriptors = os.scandir(os.path.join(process_entry.path, "fd"))
+        except OSError:
+            continue
+        with descriptors:
+            for descriptor in descriptors:
+                try:
+                    target = os.readlink(descriptor.path)
+                except OSError:
+                    continue
+                if target.startswith("socket:[") and target.endswith("]"):
+                    inode = target[8:-1]
+                    if inode in owners_by_inode:
+                        owners_by_inode[inode].add(pid)
+    if any(not owners for owners in owners_by_inode.values()):
+        raise PeerBindError("connected gateway peer owner could not be resolved")
+    if any(len(owners) > 1 for owners in owners_by_inode.values()):
+        raise PeerBindError("connected gateway peer is ambiguously owned")
+    owners = {next(iter(inode_owners)) for inode_owners in owners_by_inode.values()}
+    if len(owners) != 1:
+        raise PeerBindError("connected gateway peer is ambiguously owned")
+    return next(iter(owners))
+
+
+def _windows_established_peer_pid(sock: socket.socket) -> int:  # pragma: no cover - native Windows
+    from ctypes import wintypes
+
+    local_ip, local_port, remote_ip, remote_port = socket_endpoints(sock)
+    iphlpapi = ctypes.WinDLL("iphlpapi", use_last_error=True)
+    get_table = iphlpapi.GetExtendedTcpTable
+    get_table.argtypes = (
+        wintypes.LPVOID,
+        ctypes.POINTER(wintypes.ULONG),
+        wintypes.BOOL,
+        wintypes.ULONG,
+        wintypes.ULONG,
+        wintypes.ULONG,
+    )
+    get_table.restype = wintypes.DWORD
+    error_insufficient_buffer = 122
+
+    class TCP4Row(ctypes.Structure):
+        _fields_ = [
+            ("state", wintypes.DWORD),
+            ("local_addr", wintypes.DWORD),
+            ("local_port", wintypes.DWORD),
+            ("remote_addr", wintypes.DWORD),
+            ("remote_port", wintypes.DWORD),
+            ("pid", wintypes.DWORD),
+        ]
+
+    class TCP6Row(ctypes.Structure):
+        _fields_ = [
+            ("local_addr", ctypes.c_ubyte * 16),
+            ("local_scope", wintypes.DWORD),
+            ("local_port", wintypes.DWORD),
+            ("remote_addr", ctypes.c_ubyte * 16),
+            ("remote_scope", wintypes.DWORD),
+            ("remote_port", wintypes.DWORD),
+            ("state", wintypes.DWORD),
+            ("pid", wintypes.DWORD),
+        ]
+
+    family = socket.AF_INET if local_ip.version == 4 else socket.AF_INET6
+    row_type = TCP4Row if family == socket.AF_INET else TCP6Row
+    size = wintypes.ULONG(0)
+    result = get_table(
+        None,
+        ctypes.byref(size),
+        False,
+        family,
+        _WINDOWS_TCP_TABLE_OWNER_PID_CONNECTIONS,
+        0,
+    )
+    if result not in (0, error_insufficient_buffer) or not size.value:
+        raise PeerBindError("Windows connection table could not be queried")
+    buffer = ctypes.create_string_buffer(size.value)
+    result = get_table(
+        buffer,
+        ctypes.byref(size),
+        False,
+        family,
+        _WINDOWS_TCP_TABLE_OWNER_PID_CONNECTIONS,
+        0,
+    )
+    if result == error_insufficient_buffer and size.value > len(buffer):
+        buffer = ctypes.create_string_buffer(size.value)
+        result = get_table(
+            buffer,
+            ctypes.byref(size),
+            False,
+            family,
+            _WINDOWS_TCP_TABLE_OWNER_PID_CONNECTIONS,
+            0,
+        )
+    if result != 0:
+        raise PeerBindError("Windows connection table could not be queried")
+    count = ctypes.cast(buffer, ctypes.POINTER(wintypes.DWORD)).contents.value
+    offset = ctypes.sizeof(wintypes.DWORD)
+    alignment = ctypes.alignment(row_type)
+    offset = (offset + alignment - 1) & ~(alignment - 1)
+    rows: list[tuple[int, str, int, str, int, int]] = []
+    for index in range(count):
+        row = row_type.from_buffer_copy(buffer, offset + index * ctypes.sizeof(row_type))
+        try:
+            if family == socket.AF_INET:
+                local_packed = int(row.local_addr).to_bytes(4, byteorder=sys.byteorder)
+                remote_packed = int(row.remote_addr).to_bytes(4, byteorder=sys.byteorder)
+            else:
+                local_packed = bytes(row.local_addr)
+                remote_packed = bytes(row.remote_addr)
+            rows.append(
+                (
+                    int(row.state),
+                    socket.inet_ntop(family, local_packed),
+                    socket.ntohs(row.local_port & 0xFFFF),
+                    socket.inet_ntop(family, remote_packed),
+                    socket.ntohs(row.remote_port & 0xFFFF),
+                    int(row.pid),
+                )
+            )
+        except (OSError, OverflowError, ValueError):
+            continue
+    return windows_established_peer_pid_from_rows(
+        rows,
+        local_ip,
+        local_port,
+        remote_ip,
+        remote_port,
+    )
+
+
+def _lsof_established_peer_pid(sock: socket.socket) -> int:
+    local_ip, local_port, remote_ip, remote_port = socket_endpoints(sock)
+    lsof_path = _trusted_lsof_path()
+    if not lsof_path:
+        raise PeerBindError("trusted lsof binary is unavailable")
+    selector = f"-iTCP@{local_ip}:{local_port}"
+    try:
+        proc = subprocess.run(
+            [
+                lsof_path,
+                "-nP",
+                "-a",
+                selector,
+                "-sTCP:ESTABLISHED",
+                "-Fpn",
+            ],
+            capture_output=True,
+            text=True,
+            shell=False,
+            stdin=subprocess.DEVNULL,
+            env=trusted_system_subprocess_env(),
+            timeout=2.0,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        raise PeerBindError("lsof connection inspection failed") from exc
+    if proc.returncode not in {0, 1}:
+        raise PeerBindError("lsof connection inspection failed")
+    return lsof_established_peer_pid_from_output(
+        proc.stdout,
+        local_ip,
+        local_port,
+        remote_ip,
+        remote_port,
+    )
+
+
+def _lsof_established_name_matches(
+    endpoint: str,
+    local_ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    local_port: int,
+    remote_ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    remote_port: int,
+) -> bool:
+    name = endpoint.strip()
+    if "->" not in name:
+        return False
+    left, right = name.split("->", 1)
+    parsed_local = _lsof_endpoint(left)
+    parsed_remote = _lsof_endpoint(right)
+    if parsed_local is None or parsed_remote is None:
+        return False
+    return parsed_local == (remote_ip, remote_port) and parsed_remote == (local_ip, local_port)
+
+
+def _lsof_endpoint(
+    value: str,
+) -> tuple[ipaddress.IPv4Address | ipaddress.IPv6Address, int] | None:
+    address, separator, raw_port = value.strip().strip("[]").rpartition(":")
+    if not separator:
+        return None
+    try:
+        return ipaddress.ip_address(address.strip("[]")), int(raw_port)
+    except ValueError:
+        return None
+
+
+def _trusted_lsof_path() -> str:
+    for candidate in ("/usr/sbin/lsof", "/usr/bin/lsof"):
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return ""

--- a/cli/defenseclaw/doctor_peer.py
+++ b/cli/defenseclaw/doctor_peer.py
@@ -164,6 +164,8 @@ def linux_established_peer_pid_from_proc(
     proc_root: str,
 ) -> int:
     """Resolve an ESTABLISHED Linux peer from a (possibly fake) proc tree."""
+    local_ip = _canonical_ip(local_ip)
+    remote_ip = _canonical_ip(remote_ip)
     matching_inodes: set[str] = set()
     table_found = False
     for table_name in ("tcp", "tcp6"):
@@ -426,7 +428,7 @@ class _PeerBoundHTTPSHandler(urllib.request.HTTPSHandler):
         self._process_lookup = process_lookup
 
     def https_open(self, req):
-        return self.do_open(self._connection, req)
+        return self.do_open(self._connection, req, context=self._context)
 
     def _connection(self, *args, **kwargs):
         return PeerBoundHTTPSConnection(
@@ -523,8 +525,8 @@ def _linux_hex_endpoint(
     packed = bytes.fromhex(raw_address)
     if ipv6:
         network_bytes = b"".join(packed[index : index + 4][::-1] for index in range(0, len(packed), 4))
-        return ipaddress.ip_address(network_bytes), port
-    return ipaddress.ip_address(packed[::-1]), port
+        return _canonical_ip(ipaddress.ip_address(network_bytes)), port
+    return _canonical_ip(ipaddress.ip_address(packed[::-1])), port
 
 
 def _linux_socket_inode_owner(inodes: set[str], *, proc_root: str) -> int:
@@ -676,7 +678,7 @@ def _lsof_established_peer_pid(sock: socket.socket) -> int:
     lsof_path = _trusted_lsof_path()
     if not lsof_path:
         raise PeerBindError("trusted lsof binary is unavailable")
-    selector = f"-iTCP@{local_ip}:{local_port}"
+    selector = lsof_tcp_selector(local_ip, local_port)
     try:
         proc = subprocess.run(
             [
@@ -706,6 +708,17 @@ def _lsof_established_peer_pid(sock: socket.socket) -> int:
         remote_ip,
         remote_port,
     )
+
+
+def lsof_tcp_selector(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    port: int,
+) -> str:
+    """Return an lsof ``-iTCP`` selector with IPv6 literals in brackets."""
+    host = str(ip)
+    if ip.version == 6:
+        host = f"[{host}]"
+    return f"-iTCP@{host}:{port}"
 
 
 def _lsof_established_name_matches(

--- a/cli/defenseclaw/doctor_peer.py
+++ b/cli/defenseclaw/doctor_peer.py
@@ -675,7 +675,7 @@ def _windows_established_peer_pid(sock: socket.socket) -> int:  # pragma: no cov
 
 def _lsof_established_peer_pid(sock: socket.socket) -> int:
     local_ip, local_port, remote_ip, remote_port = socket_endpoints(sock)
-    lsof_path = _trusted_lsof_path()
+    lsof_path = trusted_lsof_path()
     if not lsof_path:
         raise PeerBindError("trusted lsof binary is unavailable")
     selector = lsof_tcp_selector(local_ip, local_port)
@@ -751,7 +751,7 @@ def _lsof_endpoint(
         return None
 
 
-def _trusted_lsof_path() -> str:
+def trusted_lsof_path() -> str:
     for candidate in ("/usr/sbin/lsof", "/usr/bin/lsof"):
         if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
             return candidate

--- a/cli/tests/test_cmd_doctor_connector.py
+++ b/cli/tests/test_cmd_doctor_connector.py
@@ -118,6 +118,9 @@ class TestCodexOtelAlignment(unittest.TestCase):
         ), patch(
             "defenseclaw.commands.cmd_doctor._http_probe",
             return_value=(200, json.dumps(payload)),
+        ), patch(
+            "defenseclaw.commands.cmd_doctor._trusted_gateway_listener",
+            return_value=MagicMock(trusted=True),
         ):
             self._write_codex_config(home, '[otel]\nenvironment = "windows"\n')
             result = _DoctorResult()
@@ -139,6 +142,9 @@ class TestCodexOtelAlignment(unittest.TestCase):
         ), patch(
             "defenseclaw.commands.cmd_doctor._http_probe",
             return_value=(200, json.dumps(payload)),
+        ), patch(
+            "defenseclaw.commands.cmd_doctor._trusted_gateway_listener",
+            return_value=MagicMock(trusted=True),
         ):
             self._write_codex_config(home, "[otel]\nlog_user_prompt = true\n")
             result = _DoctorResult()
@@ -160,6 +166,9 @@ class TestCodexOtelAlignment(unittest.TestCase):
         ), patch(
             "defenseclaw.commands.cmd_doctor._http_probe",
             return_value=(200, json.dumps(payload)),
+        ), patch(
+            "defenseclaw.commands.cmd_doctor._trusted_gateway_listener",
+            return_value=MagicMock(trusted=True),
         ):
             self._write_codex_config(home, '[otel]\nenvironment = "windows"\n')
             result = _DoctorResult()
@@ -181,6 +190,9 @@ class TestCodexOtelAlignment(unittest.TestCase):
         ), patch(
             "defenseclaw.commands.cmd_doctor._http_probe",
             return_value=(200, json.dumps(payload)),
+        ), patch(
+            "defenseclaw.commands.cmd_doctor._trusted_gateway_listener",
+            return_value=MagicMock(trusted=True),
         ):
             self._write_codex_config(home, '[otel]\nenvironment = "windows"\n')
             result = _DoctorResult()
@@ -749,8 +761,10 @@ class TestCheckConnectorHooks(unittest.TestCase):
         ),
     )
     @patch("defenseclaw.commands.cmd_doctor._run_cursor_windows_runtime_process")
+    @patch("defenseclaw.commands.cmd_doctor.bind_trusted_executable")
     def test_cursor_windows_runtime_probe_accepts_event_native_json_and_counter_advance(
         self,
+        _bind_mock,
         run_mock,
         _powershell_mock,
         http_probe_mock,
@@ -814,8 +828,10 @@ class TestCheckConnectorHooks(unittest.TestCase):
         ),
     )
     @patch("defenseclaw.commands.cmd_doctor._run_cursor_windows_runtime_process")
+    @patch("defenseclaw.commands.cmd_doctor.bind_trusted_executable")
     def test_cursor_windows_runtime_probe_retries_only_after_contained_timeout(
         self,
+        _bind_mock,
         run_mock,
         _powershell_mock,
         http_probe_mock,
@@ -858,8 +874,10 @@ class TestCheckConnectorHooks(unittest.TestCase):
         ),
     )
     @patch("defenseclaw.commands.cmd_doctor._run_cursor_windows_runtime_process")
+    @patch("defenseclaw.commands.cmd_doctor.bind_trusted_executable")
     def test_cursor_windows_runtime_probe_fails_after_strict_bounded_attempts(
         self,
+        _bind_mock,
         run_mock,
         _powershell_mock,
         http_probe_mock,
@@ -889,8 +907,10 @@ class TestCheckConnectorHooks(unittest.TestCase):
         ),
     )
     @patch("defenseclaw.commands.cmd_doctor._run_cursor_windows_runtime_process")
+    @patch("defenseclaw.commands.cmd_doctor.bind_trusted_executable")
     def test_cursor_windows_runtime_probe_never_retries_incomplete_tree_cleanup(
         self,
+        _bind_mock,
         run_mock,
         _powershell_mock,
         http_probe_mock,
@@ -1011,8 +1031,10 @@ class TestCheckConnectorHooks(unittest.TestCase):
         ),
     )
     @patch("defenseclaw.commands.cmd_doctor._run_cursor_windows_runtime_process")
+    @patch("defenseclaw.commands.cmd_doctor.bind_trusted_executable")
     def test_cursor_windows_runtime_probe_rejects_generic_continue_output(
         self,
+        _bind_mock,
         run_mock,
         _powershell_mock,
         http_probe_mock,
@@ -1046,8 +1068,10 @@ class TestCheckConnectorHooks(unittest.TestCase):
         ),
     )
     @patch("defenseclaw.commands.cmd_doctor._run_cursor_windows_runtime_process")
+    @patch("defenseclaw.commands.cmd_doctor.bind_trusted_executable")
     def test_cursor_windows_runtime_probe_rejects_fail_open_without_delivery(
         self,
+        _bind_mock,
         run_mock,
         _powershell_mock,
         http_probe_mock,

--- a/cli/tests/test_cmd_doctor_connector.py
+++ b/cli/tests/test_cmd_doctor_connector.py
@@ -130,6 +130,33 @@ class TestCodexOtelAlignment(unittest.TestCase):
         self.assertIn("'windows'", result.checks[0]["detail"])
         self.assertIn("running", result.checks[1]["detail"])
 
+    def test_runtime_probe_uses_configured_ipv6_api_bind(self) -> None:
+        payload = {
+            "runtime": {"environment": "windows"},
+            "health": {"telemetry": {"state": "running"}},
+        }
+        probe = MagicMock(return_value=(200, json.dumps(payload)))
+        cfg = self._cfg()
+        cfg.gateway.api_bind = "::1"
+        with tempfile.TemporaryDirectory() as home, patch.dict(
+            os.environ,
+            {"CODEX_HOME": home},
+            clear=False,
+        ), patch(
+            "defenseclaw.commands.cmd_doctor._http_probe",
+            probe,
+        ), patch(
+            "defenseclaw.commands.cmd_doctor._trusted_gateway_listener",
+            return_value=MagicMock(trusted=True),
+        ):
+            self._write_codex_config(home, '[otel]\nenvironment = "windows"\n')
+            result = _DoctorResult()
+            _check_codex_otel_alignment(cfg, result)
+
+        self.assertEqual([check["status"] for check in result.checks], ["pass", "pass"])
+        probe.assert_called()
+        self.assertEqual(probe.call_args.args[0], "http://[::1]:18970/status")
+
     def test_missing_codex_environment_exposes_dev_default(self) -> None:
         payload = {
             "runtime": {"environment": "windows"},

--- a/cli/tests/test_doctor_exec.py
+++ b/cli/tests/test_doctor_exec.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import os
-import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -50,7 +49,7 @@ def test_bind_trusted_executable_rejects_relative_and_missing(tmp_path: Path) ->
 def test_posix_spawn_executes_held_inode_after_path_replacement(tmp_path: Path) -> None:
     tool = tmp_path / "defenseclaw-gateway"
     _write_exec(tool, "#!/bin/sh\necho ORIGINAL-GENERATION\n")
-    bound = bind_trusted_executable(str(tool))
+    bound = bind_trusted_executable(str(tool), verify_custody=False)
     try:
         tool.unlink()
         _write_exec(tool, "#!/bin/sh\necho REPLACED-GENERATION\n")
@@ -73,7 +72,7 @@ def test_run_bound_keeps_explicit_argv_and_disables_shell(tmp_path: Path) -> Non
     tool = tmp_path / "defenseclaw-gateway"
     _write_exec(tool, "#!/bin/sh\necho ok\n")
     runner = MagicMock(return_value=subprocess.CompletedProcess(["x"], 0, "", ""))
-    bound = bind_trusted_executable(str(tool))
+    bound = bind_trusted_executable(str(tool), verify_custody=False)
     try:
         run_bound_executable(bound, ["restart"], runner=runner, timeout=1)
         argv, kwargs = runner.call_args
@@ -94,7 +93,7 @@ def test_run_bound_keeps_explicit_argv_and_disables_shell(tmp_path: Path) -> Non
 def test_darwin_spawn_fails_closed_after_path_replacement(tmp_path: Path) -> None:
     tool = tmp_path / "defenseclaw-gateway"
     _write_exec(tool, "#!/bin/sh\necho ORIGINAL-GENERATION\n")
-    bound = bind_trusted_executable(str(tool))
+    bound = bind_trusted_executable(str(tool), verify_custody=False)
     try:
         tool.unlink()
         _write_exec(tool, "#!/bin/sh\necho REPLACED-GENERATION\n")
@@ -124,7 +123,7 @@ def test_windows_path_identity_change_fails_closed(monkeypatch) -> None:
 
 
 def test_bind_uses_python_interpreter_as_real_executable() -> None:
-    bound = bind_trusted_executable(os.path.realpath(sys.executable))
+    bound = bind_trusted_executable(os.path.realpath(sys.executable), verify_custody=False)
     try:
         assert bound.fd >= 0
         assert bound.identity.size > 0

--- a/cli/tests/test_doctor_exec.py
+++ b/cli/tests/test_doctor_exec.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from defenseclaw.commands.cmd_doctor import _windows_system_powershell
 from defenseclaw.doctor_exec import (
     ExecBindError,
     bind_trusted_executable,
@@ -127,6 +128,68 @@ def test_bind_uses_python_interpreter_as_real_executable() -> None:
     try:
         assert bound.fd >= 0
         assert bound.identity.size > 0
+        revalidate_bound_executable(bound)
+    finally:
+        bound.close()
+
+
+def test_windows_pathname_custody_uses_executable_acl_not_private_file_owner(monkeypatch) -> None:
+    from defenseclaw import doctor_exec
+
+    powershell = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+    parent = r"C:\Windows\System32\WindowsPowerShell\v1.0"
+
+    monkeypatch.setattr(doctor_exec.os, "name", "nt")
+    monkeypatch.setattr(doctor_exec.os.path, "abspath", lambda value: value)
+    monkeypatch.setattr(doctor_exec.os.path, "dirname", lambda value: parent if value == powershell else value)
+    monkeypatch.setattr(doctor_exec.os.path, "isfile", lambda _value: True)
+    monkeypatch.setattr(
+        "defenseclaw.gateway.packaged_windows_gateway_path",
+        lambda: None,
+    )
+    seen: list[tuple[str, bool]] = []
+
+    def custody(path: str, *, allow_current_user: bool = False, **_kwargs):
+        seen.append((path, allow_current_user))
+        return None
+
+    monkeypatch.setattr(doctor_exec, "windows_acl_custody_write_error", custody)
+
+    assert doctor_exec._verify_pathname_custody(powershell) == powershell
+    assert seen == [(powershell, True), (parent, True)]
+
+
+def test_windows_pathname_custody_refuses_untrusted_writers(monkeypatch) -> None:
+    from defenseclaw import doctor_exec
+    from defenseclaw.doctor_exec import ExecBindError
+
+    tool = r"C:\Users\runneradmin\cursor-hook.exe"
+    monkeypatch.setattr(doctor_exec.os, "name", "nt")
+    monkeypatch.setattr(doctor_exec.os.path, "abspath", lambda value: value)
+    monkeypatch.setattr(doctor_exec.os.path, "dirname", lambda value: r"C:\Users\runneradmin")
+    monkeypatch.setattr(doctor_exec.os.path, "isfile", lambda _value: True)
+    monkeypatch.setattr(
+        "defenseclaw.gateway.packaged_windows_gateway_path",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        doctor_exec,
+        "windows_acl_custody_write_error",
+        lambda _path, **_kwargs: "ACL grants write access to untrusted SID S-1-5-32-545",
+    )
+    with pytest.raises(ExecBindError, match="custody"):
+        doctor_exec._verify_pathname_custody(tool)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="native Windows PowerShell bind")
+def test_bind_system_powershell_with_executable_custody() -> None:
+    powershell, windows_directory = _windows_system_powershell()
+    assert powershell
+    assert windows_directory
+    bound = bind_trusted_executable(powershell)
+    try:
+        assert bound.fd >= 0
+        assert bound.path == powershell
         revalidate_bound_executable(bound)
     finally:
         bound.close()

--- a/cli/tests/test_doctor_exec.py
+++ b/cli/tests/test_doctor_exec.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Check-to-exec replacement-race coverage for Doctor lifecycle spawn."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from defenseclaw.doctor_exec import (
+    ExecBindError,
+    bind_trusted_executable,
+    revalidate_bound_executable,
+    run_bound_executable,
+)
+
+
+def _write_exec(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_bind_trusted_executable_rejects_relative_and_missing(tmp_path: Path) -> None:
+    with pytest.raises(ExecBindError, match="not absolute"):
+        bind_trusted_executable("defenseclaw-gateway")
+    with pytest.raises(ExecBindError):
+        bind_trusted_executable(str(tmp_path / "missing-gateway"))
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux fexec via /proc/self/fd")
+def test_posix_spawn_executes_held_inode_after_path_replacement(tmp_path: Path) -> None:
+    tool = tmp_path / "defenseclaw-gateway"
+    _write_exec(tool, "#!/bin/sh\necho ORIGINAL-GENERATION\n")
+    bound = bind_trusted_executable(str(tool))
+    try:
+        tool.unlink()
+        _write_exec(tool, "#!/bin/sh\necho REPLACED-GENERATION\n")
+        result = run_bound_executable(
+            bound,
+            ["status"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        assert result.returncode == 0
+        assert "ORIGINAL-GENERATION" in result.stdout
+        assert "REPLACED-GENERATION" not in result.stdout
+    finally:
+        bound.close()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX bind")
+def test_run_bound_keeps_explicit_argv_and_disables_shell(tmp_path: Path) -> None:
+    tool = tmp_path / "defenseclaw-gateway"
+    _write_exec(tool, "#!/bin/sh\necho ok\n")
+    runner = MagicMock(return_value=subprocess.CompletedProcess(["x"], 0, "", ""))
+    bound = bind_trusted_executable(str(tool))
+    try:
+        run_bound_executable(bound, ["restart"], runner=runner, timeout=1)
+        argv, kwargs = runner.call_args
+        assert argv[0][0] == bound.path
+        assert argv[0][1:] == ["restart"]
+        assert kwargs["shell"] is False
+        if sys.platform.startswith("linux"):
+            assert kwargs["executable"] == f"/proc/self/fd/{bound.fd}"
+            assert bound.fd in kwargs["pass_fds"]
+        else:
+            assert kwargs["executable"] == bound.path
+            assert "pass_fds" not in kwargs
+    finally:
+        bound.close()
+
+
+@pytest.mark.skipif(os.name == "nt" or sys.platform.startswith("linux"), reason="Darwin path-identity fail-closed")
+def test_darwin_spawn_fails_closed_after_path_replacement(tmp_path: Path) -> None:
+    tool = tmp_path / "defenseclaw-gateway"
+    _write_exec(tool, "#!/bin/sh\necho ORIGINAL-GENERATION\n")
+    bound = bind_trusted_executable(str(tool))
+    try:
+        tool.unlink()
+        _write_exec(tool, "#!/bin/sh\necho REPLACED-GENERATION\n")
+        with pytest.raises(ExecBindError, match="replaced"):
+            run_bound_executable(bound, ["status"], timeout=5)
+    finally:
+        bound.close()
+
+
+def test_windows_path_identity_change_fails_closed(monkeypatch) -> None:
+    from defenseclaw.doctor_exec import BoundExecutable, ExecutableIdentity, _assert_windows_path_still_bound
+
+    bound = BoundExecutable(
+        r"C:\Program Files\DefenseClaw\defenseclaw-gateway.exe",
+        fd=3,
+        identity=ExecutableIdentity(
+            device=1,
+            inode=2,
+            size=3,
+            windows_volume=10,
+            windows_index=20,
+        ),
+    )
+    monkeypatch.setattr("defenseclaw.doctor_exec._windows_path_file_id", lambda _path: (11, 21))
+    with pytest.raises(ExecBindError, match="replaced"):
+        _assert_windows_path_still_bound(bound)
+
+
+def test_bind_uses_python_interpreter_as_real_executable() -> None:
+    bound = bind_trusted_executable(os.path.realpath(sys.executable))
+    try:
+        assert bound.fd >= 0
+        assert bound.identity.size > 0
+        revalidate_bound_executable(bound)
+    finally:
+        bound.close()

--- a/cli/tests/test_doctor_peer.py
+++ b/cli/tests/test_doctor_peer.py
@@ -1,0 +1,269 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Replacement-race coverage for Doctor peer-bound credential probes."""
+
+from __future__ import annotations
+
+import http.server
+import ipaddress
+import os
+import threading
+from pathlib import Path
+
+import pytest
+from defenseclaw.commands.cmd_doctor import _http_probe
+from defenseclaw.doctor_peer import (
+    PeerBindError,
+    TrustedPeer,
+    bind_connected_peer,
+    linux_established_peer_pid_from_proc,
+    loopback_bearer_requires_peer,
+    lsof_established_peer_pid_from_output,
+    windows_established_peer_pid_from_rows,
+)
+
+_TOKEN = "peer-bind-token-must-not-render"
+
+
+def test_trusted_peer_requires_positive_pid_and_start_identity() -> None:
+    with pytest.raises(PeerBindError):
+        TrustedPeer(pid=0, start_identity="start-1")
+    with pytest.raises(PeerBindError):
+        TrustedPeer(pid=4242, start_identity="  ")
+
+
+def test_loopback_bearer_requires_peer_but_remote_and_non_bearer_do_not() -> None:
+    assert loopback_bearer_requires_peer(
+        "http://127.0.0.1:18790/status",
+        {"Authorization": f"Bearer {_TOKEN}"},
+    )
+    assert loopback_bearer_requires_peer(
+        "http://localhost:18790/status",
+        {"Authorization": f"Bearer {_TOKEN}"},
+    )
+    assert not loopback_bearer_requires_peer(
+        "http://127.0.0.1:18790/status",
+        {"Authorization": f"Splunk {_TOKEN}"},
+    )
+    assert not loopback_bearer_requires_peer(
+        "https://api.openai.com/v1/models",
+        {"Authorization": f"Bearer {_TOKEN}"},
+    )
+
+
+def test_bind_connected_peer_rejects_pid_and_generation_mismatch() -> None:
+    trusted = TrustedPeer(pid=4242, start_identity="start-1")
+    with pytest.raises(PeerBindError, match="verified gateway process"):
+        bind_connected_peer(
+            object(),  # type: ignore[arg-type]
+            trusted,
+            peer_lookup=lambda _sock: 4243,
+            process_lookup=lambda _pid: "start-1",
+        )
+    with pytest.raises(PeerBindError, match="verified gateway generation"):
+        bind_connected_peer(
+            object(),  # type: ignore[arg-type]
+            trusted,
+            peer_lookup=lambda _sock: 4242,
+            process_lookup=lambda _pid: "start-2",
+        )
+    with pytest.raises(PeerBindError, match="start identity is unavailable"):
+        bind_connected_peer(
+            object(),  # type: ignore[arg-type]
+            trusted,
+            peer_lookup=lambda _sock: 4242,
+            process_lookup=lambda _pid: "",
+        )
+
+
+def test_linux_established_peer_pid_from_fake_proc(tmp_path: Path) -> None:
+    local_ip = ipaddress.ip_address("127.0.0.1")
+    remote_ip = ipaddress.ip_address("127.0.0.1")
+    local_port = 54321
+    remote_port = 18790
+    proc_root = tmp_path / "proc"
+    net = proc_root / "net"
+    net.mkdir(parents=True)
+    (proc_root / "4242" / "fd").mkdir(parents=True)
+    (proc_root / "9" / "fd").mkdir(parents=True)
+    (net / "tcp").write_text(
+        "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n"
+        f"   0: 0100007F:{remote_port:04X} 0100007F:{local_port:04X} 01 00000000:00000000 00:00000000 00000000     0        0 99 1 0000000000000000 20 0 0 1 0\n",
+        encoding="ascii",
+    )
+    os.symlink("socket:[99]", proc_root / "4242" / "fd" / "3")
+    os.symlink("socket:[8]", proc_root / "9" / "fd" / "3")
+
+    assert (
+        linux_established_peer_pid_from_proc(
+            local_ip,
+            local_port,
+            remote_ip,
+            remote_port,
+            proc_root=str(proc_root),
+        )
+        == 4242
+    )
+
+
+def test_linux_established_peer_pid_fails_closed_when_missing(tmp_path: Path) -> None:
+    proc_root = tmp_path / "proc"
+    (proc_root / "net").mkdir(parents=True)
+    (proc_root / "net" / "tcp").write_text(
+        "  sl  local_address rem_address   st inode\n",
+        encoding="ascii",
+    )
+    with pytest.raises(PeerBindError, match="ESTABLISHED"):
+        linux_established_peer_pid_from_proc(
+            ipaddress.ip_address("127.0.0.1"),
+            1,
+            ipaddress.ip_address("127.0.0.1"),
+            2,
+            proc_root=str(proc_root),
+        )
+
+
+def test_windows_established_rows_require_unique_owner() -> None:
+    local_ip = ipaddress.ip_address("127.0.0.1")
+    remote_ip = ipaddress.ip_address("127.0.0.1")
+    rows = [
+        (5, "127.0.0.1", 18790, "127.0.0.1", 54321, 4242),
+        (2, "127.0.0.1", 18790, "0.0.0.0", 0, 7),
+    ]
+    assert (
+        windows_established_peer_pid_from_rows(rows, local_ip, 54321, remote_ip, 18790)
+        == 4242
+    )
+    with pytest.raises(PeerBindError, match="uniquely identified"):
+        windows_established_peer_pid_from_rows(
+            [
+                (5, "127.0.0.1", 18790, "127.0.0.1", 54321, 4242),
+                (5, "127.0.0.1", 18790, "127.0.0.1", 54321, 4243),
+            ],
+            local_ip,
+            54321,
+            remote_ip,
+            18790,
+        )
+
+
+def test_lsof_established_output_selects_gateway_side() -> None:
+    stdout = (
+        "p111\n"
+        "n127.0.0.1:54321->127.0.0.1:18790\n"
+        "p4242\n"
+        "n127.0.0.1:18790->127.0.0.1:54321\n"
+    )
+    assert (
+        lsof_established_peer_pid_from_output(
+            stdout,
+            ipaddress.ip_address("127.0.0.1"),
+            54321,
+            ipaddress.ip_address("127.0.0.1"),
+            18790,
+        )
+        == 4242
+    )
+
+
+class _RecordingHandler(http.server.BaseHTTPRequestHandler):
+    received_authorization: list[str] = []
+
+    def do_GET(self) -> None:
+        self.received_authorization.append(self.headers.get("Authorization", ""))
+        body = b'{"runtime":{"pid":4242}}'
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args) -> None:
+        return
+
+
+def _serve() -> tuple[http.server.HTTPServer, threading.Thread]:
+    _RecordingHandler.received_authorization = []
+    server = http.server.HTTPServer(("127.0.0.1", 0), _RecordingHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def test_http_probe_refuses_loopback_bearer_without_trusted_peer() -> None:
+    server, thread = _serve()
+    try:
+        url = f"http://127.0.0.1:{server.server_address[1]}/status"
+        code, body = _http_probe(
+            url,
+            headers={"Authorization": f"Bearer {_TOKEN}"},
+            timeout=2.0,
+            bypass_proxy=True,
+        )
+        assert code == 0
+        assert "before peer bind" in body
+        assert _RecordingHandler.received_authorization == []
+        assert _TOKEN not in body
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_http_probe_does_not_send_bearer_to_replaced_peer() -> None:
+    server, thread = _serve()
+    trusted = TrustedPeer(pid=4242, start_identity="start-1")
+    try:
+        url = f"http://127.0.0.1:{server.server_address[1]}/status"
+        code, body = _http_probe(
+            url,
+            headers={"Authorization": f"Bearer {_TOKEN}"},
+            timeout=2.0,
+            bypass_proxy=True,
+            trusted_peer=trusted,
+            peer_lookup=lambda _sock: 9999,
+            process_lookup=lambda _pid: "start-1",
+        )
+        assert code == 0
+        assert "verified gateway process" in body
+        assert _RecordingHandler.received_authorization == []
+        assert _TOKEN not in body
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_http_probe_sends_bearer_only_after_matching_peer_bind() -> None:
+    server, thread = _serve()
+    trusted = TrustedPeer(pid=4242, start_identity="start-1")
+    try:
+        url = f"http://127.0.0.1:{server.server_address[1]}/status"
+        code, body = _http_probe(
+            url,
+            headers={"Authorization": f"Bearer {_TOKEN}"},
+            timeout=2.0,
+            bypass_proxy=True,
+            trusted_peer=trusted,
+            peer_lookup=lambda _sock: 4242,
+            process_lookup=lambda _pid: "start-1",
+        )
+        assert code == 200, body
+        assert _RecordingHandler.received_authorization == [f"Bearer {_TOKEN}"]
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/cli/tests/test_doctor_peer.py
+++ b/cli/tests/test_doctor_peer.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import http.server
 import ipaddress
 import os
+import ssl
 import threading
 from pathlib import Path
 
@@ -33,6 +34,8 @@ from defenseclaw.doctor_peer import (
     linux_established_peer_pid_from_proc,
     loopback_bearer_requires_peer,
     lsof_established_peer_pid_from_output,
+    lsof_tcp_selector,
+    peer_bound_handlers,
     windows_established_peer_pid_from_rows,
 )
 
@@ -120,6 +123,35 @@ def test_linux_established_peer_pid_from_fake_proc(tmp_path: Path) -> None:
     )
 
 
+def test_linux_tcp6_mapped_loopback_matches_ipv4_endpoints(tmp_path: Path) -> None:
+    proc_root = tmp_path / "proc"
+    (proc_root / "net").mkdir(parents=True)
+    (proc_root / "4242" / "fd").mkdir(parents=True)
+    (proc_root / "net" / "tcp").write_text(
+        "  sl  local_address rem_address   st inode\n",
+        encoding="ascii",
+    )
+    (proc_root / "net" / "tcp6").write_text(
+        "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n"
+        "   0: 0000000000000000FFFF00000100007F:4966 "
+        "0000000000000000FFFF00000100007F:D431 01 00000000:00000000 "
+        "00:00000000 00000000     0        0 99 1 0000000000000000 20 0 0 1 0\n",
+        encoding="ascii",
+    )
+    os.symlink("socket:[99]", proc_root / "4242" / "fd" / "3")
+
+    assert (
+        linux_established_peer_pid_from_proc(
+            ipaddress.ip_address("127.0.0.1"),
+            54321,
+            ipaddress.ip_address("127.0.0.1"),
+            18790,
+            proc_root=str(proc_root),
+        )
+        == 4242
+    )
+
+
 def test_linux_established_peer_pid_fails_closed_when_missing(tmp_path: Path) -> None:
     proc_root = tmp_path / "proc"
     (proc_root / "net").mkdir(parents=True)
@@ -159,6 +191,30 @@ def test_windows_established_rows_require_unique_owner() -> None:
             remote_ip,
             18790,
         )
+
+
+def test_lsof_tcp_selector_brackets_ipv6_literals() -> None:
+    assert lsof_tcp_selector(ipaddress.ip_address("127.0.0.1"), 18790) == "-iTCP@127.0.0.1:18790"
+    assert lsof_tcp_selector(ipaddress.ip_address("::1"), 18790) == "-iTCP@[::1]:18790"
+
+
+def test_https_handler_forwards_ssl_context() -> None:
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    handler = peer_bound_handlers(
+        TrustedPeer(pid=4242, start_identity="start-1"),
+        ssl_context=context,
+    )[1]
+    captured: dict[str, object] = {}
+
+    def fake_do_open(http_class, _req, **kwargs):
+        captured["kwargs"] = kwargs
+        captured["connection"] = http_class("127.0.0.1", 443, **kwargs)
+        return object()
+
+    handler.do_open = fake_do_open  # type: ignore[method-assign]
+    assert handler.https_open(object()) is not None
+    assert captured["kwargs"] == {"context": context}
+    assert getattr(captured["connection"], "_context") is context
 
 
 def test_lsof_established_output_selects_gateway_side() -> None:


### PR DESCRIPTION
Stacked on top of #846 (`fix/archive-artifact-lineage`). Review/merge that PR first; this PR's base is the stack parent, not `main`.

Fixes #642.
Fixes #643.

## Problem

Doctor verifies the managed gateway generation, then sends the long-lived bearer on a later TCP connection and later execs the lifecycle binary by pathname. A local replacement in either interval can receive the credential or run instead of the inspected object. Post-response PID/home checks and pathname custody walks cannot close those races.

## Current Situation

Authenticated `/status` probes already disable redirects, bypass proxies, and require listener plus PID/start-identity/home trust. The urllib connect still writes `Authorization` before that generation is proven to own the established socket.

Gateway restart and the Windows Cursor runtime probe already reject links, reparses, weak ACLs, and PATH overrides. `subprocess.run([path, ...])` still opens a new object after those checks.

## Solution

Bind both intervals to the inspected object, then fail closed.

- After TCP connect and before request bytes, map the ESTABLISHED peer to a PID and start identity. Loopback bearer probes without that bind never send the token.
- Linux lifecycle spawn execs the held inode through `/proc/self/fd/<n>`. Darwin and Windows re-validate path identity against the held object and refuse a replacement.
- The Windows Cursor probe holds the system PowerShell and adapter objects across the live round trip.

```
inspect PID + start identity + listener
        │
        ├─ TCP connect ── peer bind ──▶ send bearer / refuse
        │
        └─ open executable ── hold inode/handle ──▶ spawn held object / refuse
```

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `cli/defenseclaw/doctor_peer.py` | ESTABLISHED peer PID/start-identity bind for Linux, macOS, and Windows |
| `cli/defenseclaw/doctor_exec.py` | Handle-bound lifecycle spawn and documented installation custody model |
| `cli/defenseclaw/commands/cmd_doctor.py` | Peer-bound gateway bearer probes; Cursor probe holds PowerShell and adapter |
| `cli/defenseclaw/commands/cmd_setup.py` | Restart/status/stop spawn from the held executable object |
| `cli/tests/test_doctor_peer.py` | Replacement-race coverage: bearer is never sent to an unbound peer |
| `cli/tests/test_doctor_exec.py` | Linux held-inode exec; Darwin/Windows fail-closed path swap |

## Breaking Changes

None. Untrusted or unbindable endpoints and binaries already failed closed; they now fail before the credential or spawn is used.

## Open Issues / Follow-ups

None

## Test Plan

```
python -m pytest cli/tests/test_doctor_peer.py cli/tests/test_doctor_exec.py \
  cli/tests/test_cmd_doctor_gateway_auth_fail_closed.py \
  cli/tests/test_guardrail.py::TestRestartDefenseGateway \
  cli/tests/test_doctor_security_boundaries.py \
  cli/tests/test_cmd_doctor.py::DoctorHttpProbeRedirectTests -q
```

Observed: `19 passed, 1 skipped` for the new modules plus the listed restart/auth/security classes; HTTP redirect probes passed.

```
PYTHONPATH=cli python -c "from defenseclaw.commands import cmd_setup, cmd_doctor; from defenseclaw import doctor_peer, doctor_exec"
```

Observed: `imports ok`