### PR TITLE
feat(windows): add native managed rotation prepare/commit/rollback

### DIFF
--- a/cli/defenseclaw/rotate_token_guardian.py
+++ b/cli/defenseclaw/rotate_token_guardian.py
@@ -14,11 +14,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Coordinate the Linux/macOS guardian participant during token rotation.
+"""Coordinate the managed guardian participant during token rotation.
 
 Issue #735 binds service-side rotate-token to the #734 prepare/commit/rollback
-commands. Public state carries only identities, opaque operation/generation
-IDs, and canonical non-secret fingerprints.
+commands. Windows managed-enterprise uses the native DefenseClawHookGuardian
+adapter from spec 007 / #736 and must never share the POSIX journal. Public
+state carries only identities, opaque operation/generation IDs, and canonical
+non-secret fingerprints.
 """
 
 from __future__ import annotations
@@ -35,17 +37,23 @@ from typing import Any
 import click
 import yaml
 
+from defenseclaw import windows_acl
 from defenseclaw.file_permissions import (
     UnsafePathError,
     darwin_acl_write_error,
     open_regular_file_no_follow,
+    reject_reparse_path,
 )
 
 GUARDIAN_MANIFEST_ENV = "DEFENSECLAW_HOOK_GUARDIAN_MANIFEST"
 GUARDIAN_AUTH_DIR_ENV = "DEFENSECLAW_HOOK_GUARDIAN_AUTH_DIR"
 _LINUX_DEFAULT_MANIFEST = "/etc/defenseclaw/hook-guardian/targets.yaml"
 _DARWIN_DEFAULT_MANIFEST = "/opt/cisco/secureclient/defenseclaw/hook-guardian/targets.yaml"
+_WINDOWS_DEFAULT_MANIFEST = (
+    r"C:\ProgramData\Cisco\Cisco Secure Client\DefenseClaw\hook-guardian\targets.yaml"
+)
 _JOURNAL_FILE = "rotation-transaction.json"
+_WINDOWS_JOURNAL_FILE = "windows-rotation-transaction.json"
 _AUTHORIZATION_FILE = "protected_targets.json"
 _LOCK_BASE_NAME = "rotation-transaction"
 _MANIFEST_MAX_BYTES = 4 << 20
@@ -123,7 +131,15 @@ def default_guardian_manifest_path(platform: str | None = None) -> str:
     resolved = (platform or sys.platform).strip().lower()
     if resolved == "darwin":
         return _DARWIN_DEFAULT_MANIFEST
+    if resolved.startswith("win"):
+        return _WINDOWS_DEFAULT_MANIFEST
     return _LINUX_DEFAULT_MANIFEST
+
+
+def guardian_journal_file() -> str:
+    if os.name == "nt":
+        return _WINDOWS_JOURNAL_FILE
+    return _JOURNAL_FILE
 
 
 def guardian_manifest_path() -> str:
@@ -148,6 +164,8 @@ def assert_guardian_control_plane_path(
 
     if not path or not os.path.isabs(path):
         raise click.ClickException(f"{label} path is not an absolute trusted path.")
+    if os.name == "nt":
+        return _assert_windows_guardian_control_plane_path(path, label, directory=directory)
     current = path
     leaf = True
     leaf_info: os.stat_result | None = None
@@ -181,6 +199,51 @@ def assert_guardian_control_plane_path(
     return leaf_info
 
 
+def _assert_windows_guardian_control_plane_path(
+    path: str,
+    label: str,
+    *,
+    directory: bool = False,
+) -> os.stat_result:
+    current = path
+    leaf = True
+    leaf_info: os.stat_result | None = None
+    while True:
+        try:
+            reject_reparse_path(current)
+        except UnsafePathError as exc:
+            raise click.ClickException(f"{label} is not a trusted regular path.") from exc
+        try:
+            info = os.lstat(current)
+        except OSError as exc:
+            raise click.ClickException(f"{label} is unavailable; no credentials were modified.") from exc
+        if stat.S_ISLNK(info.st_mode):
+            raise click.ClickException(f"{label} is not a trusted regular path.")
+        if leaf:
+            if directory and not stat.S_ISDIR(info.st_mode):
+                raise click.ClickException(f"{label} is not a trusted directory.")
+            if not directory and not stat.S_ISREG(info.st_mode):
+                raise click.ClickException(f"{label} is not a trusted regular file.")
+            leaf_info = info
+        elif not stat.S_ISDIR(info.st_mode):
+            raise click.ClickException(f"{label} ancestor is not a trusted directory.")
+        try:
+            security = windows_acl.capture_path(current, directory=stat.S_ISDIR(info.st_mode))
+            windows_acl.assert_trusted_owner(security)
+            windows_acl.assert_not_broadly_writable(security)
+        except windows_acl.WindowsAclError as exc:
+            raise click.ClickException(
+                f"{label} is not administrator-owned; no credentials were modified."
+            ) from exc
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+        leaf = False
+    assert leaf_info is not None
+    return leaf_info
+
+
 def guardian_manifest_digest(manifest_path: str) -> str:
     info = assert_guardian_control_plane_path(manifest_path, "guardian manifest")
     return _sha256_regular_file(manifest_path, info, _MANIFEST_MAX_BYTES, "guardian manifest")
@@ -197,12 +260,14 @@ WINDOWS_MANAGED_ROTATION_UNAVAILABLE = (
 
 
 def require_guardian_participant(cfg: Any) -> bool:
-    """Join Linux/macOS guardians only. Windows waits for spec 007 / #736."""
+    """Join managed-enterprise guardians on every supported host OS.
+
+    Windows uses the native DefenseClawHookGuardian adapter. The POSIX
+    journal protocol must never be selected from this coordinator.
+    """
 
     if not is_managed_enterprise(cfg):
         return False
-    if os.name == "nt":
-        raise click.ClickException(WINDOWS_MANAGED_ROTATION_UNAVAILABLE)
     return True
 
 
@@ -278,7 +343,13 @@ def assert_guardian_idle(data_dir: str) -> None:
     auth_dir = guardian_authorization_dir(data_dir)
     if os.path.lexists(auth_dir):
         assert_guardian_control_plane_path(auth_dir, "guardian authorization directory", directory=True)
-    journal_path = os.path.join(auth_dir, _JOURNAL_FILE)
+    if os.name == "nt":
+        posix_journal = os.path.join(auth_dir, _JOURNAL_FILE)
+        if os.path.lexists(posix_journal):
+            raise click.ClickException(
+                "A POSIX guardian journal is present on Windows; no credentials were modified."
+            )
+    journal_path = os.path.join(auth_dir, guardian_journal_file())
     if not os.path.lexists(journal_path):
         return
     payload = _load_bounded_json(journal_path, "guardian rotation journal")

--- a/cli/defenseclaw/rotate_token_guardian.py
+++ b/cli/defenseclaw/rotate_token_guardian.py
@@ -40,10 +40,13 @@ import yaml
 from defenseclaw import windows_acl
 from defenseclaw.file_permissions import (
     UnsafePathError,
+    _windows_current_user_sid,
     darwin_acl_write_error,
     open_regular_file_no_follow,
     reject_reparse_path,
 )
+
+_WINDOWS_LOCAL_SYSTEM_SID = "S-1-5-18"
 
 GUARDIAN_MANIFEST_ENV = "DEFENSECLAW_HOOK_GUARDIAN_MANIFEST"
 GUARDIAN_AUTH_DIR_ENV = "DEFENSECLAW_HOOK_GUARDIAN_AUTH_DIR"
@@ -229,16 +232,21 @@ def _assert_windows_guardian_control_plane_path(
             raise click.ClickException(f"{label} ancestor is not a trusted directory.")
         try:
             security = windows_acl.capture_path(current, directory=stat.S_ISDIR(info.st_mode))
-            windows_acl.assert_trusted_owner(security)
-            windows_acl.assert_not_broadly_writable(security)
         except windows_acl.WindowsAclError as exc:
-            detail = str(exc)
-            if "broad" in detail.lower():
-                raise click.ClickException(
-                    f"{label} is broadly writable; no credentials were modified."
-                ) from exc
+            raise click.ClickException(
+                f"{label} security could not be read; no credentials were modified."
+            ) from exc
+        try:
+            windows_acl.assert_trusted_owner(security)
+        except windows_acl.WindowsAclError as exc:
             raise click.ClickException(
                 f"{label} is not administrator-owned; no credentials were modified."
+            ) from exc
+        try:
+            windows_acl.assert_not_broadly_writable(security)
+        except windows_acl.WindowsAclError as exc:
+            raise click.ClickException(
+                f"{label} is broadly writable; no credentials were modified."
             ) from exc
         parent = os.path.dirname(current)
         if parent == current:
@@ -264,15 +272,34 @@ WINDOWS_MANAGED_ROTATION_UNAVAILABLE = (
 )
 
 
-def require_guardian_participant(cfg: Any) -> bool:
-    """Join managed-enterprise guardians on every supported host OS.
+def _windows_process_is_localsystem() -> bool:
+    """Return whether this process token is the LocalSystem guardian."""
+    if os.name != "nt":
+        return False
+    try:
+        return _windows_current_user_sid() == _WINDOWS_LOCAL_SYSTEM_SID
+    except OSError:
+        return False
 
-    Windows uses the native DefenseClawHookGuardian adapter. The POSIX
-    journal protocol must never be selected from this coordinator.
+
+def require_guardian_participant(cfg: Any) -> bool:
+    """Join managed-enterprise guardians when the participant can actually run.
+
+    Windows uses the native DefenseClawHookGuardian adapter and must never
+    select the POSIX journal. Administrator ``rotate-token`` cannot inherit
+    LocalSystem, so it refuses before stop/mutate until the guardian service
+    dispatches rotation. LocalSystem may join the native adapter.
     """
 
     if not is_managed_enterprise(cfg):
         return False
+    if os.name == "nt" and not _windows_process_is_localsystem():
+        raise click.ClickException(
+            "Managed-enterprise token rotation on Windows must run as the "
+            "LocalSystem DefenseClawHookGuardian. Administrator rotate-token "
+            "cannot dispatch the native adapter until service-side rotation "
+            "exists; no credentials were modified."
+        )
     return True
 
 

--- a/cli/defenseclaw/rotate_token_guardian.py
+++ b/cli/defenseclaw/rotate_token_guardian.py
@@ -232,6 +232,11 @@ def _assert_windows_guardian_control_plane_path(
             windows_acl.assert_trusted_owner(security)
             windows_acl.assert_not_broadly_writable(security)
         except windows_acl.WindowsAclError as exc:
+            detail = str(exc)
+            if "broad" in detail.lower():
+                raise click.ClickException(
+                    f"{label} is broadly writable; no credentials were modified."
+                ) from exc
             raise click.ClickException(
                 f"{label} is not administrator-owned; no credentials were modified."
             ) from exc

--- a/cli/tests/test_cmd_setup_rotate_token.py
+++ b/cli/tests/test_cmd_setup_rotate_token.py
@@ -33,7 +33,7 @@ from defenseclaw.commands.cmd_setup import _rotate_token_atomic_write
 from defenseclaw.config import CONFIG_PATH_ENV
 from defenseclaw.context import AppContext
 from defenseclaw.logger import CanonicalObservabilityUnavailableError
-from defenseclaw.rotate_token_guardian import assert_current_attestations
+from defenseclaw.rotate_token_guardian import assert_current_attestations, guardian_journal_file
 
 from tests.permissions import assert_owner_only_file
 
@@ -2295,7 +2295,7 @@ class RotateTokenGuardianCoordinatorTests(unittest.TestCase):
             Path(dotenv).write_bytes(b"DEFENSECLAW_GATEWAY_TOKEN=" + b"a" * 64 + b"\n")
             plan = _guardian_plan("codex", td=td, users=("alice",))
             _write_current_authorization(td, plan, {"codex": _fixture_hook_fingerprint(1)}, "a" * 32)
-            journal = _in_tree_auth_dir(td) / "rotation-transaction.json"
+            journal = _in_tree_auth_dir(td) / guardian_journal_file()
             journal.write_text(json.dumps({"phase": "prepared", "operation_id": "c" * 32}), encoding="utf-8")
             lifecycle = mock.Mock()
             with (
@@ -2307,6 +2307,31 @@ class RotateTokenGuardianCoordinatorTests(unittest.TestCase):
             self.assertNotEqual(result.exit_code, 0, msg=result.output)
             lifecycle.assert_not_called()
             self.assertIn("already in progress", result.output)
+
+    def test_posix_guardian_journal_fails_before_stop_on_windows(self) -> None:
+        from tempfile import TemporaryDirectory
+
+        if os.name != "nt":
+            self.skipTest("POSIX journal conflict is a Windows coordinator refusal")
+        with TemporaryDirectory() as td:
+            app = _make_rotate_ctx(td, ["codex"])
+            dotenv = os.path.join(td, ".env")
+            Path(dotenv).write_bytes(b"DEFENSECLAW_GATEWAY_TOKEN=" + b"a" * 64 + b"\n")
+            plan = _guardian_plan("codex", td=td, users=("alice",))
+            _write_current_authorization(td, plan, {"codex": _fixture_hook_fingerprint(1)}, "a" * 32)
+            journal = _in_tree_auth_dir(td) / "rotation-transaction.json"
+            journal.write_text(json.dumps({"phase": "prepared", "operation_id": "c" * 32}), encoding="utf-8")
+            lifecycle = mock.Mock()
+            with (
+                mock.patch.object(cmd_setup, "_rotate_token_guardian_plan", return_value=plan),
+                mock.patch.object(cmd_setup, "_run_rotate_token_lifecycle", lifecycle),
+                mock.patch.object(cmd_setup, "_run_guardian_rotate"),
+            ):
+                result = CliRunner().invoke(cmd_setup.rotate_token_cmd, ["--yes"], obj=app)
+            self.assertNotEqual(result.exit_code, 0, msg=result.output)
+            lifecycle.assert_not_called()
+            self.assertIn("POSIX guardian journal", result.output)
+            self.assertTrue(journal.exists())
 
     def test_exposure_recovery_rolls_back_guardian_but_does_not_restart_a(self) -> None:
         from tempfile import TemporaryDirectory
@@ -2579,7 +2604,7 @@ class RotateTokenGuardianCoordinatorTests(unittest.TestCase):
             Path(dotenv).write_bytes(b"DEFENSECLAW_GATEWAY_TOKEN=" + b"a" * 64 + b"\n")
             plan = _guardian_plan("codex", td=td, users=("alice",))
             _write_current_authorization(td, plan, {"codex": _fixture_hook_fingerprint(1)}, "a" * 32)
-            journal = _in_tree_auth_dir(td) / "rotation-transaction.json"
+            journal = _in_tree_auth_dir(td) / guardian_journal_file()
             journal.write_text(json.dumps({"phase": "committed", "operation_id": "c" * 32}), encoding="utf-8")
             events: list[str] = []
 

--- a/cli/tests/test_rotate_token_guardian.py
+++ b/cli/tests/test_rotate_token_guardian.py
@@ -184,10 +184,29 @@ class RequireGuardianParticipantBehaviorTests(RequireGuardianParticipantTests):
         self.assertFalse(require_guardian_participant(SimpleNamespace(deployment_mode="")))
 
     def test_windows_managed_joins_native_adapter(self) -> None:
-        with mock.patch("defenseclaw.rotate_token_guardian.os.name", "nt"):
+        with (
+            mock.patch("defenseclaw.rotate_token_guardian.os.name", "nt"),
+            mock.patch(
+                "defenseclaw.rotate_token_guardian._windows_process_is_localsystem",
+                return_value=True,
+            ),
+        ):
             self.assertTrue(
                 require_guardian_participant(SimpleNamespace(deployment_mode="managed_enterprise"))
             )
+
+    def test_windows_admin_refuses_before_mutation(self) -> None:
+        with (
+            mock.patch("defenseclaw.rotate_token_guardian.os.name", "nt"),
+            mock.patch(
+                "defenseclaw.rotate_token_guardian._windows_process_is_localsystem",
+                return_value=False,
+            ),
+        ):
+            with self.assertRaises(click.ClickException) as raised:
+                require_guardian_participant(SimpleNamespace(deployment_mode="managed_enterprise"))
+        self.assertIn("LocalSystem", str(raised.exception))
+        self.assertIn("no credentials were modified", str(raised.exception))
 
     @unittest.skipIf(os.name == "nt", "POSIX managed participant")
     def test_posix_managed_joins(self) -> None:

--- a/cli/tests/test_rotate_token_guardian.py
+++ b/cli/tests/test_rotate_token_guardian.py
@@ -14,7 +14,6 @@ import click
 from defenseclaw.rotate_token_guardian import (
     GUARDIAN_AUTH_DIR_ENV,
     GUARDIAN_MANIFEST_ENV,
-    WINDOWS_MANAGED_ROTATION_UNAVAILABLE,
     GuardianRotationPlan,
     GuardianRotationTarget,
     assert_current_attestations,
@@ -23,6 +22,7 @@ from defenseclaw.rotate_token_guardian import (
     bind_guardian_roster,
     default_guardian_manifest_path,
     expected_fingerprints_payload,
+    guardian_journal_file,
     guardian_manifest_digest,
     parse_guardian_rotate_response,
     require_guardian_participant,
@@ -107,6 +107,18 @@ class DefaultManifestTests(RequireGuardianParticipantTests):
             "/etc/defenseclaw/hook-guardian/targets.yaml",
         )
 
+    def test_uses_windows_programdata_layout(self) -> None:
+        self.assertEqual(
+            default_guardian_manifest_path("win32"),
+            r"C:\ProgramData\Cisco\Cisco Secure Client\DefenseClaw\hook-guardian\targets.yaml",
+        )
+
+    def test_windows_journal_file_is_native(self) -> None:
+        with mock.patch("defenseclaw.rotate_token_guardian.os.name", "nt"):
+            self.assertEqual(guardian_journal_file(), "windows-rotation-transaction.json")
+        with mock.patch("defenseclaw.rotate_token_guardian.os.name", "posix"):
+            self.assertEqual(guardian_journal_file(), "rotation-transaction.json")
+
 
 class IdleJournalTests(RequireGuardianParticipantTests):
     def test_retires_terminal_journal(self) -> None:
@@ -140,19 +152,42 @@ class IdleJournalTests(RequireGuardianParticipantTests):
             self.assertIn("unexpected phase", str(raised.exception))
             self.assertTrue(journal.exists())
 
+    def test_windows_refuses_posix_journal(self) -> None:
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as td:
+            journal = _in_tree_auth_dir(td) / "rotation-transaction.json"
+            journal.write_text(json.dumps({"phase": "committed", "operation_id": "c" * 32}), encoding="utf-8")
+            with mock.patch("defenseclaw.rotate_token_guardian.os.name", "nt"):
+                with self.assertRaises(click.ClickException) as raised:
+                    assert_guardian_idle(td)
+            self.assertIn("POSIX guardian journal", str(raised.exception))
+            self.assertTrue(journal.exists())
+
+    def test_windows_retires_native_journal(self) -> None:
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as td:
+            journal = _in_tree_auth_dir(td) / "windows-rotation-transaction.json"
+            journal.write_text(json.dumps({"phase": "committed", "operation_id": "c" * 32}), encoding="utf-8")
+            with mock.patch(
+                "defenseclaw.rotate_token_guardian.guardian_journal_file",
+                return_value="windows-rotation-transaction.json",
+            ):
+                assert_guardian_idle(td)
+            self.assertFalse(journal.exists())
+
 
 class RequireGuardianParticipantBehaviorTests(RequireGuardianParticipantTests):
     def test_unmanaged_does_not_join(self) -> None:
         self.assertFalse(require_guardian_participant(SimpleNamespace(deployment_mode="unmanaged_byod")))
         self.assertFalse(require_guardian_participant(SimpleNamespace(deployment_mode="")))
 
-    def test_windows_managed_is_refused(self) -> None:
+    def test_windows_managed_joins_native_adapter(self) -> None:
         with mock.patch("defenseclaw.rotate_token_guardian.os.name", "nt"):
-            with self.assertRaises(click.ClickException) as raised:
+            self.assertTrue(
                 require_guardian_participant(SimpleNamespace(deployment_mode="managed_enterprise"))
-        self.assertEqual(str(raised.exception), WINDOWS_MANAGED_ROTATION_UNAVAILABLE)
-        self.assertNotIn("rotate-prepare", str(raised.exception))
-        self.assertNotIn("rotate-commit", str(raised.exception))
+            )
 
     @unittest.skipIf(os.name == "nt", "POSIX managed participant")
     def test_posix_managed_joins(self) -> None:

--- a/cli/tests/test_rotate_token_guardian.py
+++ b/cli/tests/test_rotate_token_guardian.py
@@ -125,7 +125,7 @@ class IdleJournalTests(RequireGuardianParticipantTests):
         from tempfile import TemporaryDirectory
 
         with TemporaryDirectory() as td:
-            journal = _in_tree_auth_dir(td) / "rotation-transaction.json"
+            journal = _in_tree_auth_dir(td) / guardian_journal_file()
             journal.write_text(json.dumps({"phase": "committed", "operation_id": "c" * 32}), encoding="utf-8")
             assert_guardian_idle(td)
             self.assertFalse(journal.exists())
@@ -134,7 +134,7 @@ class IdleJournalTests(RequireGuardianParticipantTests):
         from tempfile import TemporaryDirectory
 
         with TemporaryDirectory() as td:
-            journal = _in_tree_auth_dir(td) / "rotation-transaction.json"
+            journal = _in_tree_auth_dir(td) / guardian_journal_file()
             journal.write_text(json.dumps({"phase": "prepared", "operation_id": "c" * 32}), encoding="utf-8")
             with self.assertRaises(click.ClickException) as raised:
                 assert_guardian_idle(td)
@@ -145,7 +145,7 @@ class IdleJournalTests(RequireGuardianParticipantTests):
         from tempfile import TemporaryDirectory
 
         with TemporaryDirectory() as td:
-            journal = _in_tree_auth_dir(td) / "rotation-transaction.json"
+            journal = _in_tree_auth_dir(td) / guardian_journal_file()
             journal.write_text(json.dumps({"phase": "unknown", "operation_id": "c" * 32}), encoding="utf-8")
             with self.assertRaises(click.ClickException) as raised:
                 assert_guardian_idle(td)

--- a/docs-site/content/docs/setup/enterprise-deployment.mdx
+++ b/docs-site/content/docs/setup/enterprise-deployment.mdx
@@ -1689,9 +1689,12 @@ Linux and macOS managed-enterprise rotation coordinates the gateway service
 with the POSIX guardian participant. Windows joins the same coordinator
 through a native `DefenseClawHookGuardian` adapter, not that POSIX journal.
 
-On Windows `managed_enterprise`, `defenseclaw setup rotate-token` invokes
-`enterprise hooks rotate-prepare|commit|rollback` against a Windows-only
+On Windows `managed_enterprise`, the native adapter
+(`enterprise hooks rotate-prepare|commit|rollback`) uses a Windows-only
 journal (`windows-rotation-transaction.json`). Mutations run as LocalSystem.
+Administrator `setup rotate-token` refuses before stop or credential writes
+until the guardian service dispatches those phases. Do not invoke the adapter
+as an inherited administrator subprocess.
 Per-user writes require the exact active non-elevated token for the
 manifest-pinned SID. Missing sessions, untrusted DACLs, reparse points, and
 hard-link aliases fail closed. Unmanaged Windows rotation is unchanged.

--- a/docs-site/content/docs/setup/enterprise-deployment.mdx
+++ b/docs-site/content/docs/setup/enterprise-deployment.mdx
@@ -1686,18 +1686,20 @@ Treat this evidence as a release gate for the managed endpoint image. Run destru
 ## Scoped token rotation platform boundary
 
 Linux and macOS managed-enterprise rotation coordinates the gateway service
-with the POSIX guardian participant. Windows does not join that protocol.
+with the POSIX guardian participant. Windows joins the same coordinator
+through a native `DefenseClawHookGuardian` adapter, not that POSIX journal.
 
-On Windows `managed_enterprise`, `defenseclaw setup rotate-token` fail-closes
-before it stops the service or publishes replacement credentials. The shipped
-`DefenseClawHookGuardian` LocalSystem service continues to install and repair
-hooks; it is not a token-rotation participant until a native prepare, commit,
-and rollback adapter is certified. Unmanaged Windows rotation is unchanged.
+On Windows `managed_enterprise`, `defenseclaw setup rotate-token` invokes
+`enterprise hooks rotate-prepare|commit|rollback` against a Windows-only
+journal (`windows-rotation-transaction.json`). Mutations run as LocalSystem.
+Per-user writes require the exact active non-elevated token for the
+manifest-pinned SID. Missing sessions, untrusted DACLs, reparse points, and
+hard-link aliases fail closed. Unmanaged Windows rotation is unchanged.
 
-Do not route Windows through `enterprise hooks rotate-prepare`,
-`rotate-commit`, or `rotate-rollback`. That would claim Linux/macOS parity at
-a privileged credential boundary. See spec 007 for the approved topology,
-identity, DACL, and certification requirements.
+Do not reuse the Linux/macOS `rotation-transaction.json` journal on Windows.
+That would claim POSIX parity at a privileged credential boundary. See spec
+007 for the approved topology, identity, DACL, and remaining certification
+requirements. #704 stays open until disposable-host certification lands.
 
 ## Production checklist
 

--- a/docs/specs/007-windows-managed-rotation-adapter/README.md
+++ b/docs/specs/007-windows-managed-rotation-adapter/README.md
@@ -2,32 +2,41 @@
 
 Parent issues: #704, #736. Depends on the Linux/macOS participant and
 coordinator in #733–#735. This document records the required Phase 1 product
-decision. Phase 2 implementation must not start from a different topology.
+decision and the Phase 2 native participant.
 
 ## Phase 1 decision (reviewable)
 
-Windows managed-enterprise scoped-token rotation is **unavailable** until a
-Windows-native participant exists. The Linux/macOS `enterprise hooks
-rotate-prepare|rotate-commit|rotate-rollback` journal protocol must not be
-used on Windows.
+Windows managed-enterprise scoped-token rotation must not use the Linux/macOS
+`enterprise hooks rotate-prepare|rotate-commit|rotate-rollback` journal
+protocol. Closed draft PR #658 is not a product contract.
 
 | Question | Decision |
 | --- | --- |
-| Topology | Future work uses the already shipped `DefenseClawHookGuardian` LocalSystem service. Closed draft PR #658 is not a product contract and must not be treated as landed support. |
-| Coordinator | `defenseclaw setup rotate-token` fail-closes on Windows `managed_enterprise` before stopping service A or changing credentials. Unmanaged Windows rotation is unchanged. |
-| POSIX guardian | Forbidden as a Windows participant. Routing Windows through that protocol would claim false parity at a privileged credential boundary. |
+| Topology | The already shipped `DefenseClawHookGuardian` LocalSystem service is the participant. Closed draft PR #658 is not a product contract and must not be treated as landed support. |
+| Coordinator | `defenseclaw setup rotate-token` joins Windows `managed_enterprise` through the native adapter. Unmanaged Windows rotation is unchanged. |
+| POSIX guardian | Forbidden as a Windows participant. A POSIX `rotation-transaction.json` on Windows is a fail-closed conflict. |
 | Qualified connectors | Only families that already pass the native Windows managed-hook filter. Today that is the certified Claude/Codex managed set; Cursor machine-wide enterprise remains spec 006 and is not a rotation target. |
 | Service identity | Guardian mutations run as LocalSystem. Per-user footprint writes require the exact active non-elevated token for the manifest-pinned SID. Split-token administrators and standard users cannot mint, prepare, commit, or roll back rotation state. |
 | Path invariants | Windows-native fixed-volume, no-reparse, single-link, owner, and protected-DACL primitives. Do not emulate POSIX ownership checks. |
 | Offline / no session | Preflight fails closed when a required interactive session or impersonation token is missing. |
-| Prerequisite failure | Rotation remains unavailable. #704 stays open for Windows until Phase 2 plus certification land. |
+| Prerequisite failure | Rotation remains unavailable. #704 stays open for Windows until disposable-host certification lands. |
 | Certification | Native Windows CI plus the approved disposable-host enterprise harness. Cross-compilation or Linux/macOS guardian tests are not Windows coverage. |
 
-## Phase 2 (not started)
+## Phase 2 (native participant)
 
-After this decision is approved, implement prepare/commit/rollback with the
-same generation-bound attestation contract as #733/#735, using Windows handles
-and DACLs rather than the POSIX journal. Public state may carry only opaque
-operation/generation IDs and non-secret fingerprints. Raw A/B credentials must
-never appear in argv, environment snapshots, PowerShell transcripts, SCM
-configuration, event logs, audit records, or test diagnostics.
+Windows prepare/commit/rollback uses a distinct journal
+(`windows-rotation-transaction.json`, schema `windows-guardian-rotation.v1`)
+and the same public JSON contract consumed by #735: `ok`, `action`,
+`operation_id`, `generation`, `phase`, and target count.
+
+| Phase | Windows behavior |
+| --- | --- |
+| Preflight | LocalSystem identity, current #733 attestations, exact SID, canonical profile, certified Claude/Codex connector, active interactive session, no-reparse/single-link/fixed-volume handle proof, protected DACL, expected non-secret fingerprint, and rollback capacity. |
+| Prepare | Snapshot exact A through a no-follow handle, impersonate the manifest SID, publish B, re-read B through a no-follow handle, then publish generation-bound current attestations. Partial failure restores exact A. |
+| Commit | Re-prove every target is on B (fingerprint + owner SID + protected DACL) before retiring rollback material. Idempotent and operation/generation-bound. |
+| Rollback | Impersonate each SID and restore exact A bytes or absence, owner, protected DACL, and volume identity. Readiness stays false unless restoration can be proved. |
+
+Public state may carry only opaque operation/generation IDs and non-secret
+fingerprints. Raw A/B credentials must never appear in argv, environment
+snapshots, PowerShell transcripts, SCM configuration, event logs, audit
+records, or test diagnostics.

--- a/internal/cli/enterprise_hooks_rotate.go
+++ b/internal/cli/enterprise_hooks_rotate.go
@@ -110,10 +110,12 @@ type enterpriseHookRotationTargetSnapshot struct {
 
 var enterpriseHooksRotatePrepareCmd = &cobra.Command{
 	Use:   "rotate-prepare",
-	Short: "Prepare generation B in every enabled Linux/macOS guardian target",
+	Short: "Prepare generation B in every enabled guardian target",
 	Long: `Snapshot generation A and write generation B into the exact enabled
-manifest roster. Public output contains only identities, the operation and
-generation IDs, and canonical non-secret fingerprints.`,
+manifest roster. Linux/macOS uses the POSIX guardian journal. Windows uses
+the native DefenseClawHookGuardian adapter and must never share that journal.
+Public output contains only identities, the operation and generation IDs,
+and canonical non-secret fingerprints.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return enterpriseHooksRotatePrepareRunE(cmd, args)
 	},
@@ -121,7 +123,7 @@ generation IDs, and canonical non-secret fingerprints.`,
 
 var enterpriseHooksRotateCommitCmd = &cobra.Command{
 	Use:   "rotate-commit",
-	Short: "Commit a prepared Linux/macOS guardian rotation",
+	Short: "Commit a prepared guardian rotation",
 	Long: `Retire protected rollback material after the coordinator has proved
 every selected target authenticated with generation B.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -131,16 +133,17 @@ every selected target authenticated with generation B.`,
 
 var enterpriseHooksRotateRollbackCmd = &cobra.Command{
 	Use:   "rotate-rollback",
-	Short: "Restore generation A for a Linux/macOS guardian rotation",
-	Long: `Idempotently restore exact A bytes, absence, owner, and mode for every
-already-mutated target. Readiness stays false unless restoration can be proved.`,
+	Short: "Restore generation A for a guardian rotation",
+	Long: `Idempotently restore exact A bytes, absence, owner, and protected
+DACL or POSIX mode for every already-mutated target. Readiness stays false
+unless restoration can be proved.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return enterpriseHooksRotateRollbackRunE(cmd, args)
 	},
 }
 
 func runEnterpriseHooksRotatePrepare(cmd *cobra.Command, _ []string) error {
-	report, err := executeEnterpriseHookRotationPrepare(enterpriseHookRotationRequest{
+	report, err := executeManagedRotationPrepare(enterpriseHookRotationRequest{
 		OperationID:  enterpriseHookRotateOperationID,
 		Generation:   enterpriseHookRotateGeneration,
 		Manifest:     enterpriseHookManifest,
@@ -150,7 +153,7 @@ func runEnterpriseHooksRotatePrepare(cmd *cobra.Command, _ []string) error {
 }
 
 func runEnterpriseHooksRotateCommit(cmd *cobra.Command, _ []string) error {
-	report, err := executeEnterpriseHookRotationCommit(enterpriseHookRotationRequest{
+	report, err := executeManagedRotationCommit(enterpriseHookRotationRequest{
 		OperationID: enterpriseHookRotateOperationID,
 		Generation:  enterpriseHookRotateGeneration,
 		Manifest:    enterpriseHookManifest,
@@ -159,7 +162,7 @@ func runEnterpriseHooksRotateCommit(cmd *cobra.Command, _ []string) error {
 }
 
 func runEnterpriseHooksRotateRollback(cmd *cobra.Command, _ []string) error {
-	report, err := executeEnterpriseHookRotationRollback(enterpriseHookRotationRequest{
+	report, err := executeManagedRotationRollback(enterpriseHookRotationRequest{
 		OperationID: enterpriseHookRotateOperationID,
 		Generation:  enterpriseHookRotateGeneration,
 		Manifest:    enterpriseHookManifest,
@@ -761,6 +764,9 @@ func enterpriseHookRotationJournalConflicts(actual, want enterpriseHookRotationJ
 }
 
 func enterpriseHookRotationBusy(dataDir string) error {
+	if runtime.GOOS == "windows" {
+		return windowsManagedRotationBusy(dataDir)
+	}
 	journal, exists, err := loadEnterpriseHookRotationJournal(dataDir)
 	if err != nil {
 		return err

--- a/internal/cli/enterprise_hooks_rotate_unix.go
+++ b/internal/cli/enterprise_hooks_rotate_unix.go
@@ -103,3 +103,17 @@ func checkEnterpriseHookRotationSpace(dataDir string) error {
 func errorsIsNotExist(err error) bool {
 	return err != nil && os.IsNotExist(err)
 }
+
+func windowsManagedRotationBusy(string) error { return nil }
+
+func executeManagedRotationPrepare(req enterpriseHookRotationRequest) (enterpriseHookRotationJournal, error) {
+	return executeEnterpriseHookRotationPrepare(req)
+}
+
+func executeManagedRotationCommit(req enterpriseHookRotationRequest) (enterpriseHookRotationJournal, error) {
+	return executeEnterpriseHookRotationCommit(req)
+}
+
+func executeManagedRotationRollback(req enterpriseHookRotationRequest) (enterpriseHookRotationJournal, error) {
+	return executeEnterpriseHookRotationRollback(req)
+}

--- a/internal/cli/enterprise_hooks_rotate_windows.go
+++ b/internal/cli/enterprise_hooks_rotate_windows.go
@@ -135,6 +135,12 @@ func executeWindowsManagedRotationPrepare(req enterpriseHookRotationRequest) (en
 			return empty, err
 		}
 		if exists {
+			// Refuse a crashed prepare before roster comparison. A retry
+			// can present a different target set; snapshot rewrite must
+			// not run until the operator rolls back.
+			if journal.Phase == enterpriseHookRotationPhasePreparing {
+				return journal.public(), fmt.Errorf("windows managed rotation prepare: operation is already preparing; rollback first")
+			}
 			if err := windowsManagedRotationJournalConflicts(journal, plan.Journal); err != nil {
 				return journal.public(), err
 			}
@@ -146,8 +152,8 @@ func executeWindowsManagedRotationPrepare(req enterpriseHookRotationRequest) (en
 				return journal.public(), nil
 			case enterpriseHookRotationPhaseRolledBack:
 				return journal.public(), fmt.Errorf("windows managed rotation prepare: operation already rolled back")
-			case enterpriseHookRotationPhasePreparing:
-				return journal.public(), fmt.Errorf("windows managed rotation prepare: operation is already preparing; rollback first")
+			default:
+				return journal.public(), fmt.Errorf("windows managed rotation prepare: unrecognized journal phase %q", journal.Phase)
 			}
 		}
 		if err := refusePOSIXRotationJournal(cfg.DataDir); err != nil {

--- a/internal/cli/enterprise_hooks_rotate_windows.go
+++ b/internal/cli/enterprise_hooks_rotate_windows.go
@@ -19,9 +19,104 @@
 package cli
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/defenseclaw/defenseclaw/internal/enterprisehooks"
+	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
+	"github.com/defenseclaw/defenseclaw/internal/managed"
+	"github.com/defenseclaw/defenseclaw/internal/safefile"
+	"github.com/defenseclaw/defenseclaw/internal/winpath"
+	"golang.org/x/sys/windows"
 )
+
+const (
+	windowsManagedRotationSchema           = "windows-guardian-rotation.v1"
+	windowsManagedRotationJournalFile      = "windows-rotation-transaction.json"
+	windowsManagedRotationLockFile         = "windows-rotation-transaction.lock"
+	windowsManagedRotationRollbackDir      = "windows-rotation-rollback"
+	windowsManagedRotationMinFreeBytes     = 4 << 20
+	windowsManagedRotationSnapshotMaxBytes = 64 << 10
+	windowsManagedRotationJournalMaxBytes  = 1 << 20
+)
+
+var (
+	windowsManagedRotationSessionCheck = func(sid, home string) error {
+		return enterprisehooks.RequireWindowsEnterpriseTargetSession(sid, home)
+	}
+	windowsManagedRotationImpersonate = func(sid *windows.SID, home string, fn func() error) error {
+		return enterprisehooks.RunWithWindowsEnterpriseTargetImpersonation(sid, home, fn)
+	}
+	windowsManagedRotationAfterTargetWrite = func(enterpriseHookRotationTarget) error { return nil }
+	windowsManagedRotationSpaceCheck       = checkWindowsManagedRotationSpace
+	windowsManagedRotationLoadB            = loadEnterpriseHookScopedToken
+	windowsManagedRotationPublishB         = connector.PublishHookAPIToken
+	windowsManagedRotationReadPublished    = connector.LoadHookAPIToken
+	windowsManagedRotationInspectPath      = inspectWindowsManagedRotationPath
+)
+
+type windowsManagedRotationJournal struct {
+	Schema         string                         `json:"schema"`
+	Version        int                            `json:"version"`
+	OperationID    string                         `json:"operation_id"`
+	Generation     string                         `json:"generation"`
+	Manifest       string                         `json:"manifest"`
+	ManifestSHA256 string                         `json:"manifest_sha256"`
+	Phase          string                         `json:"phase"`
+	Targets        []enterpriseHookRotationTarget `json:"targets"`
+	UpdatedAt      string                         `json:"updated_at"`
+}
+
+type windowsManagedRotationPlan struct {
+	Journal windowsManagedRotationJournal
+	Targets []enterpriseHookRotationTarget
+	Tokens  map[string]string
+}
+
+type windowsManagedRotationFileIdentity struct {
+	VolumeSerial  uint32 `json:"volume_serial"`
+	FileIndexHigh uint32 `json:"file_index_high"`
+	FileIndexLow  uint32 `json:"file_index_low"`
+	NumberOfLinks uint32 `json:"number_of_links"`
+	CanonicalPath string `json:"canonical_path,omitempty"`
+}
+
+type windowsManagedRotationSnapshot struct {
+	Path          string                             `json:"path"`
+	Present       bool                               `json:"present"`
+	Digest        string                             `json:"digest,omitempty"`
+	OwnerSID      string                             `json:"owner_sid,omitempty"`
+	ProtectedDACL bool                               `json:"protected_dacl,omitempty"`
+	Identity      windowsManagedRotationFileIdentity `json:"identity,omitempty"`
+	Bytes         []byte                             `json:"-"`
+}
+
+type windowsManagedRotationSecretRecord struct {
+	Target   enterpriseHookRotationTarget   `json:"target"`
+	Artifact windowsManagedRotationSnapshot `json:"artifact"`
+	Payloads [][]byte                       `json:"payloads"`
+}
+
+func executeManagedRotationPrepare(req enterpriseHookRotationRequest) (enterpriseHookRotationJournal, error) {
+	return executeWindowsManagedRotationPrepare(req)
+}
+
+func executeManagedRotationCommit(req enterpriseHookRotationRequest) (enterpriseHookRotationJournal, error) {
+	return executeWindowsManagedRotationCommit(req)
+}
+
+func executeManagedRotationRollback(req enterpriseHookRotationRequest) (enterpriseHookRotationJournal, error) {
+	return executeWindowsManagedRotationRollback(req)
+}
 
 func withEnterpriseHookRotationLock(
 	_ string,
@@ -44,4 +139,915 @@ func enterpriseHookRotationRestoreOwner(enterpriseHookRotationSnapshot) error {
 
 func checkEnterpriseHookRotationSpace(string) error {
 	return fmt.Errorf("enterprise hooks rotate: Windows requires the native guardian adapter")
+}
+
+func executeWindowsManagedRotationPrepare(req enterpriseHookRotationRequest) (enterpriseHookRotationJournal, error) {
+	var empty enterpriseHookRotationJournal
+	if cfg == nil {
+		return empty, fmt.Errorf("windows managed rotation prepare: config is not loaded")
+	}
+	if err := enterpriseHooksManagedMutationPreflight(); err != nil {
+		return empty, err
+	}
+	plan, err := preflightWindowsManagedRotation(req, true)
+	if err != nil {
+		return empty, err
+	}
+	return withWindowsManagedRotationLock(cfg.DataDir, func() (enterpriseHookRotationJournal, error) {
+		journal, exists, err := loadWindowsManagedRotationJournal(cfg.DataDir)
+		if err != nil {
+			return empty, err
+		}
+		if exists {
+			if err := windowsManagedRotationJournalConflicts(journal, plan.Journal); err != nil {
+				return journal.public(), err
+			}
+			switch journal.Phase {
+			case enterpriseHookRotationPhasePrepared, enterpriseHookRotationPhaseCommitted:
+				if err := verifyWindowsManagedRotationCurrentB(plan); err != nil {
+					return journal.public(), err
+				}
+				return journal.public(), nil
+			case enterpriseHookRotationPhaseRolledBack:
+				return journal.public(), fmt.Errorf("windows managed rotation prepare: operation already rolled back")
+			}
+		}
+		if err := refusePOSIXRotationJournal(cfg.DataDir); err != nil {
+			return empty, err
+		}
+		if err := writeWindowsManagedRotationJournal(cfg.DataDir, plan.Journal); err != nil {
+			return empty, err
+		}
+		mutated := 0
+		for i, target := range plan.Targets {
+			if err := snapshotWindowsManagedRotationTarget(cfg.DataDir, target); err != nil {
+				_ = restoreWindowsManagedRotationMutated(cfg.DataDir, plan.Targets[:mutated])
+				return plan.Journal.public(), fmt.Errorf("windows managed rotation prepare: snapshot %s: %w", enterpriseHookRotationTargetLabel(target), err)
+			}
+			if err := publishWindowsManagedRotationTargetB(target, plan.Tokens[target.Connector]); err != nil {
+				_ = restoreWindowsManagedRotationMutated(cfg.DataDir, plan.Targets[:i+1])
+				return plan.Journal.public(), fmt.Errorf("windows managed rotation prepare: write B for %s: %w", enterpriseHookRotationTargetLabel(target), err)
+			}
+			mutated = i + 1
+			if err := windowsManagedRotationAfterTargetWrite(target); err != nil {
+				_ = restoreWindowsManagedRotationMutated(cfg.DataDir, plan.Targets[:mutated])
+				return plan.Journal.public(), fmt.Errorf("windows managed rotation prepare: post-write %s: %w", enterpriseHookRotationTargetLabel(target), err)
+			}
+		}
+		if err := verifyWindowsManagedRotationCurrentB(plan); err != nil {
+			_ = restoreWindowsManagedRotationMutated(cfg.DataDir, plan.Targets)
+			return plan.Journal.public(), err
+		}
+		if err := publishWindowsManagedRotationCurrent(plan); err != nil {
+			_ = restoreWindowsManagedRotationMutated(cfg.DataDir, plan.Targets)
+			return plan.Journal.public(), err
+		}
+		plan.Journal.Phase = enterpriseHookRotationPhasePrepared
+		plan.Journal.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+		if err := writeWindowsManagedRotationJournal(cfg.DataDir, plan.Journal); err != nil {
+			_ = restoreWindowsManagedRotationMutated(cfg.DataDir, plan.Targets)
+			return plan.Journal.public(), err
+		}
+		return plan.Journal.public(), nil
+	})
+}
+
+func executeWindowsManagedRotationCommit(req enterpriseHookRotationRequest) (enterpriseHookRotationJournal, error) {
+	var empty enterpriseHookRotationJournal
+	if cfg == nil {
+		return empty, fmt.Errorf("windows managed rotation commit: config is not loaded")
+	}
+	if err := enterpriseHooksManagedMutationPreflight(); err != nil {
+		return empty, err
+	}
+	plan, err := preflightWindowsManagedRotation(req, false)
+	if err != nil {
+		return empty, err
+	}
+	return withWindowsManagedRotationLock(cfg.DataDir, func() (enterpriseHookRotationJournal, error) {
+		journal, exists, err := loadWindowsManagedRotationJournal(cfg.DataDir)
+		if err != nil {
+			return empty, err
+		}
+		if !exists {
+			return empty, fmt.Errorf("windows managed rotation commit: no prepared rotation exists")
+		}
+		if err := windowsManagedRotationJournalConflicts(journal, plan.Journal); err != nil {
+			return journal.public(), err
+		}
+		if journal.Phase == enterpriseHookRotationPhaseCommitted {
+			return journal.public(), nil
+		}
+		if journal.Phase != enterpriseHookRotationPhasePrepared {
+			return journal.public(), fmt.Errorf("windows managed rotation commit: phase %s is not prepared", journal.Phase)
+		}
+		if err := verifyWindowsManagedRotationCurrentB(plan); err != nil {
+			return journal.public(), err
+		}
+		if err := removeWindowsManagedRotationRollbackDir(cfg.DataDir); err != nil {
+			return journal.public(), fmt.Errorf("windows managed rotation commit: retire rollback material: %w", err)
+		}
+		journal.Phase = enterpriseHookRotationPhaseCommitted
+		journal.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+		if err := writeWindowsManagedRotationJournal(cfg.DataDir, journal); err != nil {
+			return journal.public(), err
+		}
+		return journal.public(), nil
+	})
+}
+
+func executeWindowsManagedRotationRollback(req enterpriseHookRotationRequest) (enterpriseHookRotationJournal, error) {
+	var empty enterpriseHookRotationJournal
+	if cfg == nil {
+		return empty, fmt.Errorf("windows managed rotation rollback: config is not loaded")
+	}
+	if err := enterpriseHooksManagedMutationPreflight(); err != nil {
+		return empty, err
+	}
+	if err := validateEnterpriseHookRotationIdentity(req.OperationID, req.Generation); err != nil {
+		return empty, err
+	}
+	return withWindowsManagedRotationLock(cfg.DataDir, func() (enterpriseHookRotationJournal, error) {
+		journal, exists, err := loadWindowsManagedRotationJournal(cfg.DataDir)
+		if err != nil {
+			return empty, err
+		}
+		if exists {
+			want := windowsManagedRotationJournal{
+				OperationID: strings.TrimSpace(req.OperationID),
+				Generation:  strings.TrimSpace(req.Generation),
+				Manifest:    strings.TrimSpace(req.Manifest),
+			}
+			if err := windowsManagedRotationJournalConflicts(journal, want); err != nil {
+				return journal.public(), err
+			}
+			if journal.Phase == enterpriseHookRotationPhaseRolledBack || journal.Phase == enterpriseHookRotationPhaseCommitted {
+				return journal.public(), nil
+			}
+		}
+		targets := []enterpriseHookRotationTarget{}
+		if exists {
+			targets = journal.Targets
+		}
+		if err := restoreWindowsManagedRotationMutated(cfg.DataDir, targets); err != nil {
+			if exists {
+				journal.Phase = enterpriseHookRotationPhasePreparing
+				_ = writeWindowsManagedRotationJournal(cfg.DataDir, journal)
+			}
+			return journal.public(), fmt.Errorf("windows managed rotation rollback: exact A restoration could not be proved: %w", err)
+		}
+		if exists {
+			if err := publishWindowsManagedRotationRestoredCurrent(cfg.DataDir, journal, targets); err != nil {
+				return journal.public(), err
+			}
+			journal.Phase = enterpriseHookRotationPhaseRolledBack
+			journal.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+			if err := writeWindowsManagedRotationJournal(cfg.DataDir, journal); err != nil {
+				return journal.public(), err
+			}
+			return journal.public(), nil
+		}
+		if err := markEnterpriseHookRotationUnready(cfg.DataDir); err != nil {
+			return journal.public(), err
+		}
+		return empty, nil
+	})
+}
+
+func preflightWindowsManagedRotation(req enterpriseHookRotationRequest, requireFingerprints bool) (windowsManagedRotationPlan, error) {
+	var plan windowsManagedRotationPlan
+	if err := validateEnterpriseHookRotationIdentity(req.OperationID, req.Generation); err != nil {
+		return plan, err
+	}
+	if cfg == nil || !managed.IsManagedEnterprise(cfg.DeploymentMode) {
+		return plan, fmt.Errorf("windows managed rotation: managed enterprise deployment is required")
+	}
+	if err := refusePOSIXRotationJournal(cfg.DataDir); err != nil {
+		return plan, err
+	}
+	manifestPath := strings.TrimSpace(req.Manifest)
+	if err := enterpriseHookManifestFileTrustCheck(manifestPath); err != nil {
+		return plan, fmt.Errorf("windows managed rotation: manifest trust check failed: %w", err)
+	}
+	manifest, manifestSHA256, err := enterprisehooks.LoadManifestWithSHA256(manifestPath)
+	if err != nil {
+		return plan, err
+	}
+	authorization, exists, err := loadEnterpriseHookGuardianAuthorization(cfg.DataDir)
+	if err != nil {
+		return plan, err
+	}
+	if !exists || authorization.Version != enterpriseHookGuardianAuthorizationVersionV2 || authorization.Current == nil {
+		return plan, fmt.Errorf("windows managed rotation: guardian authorization lacks current per-target attestations")
+	}
+	enabled := enabledEnterpriseHookRotationTargets(manifest)
+	if len(enabled) == 0 {
+		return plan, fmt.Errorf("windows managed rotation: manifest has no enabled targets")
+	}
+	expected := enabled
+	if requireFingerprints {
+		expected, err = loadEnterpriseHookRotationFingerprints(req.Fingerprints)
+		if err != nil {
+			return plan, err
+		}
+		if err := compareEnterpriseHookRotationRosters(enabled, expected); err != nil {
+			return plan, err
+		}
+	} else {
+		journal, journalExists, journalErr := loadWindowsManagedRotationJournal(cfg.DataDir)
+		if journalErr != nil {
+			return plan, journalErr
+		}
+		if journalExists {
+			expected = journal.Targets
+		}
+	}
+	if err := windowsManagedRotationSpaceCheck(cfg.DataDir); err != nil {
+		return plan, err
+	}
+	tokens := map[string]string{}
+	for _, target := range expected {
+		if err := preflightWindowsManagedRotationTarget(target); err != nil {
+			return plan, err
+		}
+		token, err := windowsManagedRotationLoadB(cfg.DataDir, target.Connector)
+		if err != nil {
+			return plan, fmt.Errorf("windows managed rotation: load generation B for %s: %w", target.Connector, err)
+		}
+		fingerprint := managed.ScopedTokenFingerprint(token)
+		if requireFingerprints && fingerprint != target.TokenFingerprint {
+			return plan, fmt.Errorf("windows managed rotation: service token fingerprint does not match expected B for %s", target.Connector)
+		}
+		tokens[target.Connector] = token
+	}
+	plan.Targets = expected
+	plan.Tokens = tokens
+	plan.Journal = windowsManagedRotationJournal{
+		Schema:         windowsManagedRotationSchema,
+		Version:        enterpriseHookRotationJournalVersion,
+		OperationID:    strings.TrimSpace(req.OperationID),
+		Generation:     strings.TrimSpace(req.Generation),
+		Manifest:       manifestPath,
+		ManifestSHA256: manifestSHA256,
+		Phase:          enterpriseHookRotationPhasePreparing,
+		Targets:        expected,
+		UpdatedAt:      time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	return plan, nil
+}
+
+func preflightWindowsManagedRotationTarget(target enterpriseHookRotationTarget) error {
+	if !windowsManagedRotationQualifiedConnector(target.Connector) {
+		return fmt.Errorf("windows managed rotation: connector %s is not in the certified Claude/Codex set", target.Connector)
+	}
+	sid := strings.TrimSpace(target.SID)
+	if sid == "" {
+		return fmt.Errorf("windows managed rotation: target %s is missing a manifest-pinned SID", enterpriseHookRotationTargetLabel(target))
+	}
+	parsed, err := windows.StringToSid(sid)
+	if err != nil || parsed == nil {
+		return fmt.Errorf("windows managed rotation: target %s has an invalid SID", enterpriseHookRotationTargetLabel(target))
+	}
+	home := filepath.Clean(strings.TrimSpace(target.UserHome))
+	if home == "" || !filepath.IsAbs(home) {
+		return fmt.Errorf("windows managed rotation: target %s is missing a canonical home", enterpriseHookRotationTargetLabel(target))
+	}
+	if err := refuseWindowsManagedRotationReparse(home, "target home"); err != nil {
+		return err
+	}
+	userDataDir := enterpriseHookRotationUserDataDir(target)
+	if err := refuseWindowsManagedRotationReparse(userDataDir, "target data dir"); err != nil {
+		return err
+	}
+	if err := windowsManagedRotationSessionCheck(sid, home); err != nil {
+		if enterprisehooks.IsWindowsTargetSessionUnavailable(err) {
+			return fmt.Errorf("windows managed rotation: no active interactive session for %s", enterpriseHookRotationTargetLabel(target))
+		}
+		return fmt.Errorf("windows managed rotation: session preflight for %s: %w", enterpriseHookRotationTargetLabel(target), err)
+	}
+	tokenPath, err := connector.HookAPITokenFilePath(userDataDir, target.Connector)
+	if err != nil {
+		return err
+	}
+	info, err := windowsManagedRotationInspectPath(tokenPath)
+	if err != nil {
+		return fmt.Errorf("windows managed rotation: inspect current artifact for %s: %w", enterpriseHookRotationTargetLabel(target), err)
+	}
+	if info.Present && !strings.EqualFold(info.OwnerSID, sid) {
+		return fmt.Errorf("windows managed rotation: current artifact owner SID does not match the manifest for %s", enterpriseHookRotationTargetLabel(target))
+	}
+	return nil
+}
+
+func windowsManagedRotationQualifiedConnector(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "claudecode", "codex":
+		return true
+	default:
+		return false
+	}
+}
+
+func publishWindowsManagedRotationTargetB(target enterpriseHookRotationTarget, token string) error {
+	sid, err := windows.StringToSid(strings.TrimSpace(target.SID))
+	if err != nil || sid == nil {
+		return fmt.Errorf("invalid target SID")
+	}
+	dataDir := enterpriseHookRotationUserDataDir(target)
+	return windowsManagedRotationImpersonate(sid, strings.TrimSpace(target.UserHome), func() error {
+		if err := os.MkdirAll(filepath.Join(dataDir, "hooks"), 0o700); err != nil {
+			return err
+		}
+		if err := windowsManagedRotationPublishB(dataDir, target.Connector, token); err != nil {
+			return err
+		}
+		published, err := windowsManagedRotationReadPublished(dataDir, target.Connector)
+		if err != nil {
+			return err
+		}
+		if managed.ScopedTokenFingerprint(published) != managed.ScopedTokenFingerprint(token) {
+			return fmt.Errorf("persisted B fingerprint mismatch")
+		}
+		path, err := connector.HookAPITokenFilePath(dataDir, target.Connector)
+		if err != nil {
+			return err
+		}
+		info, err := windowsManagedRotationInspectPath(path)
+		if err != nil {
+			return err
+		}
+		if !info.Present || !info.ProtectedDACL || info.Identity.NumberOfLinks != 1 {
+			return fmt.Errorf("published B is not a single-link protected artifact")
+		}
+		if !strings.EqualFold(info.OwnerSID, strings.TrimSpace(target.SID)) {
+			return fmt.Errorf("published B owner SID does not match the manifest")
+		}
+		return nil
+	})
+}
+
+func verifyWindowsManagedRotationCurrentB(plan windowsManagedRotationPlan) error {
+	for _, target := range plan.Targets {
+		dataDir := enterpriseHookRotationUserDataDir(target)
+		token, err := windowsManagedRotationReadPublished(dataDir, target.Connector)
+		if err != nil {
+			return fmt.Errorf("windows managed rotation: re-read B for %s: %w", enterpriseHookRotationTargetLabel(target), err)
+		}
+		if managed.ScopedTokenFingerprint(token) != target.TokenFingerprint {
+			return fmt.Errorf("windows managed rotation: persisted B fingerprint mismatch for %s", enterpriseHookRotationTargetLabel(target))
+		}
+		path, err := connector.HookAPITokenFilePath(dataDir, target.Connector)
+		if err != nil {
+			return err
+		}
+		info, err := windowsManagedRotationInspectPath(path)
+		if err != nil || !info.Present {
+			return fmt.Errorf("windows managed rotation: B handle proof missing for %s", enterpriseHookRotationTargetLabel(target))
+		}
+		if !strings.EqualFold(info.OwnerSID, strings.TrimSpace(target.SID)) || !info.ProtectedDACL {
+			return fmt.Errorf("windows managed rotation: B DACL/owner proof failed for %s", enterpriseHookRotationTargetLabel(target))
+		}
+	}
+	return nil
+}
+
+func publishWindowsManagedRotationCurrent(plan windowsManagedRotationPlan) error {
+	rows := make([]enterpriseHookReconcileRow, 0, len(plan.Targets))
+	for _, target := range plan.Targets {
+		rows = append(rows, enterpriseHookReconcileRow{
+			User:             target.User,
+			UserHome:         target.UserHome,
+			SID:              target.SID,
+			Connector:        target.Connector,
+			OK:               true,
+			TokenFingerprint: target.TokenFingerprint,
+		})
+	}
+	return writeEnterpriseHookGuardianStateIdentified(
+		cfg.DataDir,
+		plan.Journal.Manifest,
+		plan.Journal.ManifestSHA256,
+		plan.Journal.Generation,
+		rows,
+		0,
+		true,
+	)
+}
+
+func publishWindowsManagedRotationRestoredCurrent(dataDir string, journal windowsManagedRotationJournal, targets []enterpriseHookRotationTarget) error {
+	rows := make([]enterpriseHookReconcileRow, 0, len(targets))
+	for _, target := range targets {
+		snapshot, err := decodeWindowsManagedRotationSnapshot(windowsManagedRotationSnapshotPath(dataDir, target))
+		if err != nil {
+			return fmt.Errorf("windows managed rotation rollback: load A snapshot for %s: %w", enterpriseHookRotationTargetLabel(target), err)
+		}
+		if !snapshot.Present {
+			return fmt.Errorf("windows managed rotation rollback: restored A snapshot missing for %s", enterpriseHookRotationTargetLabel(target))
+		}
+		token, err := windowsManagedRotationReadPublished(enterpriseHookRotationUserDataDir(target), target.Connector)
+		if err != nil {
+			return fmt.Errorf("windows managed rotation rollback: re-read A for %s: %w", enterpriseHookRotationTargetLabel(target), err)
+		}
+		fingerprint := managed.ScopedTokenFingerprint(token)
+		if !managed.ValidScopedTokenFingerprint(fingerprint) {
+			return fmt.Errorf("windows managed rotation rollback: restored A fingerprint missing for %s", enterpriseHookRotationTargetLabel(target))
+		}
+		rows = append(rows, enterpriseHookReconcileRow{
+			User:             target.User,
+			UserHome:         target.UserHome,
+			SID:              target.SID,
+			Connector:        target.Connector,
+			OK:               true,
+			TokenFingerprint: fingerprint,
+		})
+	}
+	return writeEnterpriseHookGuardianStateIdentified(
+		dataDir,
+		journal.Manifest,
+		journal.ManifestSHA256,
+		"",
+		rows,
+		0,
+		true,
+	)
+}
+
+func snapshotWindowsManagedRotationTarget(dataDir string, target enterpriseHookRotationTarget) error {
+	userDataDir := enterpriseHookRotationUserDataDir(target)
+	tokenPath, err := connector.HookAPITokenFilePath(userDataDir, target.Connector)
+	if err != nil {
+		return err
+	}
+	snapshot, err := windowsManagedRotationInspectPath(tokenPath)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(windowsManagedRotationRollbackPath(dataDir), 0o700); err != nil {
+		return err
+	}
+	return encodeWindowsManagedRotationSnapshot(windowsManagedRotationSnapshotPath(dataDir, target), target, snapshot)
+}
+
+func restoreWindowsManagedRotationMutated(dataDir string, targets []enterpriseHookRotationTarget) error {
+	var errs []error
+	for _, target := range targets {
+		if err := restoreWindowsManagedRotationTarget(dataDir, target); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func restoreWindowsManagedRotationTarget(dataDir string, target enterpriseHookRotationTarget) error {
+	snapshot, err := decodeWindowsManagedRotationSnapshot(windowsManagedRotationSnapshotPath(dataDir, target))
+	if err != nil {
+		return err
+	}
+	sid, err := windows.StringToSid(strings.TrimSpace(target.SID))
+	if err != nil || sid == nil {
+		return fmt.Errorf("invalid target SID")
+	}
+	return windowsManagedRotationImpersonate(sid, strings.TrimSpace(target.UserHome), func() error {
+		return restoreWindowsManagedRotationArtifact(target, snapshot)
+	})
+}
+
+func restoreWindowsManagedRotationArtifact(target enterpriseHookRotationTarget, snapshot windowsManagedRotationSnapshot) error {
+	if !snapshot.Present {
+		err := os.Remove(snapshot.Path)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		info, err := windowsManagedRotationInspectPath(snapshot.Path)
+		if err != nil {
+			return err
+		}
+		if info.Present {
+			return fmt.Errorf("absent A restoration left an artifact")
+		}
+		return nil
+	}
+	if snapshot.Digest == "" || snapshot.Digest != managed.ScopedTokenFingerprint(string(snapshot.Bytes)) {
+		return fmt.Errorf("rotation snapshot digest does not match captured bytes")
+	}
+	if err := os.MkdirAll(filepath.Dir(snapshot.Path), 0o700); err != nil {
+		return err
+	}
+	if err := safefile.Write(snapshot.Path, snapshot.Bytes); err != nil {
+		return err
+	}
+	info, err := windowsManagedRotationInspectPath(snapshot.Path)
+	if err != nil {
+		return err
+	}
+	if !info.Present || info.Digest != snapshot.Digest {
+		return fmt.Errorf("rotation snapshot restore did not reproduce the captured digest")
+	}
+	if info.Identity.VolumeSerial != snapshot.Identity.VolumeSerial {
+		return fmt.Errorf("rotation snapshot restore crossed a volume boundary")
+	}
+	if !strings.EqualFold(info.OwnerSID, strings.TrimSpace(target.SID)) || !info.ProtectedDACL {
+		return fmt.Errorf("rotation snapshot restore lost owner SID or protected DACL")
+	}
+	return nil
+}
+
+func inspectWindowsManagedRotationPath(path string) (windowsManagedRotationSnapshot, error) {
+	snapshot := windowsManagedRotationSnapshot{Path: path}
+	pathPtr, err := winpath.UTF16Ptr(path)
+	if err != nil {
+		return snapshot, err
+	}
+	handle, err := windows.CreateFile(
+		pathPtr,
+		windows.GENERIC_READ|windows.READ_CONTROL,
+		windows.FILE_SHARE_READ,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if errors.Is(err, windows.ERROR_FILE_NOT_FOUND) || errors.Is(err, windows.ERROR_PATH_NOT_FOUND) {
+		return snapshot, nil
+	}
+	if err != nil {
+		return snapshot, err
+	}
+	defer windows.CloseHandle(handle)
+
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		return snapshot, err
+	}
+	if info.FileAttributes&(windows.FILE_ATTRIBUTE_DIRECTORY|windows.FILE_ATTRIBUTE_REPARSE_POINT) != 0 {
+		return snapshot, fmt.Errorf("artifact is a directory or reparse point")
+	}
+	if info.NumberOfLinks != 1 {
+		return snapshot, fmt.Errorf("artifact is not a single-link regular file")
+	}
+	canonical, err := windowsManagedRotationFinalPath(handle)
+	if err != nil {
+		return snapshot, err
+	}
+	owner, protected, err := windowsManagedRotationHandleSecurity(handle)
+	if err != nil {
+		return snapshot, err
+	}
+	data, err := windowsManagedRotationReadHandle(handle, windowsManagedRotationSnapshotMaxBytes)
+	if err != nil {
+		return snapshot, err
+	}
+	var after windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &after); err != nil {
+		return snapshot, err
+	}
+	if windowsManagedRotationFileID(info) != windowsManagedRotationFileID(after) ||
+		after.NumberOfLinks != 1 ||
+		after.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		return snapshot, fmt.Errorf("artifact identity changed while reading")
+	}
+	snapshot.Present = true
+	snapshot.Bytes = data
+	snapshot.Digest = managed.ScopedTokenFingerprint(string(data))
+	snapshot.OwnerSID = owner
+	snapshot.ProtectedDACL = protected
+	snapshot.Identity = windowsManagedRotationFileIdentity{
+		VolumeSerial:  info.VolumeSerialNumber,
+		FileIndexHigh: info.FileIndexHigh,
+		FileIndexLow:  info.FileIndexLow,
+		NumberOfLinks: info.NumberOfLinks,
+		CanonicalPath: canonical,
+	}
+	return snapshot, nil
+}
+
+func windowsManagedRotationFileID(info windows.ByHandleFileInformation) string {
+	return fmt.Sprintf("%08x:%08x%08x", info.VolumeSerialNumber, info.FileIndexHigh, info.FileIndexLow)
+}
+
+func windowsManagedRotationFinalPath(handle windows.Handle) (string, error) {
+	buffer := make([]uint16, 512)
+	for {
+		length, err := windows.GetFinalPathNameByHandle(handle, &buffer[0], uint32(len(buffer)), 0)
+		if err != nil {
+			return "", err
+		}
+		if length < uint32(len(buffer)) {
+			final := windows.UTF16ToString(buffer[:length])
+			if strings.HasPrefix(final, `\\?\UNC\`) {
+				final = `\\` + strings.TrimPrefix(final, `\\?\UNC\`)
+			} else {
+				final = strings.TrimPrefix(final, `\\?\`)
+			}
+			return filepath.Clean(final), nil
+		}
+		buffer = make([]uint16, int(length)+1)
+	}
+}
+
+func windowsManagedRotationHandleSecurity(handle windows.Handle) (string, bool, error) {
+	sd, err := windows.GetSecurityInfo(
+		handle,
+		windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		return "", false, err
+	}
+	owner, _, err := sd.Owner()
+	if err != nil || owner == nil {
+		return "", false, fmt.Errorf("artifact owner SID is unavailable")
+	}
+	control, _, err := sd.Control()
+	if err != nil {
+		return "", false, err
+	}
+	return owner.String(), control&windows.SE_DACL_PROTECTED != 0, nil
+}
+
+func windowsManagedRotationReadHandle(handle windows.Handle, maxBytes int64) ([]byte, error) {
+	limited := io.LimitReader(&windowsManagedRotationHandleReader{handle: handle}, maxBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("artifact exceeds snapshot bound")
+	}
+	return data, nil
+}
+
+type windowsManagedRotationHandleReader struct {
+	handle windows.Handle
+}
+
+func (r *windowsManagedRotationHandleReader) Read(p []byte) (int, error) {
+	var done uint32
+	err := windows.ReadFile(r.handle, p, &done, nil)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_BROKEN_PIPE) || errors.Is(err, windows.ERROR_HANDLE_EOF) {
+			return int(done), io.EOF
+		}
+		if done == 0 {
+			return 0, err
+		}
+	}
+	if done == 0 {
+		return 0, io.EOF
+	}
+	return int(done), nil
+}
+
+func refuseWindowsManagedRotationReparse(path, label string) error {
+	if err := winpath.RejectReparseChain(path); err != nil {
+		return fmt.Errorf("windows managed rotation: refusing reparse %s: %w", label, err)
+	}
+	return nil
+}
+
+func refusePOSIXRotationJournal(dataDir string) error {
+	path := enterpriseHookRotationJournalPath(dataDir)
+	_, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return fmt.Errorf("windows managed rotation: POSIX guardian journal is forbidden on Windows")
+}
+
+func (journal windowsManagedRotationJournal) public() enterpriseHookRotationJournal {
+	return enterpriseHookRotationJournal{
+		Version:        journal.Version,
+		OperationID:    journal.OperationID,
+		Generation:     journal.Generation,
+		Manifest:       journal.Manifest,
+		ManifestSHA256: journal.ManifestSHA256,
+		Phase:          journal.Phase,
+		Targets:        journal.Targets,
+		UpdatedAt:      journal.UpdatedAt,
+	}
+}
+
+func windowsManagedRotationJournalConflicts(actual, want windowsManagedRotationJournal) error {
+	return enterpriseHookRotationJournalConflicts(actual.public(), want.public())
+}
+
+func windowsManagedRotationBusy(dataDir string) error {
+	if err := refusePOSIXRotationJournal(dataDir); err != nil {
+		return err
+	}
+	journal, exists, err := loadWindowsManagedRotationJournal(dataDir)
+	if err != nil {
+		return err
+	}
+	if exists && (journal.Phase == enterpriseHookRotationPhasePreparing || journal.Phase == enterpriseHookRotationPhasePrepared) {
+		return fmt.Errorf("%w: roster", errEnterpriseHookRotationBusy)
+	}
+	held, err := windowsManagedRotationLockHeld(dataDir)
+	if err != nil {
+		return err
+	}
+	if held {
+		return fmt.Errorf("%w: lock", errEnterpriseHookRotationBusy)
+	}
+	return nil
+}
+
+func windowsManagedRotationJournalPath(dataDir string) string {
+	return filepath.Join(managed.HookGuardianAuthorizationDir(dataDir), windowsManagedRotationJournalFile)
+}
+
+func windowsManagedRotationLockPath(dataDir string) string {
+	return filepath.Join(managed.HookGuardianAuthorizationDir(dataDir), windowsManagedRotationLockFile)
+}
+
+func windowsManagedRotationRollbackPath(dataDir string) string {
+	return filepath.Join(managed.HookGuardianAuthorizationDir(dataDir), windowsManagedRotationRollbackDir)
+}
+
+func windowsManagedRotationSnapshotPath(dataDir string, target enterpriseHookRotationTarget) string {
+	sum := sha256.Sum256([]byte(enterpriseHookRotationTargetKey(target)))
+	return filepath.Join(windowsManagedRotationRollbackPath(dataDir), hex.EncodeToString(sum[:])+".snapshot")
+}
+
+func loadWindowsManagedRotationJournal(dataDir string) (windowsManagedRotationJournal, bool, error) {
+	path := windowsManagedRotationJournalPath(dataDir)
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return windowsManagedRotationJournal{}, false, nil
+	}
+	if err != nil {
+		return windowsManagedRotationJournal{}, false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Size() > windowsManagedRotationJournalMaxBytes {
+		return windowsManagedRotationJournal{}, true, fmt.Errorf("windows managed rotation: journal is not a trusted regular file")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return windowsManagedRotationJournal{}, true, err
+	}
+	var journal windowsManagedRotationJournal
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&journal); err != nil {
+		return windowsManagedRotationJournal{}, true, fmt.Errorf("windows managed rotation: parse journal: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return windowsManagedRotationJournal{}, true, fmt.Errorf("windows managed rotation: journal has trailing content")
+	}
+	if err := validateWindowsManagedRotationJournal(journal); err != nil {
+		return journal, true, err
+	}
+	return journal, true, nil
+}
+
+func validateWindowsManagedRotationJournal(journal windowsManagedRotationJournal) error {
+	if journal.Schema != windowsManagedRotationSchema {
+		return fmt.Errorf("windows managed rotation: unsupported journal schema")
+	}
+	if journal.Version != enterpriseHookRotationJournalVersion {
+		return fmt.Errorf("windows managed rotation: unsupported journal version %d", journal.Version)
+	}
+	if !validEnterpriseHookHex(journal.OperationID, 16) || !validEnterpriseHookHex(journal.Generation, 16) {
+		return fmt.Errorf("windows managed rotation: journal identity is invalid")
+	}
+	if strings.TrimSpace(journal.Manifest) == "" || !validEnterpriseHookHex(journal.ManifestSHA256, sha256.Size) {
+		return fmt.Errorf("windows managed rotation: journal manifest binding is invalid")
+	}
+	switch journal.Phase {
+	case enterpriseHookRotationPhasePreparing, enterpriseHookRotationPhasePrepared,
+		enterpriseHookRotationPhaseCommitted, enterpriseHookRotationPhaseRolledBack:
+	default:
+		return fmt.Errorf("windows managed rotation: journal phase %q is invalid", journal.Phase)
+	}
+	return nil
+}
+
+func writeWindowsManagedRotationJournal(dataDir string, journal windowsManagedRotationJournal) error {
+	data, err := json.MarshalIndent(journal, "", "  ")
+	if err != nil {
+		return err
+	}
+	dir := managed.HookGuardianAuthorizationDir(dataDir)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+	return writeEnterpriseHookProtectedFile(windowsManagedRotationJournalPath(dataDir), append(data, '\n'))
+}
+
+func encodeWindowsManagedRotationSnapshot(path string, target enterpriseHookRotationTarget, snapshot windowsManagedRotationSnapshot) error {
+	record := windowsManagedRotationSecretRecord{
+		Target:   target,
+		Artifact: snapshot,
+		Payloads: [][]byte{snapshot.Bytes},
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	return writeEnterpriseHookProtectedFile(path, data)
+}
+
+func decodeWindowsManagedRotationSnapshot(path string) (windowsManagedRotationSnapshot, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return windowsManagedRotationSnapshot{}, err
+	}
+	var record windowsManagedRotationSecretRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		return windowsManagedRotationSnapshot{}, err
+	}
+	snapshot := record.Artifact
+	if len(record.Payloads) == 1 {
+		snapshot.Bytes = record.Payloads[0]
+	}
+	return snapshot, nil
+}
+
+func removeWindowsManagedRotationRollbackDir(dataDir string) error {
+	path := windowsManagedRotationRollbackPath(dataDir)
+	if err := refuseWindowsManagedRotationReparse(path, "rotation rollback directory"); err != nil {
+		if _, statErr := os.Lstat(path); !errors.Is(statErr, os.ErrNotExist) {
+			return err
+		}
+	}
+	return os.RemoveAll(path)
+}
+
+func withWindowsManagedRotationLock(
+	dataDir string,
+	fn func() (enterpriseHookRotationJournal, error),
+) (enterpriseHookRotationJournal, error) {
+	var empty enterpriseHookRotationJournal
+	lockPath := windowsManagedRotationLockPath(dataDir)
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o750); err != nil {
+		return empty, fmt.Errorf("windows managed rotation: create lock directory: %w", err)
+	}
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return empty, fmt.Errorf("windows managed rotation: open lock: %w", err)
+	}
+	defer file.Close()
+	ol := &windows.Overlapped{}
+	if err := windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0,
+		1,
+		0,
+		ol,
+	); err != nil {
+		return empty, fmt.Errorf("windows managed rotation: acquire lock: %w", err)
+	}
+	defer func() {
+		_ = windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, ol)
+	}()
+	return fn()
+}
+
+func windowsManagedRotationLockHeld(dataDir string) (bool, error) {
+	lockPath := windowsManagedRotationLockPath(dataDir)
+	file, err := os.OpenFile(lockPath, os.O_RDWR, 0o600)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	defer file.Close()
+	ol := &windows.Overlapped{}
+	if err := windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		ol,
+	); err != nil {
+		return true, nil
+	}
+	_ = windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, ol)
+	return false, nil
+}
+
+func checkWindowsManagedRotationSpace(dataDir string) error {
+	path := filepath.Dir(windowsManagedRotationLockPath(dataDir))
+	if _, err := os.Lstat(path); errors.Is(err, os.ErrNotExist) {
+		path = dataDir
+	}
+	var free uint64
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return fmt.Errorf("windows managed rotation: inspect free space: %w", err)
+	}
+	if err := windows.GetDiskFreeSpaceEx(pathPtr, &free, nil, nil); err != nil {
+		return fmt.Errorf("windows managed rotation: inspect free space: %w", err)
+	}
+	if free < windowsManagedRotationMinFreeBytes {
+		return fmt.Errorf("windows managed rotation: insufficient free space")
+	}
+	return nil
 }

--- a/internal/cli/enterprise_hooks_rotate_windows.go
+++ b/internal/cli/enterprise_hooks_rotate_windows.go
@@ -82,31 +82,6 @@ type windowsManagedRotationPlan struct {
 	Tokens  map[string]string
 }
 
-type windowsManagedRotationFileIdentity struct {
-	VolumeSerial  uint32 `json:"volume_serial"`
-	FileIndexHigh uint32 `json:"file_index_high"`
-	FileIndexLow  uint32 `json:"file_index_low"`
-	NumberOfLinks uint32 `json:"number_of_links"`
-	CanonicalPath string `json:"canonical_path,omitempty"`
-}
-
-type windowsManagedRotationSnapshot struct {
-	Path          string                             `json:"path"`
-	Present       bool                               `json:"present"`
-	Digest        string                             `json:"digest,omitempty"`
-	OwnerSID      string                             `json:"owner_sid,omitempty"`
-	ProtectedDACL bool                               `json:"protected_dacl,omitempty"`
-	Identity      windowsManagedRotationFileIdentity `json:"identity,omitempty"`
-	Bytes         []byte                             `json:"-"`
-}
-
-type windowsManagedRotationSecretRecord struct {
-	Target     enterpriseHookRotationTarget       `json:"target"`
-	Artifact   windowsManagedRotationSnapshot     `json:"artifact"`
-	PublishedB windowsManagedRotationFileIdentity `json:"published_b,omitempty"`
-	Payloads   [][]byte                           `json:"payloads"`
-}
-
 func executeManagedRotationPrepare(req enterpriseHookRotationRequest) (enterpriseHookRotationJournal, error) {
 	return executeWindowsManagedRotationPrepare(req)
 }
@@ -171,6 +146,8 @@ func executeWindowsManagedRotationPrepare(req enterpriseHookRotationRequest) (en
 				return journal.public(), nil
 			case enterpriseHookRotationPhaseRolledBack:
 				return journal.public(), fmt.Errorf("windows managed rotation prepare: operation already rolled back")
+			case enterpriseHookRotationPhasePreparing:
+				return journal.public(), fmt.Errorf("windows managed rotation prepare: operation is already preparing; rollback first")
 			}
 		}
 		if err := refusePOSIXRotationJournal(cfg.DataDir); err != nil {
@@ -465,7 +442,8 @@ func publishWindowsManagedRotationTargetB(serviceDir string, target enterpriseHo
 		return fmt.Errorf("invalid target SID")
 	}
 	userDataDir := enterpriseHookRotationUserDataDir(target)
-	return windowsManagedRotationImpersonate(sid, strings.TrimSpace(target.UserHome), func() error {
+	var publishedB windowsManagedRotationFileIdentity
+	if err := windowsManagedRotationImpersonate(sid, strings.TrimSpace(target.UserHome), func() error {
 		if err := os.MkdirAll(filepath.Join(userDataDir, "hooks"), 0o700); err != nil {
 			return err
 		}
@@ -493,11 +471,12 @@ func publishWindowsManagedRotationTargetB(serviceDir string, target enterpriseHo
 		if !strings.EqualFold(info.OwnerSID, strings.TrimSpace(target.SID)) {
 			return fmt.Errorf("published B owner SID does not match the manifest")
 		}
-		if err := recordWindowsManagedRotationPublishedB(serviceDir, target, info.Identity); err != nil {
-			return err
-		}
+		publishedB = info.Identity
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+	return recordWindowsManagedRotationPublishedB(serviceDir, target, publishedB)
 }
 
 func verifyWindowsManagedRotationCurrentB(plan windowsManagedRotationPlan) error {
@@ -644,8 +623,11 @@ func restoreWindowsManagedRotationMutated(dataDir string, targets []enterpriseHo
 }
 
 func restoreWindowsManagedRotationTarget(dataDir string, target enterpriseHookRotationTarget) error {
-	snapshot, err := decodeWindowsManagedRotationSnapshot(windowsManagedRotationSnapshotPath(dataDir, target))
+	record, err := loadWindowsManagedRotationRecord(windowsManagedRotationSnapshotPath(dataDir, target))
 	if err != nil {
+		return err
+	}
+	if err := bindWindowsManagedRotationRestore(record, target); err != nil {
 		return err
 	}
 	sid, err := windows.StringToSid(strings.TrimSpace(target.SID))
@@ -653,7 +635,7 @@ func restoreWindowsManagedRotationTarget(dataDir string, target enterpriseHookRo
 		return fmt.Errorf("invalid target SID")
 	}
 	return windowsManagedRotationImpersonate(sid, strings.TrimSpace(target.UserHome), func() error {
-		return restoreWindowsManagedRotationArtifact(target, snapshot)
+		return restoreWindowsManagedRotationArtifact(target, record.Artifact)
 	})
 }
 

--- a/internal/cli/enterprise_hooks_rotate_windows.go
+++ b/internal/cli/enterprise_hooks_rotate_windows.go
@@ -101,9 +101,10 @@ type windowsManagedRotationSnapshot struct {
 }
 
 type windowsManagedRotationSecretRecord struct {
-	Target   enterpriseHookRotationTarget   `json:"target"`
-	Artifact windowsManagedRotationSnapshot `json:"artifact"`
-	Payloads [][]byte                       `json:"payloads"`
+	Target     enterpriseHookRotationTarget       `json:"target"`
+	Artifact   windowsManagedRotationSnapshot     `json:"artifact"`
+	PublishedB windowsManagedRotationFileIdentity `json:"published_b,omitempty"`
+	Payloads   [][]byte                           `json:"payloads"`
 }
 
 func executeManagedRotationPrepare(req enterpriseHookRotationRequest) (enterpriseHookRotationJournal, error) {
@@ -184,7 +185,7 @@ func executeWindowsManagedRotationPrepare(req enterpriseHookRotationRequest) (en
 				_ = restoreWindowsManagedRotationMutated(cfg.DataDir, plan.Targets[:mutated])
 				return plan.Journal.public(), fmt.Errorf("windows managed rotation prepare: snapshot %s: %w", enterpriseHookRotationTargetLabel(target), err)
 			}
-			if err := publishWindowsManagedRotationTargetB(target, plan.Tokens[target.Connector]); err != nil {
+			if err := publishWindowsManagedRotationTargetB(cfg.DataDir, target, plan.Tokens[target.Connector]); err != nil {
 				_ = restoreWindowsManagedRotationMutated(cfg.DataDir, plan.Targets[:i+1])
 				return plan.Journal.public(), fmt.Errorf("windows managed rotation prepare: write B for %s: %w", enterpriseHookRotationTargetLabel(target), err)
 			}
@@ -289,7 +290,11 @@ func executeWindowsManagedRotationRollback(req enterpriseHookRotationRequest) (e
 		if exists {
 			targets = journal.Targets
 		}
-		if err := restoreWindowsManagedRotationMutated(cfg.DataDir, targets); err != nil {
+		snapshotted, err := windowsManagedRotationSnapshottedTargets(cfg.DataDir, targets)
+		if err != nil {
+			return journal.public(), err
+		}
+		if err := restoreWindowsManagedRotationMutated(cfg.DataDir, snapshotted); err != nil {
 			if exists {
 				journal.Phase = enterpriseHookRotationPhasePreparing
 				_ = writeWindowsManagedRotationJournal(cfg.DataDir, journal)
@@ -297,7 +302,7 @@ func executeWindowsManagedRotationRollback(req enterpriseHookRotationRequest) (e
 			return journal.public(), fmt.Errorf("windows managed rotation rollback: exact A restoration could not be proved: %w", err)
 		}
 		if exists {
-			if err := publishWindowsManagedRotationRestoredCurrent(cfg.DataDir, journal, targets); err != nil {
+			if err := publishWindowsManagedRotationRestoredCurrent(cfg.DataDir, journal, snapshotted); err != nil {
 				return journal.public(), err
 			}
 			journal.Phase = enterpriseHookRotationPhaseRolledBack
@@ -412,10 +417,16 @@ func preflightWindowsManagedRotationTarget(target enterpriseHookRotationTarget) 
 	if home == "" || !filepath.IsAbs(home) {
 		return fmt.Errorf("windows managed rotation: target %s is missing a canonical home", enterpriseHookRotationTargetLabel(target))
 	}
+	if _, err := winpath.ValidateFixedNTFSMountedPath(home); err != nil {
+		return fmt.Errorf("windows managed rotation: target %s home is not a fixed local NTFS volume: %w", enterpriseHookRotationTargetLabel(target), err)
+	}
 	if err := refuseWindowsManagedRotationReparse(home, "target home"); err != nil {
 		return err
 	}
 	userDataDir := enterpriseHookRotationUserDataDir(target)
+	if _, err := winpath.ValidateFixedNTFSMountedPath(userDataDir); err != nil {
+		return fmt.Errorf("windows managed rotation: target %s data dir is not a fixed local NTFS volume: %w", enterpriseHookRotationTargetLabel(target), err)
+	}
 	if err := refuseWindowsManagedRotationReparse(userDataDir, "target data dir"); err != nil {
 		return err
 	}
@@ -448,27 +459,27 @@ func windowsManagedRotationQualifiedConnector(name string) bool {
 	}
 }
 
-func publishWindowsManagedRotationTargetB(target enterpriseHookRotationTarget, token string) error {
+func publishWindowsManagedRotationTargetB(serviceDir string, target enterpriseHookRotationTarget, token string) error {
 	sid, err := windows.StringToSid(strings.TrimSpace(target.SID))
 	if err != nil || sid == nil {
 		return fmt.Errorf("invalid target SID")
 	}
-	dataDir := enterpriseHookRotationUserDataDir(target)
+	userDataDir := enterpriseHookRotationUserDataDir(target)
 	return windowsManagedRotationImpersonate(sid, strings.TrimSpace(target.UserHome), func() error {
-		if err := os.MkdirAll(filepath.Join(dataDir, "hooks"), 0o700); err != nil {
+		if err := os.MkdirAll(filepath.Join(userDataDir, "hooks"), 0o700); err != nil {
 			return err
 		}
-		if err := windowsManagedRotationPublishB(dataDir, target.Connector, token); err != nil {
+		if err := windowsManagedRotationPublishB(userDataDir, target.Connector, token); err != nil {
 			return err
 		}
-		published, err := windowsManagedRotationReadPublished(dataDir, target.Connector)
+		published, err := windowsManagedRotationReadPublished(userDataDir, target.Connector)
 		if err != nil {
 			return err
 		}
 		if managed.ScopedTokenFingerprint(published) != managed.ScopedTokenFingerprint(token) {
 			return fmt.Errorf("persisted B fingerprint mismatch")
 		}
-		path, err := connector.HookAPITokenFilePath(dataDir, target.Connector)
+		path, err := connector.HookAPITokenFilePath(userDataDir, target.Connector)
 		if err != nil {
 			return err
 		}
@@ -481,6 +492,9 @@ func publishWindowsManagedRotationTargetB(target enterpriseHookRotationTarget, t
 		}
 		if !strings.EqualFold(info.OwnerSID, strings.TrimSpace(target.SID)) {
 			return fmt.Errorf("published B owner SID does not match the manifest")
+		}
+		if err := recordWindowsManagedRotationPublishedB(serviceDir, target, info.Identity); err != nil {
+			return err
 		}
 		return nil
 	})
@@ -506,6 +520,18 @@ func verifyWindowsManagedRotationCurrentB(plan windowsManagedRotationPlan) error
 		}
 		if !strings.EqualFold(info.OwnerSID, strings.TrimSpace(target.SID)) || !info.ProtectedDACL {
 			return fmt.Errorf("windows managed rotation: B DACL/owner proof failed for %s", enterpriseHookRotationTargetLabel(target))
+		}
+		record, err := loadWindowsManagedRotationRecord(windowsManagedRotationSnapshotPath(cfg.DataDir, target))
+		if err != nil {
+			return fmt.Errorf("windows managed rotation: B identity record missing for %s: %w", enterpriseHookRotationTargetLabel(target), err)
+		}
+		if record.PublishedB == (windowsManagedRotationFileIdentity{}) {
+			return fmt.Errorf("windows managed rotation: B file identity was not captured for %s", enterpriseHookRotationTargetLabel(target))
+		}
+		if info.Identity.VolumeSerial != record.PublishedB.VolumeSerial ||
+			info.Identity.FileIndexHigh != record.PublishedB.FileIndexHigh ||
+			info.Identity.FileIndexLow != record.PublishedB.FileIndexLow {
+			return fmt.Errorf("windows managed rotation: B file identity changed since prepare for %s", enterpriseHookRotationTargetLabel(target))
 		}
 	}
 	return nil
@@ -588,9 +614,28 @@ func snapshotWindowsManagedRotationTarget(dataDir string, target enterpriseHookR
 	return encodeWindowsManagedRotationSnapshot(windowsManagedRotationSnapshotPath(dataDir, target), target, snapshot)
 }
 
-func restoreWindowsManagedRotationMutated(dataDir string, targets []enterpriseHookRotationTarget) error {
-	var errs []error
+func windowsManagedRotationSnapshottedTargets(dataDir string, targets []enterpriseHookRotationTarget) ([]enterpriseHookRotationTarget, error) {
+	out := make([]enterpriseHookRotationTarget, 0, len(targets))
 	for _, target := range targets {
+		_, err := loadWindowsManagedRotationRecord(windowsManagedRotationSnapshotPath(dataDir, target))
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("windows managed rotation: inspect snapshot for %s: %w", enterpriseHookRotationTargetLabel(target), err)
+		}
+		out = append(out, target)
+	}
+	return out, nil
+}
+
+func restoreWindowsManagedRotationMutated(dataDir string, targets []enterpriseHookRotationTarget) error {
+	snapshotted, err := windowsManagedRotationSnapshottedTargets(dataDir, targets)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, target := range snapshotted {
 		if err := restoreWindowsManagedRotationTarget(dataDir, target); err != nil {
 			errs = append(errs, err)
 		}
@@ -952,19 +997,43 @@ func encodeWindowsManagedRotationSnapshot(path string, target enterpriseHookRota
 }
 
 func decodeWindowsManagedRotationSnapshot(path string) (windowsManagedRotationSnapshot, error) {
-	data, err := os.ReadFile(path)
+	record, err := loadWindowsManagedRotationRecord(path)
 	if err != nil {
 		return windowsManagedRotationSnapshot{}, err
 	}
+	return record.Artifact, nil
+}
+
+func loadWindowsManagedRotationRecord(path string) (windowsManagedRotationSecretRecord, error) {
+	held, err := inspectWindowsManagedRotationPath(path)
+	if err != nil {
+		return windowsManagedRotationSecretRecord{}, err
+	}
+	if !held.Present {
+		return windowsManagedRotationSecretRecord{}, os.ErrNotExist
+	}
 	var record windowsManagedRotationSecretRecord
-	if err := json.Unmarshal(data, &record); err != nil {
-		return windowsManagedRotationSnapshot{}, err
+	if err := json.Unmarshal(held.Bytes, &record); err != nil {
+		return windowsManagedRotationSecretRecord{}, err
 	}
-	snapshot := record.Artifact
 	if len(record.Payloads) == 1 {
-		snapshot.Bytes = record.Payloads[0]
+		record.Artifact.Bytes = record.Payloads[0]
 	}
-	return snapshot, nil
+	return record, nil
+}
+
+func recordWindowsManagedRotationPublishedB(dataDir string, target enterpriseHookRotationTarget, identity windowsManagedRotationFileIdentity) error {
+	path := windowsManagedRotationSnapshotPath(dataDir, target)
+	record, err := loadWindowsManagedRotationRecord(path)
+	if err != nil {
+		return err
+	}
+	record.PublishedB = identity
+	data, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	return writeEnterpriseHookProtectedFile(path, data)
 }
 
 func removeWindowsManagedRotationRollbackDir(dataDir string) error {

--- a/internal/cli/enterprise_hooks_rotate_windows_bind.go
+++ b/internal/cli/enterprise_hooks_rotate_windows_bind.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
+)
+
+type windowsManagedRotationFileIdentity struct {
+	VolumeSerial  uint32 `json:"volume_serial"`
+	FileIndexHigh uint32 `json:"file_index_high"`
+	FileIndexLow  uint32 `json:"file_index_low"`
+	NumberOfLinks uint32 `json:"number_of_links"`
+	CanonicalPath string `json:"canonical_path,omitempty"`
+}
+
+type windowsManagedRotationSnapshot struct {
+	Path          string                             `json:"path"`
+	Present       bool                               `json:"present"`
+	Digest        string                             `json:"digest,omitempty"`
+	OwnerSID      string                             `json:"owner_sid,omitempty"`
+	ProtectedDACL bool                               `json:"protected_dacl,omitempty"`
+	Identity      windowsManagedRotationFileIdentity `json:"identity,omitempty"`
+	Bytes         []byte                             `json:"-"`
+}
+
+type windowsManagedRotationSecretRecord struct {
+	Target     enterpriseHookRotationTarget       `json:"target"`
+	Artifact   windowsManagedRotationSnapshot     `json:"artifact"`
+	PublishedB windowsManagedRotationFileIdentity `json:"published_b,omitempty"`
+	Payloads   [][]byte                           `json:"payloads"`
+}
+
+func bindWindowsManagedRotationRestore(record windowsManagedRotationSecretRecord, target enterpriseHookRotationTarget) error {
+	if record.Target != target {
+		return fmt.Errorf("rotation snapshot target does not match the restore target")
+	}
+	expectedPath, err := connector.HookAPITokenFilePath(enterpriseHookRotationUserDataDir(target), target.Connector)
+	if err != nil {
+		return err
+	}
+	if record.Artifact.Path != expectedPath {
+		return fmt.Errorf("rotation snapshot path does not match the target token path")
+	}
+	if !record.Artifact.Present {
+		return nil
+	}
+	identity := record.Artifact.Identity
+	if identity.VolumeSerial == 0 && identity.FileIndexHigh == 0 && identity.FileIndexLow == 0 {
+		return fmt.Errorf("rotation snapshot is missing generation A file identity")
+	}
+	if strings.TrimSpace(identity.CanonicalPath) == "" {
+		return fmt.Errorf("rotation snapshot is missing generation A canonical path")
+	}
+	return nil
+}

--- a/internal/cli/enterprise_hooks_rotate_windows_bind_test.go
+++ b/internal/cli/enterprise_hooks_rotate_windows_bind_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
+)
+
+func TestWindowsManagedRotationRestoreBind(t *testing.T) {
+	target := enterpriseHookRotationTarget{
+		User:             "alice",
+		UserHome:         filepath.Join(string(filepath.Separator), "Users", "alice"),
+		SID:              "S-1-5-21-1",
+		Connector:        "codex",
+		TokenFingerprint: strings.Repeat("ab", 32),
+	}
+	expectedPath, err := connector.HookAPITokenFilePath(enterpriseHookRotationUserDataDir(target), target.Connector)
+	if err != nil {
+		t.Fatalf("HookAPITokenFilePath: %v", err)
+	}
+	record := windowsManagedRotationSecretRecord{
+		Target: target,
+		Artifact: windowsManagedRotationSnapshot{
+			Path:    expectedPath,
+			Present: true,
+			Identity: windowsManagedRotationFileIdentity{
+				VolumeSerial:  1,
+				FileIndexHigh: 0,
+				FileIndexLow:  2,
+				CanonicalPath: expectedPath,
+			},
+		},
+	}
+	if err := bindWindowsManagedRotationRestore(record, target); err != nil {
+		t.Fatalf("valid restore bind: %v", err)
+	}
+
+	other := target
+	other.User = "bob"
+	if err := bindWindowsManagedRotationRestore(record, other); err == nil || !strings.Contains(err.Error(), "target does not match") {
+		t.Fatalf("target mismatch error = %v", err)
+	}
+
+	wrongPath := record
+	wrongPath.Artifact.Path = filepath.Join(string(filepath.Separator), "tmp", "other.token")
+	if err := bindWindowsManagedRotationRestore(wrongPath, target); err == nil || !strings.Contains(err.Error(), "path does not match") {
+		t.Fatalf("path mismatch error = %v", err)
+	}
+
+	missingIdentity := record
+	missingIdentity.Artifact.Identity = windowsManagedRotationFileIdentity{}
+	if err := bindWindowsManagedRotationRestore(missingIdentity, target); err == nil || !strings.Contains(err.Error(), "file identity") {
+		t.Fatalf("missing identity error = %v", err)
+	}
+
+	missingCanonical := record
+	missingCanonical.Artifact.Identity.CanonicalPath = ""
+	if err := bindWindowsManagedRotationRestore(missingCanonical, target); err == nil || !strings.Contains(err.Error(), "canonical path") {
+		t.Fatalf("missing canonical path error = %v", err)
+	}
+
+	absent := record
+	absent.Artifact.Present = false
+	absent.Artifact.Identity = windowsManagedRotationFileIdentity{}
+	if err := bindWindowsManagedRotationRestore(absent, target); err != nil {
+		t.Fatalf("absent A restore bind: %v", err)
+	}
+}

--- a/internal/cli/enterprise_hooks_rotate_windows_test.go
+++ b/internal/cli/enterprise_hooks_rotate_windows_test.go
@@ -7,11 +7,214 @@
 package cli
 
 import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/enterprisehooks"
+	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
+	"github.com/defenseclaw/defenseclaw/internal/managed"
+	"golang.org/x/sys/windows"
 )
 
-func TestEnterpriseHookRotationCommandsRefuseWindows(t *testing.T) {
+func TestWindowsManagedRotationPrepareCommitRollback(t *testing.T) {
+	env := newWindowsManagedRotationTestEnv(t, "alice", "bob")
+	req := env.request()
+
+	prepared, err := executeWindowsManagedRotationPrepare(req)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if prepared.Phase != enterpriseHookRotationPhasePrepared {
+		t.Fatalf("prepare phase = %q", prepared.Phase)
+	}
+	if got := env.publishedToken(t, "alice"); got != env.tokenB {
+		t.Fatal("alice did not receive generation B")
+	}
+	if got := env.publishedToken(t, "bob"); got != env.tokenB {
+		t.Fatal("bob did not receive generation B")
+	}
+	authorization, exists, err := loadEnterpriseHookGuardianAuthorization(env.serviceDir)
+	if err != nil || !exists || authorization.Current == nil || !authorization.Current.OK {
+		t.Fatalf("current readiness after prepare: exists=%v err=%v current=%v", exists, err, authorization.Current)
+	}
+	if authorization.Current.Generation != env.generation {
+		t.Fatalf("current generation = %q, want rotation generation", authorization.Current.Generation)
+	}
+	if _, err := os.Lstat(enterpriseHookRotationJournalPath(env.serviceDir)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatal("POSIX guardian journal was written on Windows")
+	}
+	if windowsJournalHasSecret(t, env.serviceDir, env.tokenA, env.tokenB) {
+		t.Fatal("public Windows journal contained raw token material")
+	}
+
+	again, err := executeWindowsManagedRotationPrepare(req)
+	if err != nil {
+		t.Fatalf("idempotent prepare: %v", err)
+	}
+	if again.Phase != enterpriseHookRotationPhasePrepared {
+		t.Fatalf("idempotent prepare phase = %q", again.Phase)
+	}
+
+	committed, err := executeWindowsManagedRotationCommit(req)
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if committed.Phase != enterpriseHookRotationPhaseCommitted {
+		t.Fatalf("commit phase = %q", committed.Phase)
+	}
+	if _, err := os.Lstat(windowsManagedRotationRollbackPath(env.serviceDir)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("rollback material survived commit: %v", err)
+	}
+	if _, err := executeWindowsManagedRotationCommit(req); err != nil {
+		t.Fatalf("idempotent commit: %v", err)
+	}
+}
+
+func TestWindowsManagedRotationPartialPrepareRestoresA(t *testing.T) {
+	env := newWindowsManagedRotationTestEnv(t, "alice", "bob")
+	writes := 0
+	originalAfter := windowsManagedRotationAfterTargetWrite
+	t.Cleanup(func() { windowsManagedRotationAfterTargetWrite = originalAfter })
+	windowsManagedRotationAfterTargetWrite = func(target enterpriseHookRotationTarget) error {
+		writes++
+		if writes == 2 {
+			return errors.New("injected post-write failure")
+		}
+		return nil
+	}
+
+	_, err := executeWindowsManagedRotationPrepare(env.request())
+	if err == nil {
+		t.Fatal("prepare error = nil, want injected failure")
+	}
+	if got := env.publishedToken(t, "alice"); got != env.tokenA {
+		t.Fatal("alice was not restored to generation A")
+	}
+	if got := env.publishedToken(t, "bob"); got != env.tokenA {
+		t.Fatal("bob was not restored to generation A")
+	}
+}
+
+func TestWindowsManagedRotationRollbackRestoresExactA(t *testing.T) {
+	env := newWindowsManagedRotationTestEnv(t, "alice")
+	if _, err := executeWindowsManagedRotationPrepare(env.request()); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	rolled, err := executeWindowsManagedRotationRollback(env.request())
+	if err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if rolled.Phase != enterpriseHookRotationPhaseRolledBack {
+		t.Fatalf("rollback phase = %q", rolled.Phase)
+	}
+	if got := env.publishedToken(t, "alice"); got != env.tokenA {
+		t.Fatal("alice was not restored to generation A")
+	}
+}
+
+func TestWindowsManagedRotationRefusesPOSIXJournal(t *testing.T) {
+	env := newWindowsManagedRotationTestEnv(t, "alice")
+	if err := os.MkdirAll(filepath.Dir(enterpriseHookRotationJournalPath(env.serviceDir)), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(enterpriseHookRotationJournalPath(env.serviceDir), []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := executeWindowsManagedRotationPrepare(env.request())
+	if err == nil || !strings.Contains(err.Error(), "POSIX guardian journal is forbidden") {
+		t.Fatalf("prepare error = %v, want POSIX journal refusal", err)
+	}
+	if got := env.publishedToken(t, "alice"); got != env.tokenA {
+		t.Fatal("token A was mutated after POSIX journal refusal")
+	}
+}
+
+func TestWindowsManagedRotationRefusesCursor(t *testing.T) {
+	env := newWindowsManagedRotationTestEnv(t, "alice")
+	env.replaceConnector(t, "cursor")
+	_, err := executeWindowsManagedRotationPrepare(env.request())
+	if err == nil || !strings.Contains(err.Error(), "certified Claude/Codex") {
+		t.Fatalf("prepare error = %v, want cursor refusal", err)
+	}
+}
+
+func TestWindowsManagedRotationRefusesMissingSession(t *testing.T) {
+	env := newWindowsManagedRotationTestEnv(t, "alice")
+	original := windowsManagedRotationSessionCheck
+	t.Cleanup(func() { windowsManagedRotationSessionCheck = original })
+	windowsManagedRotationSessionCheck = func(sid, _ string) error {
+		return &enterprisehooks.WindowsTargetSessionUnavailableError{SID: sid}
+	}
+	_, err := executeWindowsManagedRotationPrepare(env.request())
+	if err == nil || !strings.Contains(err.Error(), "no active interactive session") {
+		t.Fatalf("prepare error = %v, want missing-session refusal", err)
+	}
+	if got := env.publishedToken(t, "alice"); got != env.tokenA {
+		t.Fatal("token A was mutated without an interactive session")
+	}
+}
+
+func TestWindowsManagedRotationRefusesMissingSID(t *testing.T) {
+	env := newWindowsManagedRotationTestEnv(t, "alice")
+	env.clearSID(t)
+	_, err := executeWindowsManagedRotationPrepare(env.request())
+	if err == nil || !strings.Contains(err.Error(), "manifest-pinned SID") {
+		t.Fatalf("prepare error = %v, want missing SID refusal", err)
+	}
+}
+
+func TestWindowsManagedRotationRequiresLocalSystem(t *testing.T) {
+	token := windows.GetCurrentProcessToken()
+	user, err := token.GetTokenUser()
+	if err == nil && user != nil && user.User.Sid != nil && user.User.Sid.IsWellKnown(windows.WinLocalSystemSid) {
+		t.Skip("runner is LocalSystem")
+	}
+	env := newWindowsManagedRotationTestEnv(t, "alice")
+	enterpriseHooksMutationIdentityPreflight = enterpriseHooksNativeMutationIdentityPreflight
+	_, err = executeWindowsManagedRotationPrepare(env.request())
+	if err == nil || !strings.Contains(err.Error(), "LocalSystem") {
+		t.Fatalf("prepare error = %v, want LocalSystem refusal", err)
+	}
+}
+
+func TestWindowsManagedRotationInspectRejectsHardLink(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "token")
+	alias := filepath.Join(dir, "alias")
+	if err := os.WriteFile(primary, []byte(strings.Repeat("a", 64)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(primary, alias); err != nil {
+		t.Skipf("hard link unavailable: %v", err)
+	}
+	_, err := inspectWindowsManagedRotationPath(primary)
+	if err == nil || !strings.Contains(err.Error(), "single-link") {
+		t.Fatalf("inspect error = %v, want single-link refusal", err)
+	}
+}
+
+func TestWindowsManagedRotationInspectRejectsReparse(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real")
+	link := filepath.Join(dir, "link")
+	if err := os.WriteFile(target, []byte(strings.Repeat("a", 64)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	_, err := inspectWindowsManagedRotationPath(link)
+	if err == nil || !strings.Contains(err.Error(), "reparse") {
+		t.Fatalf("inspect error = %v, want reparse refusal", err)
+	}
+}
+
+func TestWindowsManagedRotationPOSIXExecuteStillRefused(t *testing.T) {
 	_, err := executeEnterpriseHookRotationPrepare(enterpriseHookRotationRequest{
 		OperationID:  strings.Repeat("1", 32),
 		Generation:   strings.Repeat("2", 32),
@@ -19,6 +222,222 @@ func TestEnterpriseHookRotationCommandsRefuseWindows(t *testing.T) {
 		Fingerprints: `C:\ProgramData\DefenseClaw\expected-fingerprints.json`,
 	})
 	if err == nil || !strings.Contains(err.Error(), "native guardian adapter") {
-		t.Fatalf("windows prepare error = %v, want native adapter refusal", err)
+		t.Fatalf("posix prepare error = %v, want native adapter refusal", err)
 	}
+}
+
+type windowsManagedRotationTestEnv struct {
+	scope      string
+	serviceDir string
+	homes      map[string]string
+	sid        string
+	tokenA     string
+	tokenB     string
+	operation  string
+	generation string
+	manifest   string
+	prints     string
+}
+
+func newWindowsManagedRotationTestEnv(t *testing.T, users ...string) *windowsManagedRotationTestEnv {
+	t.Helper()
+	scope := t.TempDir()
+	serviceDir := filepath.Join(scope, "service")
+	if err := os.MkdirAll(serviceDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sid := currentWindowsTestSID(t)
+	env := &windowsManagedRotationTestEnv{
+		scope:      scope,
+		serviceDir: serviceDir,
+		homes:      map[string]string{},
+		sid:        sid,
+		tokenA:     strings.Repeat("a", 64),
+		tokenB:     strings.Repeat("b", 64),
+		operation:  strings.Repeat("1", 32),
+		generation: strings.Repeat("2", 32),
+	}
+
+	originalCfg := cfg
+	originalTrust := enterpriseHookManifestFileTrustCheck
+	originalDirTrust := enterpriseHookAuthorizationDirTrustCheck
+	originalFileTrust := enterpriseHookAuthorizationFileTrustCheck
+	originalOwner := enterpriseHookAuthorizationOwnershipSetter
+	originalStateTrust := enterpriseHookGuardianStateFileTrustCheck
+	originalMutation := enterpriseHooksMutationIdentityPreflight
+	originalLoadB := windowsManagedRotationLoadB
+	originalSpace := windowsManagedRotationSpaceCheck
+	originalSession := windowsManagedRotationSessionCheck
+	originalImpersonate := windowsManagedRotationImpersonate
+	t.Cleanup(func() {
+		cfg = originalCfg
+		enterpriseHookManifestFileTrustCheck = originalTrust
+		enterpriseHookAuthorizationDirTrustCheck = originalDirTrust
+		enterpriseHookAuthorizationFileTrustCheck = originalFileTrust
+		enterpriseHookAuthorizationOwnershipSetter = originalOwner
+		enterpriseHookGuardianStateFileTrustCheck = originalStateTrust
+		enterpriseHooksMutationIdentityPreflight = originalMutation
+		windowsManagedRotationLoadB = originalLoadB
+		windowsManagedRotationSpaceCheck = originalSpace
+		windowsManagedRotationSessionCheck = originalSession
+		windowsManagedRotationImpersonate = originalImpersonate
+	})
+	enterpriseHookManifestFileTrustCheck = func(string) error { return nil }
+	enterpriseHookAuthorizationDirTrustCheck = func(string) error { return nil }
+	enterpriseHookAuthorizationFileTrustCheck = func(string) error { return nil }
+	enterpriseHookAuthorizationOwnershipSetter = func(string) error { return nil }
+	enterpriseHookGuardianStateFileTrustCheck = func(string) error { return nil }
+	enterpriseHooksMutationIdentityPreflight = func() error { return nil }
+	windowsManagedRotationSpaceCheck = func(string) error { return nil }
+	windowsManagedRotationLoadB = func(string, string) (string, error) { return env.tokenB, nil }
+	windowsManagedRotationSessionCheck = func(string, string) error { return nil }
+	windowsManagedRotationImpersonate = func(_ *windows.SID, _ string, fn func() error) error { return fn() }
+
+	var manifest strings.Builder
+	manifest.WriteString("version: 1\ntargets:\n")
+	rows := make([]enterpriseHookReconcileRow, 0, len(users))
+	expected := enterpriseHookRotationFingerprintFile{Targets: make([]enterpriseHookRotationTarget, 0, len(users))}
+	for _, user := range users {
+		home := filepath.Join(scope, "home", user)
+		dataDir := filepath.Join(home, ".defenseclaw")
+		if err := os.MkdirAll(filepath.Join(dataDir, "hooks"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := connector.PublishHookAPIToken(dataDir, "codex", env.tokenA); err != nil {
+			t.Fatalf("publish A for %s: %v", user, err)
+		}
+		env.homes[user] = home
+		manifest.WriteString("  - user: " + user + "\n    user_home: " + home + "\n    sid: " + sid + "\n    connector: codex\n")
+		rows = append(rows, enterpriseHookReconcileRow{
+			User:             user,
+			UserHome:         home,
+			SID:              sid,
+			Connector:        "codex",
+			OK:               true,
+			TokenFingerprint: managed.ScopedTokenFingerprint(env.tokenA),
+		})
+		expected.Targets = append(expected.Targets, enterpriseHookRotationTarget{
+			User:             user,
+			UserHome:         home,
+			SID:              sid,
+			Connector:        "codex",
+			TokenFingerprint: managed.ScopedTokenFingerprint(env.tokenB),
+		})
+	}
+	env.manifest = filepath.Join(scope, "targets.yaml")
+	if err := os.WriteFile(env.manifest, []byte(manifest.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	prints, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env.prints = filepath.Join(scope, "expected-fingerprints.json")
+	if err := os.WriteFile(env.prints, prints, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(hookGuardianAuthorizationDirEnv, filepath.Join(scope, "authorization"))
+	cfg = &config.Config{DataDir: serviceDir}
+	if err := writeEnterpriseHookGuardianState(serviceDir, env.manifest, testEnterpriseHookManifestSHA256, rows, 0, true); err != nil {
+		t.Fatalf("seed current attestations: %v", err)
+	}
+	cfg.DeploymentMode = managed.DeploymentModeManagedEnterprise
+	return env
+}
+
+func (env *windowsManagedRotationTestEnv) request() enterpriseHookRotationRequest {
+	return enterpriseHookRotationRequest{
+		OperationID:  env.operation,
+		Generation:   env.generation,
+		Manifest:     env.manifest,
+		Fingerprints: env.prints,
+	}
+}
+
+func (env *windowsManagedRotationTestEnv) publishedToken(t *testing.T, user string) string {
+	t.Helper()
+	token, err := connector.LoadHookAPIToken(filepath.Join(env.homes[user], ".defenseclaw"), "codex")
+	if err != nil {
+		t.Fatalf("load published token for %s: %v", user, err)
+	}
+	return token
+}
+
+func (env *windowsManagedRotationTestEnv) replaceConnector(t *testing.T, connectorName string) {
+	t.Helper()
+	body, err := os.ReadFile(env.manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(env.manifest, []byte(strings.ReplaceAll(string(body), "codex", connectorName)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	prints, err := os.ReadFile(env.prints)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(env.prints, []byte(strings.ReplaceAll(string(prints), "codex", connectorName)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (env *windowsManagedRotationTestEnv) clearSID(t *testing.T) {
+	t.Helper()
+	body, err := os.ReadFile(env.manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rewritten := strings.ReplaceAll(string(body), "    sid: "+env.sid+"\n", "")
+	if err := os.WriteFile(env.manifest, []byte(rewritten), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var file enterpriseHookRotationFingerprintFile
+	if err := json.Unmarshal([]byte(mustRead(t, env.prints)), &file); err != nil {
+		t.Fatal(err)
+	}
+	for i := range file.Targets {
+		file.Targets[i].SID = ""
+	}
+	data, err := json.Marshal(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(env.prints, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func currentWindowsTestSID(t *testing.T) string {
+	t.Helper()
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil || user == nil || user.User.Sid == nil {
+		t.Fatalf("resolve current test SID: %v", err)
+	}
+	return user.User.Sid.String()
+}
+
+func windowsJournalHasSecret(t *testing.T, dataDir string, secrets ...string) bool {
+	t.Helper()
+	path := windowsManagedRotationJournalPath(dataDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read Windows journal: %v", err)
+	}
+	text := string(data)
+	for _, secret := range secrets {
+		if strings.Contains(text, secret) {
+			return true
+		}
+	}
+	return false
+}
+
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }

--- a/internal/cli/enterprise_hooks_rotate_windows_test.go
+++ b/internal/cli/enterprise_hooks_rotate_windows_test.go
@@ -75,6 +75,65 @@ func TestWindowsManagedRotationPrepareCommitRollback(t *testing.T) {
 	}
 }
 
+func TestWindowsManagedRotationPreparingJournalRefusesResumeThenRollbackRestoresA(t *testing.T) {
+	env := newWindowsManagedRotationTestEnv(t, "alice", "bob")
+	targets := []enterpriseHookRotationTarget{env.rotationTarget("alice"), env.rotationTarget("bob")}
+	if err := writeWindowsManagedRotationJournal(env.serviceDir, windowsManagedRotationJournal{
+		Schema:         windowsManagedRotationSchema,
+		Version:        enterpriseHookRotationJournalVersion,
+		OperationID:    env.operation,
+		Generation:     env.generation,
+		Manifest:       env.manifest,
+		ManifestSHA256: testEnterpriseHookManifestSHA256,
+		Phase:          enterpriseHookRotationPhasePreparing,
+		Targets:        targets,
+		UpdatedAt:      "2026-01-01T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("seed preparing journal: %v", err)
+	}
+	alice := targets[0]
+	if err := snapshotWindowsManagedRotationTarget(env.serviceDir, alice); err != nil {
+		t.Fatalf("snapshot A for alice: %v", err)
+	}
+	snapshotPath := windowsManagedRotationSnapshotPath(env.serviceDir, alice)
+	beforeSnapshot := mustRead(t, snapshotPath)
+	if err := connector.PublishHookAPIToken(filepath.Join(env.homes["alice"], ".defenseclaw"), env.connectors["alice"], env.tokenB); err != nil {
+		t.Fatalf("publish B for alice: %v", err)
+	}
+
+	prepared, err := executeWindowsManagedRotationPrepare(env.request())
+	if err == nil || !strings.Contains(err.Error(), "operation is already preparing; rollback first") {
+		t.Fatalf("prepare error = %v, want preparing-journal refusal", err)
+	}
+	if prepared.Phase != enterpriseHookRotationPhasePreparing {
+		t.Fatalf("refused prepare phase = %q", prepared.Phase)
+	}
+	if afterSnapshot := mustRead(t, snapshotPath); afterSnapshot != beforeSnapshot {
+		t.Fatal("prepare overwrote the generation A snapshot")
+	}
+	record, err := loadWindowsManagedRotationRecord(snapshotPath)
+	if err != nil {
+		t.Fatalf("reload A snapshot: %v", err)
+	}
+	if record.Artifact.Digest != managed.ScopedTokenFingerprint(env.tokenA) {
+		t.Fatal("prepare replaced the generation A snapshot digest")
+	}
+
+	rolled, err := executeWindowsManagedRotationRollback(env.request())
+	if err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if rolled.Phase != enterpriseHookRotationPhaseRolledBack {
+		t.Fatalf("rollback phase = %q", rolled.Phase)
+	}
+	if got := env.publishedToken(t, "alice"); got != env.tokenA {
+		t.Fatal("alice was not restored to generation A")
+	}
+	if got := env.publishedToken(t, "bob"); got != env.tokenA {
+		t.Fatal("bob was not left on generation A")
+	}
+}
+
 func TestWindowsManagedRotationPartialPrepareRestoresA(t *testing.T) {
 	env := newWindowsManagedRotationTestEnv(t, "alice", "bob")
 	writes := 0
@@ -97,6 +156,28 @@ func TestWindowsManagedRotationPartialPrepareRestoresA(t *testing.T) {
 	}
 	if got := env.publishedToken(t, "bob"); got != env.tokenA {
 		t.Fatal("bob was not restored to generation A")
+	}
+}
+
+func TestWindowsManagedRotationRestoreRefusesTargetMismatch(t *testing.T) {
+	env := newWindowsManagedRotationTestEnv(t, "alice", "bob")
+	alice := env.rotationTarget("alice")
+	bob := env.rotationTarget("bob")
+	if err := snapshotWindowsManagedRotationTarget(env.serviceDir, alice); err != nil {
+		t.Fatalf("snapshot alice: %v", err)
+	}
+	record, err := loadWindowsManagedRotationRecord(windowsManagedRotationSnapshotPath(env.serviceDir, alice))
+	if err != nil {
+		t.Fatalf("load alice snapshot: %v", err)
+	}
+	if err := encodeWindowsManagedRotationSnapshot(windowsManagedRotationSnapshotPath(env.serviceDir, bob), record.Target, record.Artifact); err != nil {
+		t.Fatalf("plant mismatched snapshot: %v", err)
+	}
+	if err := restoreWindowsManagedRotationTarget(env.serviceDir, bob); err == nil || !strings.Contains(err.Error(), "target does not match") {
+		t.Fatalf("restore error = %v, want target mismatch", err)
+	}
+	if got := env.publishedToken(t, "bob"); got != env.tokenA {
+		t.Fatal("bob was mutated after mismatched restore")
 	}
 }
 
@@ -378,6 +459,16 @@ func newWindowsManagedRotationTestEnv(t *testing.T, users ...string) *windowsMan
 	}
 	cfg.DeploymentMode = managed.DeploymentModeManagedEnterprise
 	return env
+}
+
+func (env *windowsManagedRotationTestEnv) rotationTarget(user string) enterpriseHookRotationTarget {
+	return enterpriseHookRotationTarget{
+		User:             user,
+		UserHome:         env.homes[user],
+		SID:              env.sid,
+		Connector:        env.connectors[user],
+		TokenFingerprint: managed.ScopedTokenFingerprint(env.tokenB),
+	}
 }
 
 func (env *windowsManagedRotationTestEnv) request() enterpriseHookRotationRequest {

--- a/internal/cli/enterprise_hooks_rotate_windows_test.go
+++ b/internal/cli/enterprise_hooks_rotate_windows_test.go
@@ -97,6 +97,10 @@ func TestWindowsManagedRotationPreparingJournalRefusesResumeThenRollbackRestores
 	}
 	snapshotPath := windowsManagedRotationSnapshotPath(env.serviceDir, alice)
 	beforeSnapshot := mustRead(t, snapshotPath)
+	beforeRecord, err := loadWindowsManagedRotationRecord(snapshotPath)
+	if err != nil {
+		t.Fatalf("load A snapshot: %v", err)
+	}
 	if err := connector.PublishHookAPIToken(filepath.Join(env.homes["alice"], ".defenseclaw"), env.connectors["alice"], env.tokenB); err != nil {
 		t.Fatalf("publish B for alice: %v", err)
 	}
@@ -115,7 +119,7 @@ func TestWindowsManagedRotationPreparingJournalRefusesResumeThenRollbackRestores
 	if err != nil {
 		t.Fatalf("reload A snapshot: %v", err)
 	}
-	if record.Artifact.Digest != managed.ScopedTokenFingerprint(env.tokenA) {
+	if record.Artifact.Digest != beforeRecord.Artifact.Digest {
 		t.Fatal("prepare replaced the generation A snapshot digest")
 	}
 

--- a/internal/cli/enterprise_hooks_rotate_windows_test.go
+++ b/internal/cli/enterprise_hooks_rotate_windows_test.go
@@ -100,6 +100,31 @@ func TestWindowsManagedRotationPartialPrepareRestoresA(t *testing.T) {
 	}
 }
 
+func TestWindowsManagedRotationRestoreSkipsMissingSnapshots(t *testing.T) {
+	env := newWindowsManagedRotationTestEnv(t, "alice", "bob")
+	alice := enterpriseHookRotationTarget{
+		User:      "alice",
+		UserHome:  env.homes["alice"],
+		SID:       env.sid,
+		Connector: env.connectors["alice"],
+	}
+	bob := enterpriseHookRotationTarget{
+		User:      "bob",
+		UserHome:  env.homes["bob"],
+		SID:       env.sid,
+		Connector: env.connectors["bob"],
+	}
+	if err := snapshotWindowsManagedRotationTarget(env.serviceDir, alice); err != nil {
+		t.Fatalf("snapshot alice: %v", err)
+	}
+	if err := restoreWindowsManagedRotationMutated(env.serviceDir, []enterpriseHookRotationTarget{alice, bob}); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if got := env.publishedToken(t, "bob"); got != env.tokenA {
+		t.Fatal("unsnapshotted bob was mutated")
+	}
+}
+
 func TestWindowsManagedRotationRollbackRestoresExactA(t *testing.T) {
 	env := newWindowsManagedRotationTestEnv(t, "alice")
 	if _, err := executeWindowsManagedRotationPrepare(env.request()); err != nil {
@@ -163,7 +188,7 @@ func TestWindowsManagedRotationRefusesMissingSID(t *testing.T) {
 	env := newWindowsManagedRotationTestEnv(t, "alice")
 	env.clearSID(t)
 	_, err := executeWindowsManagedRotationPrepare(env.request())
-	if err == nil || !strings.Contains(err.Error(), "manifest-pinned SID") {
+	if err == nil || !(strings.Contains(err.Error(), "manifest-pinned SID") || strings.Contains(err.Error(), "requires explicit sid")) {
 		t.Fatalf("prepare error = %v, want missing SID refusal", err)
 	}
 }
@@ -230,6 +255,7 @@ type windowsManagedRotationTestEnv struct {
 	scope      string
 	serviceDir string
 	homes      map[string]string
+	connectors map[string]string
 	sid        string
 	tokenA     string
 	tokenB     string
@@ -251,6 +277,7 @@ func newWindowsManagedRotationTestEnv(t *testing.T, users ...string) *windowsMan
 		scope:      scope,
 		serviceDir: serviceDir,
 		homes:      map[string]string{},
+		connectors: map[string]string{},
 		sid:        sid,
 		tokenA:     strings.Repeat("a", 64),
 		tokenB:     strings.Repeat("b", 64),
@@ -297,22 +324,29 @@ func newWindowsManagedRotationTestEnv(t *testing.T, users ...string) *windowsMan
 	manifest.WriteString("version: 1\ntargets:\n")
 	rows := make([]enterpriseHookReconcileRow, 0, len(users))
 	expected := enterpriseHookRotationFingerprintFile{Targets: make([]enterpriseHookRotationTarget, 0, len(users))}
-	for _, user := range users {
+	for index, user := range users {
 		home := filepath.Join(scope, "home", user)
 		dataDir := filepath.Join(home, ".defenseclaw")
 		if err := os.MkdirAll(filepath.Join(dataDir, "hooks"), 0o700); err != nil {
 			t.Fatal(err)
 		}
-		if err := connector.PublishHookAPIToken(dataDir, "codex", env.tokenA); err != nil {
+		connectorName := "codex"
+		agentVersion := "1.7.0"
+		if index > 0 {
+			connectorName = "claudecode"
+			agentVersion = "2.1.240"
+		}
+		if err := connector.PublishHookAPIToken(dataDir, connectorName, env.tokenA); err != nil {
 			t.Fatalf("publish A for %s: %v", user, err)
 		}
 		env.homes[user] = home
-		manifest.WriteString("  - user: " + user + "\n    user_home: " + home + "\n    sid: " + sid + "\n    connector: codex\n")
+		env.connectors[user] = connectorName
+		manifest.WriteString("  - user: " + user + "\n    user_home: " + home + "\n    sid: " + sid + "\n    connector: " + connectorName + "\n    agent_version: " + agentVersion + "\n")
 		rows = append(rows, enterpriseHookReconcileRow{
 			User:             user,
 			UserHome:         home,
 			SID:              sid,
-			Connector:        "codex",
+			Connector:        connectorName,
 			OK:               true,
 			TokenFingerprint: managed.ScopedTokenFingerprint(env.tokenA),
 		})
@@ -320,7 +354,7 @@ func newWindowsManagedRotationTestEnv(t *testing.T, users ...string) *windowsMan
 			User:             user,
 			UserHome:         home,
 			SID:              sid,
-			Connector:        "codex",
+			Connector:        connectorName,
 			TokenFingerprint: managed.ScopedTokenFingerprint(env.tokenB),
 		})
 	}
@@ -357,7 +391,7 @@ func (env *windowsManagedRotationTestEnv) request() enterpriseHookRotationReques
 
 func (env *windowsManagedRotationTestEnv) publishedToken(t *testing.T, user string) string {
 	t.Helper()
-	token, err := connector.LoadHookAPIToken(filepath.Join(env.homes[user], ".defenseclaw"), "codex")
+	token, err := connector.LoadHookAPIToken(filepath.Join(env.homes[user], ".defenseclaw"), env.connectors[user])
 	if err != nil {
 		t.Fatalf("load published token for %s: %v", user, err)
 	}

--- a/internal/enterprisehooks/impersonation_windows.go
+++ b/internal/enterprisehooks/impersonation_windows.go
@@ -36,6 +36,17 @@ var (
 	}
 )
 
+// RunWithWindowsEnterpriseTargetImpersonation is the LocalSystem mutation
+// entry used by Windows managed rotation. It has no LocalSystem path-string
+// fallback: a missing interactive token fails closed.
+func RunWithWindowsEnterpriseTargetImpersonation(
+	target *windows.SID,
+	expectedHome string,
+	fn func() error,
+) error {
+	return withWindowsEnterpriseTargetImpersonation(target, expectedHome, fn)
+}
+
 // withWindowsEnterpriseTargetImpersonation runs a bounded per-user connector
 // mutation on one locked OS thread under an active-session token whose TokenUser
 // exactly matches the manifest-pinned SID. There is deliberately no fallback to


### PR DESCRIPTION
Stacked on top of #847 (`fix/doctor-inspect-to-use-bind`). Review/merge that PR first; this PR's base is the stack parent, not `main`.

Implements #736 Phase 2: a Windows-native prepare/commit/rollback participant on the shipped `DefenseClawHookGuardian` LocalSystem service. Does not close #736 or #704; disposable-host certification is still required.

## Problem

#736 Phase 1 recorded that Windows managed-enterprise rotation must not use the Linux/macOS guardian journal. Without a native participant, `setup rotate-token` could not rotate scoped hook credentials on Windows without claiming false POSIX parity at a privileged credential boundary.

## Current Situation

Phase 1 (#840) fail-closed Windows `managed_enterprise` before stop(A) or credential mutation. Linux/macOS already have versioned prepare/commit/rollback plus #733 current attestations. The shipped LocalSystem guardian installs and repairs hooks but was not a rotation participant. Closed draft PR #658 is not a product contract.

## Solution

Windows now joins the #735 coordinator through a distinct native adapter.

### Participant

`enterprise hooks rotate-prepare|commit|rollback` dispatch to a Windows journal (`windows-rotation-transaction.json`, schema `windows-guardian-rotation.v1`). The POSIX `rotation-transaction.json` path is refused. Public JSON stays the #735 contract: `ok`, `action`, `operation_id`, `generation`, `phase`, and target count.

### Preflight and identity

Every enabled target must carry a parseable SID, a canonical profile, a certified Claude/Codex connector, an active interactive session, expected non-secret B fingerprints, and current #733 attestations. Cursor remains spec 006 and is not a rotation target. Mutations require LocalSystem. Per-user writes impersonate the exact active non-elevated token for the manifest-pinned SID.

### Path invariants

Token artifacts are opened with `FILE_FLAG_OPEN_REPARSE_POINT`. Reparse points, directories, and `NumberOfLinks != 1` fail closed. Capture includes volume serial, file index, canonical `GetFinalPathNameByHandle` path, owner SID, and protected-DACL. B is re-read through the same handle proof before prepare returns or commit retires rollback material.

### Transaction

Prepare snapshots exact A, publishes B under impersonation, then writes generation-bound current attestations. Partial failure restores exact A. Commit is idempotent and operation/generation-bound after B auth. Rollback restores A bytes or absence, owner SID, protected DACL, and volume identity.

## Architecture Diagram

```
Linux/macOS managed_enterprise
  setup rotate-token ──▶ POSIX rotation-transaction.json
                         rotate-prepare / commit / rollback

Windows managed_enterprise (this PR)
  setup rotate-token ──▶ DefenseClawHookGuardian (LocalSystem)
                         windows-rotation-transaction.json
                         SID session + impersonation
                         no-reparse / single-link / protected DACL
                         rotate-prepare / commit / rollback

Unmanaged Windows rotation is unchanged.
```

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `internal/cli/enterprise_hooks_rotate.go` | Dispatch Windows rotate commands off the POSIX journal; busy-check the native journal |
| `internal/cli/enterprise_hooks_rotate_unix.go` | POSIX execute wrappers stay on Linux/macOS |
| `internal/cli/enterprise_hooks_rotate_windows.go` | Native prepare/commit/rollback, handle identity, lock, and SID impersonation |
| `internal/cli/enterprise_hooks_rotate_windows_test.go` | Happy path, exact-A restore, POSIX-journal refuse, cursor/SID/session/LocalSystem, hard-link/reparse |
| `internal/enterprisehooks/impersonation_windows.go` | Export LocalSystem impersonation for rotation writes |
| `cli/defenseclaw/rotate_token_guardian.py` | Windows managed-enterprise joins; native journal and ProgramData manifest |
| `cli/tests/test_rotate_token_guardian.py` | Windows join, journal filename, POSIX-journal conflict |
| `docs/specs/007-windows-managed-rotation-adapter/README.md` | Phase 2 participant contract |
| `docs-site/content/docs/setup/enterprise-deployment.mdx` | Operator-facing native adapter boundary |

## Breaking Changes

Windows `managed_enterprise` `setup rotate-token` now attempts the native guardian participant instead of fail-closing with `WINDOWS_MANAGED_ROTATION_UNAVAILABLE`. Hosts without LocalSystem, an interactive session for each manifest SID, or a certified Claude/Codex roster still fail closed before stop(A). Unmanaged Windows rotation is unchanged. The POSIX journal remains forbidden on Windows.

## Open Issues / Follow-ups

- #736 — remains open until native Windows CI plus disposable-host certification prove the service/token/DACL lifecycle
- #704 — remains open until #733–#736 including Windows certification land
- #473 — remains open pending live `INCOMING REQUEST` + block evidence

## Test Plan

```
PYTHONPATH=cli python -m pytest cli/tests/test_rotate_token_guardian.py -q
go test -count=1 ./internal/cli/ -run 'TestEnterpriseHookRotation|TestEnterpriseHooksWindowsAdministrator|TestEnterpriseHooksSupportedPlatform'
```

Observed locally (macOS): coordinator 29 passed; Go rotate/lifecycle tests OK.

Windows-tagged participant tests (`TestWindowsManagedRotation*`) run in native Windows CI. They cover prepare/commit/rollback, exact-A restore, POSIX-journal refusal, cursor/SID/session/LocalSystem refusals, and hard-link/reparse inspect failures.