### PR TITLE
fix(openclaw): prove interceptor rewrite and fail doctor on silent bypass

### DIFF
--- a/cli/defenseclaw/commands/cmd_doctor.py
+++ b/cli/defenseclaw/commands/cmd_doctor.py
@@ -58,6 +58,7 @@ except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10
 
 from defenseclaw import credential_provenance, rulepack_validation, ux
 from defenseclaw.audit_actions import ACTION_DOCTOR
+from defenseclaw.connector_contracts import openclaw_needs_interception_advisory
 from defenseclaw.connector_paths import (
     amp_config_home,
     amp_managed_settings_path,
@@ -75,7 +76,6 @@ from defenseclaw.connector_paths import (
     rule_paths,
 )
 from defenseclaw.context import AppContext, pass_ctx
-from defenseclaw.connector_contracts import openclaw_needs_interception_advisory
 from defenseclaw.cursor_contract import validate_cursor_registration
 from defenseclaw.doctor_engine import (
     RepairDecision,
@@ -5763,7 +5763,8 @@ def _check_openclaw_transport_advisory(cfg, r: _DoctorResult) -> None:
     _emit(
         "warn",
         "OpenClaw transport",
-        f"OpenClaw {version or 'unknown'} is ≥2026.6.8; confirm the OpenClaw interception check rather than the :4000 port alone",
+        f"OpenClaw {version or 'unknown'} is ≥2026.6.8; confirm the OpenClaw interception "
+        "check rather than the :4000 port alone",
         remediation="run doctor after the DefenseClaw plugin has loaded and look for 'OpenClaw interception'",
         r=r,
     )

--- a/cli/defenseclaw/commands/cmd_doctor.py
+++ b/cli/defenseclaw/commands/cmd_doctor.py
@@ -45,8 +45,8 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
-from datetime import datetime, timedelta, timezone
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 

--- a/cli/defenseclaw/commands/cmd_doctor.py
+++ b/cli/defenseclaw/commands/cmd_doctor.py
@@ -5710,7 +5710,11 @@ def _check_proxy_interception(cfg, r: _DoctorResult, *, live_health: dict | None
         return
     if _guardrail_proxy_intentionally_closed(cfg):
         return
-    connectors = [c for c in _doctor_active_connectors(cfg) if c in _PROXY_DOCTOR_CONNECTORS]
+    connectors = [
+        c
+        for c in _doctor_active_connectors(cfg)
+        if c in _PROXY_DOCTOR_CONNECTORS and _connector_enabled(cfg, c)
+    ]
     if not connectors:
         return
 
@@ -5718,7 +5722,7 @@ def _check_proxy_interception(cfg, r: _DoctorResult, *, live_health: dict | None
     info = live_health.get("interception") if isinstance(live_health, dict) else None
     if not isinstance(info, dict):
         _emit(
-            "warn",
+            "fail",
             label,
             "guardrail proxy is up but the sidecar has not reported an interceptor self-test",
             remediation=(
@@ -5775,8 +5779,12 @@ def _interception_self_test_is_fresh(info: dict) -> bool:
 
 def _check_openclaw_transport_advisory(cfg, r: _DoctorResult) -> None:
     """Warn when the installed OpenClaw is in the changed-transport range."""
-    connectors = _doctor_active_connectors(cfg)
-    if "openclaw" not in connectors:
+    connectors = [
+        c
+        for c in _doctor_active_connectors(cfg)
+        if c == "openclaw" and _connector_enabled(cfg, c)
+    ]
+    if not connectors:
         return
     try:
         from defenseclaw.inventory import agent_discovery

--- a/cli/defenseclaw/commands/cmd_doctor.py
+++ b/cli/defenseclaw/commands/cmd_doctor.py
@@ -5690,7 +5690,9 @@ def _check_guardrail_proxy(cfg, r: _DoctorResult) -> None:
         _emit("fail", "Guardrail proxy", f"not responding on port {cfg.guardrail.port}", r=r)
 
 
-_PROXY_DOCTOR_CONNECTORS = frozenset({"openclaw", "zeptoclaw"})
+# ZeptoClaw rewrites api_base natively and does not run the fetch
+# interceptor or publish the OpenClaw self-test document.
+_PROXY_DOCTOR_CONNECTORS = frozenset({"openclaw"})
 
 
 def _check_proxy_interception(cfg, r: _DoctorResult, *, live_health: dict | None = None) -> None:

--- a/cli/defenseclaw/commands/cmd_doctor.py
+++ b/cli/defenseclaw/commands/cmd_doctor.py
@@ -75,6 +75,7 @@ from defenseclaw.connector_paths import (
     rule_paths,
 )
 from defenseclaw.context import AppContext, pass_ctx
+from defenseclaw.connector_contracts import openclaw_needs_interception_advisory
 from defenseclaw.cursor_contract import validate_cursor_registration
 from defenseclaw.doctor_engine import (
     RepairDecision,
@@ -5689,6 +5690,85 @@ def _check_guardrail_proxy(cfg, r: _DoctorResult) -> None:
         _emit("fail", "Guardrail proxy", f"not responding on port {cfg.guardrail.port}", r=r)
 
 
+_PROXY_DOCTOR_CONNECTORS = frozenset({"openclaw", "zeptoclaw"})
+
+
+def _check_proxy_interception(cfg, r: _DoctorResult, *, live_health: dict | None = None) -> None:
+    """Fail closed when a proxy connector's :4000 listener is unused.
+
+    Liveness on ``/health/liveliness`` only proves the port is open. OpenClaw
+    2026.6.x can talk to a provider without hopping the interceptor, so doctor
+    reads the sidecar's additive ``interception`` document (plugin self-test
+    plus last ``X-DC-Target-URL`` hop).
+    """
+    if not cfg.guardrail.enabled:
+        return
+    if _guardrail_proxy_intentionally_closed(cfg):
+        return
+    connectors = [c for c in _doctor_active_connectors(cfg) if c in _PROXY_DOCTOR_CONNECTORS]
+    if not connectors:
+        return
+
+    label = "OpenClaw interception" if connectors == ["openclaw"] else "Proxy interception"
+    info = live_health.get("interception") if isinstance(live_health, dict) else None
+    if not isinstance(info, dict):
+        _emit(
+            "warn",
+            label,
+            "guardrail proxy is up but the sidecar has not reported an interceptor self-test",
+            remediation=(
+                "restart the OpenClaw gateway so the DefenseClaw plugin can publish "
+                "its interception self-test, then rerun doctor"
+            ),
+            r=r,
+        )
+        return
+    if info.get("verified") is True:
+        detail = "plugin self-test rewrote an LLM URL onto the local guardrail proxy"
+        last_traffic = info.get("last_agent_traffic_at")
+        if isinstance(last_traffic, str) and last_traffic.strip():
+            detail += "; agent traffic has reached :4000"
+        _emit("pass", label, detail, r=r)
+        return
+    _emit(
+        "fail",
+        label,
+        "guardrail proxy is up but OpenClaw agent traffic is not being intercepted — possible bypass",
+        remediation=(
+            "inspect gateway.log for '[defenseclaw] interceptor layers' and "
+            "'interception self-test', confirm the DefenseClaw plugin is enabled, "
+            "then rerun doctor"
+        ),
+        r=r,
+    )
+
+
+def _check_openclaw_transport_advisory(cfg, r: _DoctorResult) -> None:
+    """Warn when the installed OpenClaw is in the changed-transport range."""
+    connectors = _doctor_active_connectors(cfg)
+    if "openclaw" not in connectors:
+        return
+    try:
+        from defenseclaw.inventory import agent_discovery
+
+        disc = agent_discovery.discover_agents(use_cache=True, data_dir=getattr(cfg, "data_dir", None))
+        signal = disc.agents.get("openclaw")
+    except Exception:
+        return
+    version = ""
+    if signal is not None:
+        version = signal.version or ""
+    if not openclaw_needs_interception_advisory(version):
+        return
+    _emit(
+        "warn",
+        "OpenClaw transport",
+        f"OpenClaw {version or 'unknown'} is ≥2026.6.8; confirm the OpenClaw interception check rather than the :4000 port alone",
+        remediation="run doctor after the DefenseClaw plugin has loaded and look for 'OpenClaw interception'",
+        r=r,
+    )
+
+
 def _check_semantic_routing(cfg, r: _DoctorResult, *, live_health: dict | None = None) -> None:
     routing = getattr(cfg, "routing", None)
     if routing is None or not bool(getattr(routing, "enabled", False)):
@@ -7423,6 +7503,8 @@ def doctor(
             # hook rows) instead of only the primary.
             _check_hilt_support(cfg, _conn, r)
     _check_guardrail_proxy(cfg, r)
+    _check_proxy_interception(cfg, r, live_health=sidecar_health)
+    _check_openclaw_transport_advisory(cfg, r)
     if not json_out:
         _doctor_subsection("Credentials")
     r.set_section("credentials")

--- a/cli/defenseclaw/commands/cmd_doctor.py
+++ b/cli/defenseclaw/commands/cmd_doctor.py
@@ -45,6 +45,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
+from datetime import datetime, timedelta, timezone
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
@@ -5693,6 +5694,8 @@ def _check_guardrail_proxy(cfg, r: _DoctorResult) -> None:
 # ZeptoClaw rewrites api_base natively and does not run the fetch
 # interceptor or publish the OpenClaw self-test document.
 _PROXY_DOCTOR_CONNECTORS = frozenset({"openclaw"})
+# Three 60s plugin cadences. A stopped interceptor must not keep doctor green.
+_INTERCEPTION_SELF_TEST_FRESHNESS = timedelta(minutes=3)
 
 
 def _check_proxy_interception(cfg, r: _DoctorResult, *, live_health: dict | None = None) -> None:
@@ -5725,12 +5728,24 @@ def _check_proxy_interception(cfg, r: _DoctorResult, *, live_health: dict | None
             r=r,
         )
         return
-    if info.get("verified") is True:
+    if info.get("verified") is True and _interception_self_test_is_fresh(info):
         detail = "plugin self-test rewrote an LLM URL onto the local guardrail proxy"
         last_traffic = info.get("last_agent_traffic_at")
         if isinstance(last_traffic, str) and last_traffic.strip():
             detail += "; agent traffic has reached :4000"
         _emit("pass", label, detail, r=r)
+        return
+    if info.get("verified") is True:
+        _emit(
+            "fail",
+            label,
+            "guardrail proxy is up but the interceptor self-test is stale — possible bypass",
+            remediation=(
+                "restart the OpenClaw gateway so the DefenseClaw plugin can publish "
+                "a fresh interception self-test, then rerun doctor"
+            ),
+            r=r,
+        )
         return
     _emit(
         "fail",
@@ -5743,6 +5758,19 @@ def _check_proxy_interception(cfg, r: _DoctorResult, *, live_health: dict | None
         ),
         r=r,
     )
+
+
+def _interception_self_test_is_fresh(info: dict) -> bool:
+    raw = info.get("last_verified_at")
+    if not isinstance(raw, str) or not raw.strip():
+        return False
+    try:
+        verified_at = datetime.fromisoformat(raw.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if verified_at.tzinfo is None:
+        verified_at = verified_at.replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc) - verified_at <= _INTERCEPTION_SELF_TEST_FRESHNESS
 
 
 def _check_openclaw_transport_advisory(cfg, r: _DoctorResult) -> None:

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -91,6 +91,7 @@ from defenseclaw.connector_contracts import (
     compare_agent_versions,
     connector_lock_contract_invariant,
     normalize_connector,
+    openclaw_needs_interception_advisory,
     resolve_connector_contract,
 )
 from defenseclaw.context import SETUP_RESTART_HANDLED_META_KEY, AppContext, pass_ctx
@@ -5023,6 +5024,12 @@ def _check_connector_version_supported_for_setup(
     if compatibility.status == STATUS_NOT_GATED:
         if emit:
             ux.ok(f"{label}: version {version_display}; proxy/chat connector has no hook contract gate.")
+            if connector == "openclaw" and openclaw_needs_interception_advisory(raw_version):
+                ux.warn(
+                    f"{label}: {version_display} is in the OpenClaw ≥2026.6.8 transport range. "
+                    "A live :4000 port is not proof that agent LLM traffic is intercepted — "
+                    "run `defenseclaw doctor` and confirm the OpenClaw interception check."
+                )
         return True
 
     if compatibility.status == STATUS_UNVERSIONED:

--- a/cli/defenseclaw/connector_contracts.py
+++ b/cli/defenseclaw/connector_contracts.py
@@ -494,6 +494,27 @@ def compare_agent_versions(a: str, b: str) -> int:
     return _compare_version(a, b)
 
 
+# First OpenClaw release known to change LLM transport away from a
+# fetch-only path. Setup and doctor emit an advisory; they do not block.
+OPENCLAW_TRANSPORT_ADVISORY_SINCE = "2026.6.8"
+
+
+def openclaw_needs_interception_advisory(raw_version: str | None) -> bool:
+    """Return True when OpenClaw is in the transport-changed range.
+
+    OpenClaw 2026.6.8+ may emit provider traffic through undici or
+    embedded runtimes that skip a fetch-only interceptor. The
+    interceptor now covers those layers; this advisory tells the
+    operator to confirm doctor's interception self-test rather than
+    treating a live proxy port as proof.
+    """
+
+    normalized = normalize_agent_version(raw_version or "")
+    if not normalized:
+        return False
+    return compare_agent_versions(normalized, OPENCLAW_TRANSPORT_ADVISORY_SINCE) >= 0
+
+
 def _version_tuple(value: str) -> tuple[int, int, int]:
     normalized = normalize_agent_version(value)
     if not normalized:

--- a/cli/tests/test_cmd_doctor.py
+++ b/cli/tests/test_cmd_doctor.py
@@ -260,6 +260,58 @@ class DoctorGuardrailTests(unittest.TestCase):
         _check_proxy_interception(cfg, result, live_health={"interception": {"verified": False}})
         self.assertEqual(result.checks, [])
 
+    def test_proxy_interception_fails_when_document_absent(self):
+        cfg = Config(
+            data_dir="/tmp/defenseclaw",
+            audit_db="/tmp/defenseclaw/audit.db",
+            quarantine_dir="/tmp/defenseclaw/quarantine",
+            plugin_dir="/tmp/defenseclaw/plugins",
+            policy_dir="/tmp/defenseclaw/policies",
+            guardrail=GuardrailConfig(enabled=True, model="openai/gpt-4", port=4000, connector="openclaw"),
+            gateway=GatewayConfig(),
+            openshell=OpenShellConfig(),
+        )
+        result = _DoctorResult()
+        _check_proxy_interception(cfg, result, live_health={"guardrail": {"state": "running"}})
+        self.assertEqual(result.failed, 1, result.checks)
+        self.assertEqual(result.warned, 0, result.checks)
+        self.assertEqual(result.to_dict()["exit_code"], 1)
+        self.assertIn("has not reported an interceptor self-test", result.checks[0]["detail"])
+
+    def test_disabled_openclaw_is_skipped_by_interception_and_transport_checks(self):
+        cfg = Config(
+            data_dir="/tmp/defenseclaw",
+            audit_db="/tmp/defenseclaw/audit.db",
+            quarantine_dir="/tmp/defenseclaw/quarantine",
+            plugin_dir="/tmp/defenseclaw/plugins",
+            policy_dir="/tmp/defenseclaw/policies",
+            guardrail=GuardrailConfig(
+                enabled=True,
+                model="openai/gpt-4",
+                port=4000,
+                connector="openclaw",
+                connectors={"openclaw": PerConnectorGuardrailConfig(enabled=False)},
+            ),
+            gateway=GatewayConfig(),
+            openshell=OpenShellConfig(),
+        )
+        interception = _DoctorResult()
+        _check_proxy_interception(
+            cfg,
+            interception,
+            live_health={"interception": {"verified": False}},
+        )
+        self.assertEqual(interception.checks, [])
+
+        advisory = _DoctorResult()
+        signal = SimpleNamespace(version="2026.6.8", installed=True)
+        with patch(
+            "defenseclaw.inventory.agent_discovery.discover_agents",
+            return_value=SimpleNamespace(agents={"openclaw": signal}),
+        ):
+            _check_openclaw_transport_advisory(cfg, advisory)
+        self.assertEqual(advisory.checks, [])
+
     def test_openclaw_transport_advisory_for_2026_6(self):
         cfg = Config(
             data_dir="/tmp/defenseclaw",

--- a/cli/tests/test_cmd_doctor.py
+++ b/cli/tests/test_cmd_doctor.py
@@ -42,7 +42,9 @@ from defenseclaw.commands.cmd_doctor import (
     _check_hilt_support,
     _check_hook_health,
     _check_llm_api_key,
+    _check_openclaw_transport_advisory,
     _check_openhands_hooks,
+    _check_proxy_interception,
     _check_security_overrides,
     _check_sidecar,
     _DoctorResult,
@@ -161,6 +163,85 @@ class DoctorGuardrailTests(unittest.TestCase):
         self.assertEqual(result.passed, 1)
         warn_checks = [c for c in result.checks if c["status"] == "warn"]
         self.assertTrue(any("fetch-interceptor" in c["detail"] for c in warn_checks))
+
+    def test_proxy_interception_fails_when_self_test_misses(self):
+        cfg = Config(
+            data_dir="/tmp/defenseclaw",
+            audit_db="/tmp/defenseclaw/audit.db",
+            quarantine_dir="/tmp/defenseclaw/quarantine",
+            plugin_dir="/tmp/defenseclaw/plugins",
+            policy_dir="/tmp/defenseclaw/policies",
+            guardrail=GuardrailConfig(enabled=True, model="openai/gpt-4", port=4000, connector="openclaw"),
+            gateway=GatewayConfig(),
+            openshell=OpenShellConfig(),
+        )
+        result = _DoctorResult()
+        _check_proxy_interception(cfg, result, live_health={"interception": {"verified": False}})
+        self.assertEqual(result.failed, 1, result.checks)
+        self.assertIn("not being intercepted", result.checks[0]["detail"])
+
+    def test_proxy_interception_passes_when_self_test_verified(self):
+        cfg = Config(
+            data_dir="/tmp/defenseclaw",
+            audit_db="/tmp/defenseclaw/audit.db",
+            quarantine_dir="/tmp/defenseclaw/quarantine",
+            plugin_dir="/tmp/defenseclaw/plugins",
+            policy_dir="/tmp/defenseclaw/policies",
+            guardrail=GuardrailConfig(enabled=True, model="openai/gpt-4", port=4000, connector="openclaw"),
+            gateway=GatewayConfig(),
+            openshell=OpenShellConfig(),
+        )
+        result = _DoctorResult()
+        _check_proxy_interception(
+            cfg,
+            result,
+            live_health={
+                "interception": {
+                    "verified": True,
+                    "last_agent_traffic_at": "2026-09-04T12:00:00Z",
+                }
+            },
+        )
+        self.assertEqual(result.failed, 0, result.checks)
+        self.assertEqual(result.passed, 1, result.checks)
+        self.assertIn("self-test", result.checks[0]["detail"])
+        self.assertIn("agent traffic", result.checks[0]["detail"])
+
+    def test_proxy_interception_skips_hook_connectors(self):
+        cfg = Config(
+            data_dir="/tmp/defenseclaw",
+            audit_db="/tmp/defenseclaw/audit.db",
+            quarantine_dir="/tmp/defenseclaw/quarantine",
+            plugin_dir="/tmp/defenseclaw/plugins",
+            policy_dir="/tmp/defenseclaw/policies",
+            guardrail=GuardrailConfig(enabled=True, port=4000, connector="codex"),
+            gateway=GatewayConfig(),
+            openshell=OpenShellConfig(),
+        )
+        result = _DoctorResult()
+        _check_proxy_interception(cfg, result, live_health={"interception": {"verified": False}})
+        self.assertEqual(result.checks, [])
+
+    def test_openclaw_transport_advisory_for_2026_6(self):
+        cfg = Config(
+            data_dir="/tmp/defenseclaw",
+            audit_db="/tmp/defenseclaw/audit.db",
+            quarantine_dir="/tmp/defenseclaw/quarantine",
+            plugin_dir="/tmp/defenseclaw/plugins",
+            policy_dir="/tmp/defenseclaw/policies",
+            guardrail=GuardrailConfig(enabled=True, connector="openclaw"),
+            gateway=GatewayConfig(),
+            openshell=OpenShellConfig(),
+        )
+        result = _DoctorResult()
+        signal = SimpleNamespace(version="2026.6.8", installed=True)
+        with patch(
+            "defenseclaw.inventory.agent_discovery.discover_agents",
+            return_value=SimpleNamespace(agents={"openclaw": signal}),
+        ):
+            _check_openclaw_transport_advisory(cfg, result)
+        self.assertEqual(result.warned, 1, result.checks)
+        self.assertIn("2026.6.8", result.checks[0]["detail"])
 
     @patch("defenseclaw.commands.cmd_doctor._http_probe")
     def test_sidecar_check_surfaces_disabled_summary(self, mock_probe):

--- a/cli/tests/test_cmd_doctor.py
+++ b/cli/tests/test_cmd_doctor.py
@@ -207,6 +207,21 @@ class DoctorGuardrailTests(unittest.TestCase):
         self.assertIn("self-test", result.checks[0]["detail"])
         self.assertIn("agent traffic", result.checks[0]["detail"])
 
+    def test_proxy_interception_skips_zeptoclaw_only(self):
+        cfg = Config(
+            data_dir="/tmp/defenseclaw",
+            audit_db="/tmp/defenseclaw/audit.db",
+            quarantine_dir="/tmp/defenseclaw/quarantine",
+            plugin_dir="/tmp/defenseclaw/plugins",
+            policy_dir="/tmp/defenseclaw/policies",
+            guardrail=GuardrailConfig(enabled=True, port=4000, connector="zeptoclaw"),
+            gateway=GatewayConfig(),
+            openshell=OpenShellConfig(),
+        )
+        result = _DoctorResult()
+        _check_proxy_interception(cfg, result, live_health={"interception": {"verified": False}})
+        self.assertEqual(result.checks, [])
+
     def test_proxy_interception_skips_hook_connectors(self):
         cfg = Config(
             data_dir="/tmp/defenseclaw",

--- a/cli/tests/test_cmd_doctor.py
+++ b/cli/tests/test_cmd_doctor.py
@@ -22,6 +22,7 @@ import sys
 import tempfile
 import time
 import unittest
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -198,6 +199,7 @@ class DoctorGuardrailTests(unittest.TestCase):
             live_health={
                 "interception": {
                     "verified": True,
+                    "last_verified_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                     "last_agent_traffic_at": "2026-09-04T12:00:00Z",
                 }
             },
@@ -206,6 +208,27 @@ class DoctorGuardrailTests(unittest.TestCase):
         self.assertEqual(result.passed, 1, result.checks)
         self.assertIn("self-test", result.checks[0]["detail"])
         self.assertIn("agent traffic", result.checks[0]["detail"])
+
+    def test_proxy_interception_fails_when_self_test_is_stale(self):
+        cfg = Config(
+            data_dir="/tmp/defenseclaw",
+            audit_db="/tmp/defenseclaw/audit.db",
+            quarantine_dir="/tmp/defenseclaw/quarantine",
+            plugin_dir="/tmp/defenseclaw/plugins",
+            policy_dir="/tmp/defenseclaw/policies",
+            guardrail=GuardrailConfig(enabled=True, model="openai/gpt-4", port=4000, connector="openclaw"),
+            gateway=GatewayConfig(),
+            openshell=OpenShellConfig(),
+        )
+        result = _DoctorResult()
+        stale = (datetime.now(timezone.utc) - timedelta(minutes=4)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        _check_proxy_interception(
+            cfg,
+            result,
+            live_health={"interception": {"verified": True, "last_verified_at": stale}},
+        )
+        self.assertEqual(result.failed, 1, result.checks)
+        self.assertIn("stale", result.checks[0]["detail"])
 
     def test_proxy_interception_skips_zeptoclaw_only(self):
         cfg = Config(

--- a/cli/tests/test_connector_contracts.py
+++ b/cli/tests/test_connector_contracts.py
@@ -38,6 +38,7 @@ from defenseclaw.connector_contracts import (
     STATUS_UNKNOWN,
     STATUS_UNVERSIONED,
     _load_contracts_from_manifest,
+    openclaw_needs_interception_advisory,
     resolve_connector_contract,
 )
 from defenseclaw.connector_paths import KNOWN_CONNECTORS
@@ -112,6 +113,12 @@ class TestConnectorContractManifest(unittest.TestCase):
             compat = resolve_connector_contract(connector, "9.9.9")
             self.assertEqual(compat.status, STATUS_NOT_GATED)
             self.assertTrue(compat.supported)
+
+    def test_openclaw_transport_advisory_starts_at_2026_6_8(self) -> None:
+        self.assertFalse(openclaw_needs_interception_advisory("2026.4.15"))
+        self.assertTrue(openclaw_needs_interception_advisory("2026.6.8"))
+        self.assertTrue(openclaw_needs_interception_advisory("2026.6.11"))
+        self.assertFalse(openclaw_needs_interception_advisory(""))
 
     def test_codex_version_range_matches_contract(self) -> None:
         expected = (

--- a/docs-site/content/docs/connectors/openclaw.mdx
+++ b/docs-site/content/docs/connectors/openclaw.mdx
@@ -207,6 +207,11 @@ points are outside this inspection boundary. An egress event proves that the
 plugin observed a transport branch; it does not mean the request or response
 was proxied and inspected.
 
+OpenClaw ≥2026.6.8 is the release range that first required the undici
+dispatcher layer. `defenseclaw doctor` now fails the **OpenClaw
+interception** row when the plugin self-test cannot prove a rewrite onto
+`:4000`, even if `/health/liveliness` returns 200.
+
 ## What the plugin does
 
 <Sequence

--- a/docs-site/content/docs/openclaw.mdx
+++ b/docs-site/content/docs/openclaw.mdx
@@ -120,3 +120,15 @@ Pick OpenClaw when:
 - You need fail-closed behaviour on transport failures.
 
 If you're not running OpenClaw, the [Claude Code](/docs/connectors/claudecode) connector is the closest hook-only equivalent and supports native ask on PreToolUse.
+
+## OpenClaw version compatibility
+
+OpenClaw 2026.6.8 and later can emit provider traffic through undici or
+embedded runtimes that skip a fetch-only patch. The DefenseClaw plugin
+intercepts `globalThis.fetch`, Node `http`/`https.request`, and the undici
+global dispatcher, then runs a sentinel self-test that never leaves the
+host. `defenseclaw doctor` reports **OpenClaw interception** from that
+self-test. A healthy `:4000` liveliness probe is not enough; if agent
+turns succeed while doctor says traffic is not intercepted, restart
+OpenClaw so the plugin reloads and rerun doctor. Confirm a real
+`INCOMING REQUEST` delta in `gateway.log` only when that log can grow.

--- a/docs/CONNECTOR-MATRIX.md
+++ b/docs/CONNECTOR-MATRIX.md
@@ -19,3 +19,12 @@ Historical connector rollout records remain in
 [`CONNECTOR-COMMIT-SUMMARY.md`](CONNECTOR-COMMIT-SUMMARY.md), and
 [`CONNECTOR-REMAINING-FIXES.md`](CONNECTOR-REMAINING-FIXES.md). They are not
 current support matrices.
+
+## By-design / version limitation
+
+OpenClaw remains a proxy connector (`STATUS_NOT_GATED`): there is no hook
+contract gate on `openclaw --version`. Releases ≥2026.6.8 changed provider
+transport, so setup and doctor emit a transport advisory and require the
+plugin self-test rather than treating `:4000` liveness as agent-path
+coverage. Provider `base_url` injection is intentionally not used; a
+single-provider rewrite is bypassed by switching models.

--- a/docs/GUARDRAIL.md
+++ b/docs/GUARDRAIL.md
@@ -64,3 +64,16 @@ described in [`SECURITY-TEST-SUITE.md`](SECURITY-TEST-SUITE.md), and connector
 contract tests under `internal/gateway/connector/`. The public CLI examples are
 validated separately against the real Click command tree by
 [`../scripts/check_docs_cli_commands.py`](../scripts/check_docs_cli_commands.py).
+
+## Known issues / OpenClaw version compatibility
+
+OpenClaw 2026.6.8+ can emit provider traffic through undici and embedded
+runtimes that skip a fetch-only interceptor. The DefenseClaw plugin now
+patches `globalThis.fetch`, `http`/`https.request`, and the undici global
+dispatcher, then publishes an interception self-test on
+`POST /v1/events/egress` (`branch=selftest`). `defenseclaw doctor` reads
+`/health.interception.verified` for proxy connectors and warns when the
+installed OpenClaw version is in that range. A live `:4000` port or a
+stale `INCOMING REQUEST` count is not proof of agent-path enforcement;
+confirm the OpenClaw interception row and, when logs can grow, a real
+`INCOMING REQUEST` delta.

--- a/docs/GUARDRAIL_QUICKSTART.md
+++ b/docs/GUARDRAIL_QUICKSTART.md
@@ -10,3 +10,9 @@ verification, tuning, disabling, and upgrades. This repository file preserves
 older links without duplicating mutable operator commands.
 
 Engineering entry points are indexed in [`GUARDRAIL.md`](GUARDRAIL.md).
+
+If OpenClaw agent turns succeed while `:4000` looks healthy, run
+`defenseclaw doctor` and confirm the **OpenClaw interception** row. That
+self-test is the version-drift check for OpenClaw ≥2026.6.8; do not treat
+a liveliness 200 or a stale `INCOMING REQUEST` count as proof that agent
+traffic is being rewritten.

--- a/extensions/defenseclaw/dist/fetch-interceptor.js
+++ b/extensions/defenseclaw/dist/fetch-interceptor.js
@@ -946,6 +946,47 @@ export const DEFENSECLAW_CORRELATION_HEADER_NAMES = [
 const INTERCEPTION_SELF_TEST_URL = "https://api.openai.com/v1/chat/completions";
 const INTERCEPTION_SELF_TEST_INTERVAL_MS = 60_000;
 export const INTERCEPTION_PROBE_HEADER = "X-DC-Interception-Probe";
+function readUndiciHeader(headers, name) {
+    if (headers == null) {
+        return "";
+    }
+    const wanted = name.toLowerCase();
+    if (Array.isArray(headers)) {
+        for (let i = 0; i < headers.length - 1; i += 2) {
+            if (String(headers[i]).toLowerCase() === wanted) {
+                return String(headers[i + 1]);
+            }
+        }
+        return "";
+    }
+    if (typeof headers === "object") {
+        for (const [key, value] of Object.entries(headers)) {
+            if (key.toLowerCase() === wanted) {
+                return Array.isArray(value) ? String(value[0] ?? "") : String(value ?? "");
+            }
+        }
+    }
+    return "";
+}
+function completeUndiciProbe(handler) {
+    const sink = handler;
+    try {
+        sink.onConnect?.(() => undefined);
+        sink.onHeaders?.(200, [
+            Buffer.from(INTERCEPTION_PROBE_HEADER.toLowerCase()),
+            Buffer.from("1"),
+            Buffer.from("content-type"),
+            Buffer.from("application/json"),
+        ], () => undefined, "OK");
+        sink.onData?.(Buffer.from('{"id":"dc-intercept-probe"}'));
+        sink.onComplete?.([]);
+        return true;
+    }
+    catch (err) {
+        sink.onError?.(err instanceof Error ? err : new Error(String(err)));
+        return false;
+    }
+}
 /**
  * Creates an interceptor that, when started, patches globalThis.fetch to
  * redirect LLM API calls through the guardrail proxy.
@@ -971,6 +1012,7 @@ export function createFetchInterceptor(portOrOpts) {
     let chatgptCodexPassthroughWarned = false;
     let selfTestTimer = null;
     const loggedInterceptHosts = new Set();
+    let lastUndiciProbeDestination = "";
     function describeLayers() {
         return {
             fetch: originalFetch !== null && globalThis.fetch !== originalFetch,
@@ -1510,6 +1552,10 @@ export function createFetchInterceptor(portOrOpts) {
                         decision: "intercept",
                         reason: "undici-dispatcher",
                     });
+                    if (readUndiciHeader(opts.headers, INTERCEPTION_PROBE_HEADER) === "1") {
+                        lastUndiciProbeDestination = `${proxyBase}${pathStr || "/v1/chat/completions"}`;
+                        return completeUndiciProbe(handler);
+                    }
                 }
                 return parentDispatcher.dispatch(opts, handler);
             };
@@ -1537,18 +1583,19 @@ export function createFetchInterceptor(portOrOpts) {
             };
         }
         let destination = "";
+        const probeInit = {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                [INTERCEPTION_PROBE_HEADER]: "1",
+            },
+            body: JSON.stringify({
+                model: "defenseclaw-intercept-probe",
+                messages: [{ role: "user", content: "defenseclaw-intercept-probe" }],
+            }),
+        };
         try {
-            const response = await globalThis.fetch(INTERCEPTION_SELF_TEST_URL, {
-                method: "POST",
-                headers: {
-                    "content-type": "application/json",
-                    [INTERCEPTION_PROBE_HEADER]: "1",
-                },
-                body: JSON.stringify({
-                    model: "defenseclaw-intercept-probe",
-                    messages: [{ role: "user", content: "defenseclaw-intercept-probe" }],
-                }),
-            });
+            const response = await globalThis.fetch(INTERCEPTION_SELF_TEST_URL, probeInit);
             // Probe hops short-circuit inside the wrapper after rewrite. A
             // 200 with the probe header means the rewrite happened and the
             // original fetch was never used for a provider host.
@@ -1559,12 +1606,33 @@ export function createFetchInterceptor(portOrOpts) {
         catch {
             // Keep the miss path for a broken wrapper.
         }
-        const ok = destination === expectedDest && layers.fetch;
+        lastUndiciProbeDestination = "";
+        if (undici && typeof undici.request === "function" && layers.undiciDispatcher) {
+            try {
+                const response = await undici.request(INTERCEPTION_SELF_TEST_URL, probeInit);
+                await response.body?.text?.();
+            }
+            catch {
+                // Rewrite is recorded on the dispatcher even if the sink is stubbed.
+            }
+        }
+        const requiredLayers = layers.fetch && layers.httpsRequest && layers.httpRequest && layers.httpGet;
+        const undiciRequired = Boolean(undici);
+        const undiciOk = !undiciRequired ||
+            (layers.undiciDispatcher && lastUndiciProbeDestination === expectedDest);
+        const ok = destination === expectedDest && requiredLayers && undiciOk;
+        let reason = "interception-self-test-miss";
+        if (ok) {
+            reason = "interception-self-test";
+        }
+        else if (destination === expectedDest && requiredLayers && !undiciOk) {
+            reason = "interception-self-test-undici-miss";
+        }
         return {
             ok,
             destination,
             layers,
-            reason: ok ? "interception-self-test" : "interception-self-test-miss",
+            reason,
         };
     }
     async function publishSelfTest(result) {

--- a/extensions/defenseclaw/dist/fetch-interceptor.js
+++ b/extensions/defenseclaw/dist/fetch-interceptor.js
@@ -39,22 +39,41 @@ const _require = createRequire(import.meta.url);
 const https = _require("https");
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const http = _require("http");
-/**
- * Domains that should be intercepted. Seeded from the embedded
- * providers.json at import time; can be extended at runtime by
- * `bootstrapProviderOverlay()` once the sidecar's
- * GET /v1/config/providers endpoint is reachable. Declared `let` so
- * the overlay can grow the list in place without the rest of the
- * module holding a stale snapshot.
- */
-let LLM_DOMAINS = providersConfig.providers.flatMap((p) => p.domains);
-/**
- * Ollama runs locally — intercept by matching its default port.
- * Seeded from providers.json; can be extended at runtime by the
- * overlay fetch so new Ollama deployments on non-standard ports do
- * not silently bypass the guardrail.
- */
-let OLLAMA_PORTS = providersConfig.ollama_ports.map(String);
+// undici — Node 18+ backs globalThis.fetch with undici's internal dispatcher.
+// SDKs that capture the pre-patch fetch reference or call undici.request()
+// directly bypass globalThis.fetch / https.request patches entirely.
+let undici = null;
+try {
+    undici = _require("undici");
+}
+catch {
+    // undici not bundled (older Node or stripped runtime) — skip
+}
+// ─── Shared cross-instance state ───
+// The plugin .js may be evaluated in multiple V8 contexts (e.g.
+// [gateway] + [plugins] in OpenClaw). Each evaluation creates its
+// own module-scoped variables. Using a well-known globalThis slot
+// ensures all instances share one canonical domain/port list and
+// only one instance installs the transport patch.
+const INTERCEPTOR_STATE_KEY = Symbol.for("defenseclaw.interceptor.state");
+function getOrCreateSharedState() {
+    const existing = globalThis[INTERCEPTOR_STATE_KEY];
+    if (existing)
+        return existing;
+    const state = {
+        llmDomains: providersConfig.providers.flatMap((p) => p.domains),
+        ollamaPorts: providersConfig.ollama_ports.map(String),
+        installed: false,
+        guardrailPort: null,
+    };
+    globalThis[INTERCEPTOR_STATE_KEY] = state;
+    return state;
+}
+const _shared = getOrCreateSharedState();
+// Module-level aliases that point into shared state so existing code
+// (isLLMUrl, applyProviderRegistry, etc.) continues to work unchanged.
+let LLM_DOMAINS = _shared.llmDomains;
+let OLLAMA_PORTS = _shared.ollamaPorts;
 /**
  * Apply a merged provider registry from the Go sidecar. Additive
  * only — we never drop a built-in domain or port because the
@@ -578,8 +597,13 @@ function decodeUtf8Safe(buf) {
  * the cap; subsequent chunks are never read, so a pathological body
  * (GBs) never allocates past `cap` bytes. Returns the raw byte
  * sequence so the caller can decide on encoding.
+ *
+ * `cancelRemainder` defaults to true for standalone streams (sidecar
+ * overlay responses). Request.clone() tees the body; awaiting
+ * cancel() on one tee branch can stay pending until the sibling is
+ * consumed (#732), so Request peeks must pass false.
  */
-async function readStreamBounded(stream, cap) {
+async function readStreamBounded(stream, cap, options) {
     const reader = stream.getReader();
     const chunks = [];
     let total = 0;
@@ -600,13 +624,19 @@ async function readStreamBounded(stream, cap) {
         }
     }
     finally {
-        // Cancel the rest of the stream so the underlying transport
-        // does not keep delivering bytes we will never consume.
-        try {
-            await reader.cancel();
+        if (options?.cancelRemainder === false) {
+            // Fire-and-forget: awaiting tee-branch cancel() can deadlock
+            // against the unconsumed sibling (#732), but skipping cancel
+            // entirely leaves the rest of a multi-GB body queued.
+            void reader.cancel().catch(() => undefined);
         }
-        catch {
-            /* ignore */
+        else {
+            try {
+                await reader.cancel();
+            }
+            catch {
+                /* ignore */
+            }
         }
         try {
             reader.releaseLock();
@@ -623,8 +653,147 @@ async function readStreamBounded(stream, cap) {
     }
     return out;
 }
+function hasOwnBody(init) {
+    // Native fetch(request, { body: null | undefined }) inherits the
+    // Request body. Only a non-null init.body replaces it.
+    return Boolean(init &&
+        Object.prototype.hasOwnProperty.call(init, "body") &&
+        init.body != null);
+}
+/**
+ * Classify a bounded peek. Full JSON wins; if the 64 KiB cap sliced
+ * mid-document, recover the top-level LLM key from the prefix so a
+ * large messages[] body is not treated as non-LLM.
+ */
+function classifyPeekText(text) {
+    if (!text)
+        return "none";
+    try {
+        return classifyBodyShape(JSON.parse(text));
+    }
+    catch {
+        return classifyTruncatedRootKeys(text);
+    }
+}
+/** Recover an LLM shape from a 64 KiB-truncated JSON object prefix. */
+function classifyTruncatedRootKeys(text) {
+    const keys = new Set(rootObjectKeys(text));
+    if (keys.has("messages"))
+        return "messages";
+    if (keys.has("contents"))
+        return "contents";
+    if (keys.has("inputs"))
+        return "input";
+    if (keys.has("input"))
+        return "input";
+    if (keys.has("prompt"))
+        return "prompt";
+    return "none";
+}
+/**
+ * Collect object keys at depth 1 so a nested `"messages"` (or similar)
+ * cannot classify a non-LLM body after the peek cap slices the document.
+ */
+function rootObjectKeys(text) {
+    const keys = [];
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+    for (let i = 0; i < text.length; i++) {
+        const ch = text[i];
+        if (inString) {
+            if (escape) {
+                escape = false;
+                continue;
+            }
+            if (ch === "\\") {
+                escape = true;
+                continue;
+            }
+            if (ch === "\"") {
+                inString = false;
+            }
+            continue;
+        }
+        if (ch === "\"") {
+            if (depth === 1) {
+                const match = /^"((?:\\.|[^"\\])*)"\s*:/.exec(text.slice(i));
+                if (match) {
+                    keys.push(match[1].replace(/\\(.)/g, "$1"));
+                    i += match[0].length - 1;
+                    continue;
+                }
+            }
+            inString = true;
+            continue;
+        }
+        if (ch === "{" || ch === "[") {
+            depth++;
+            continue;
+        }
+        if (ch === "}" || ch === "]") {
+            depth = Math.max(0, depth - 1);
+        }
+    }
+    return keys;
+}
+function requestDuplex(value) {
+    if (!value || !("duplex" in value))
+        return undefined;
+    return value.duplex === "half" ? "half" : undefined;
+}
+function peekConcreteBody(body) {
+    if (body == null)
+        return "none";
+    if (typeof body === "string") {
+        return classifyPeekText(body.slice(0, BODY_PEEK_CAP_BYTES));
+    }
+    if (body instanceof Uint8Array) {
+        return classifyPeekText(decodeUtf8Safe(body.subarray(0, BODY_PEEK_CAP_BYTES)));
+    }
+    if (body instanceof ArrayBuffer) {
+        return classifyPeekText(decodeUtf8Safe(new Uint8Array(body).subarray(0, BODY_PEEK_CAP_BYTES)));
+    }
+    // ReadableStream, FormData, Blob, etc. — consuming them would break
+    // the downstream fetch. Fall back to path-only detection.
+    return "none";
+}
+function combineAbortSignals(requestSignal, initSignal) {
+    // Native fetch(request, { signal }) uses the init signal only.
+    if (initSignal)
+        return initSignal;
+    return requestSignal;
+}
+/**
+ * Fetch `request` + `init` precedence used by shape detection and the
+ * proxy rewrite. Caller `init` wins, matching native Fetch.
+ */
+export function resolveEffectiveFetchInit(input, init) {
+    const req = input instanceof Request ? input : null;
+    const headers = init?.headers != null
+        ? new Headers(init.headers)
+        : new Headers(req?.headers);
+    return {
+        method: String(init?.method ?? req?.method ?? "GET"),
+        headers,
+        body: hasOwnBody(init) ? init.body : (req ? req.body : undefined),
+        signal: combineAbortSignals(req?.signal, init?.signal),
+        redirect: init?.redirect ?? req?.redirect,
+        credentials: init?.credentials ?? req?.credentials,
+        cache: init?.cache ?? req?.cache,
+        integrity: init?.integrity ?? req?.integrity,
+        keepalive: init?.keepalive ?? req?.keepalive,
+        mode: init?.mode ?? req?.mode,
+        referrer: init?.referrer ?? req?.referrer,
+        referrerPolicy: init?.referrerPolicy ?? req?.referrerPolicy,
+    };
+}
 export async function peekBodyForShape(input, init) {
     try {
+        // Fetch spec: a supplied init.body replaces the Request body.
+        if (hasOwnBody(init)) {
+            return peekConcreteBody(init.body);
+        }
         if (input instanceof Request) {
             // input.clone() keeps the caller's Request body intact for the
             // downstream originalFetch call. Prefer a streaming read
@@ -637,7 +806,11 @@ export async function peekBodyForShape(input, init) {
                 .body;
             let bytes;
             if (stream && typeof stream.getReader === "function") {
-                bytes = await readStreamBounded(stream, BODY_PEEK_CAP_BYTES);
+                // Do not await tee-branch cancel(): it can deadlock against
+                // the unconsumed original Request body (#732).
+                bytes = await readStreamBounded(stream, BODY_PEEK_CAP_BYTES, {
+                    cancelRemainder: false,
+                });
             }
             else {
                 const text = await cloned.text().catch(() => "");
@@ -650,54 +823,13 @@ export async function peekBodyForShape(input, init) {
                 const capped = text.length > BODY_PEEK_CAP_BYTES
                     ? text.slice(0, BODY_PEEK_CAP_BYTES)
                     : text;
-                try {
-                    return classifyBodyShape(JSON.parse(capped));
-                }
-                catch {
-                    return "none";
-                }
+                return classifyPeekText(capped);
             }
             if (bytes.byteLength === 0)
                 return "none";
-            try {
-                return classifyBodyShape(JSON.parse(decodeUtf8Safe(bytes)));
-            }
-            catch {
-                return "none";
-            }
+            return classifyPeekText(decodeUtf8Safe(bytes));
         }
-        const body = init?.body;
-        if (body == null)
-            return "none";
-        if (typeof body === "string") {
-            try {
-                return classifyBodyShape(JSON.parse(body.slice(0, BODY_PEEK_CAP_BYTES)));
-            }
-            catch {
-                return "none";
-            }
-        }
-        if (body instanceof Uint8Array) {
-            const slice = body.subarray(0, BODY_PEEK_CAP_BYTES);
-            try {
-                return classifyBodyShape(JSON.parse(decodeUtf8Safe(slice)));
-            }
-            catch {
-                return "none";
-            }
-        }
-        if (body instanceof ArrayBuffer) {
-            const view = new Uint8Array(body).subarray(0, BODY_PEEK_CAP_BYTES);
-            try {
-                return classifyBodyShape(JSON.parse(decodeUtf8Safe(view)));
-            }
-            catch {
-                return "none";
-            }
-        }
-        // ReadableStream, FormData, Blob, etc. — consuming them would break
-        // the downstream fetch. Fall back to path-only detection.
-        return "none";
+        return peekConcreteBody(init?.body);
     }
     catch {
         return "none";
@@ -811,6 +943,9 @@ export const DEFENSECLAW_CORRELATION_HEADER_NAMES = [
     HEADER_DEFENSECLAW_SIDECAR_INSTANCE_ID,
     HEADER_DEFENSECLAW_TRACE_ID,
 ];
+const INTERCEPTION_SELF_TEST_URL = "https://api.openai.com/v1/chat/completions";
+const INTERCEPTION_SELF_TEST_INTERVAL_MS = 60_000;
+export const INTERCEPTION_PROBE_HEADER = "X-DC-Interception-Probe";
 /**
  * Creates an interceptor that, when started, patches globalThis.fetch to
  * redirect LLM API calls through the guardrail proxy.
@@ -831,8 +966,41 @@ export function createFetchInterceptor(portOrOpts) {
     let originalHttpsRequest = null;
     let originalHttpRequest = null;
     let originalHttpGet = null;
+    let originalUndiciDispatcher = null;
     let egressReporter = null;
     let chatgptCodexPassthroughWarned = false;
+    let selfTestTimer = null;
+    const loggedInterceptHosts = new Set();
+    function describeLayers() {
+        return {
+            fetch: originalFetch !== null && globalThis.fetch !== originalFetch,
+            httpRequest: originalHttpRequest !== null && http.request !== originalHttpRequest,
+            httpsRequest: originalHttpsRequest !== null && https.request !== originalHttpsRequest,
+            httpGet: originalHttpGet !== null && http.get !== originalHttpGet,
+            undiciDispatcher: Boolean(undici &&
+                originalUndiciDispatcher &&
+                undici.getGlobalDispatcher() !== originalUndiciDispatcher),
+        };
+    }
+    function logStartupBanner(layers) {
+        console.log(`[defenseclaw] interceptor layers fetch=${layers.fetch} https.request=${layers.httpsRequest} ` +
+            `http.request=${layers.httpRequest} http.get=${layers.httpGet} undici=${layers.undiciDispatcher} ` +
+            `fetch_resolvable=${typeof globalThis.fetch === "function"} undici_resolvable=${Boolean(undici)}`);
+    }
+    function noteInterceptLayer(layer, urlStr) {
+        let host = urlStr;
+        try {
+            host = new URL(urlStr).hostname;
+        }
+        catch {
+            // keep the raw string when URL parsing fails
+        }
+        const key = `${layer}:${host}`;
+        if (loggedInterceptHosts.has(key))
+            return;
+        loggedInterceptHosts.add(key);
+        console.log(`[defenseclaw] intercept via=${layer} host=${host}`);
+    }
     // Extract { host, path } from a URL string without throwing. Missing
     // pieces are tolerated so the caller's downstream fetch is never
     // perturbed by a malformed URL in telemetry. Query-parameter values are
@@ -867,7 +1035,19 @@ export function createFetchInterceptor(portOrOpts) {
     }
     function start() {
         if (originalFetch)
-            return; // already started
+            return; // this instance already started
+        // Idempotent cross-instance guard: if another module evaluation
+        // already patched the transport, we only bootstrap the overlay
+        // (so our operator-added domains merge into the shared list) and
+        // return without re-wrapping fetch/https/http/undici.
+        if (_shared.installed) {
+            void bootstrapProviderOverlay(guardrailPort, {
+                fetchImpl: globalThis.fetch,
+            });
+            return;
+        }
+        _shared.installed = true;
+        _shared.guardrailPort = guardrailPort;
         originalFetch = globalThis.fetch;
         egressReporter = createEgressReporter({ guardrailPort });
         // Layer 4 (governance): pull the sidecar's merged provider
@@ -897,12 +1077,12 @@ export function createFetchInterceptor(portOrOpts) {
             let shouldIntercept = knownLLM;
             let shapeBranch = knownLLM ? "known" : "passthrough";
             let bodyShape = "none";
+            const effective = resolveEffectiveFetchInit(input, init);
             // Layer 1: request-shape detection. Only peek the body when the
             // allowlist didn't already match — peeking costs a clone().
             if (!knownLLM) {
-                const method = (input instanceof Request ? input.method : init?.method) ?? "GET";
                 bodyShape = await peekBodyForShape(input, init);
-                if (isLLMShapedRequest(urlStr, method, bodyShape, guardrailPort)) {
+                if (isLLMShapedRequest(urlStr, effective.method, bodyShape, guardrailPort)) {
                     shouldIntercept = true;
                     shapeBranch = "shape";
                 }
@@ -932,17 +1112,59 @@ export function createFetchInterceptor(portOrOpts) {
             }
             // Rewrite: keep path + query, replace scheme://host with proxy.
             const proxied = `${proxyBase}${original.pathname}${original.search}`;
-            // Merge all original headers and add proxy-hop headers.
-            const headers = new Headers(input instanceof Request ? input.headers : init?.headers);
+            noteInterceptLayer("fetch", urlStr);
+            // Merge effective headers (Request + init overrides) and add
+            // proxy-hop headers. init wins, matching native Fetch (#742).
+            const headers = new Headers(effective.headers);
             const providerKey = extractProviderKey(headers);
             const proxyHdrs = buildProxyHeaders(original.origin, providerKey, getCorrelationHeaders);
             for (const [k, v] of Object.entries(proxyHdrs)) {
                 headers.set(k, v);
             }
-            // Build new init, preserving all original properties.
-            const newInit = input instanceof Request
-                ? { method: input.method, body: input.body, headers }
-                : { ...(init ?? {}), headers };
+            // Peek used a clone. Consume the original Request tee branch so
+            // the leftover sibling is not left unread.
+            let rewriteBody = effective.body;
+            if (!hasOwnBody(init) && input instanceof Request && !input.bodyUsed) {
+                rewriteBody = input.body ?? effective.body;
+            }
+            // Preserve Request metadata and caller init extras (duplex, etc.),
+            // then apply the resolved method/body/signal/redirect family.
+            const duplex = requestDuplex(init) ??
+                (input instanceof Request ? requestDuplex(input) : undefined) ??
+                (typeof ReadableStream !== "undefined" &&
+                    rewriteBody instanceof ReadableStream
+                    ? "half"
+                    : undefined);
+            const newInit = {
+                ...(input instanceof Request
+                    ? {
+                        method: input.method,
+                        redirect: input.redirect,
+                        credentials: input.credentials,
+                        cache: input.cache,
+                        integrity: input.integrity,
+                        keepalive: input.keepalive,
+                        mode: input.mode,
+                        referrer: input.referrer,
+                        referrerPolicy: input.referrerPolicy,
+                        signal: input.signal,
+                    }
+                    : {}),
+                ...(init ?? {}),
+                method: effective.method,
+                body: rewriteBody,
+                headers,
+                signal: effective.signal ?? undefined,
+                redirect: effective.redirect,
+                credentials: effective.credentials,
+                cache: effective.cache,
+                integrity: effective.integrity,
+                keepalive: effective.keepalive,
+                mode: effective.mode,
+                referrer: effective.referrer,
+                referrerPolicy: effective.referrerPolicy,
+                ...(duplex ? { duplex } : {}),
+            };
             if (shapeBranch === "shape") {
                 console.log(`[defenseclaw] intercepted LLM-shaped call → ${scrubUrlForLog(urlStr)} (body_shape=${bodyShape}) proxied via ${proxyBase}`);
             }
@@ -969,8 +1191,10 @@ export function createFetchInterceptor(portOrOpts) {
             });
             return response;
         };
-        // Also patch https.request so axios, undici, and other non-fetch HTTP
-        // clients are intercepted. All of them ultimately use node:https.request.
+        // Also patch https.request so axios and other HTTP clients that
+        // delegate to node:https are intercepted. Note: undici-based clients
+        // (including Node 18+ globalThis.fetch) are covered by the undici
+        // dispatcher patch above, not this https.request patch.
         originalHttpsRequest = https.request.bind(https);
         originalHttpRequest = http.request.bind(http);
         originalHttpGet = http.get.bind(http);
@@ -1085,6 +1309,7 @@ export function createFetchInterceptor(portOrOpts) {
                 hasLLMPathSuffix(urlStr));
             const knownForHTTPS = Boolean(urlStr && isLLMUrl(urlStr, guardrailPort) && !isAlreadyProxied(urlStr, guardrailPort));
             if (urlStr && (knownForHTTPS || shapedForHTTPS)) {
+                noteInterceptLayer("https.request", urlStr);
                 let opts = {};
                 let cb = callback;
                 if (typeof optionsOrCallback === "function") {
@@ -1204,15 +1429,23 @@ export function createFetchInterceptor(portOrOpts) {
         // get rewritten to "https:".
         function patchedHttpRequest(urlOrOptions, optionsOrCallback, callback) {
             const urlStr = buildUrlStringFromArgs(urlOrOptions, optionsOrCallback);
-            // Only re-route if the request shape would otherwise hit a
-            // local Ollama instance. For any other http.request path we
-            // pass through to the captured original to avoid breaking
-            // unrelated http traffic.
-            const ollamaCandidate = Boolean(urlStr &&
+            // Layer 0: known provider domain or registered local LLM port
+            // with a recognizable LLM path (original Ollama-only gate).
+            const knownCandidate = Boolean(urlStr &&
                 isLLMUrl(urlStr, guardrailPort) &&
                 hasLLMPathSuffix(urlStr) &&
                 !isAlreadyProxied(urlStr, guardrailPort));
-            if (!ollamaCandidate) {
+            // Layer 1: path-shape detection — catches local LLM proxies
+            // (e.g. http://127.0.0.1:18800/v1/chat/completions) that are
+            // not registered in ollama_ports but have a recognizable LLM
+            // path suffix. Only applies to non-safe domains so we don't
+            // accidentally intercept unrelated http traffic.
+            const shapedCandidate = Boolean(urlStr &&
+                !knownCandidate &&
+                !isKnownSafeDomain(urlStr) &&
+                !isAlreadyProxied(urlStr, guardrailPort) &&
+                hasLLMPathSuffix(urlStr));
+            if (!knownCandidate && !shapedCandidate) {
                 return originalHttpRequest(urlOrOptions, optionsOrCallback, callback);
             }
             // Re-use the https.request patched path. The proxy hop is
@@ -1236,7 +1469,151 @@ export function createFetchInterceptor(portOrOpts) {
             return req;
         }
         http.get = patchedHttpGet;
+        // ─── Undici dispatcher interception ───
+        // Node 18+ globalThis.fetch is backed by undici's internal
+        // dispatcher. If a SDK (e.g. @anthropic-ai/sdk, openai v4+)
+        // captured the original globalThis.fetch reference before our
+        // swap, or calls undici.request()/fetch() directly, traffic
+        // bypasses our globalThis.fetch patch. Intercepting at the
+        // dispatcher level catches ALL undici-routed traffic.
+        if (undici &&
+            typeof undici.getGlobalDispatcher === "function" &&
+            typeof undici.setGlobalDispatcher === "function") {
+            originalUndiciDispatcher = undici.getGlobalDispatcher();
+            const parentDispatcher = originalUndiciDispatcher;
+            const interceptingDispatch = (opts, handler) => {
+                const origin = opts.origin?.toString() ?? "";
+                const pathStr = opts.path ?? "";
+                const urlStr = origin + pathStr;
+                if (urlStr &&
+                    !isAlreadyProxied(urlStr, guardrailPort) &&
+                    !isKnownSafeDomain(urlStr) &&
+                    (isLLMUrl(urlStr, guardrailPort) || hasLLMPathSuffix(urlStr))) {
+                    opts.origin = proxyBase;
+                    const existingHeaders = (opts.headers ?? {});
+                    const providerKey = extractProviderKeyFromRecord(existingHeaders);
+                    const proxyHdrs = buildProxyHeaders(origin + pathStr, providerKey, getCorrelationHeaders);
+                    opts.headers = { ...existingHeaders, ...proxyHdrs };
+                    noteInterceptLayer("undici", urlStr);
+                    egressReporter?.report({
+                        targetHost: new URL(origin).hostname,
+                        targetPath: pathStr,
+                        bodyShape: "none",
+                        looksLikeLLM: true,
+                        branch: "undici",
+                        decision: "intercept",
+                        reason: "undici-dispatcher",
+                    });
+                }
+                return parentDispatcher.dispatch(opts, handler);
+            };
+            // Proxy object that delegates dispatch to our interceptor and
+            // all other Dispatcher methods to the original.
+            const proxyDispatcher = Object.create(parentDispatcher, {
+                dispatch: { value: interceptingDispatch, writable: true, configurable: true },
+            });
+            undici.setGlobalDispatcher(proxyDispatcher);
+        }
         console.log(`[defenseclaw] LLM fetch interceptor active (proxy: ${proxyBase})`);
+        const layers = describeLayers();
+        logStartupBanner(layers);
+        scheduleSelfTest();
+    }
+    async function verifyInterception() {
+        const layers = describeLayers();
+        const expectedDest = `${proxyBase}/v1/chat/completions`;
+        if (!originalFetch) {
+            return {
+                ok: false,
+                destination: "",
+                layers,
+                reason: "interceptor-not-started",
+            };
+        }
+        const captured = [];
+        const prev = originalFetch;
+        originalFetch = (async (input) => {
+            captured.push(String(input instanceof Request ? input.url : input));
+            return new Response(JSON.stringify({ id: "dc-intercept-probe" }), {
+                status: 200,
+                headers: { "content-type": "application/json", [INTERCEPTION_PROBE_HEADER]: "1" },
+            });
+        });
+        try {
+            await globalThis.fetch(INTERCEPTION_SELF_TEST_URL, {
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                    [INTERCEPTION_PROBE_HEADER]: "1",
+                },
+                body: JSON.stringify({
+                    model: "defenseclaw-intercept-probe",
+                    messages: [{ role: "user", content: "defenseclaw-intercept-probe" }],
+                }),
+            });
+        }
+        catch {
+            // The stub never throws; keep the miss path for a broken wrapper.
+        }
+        finally {
+            originalFetch = prev;
+        }
+        const destination = captured[0] ?? "";
+        const ok = destination === expectedDest && layers.fetch;
+        return {
+            ok,
+            destination,
+            layers,
+            reason: ok ? "interception-self-test" : "interception-self-test-miss",
+        };
+    }
+    async function publishSelfTest(result) {
+        if (!originalFetch)
+            return;
+        const token = loadSidecarConfig().token;
+        const headers = { "Content-Type": "application/json" };
+        if (token)
+            headers[DC_AUTH_HEADER] = `Bearer ${token}`;
+        try {
+            const controller = new AbortController();
+            const timeout = setTimeout(() => controller.abort(), 2_000);
+            await originalFetch(`http://127.0.0.1:${guardrailPort}/v1/events/egress`, {
+                method: "POST",
+                headers,
+                body: JSON.stringify({
+                    target_host: "api.openai.com",
+                    target_path: "/v1/chat/completions",
+                    body_shape: "messages",
+                    looks_like_llm: true,
+                    branch: "selftest",
+                    decision: result.ok ? "intercept" : "allow",
+                    reason: result.reason,
+                }),
+                signal: controller.signal,
+            });
+            clearTimeout(timeout);
+        }
+        catch {
+            // Self-test telemetry is best-effort and must not stall the plugin.
+        }
+    }
+    async function runSelfTest() {
+        const result = await verifyInterception();
+        console.log(`[defenseclaw] interception self-test ok=${result.ok} dest=${result.destination || "none"} ` +
+            `reason=${result.reason}`);
+        await publishSelfTest(result);
+        return result;
+    }
+    function scheduleSelfTest() {
+        void runSelfTest();
+        if (selfTestTimer)
+            return;
+        selfTestTimer = setInterval(() => {
+            void runSelfTest();
+        }, INTERCEPTION_SELF_TEST_INTERVAL_MS);
+        if (typeof selfTestTimer === "object" && selfTestTimer && "unref" in selfTestTimer) {
+            selfTestTimer.unref?.();
+        }
     }
     function stop() {
         if (originalFetch) {
@@ -1258,12 +1635,24 @@ export function createFetchInterceptor(portOrOpts) {
             http.get = originalHttpGet;
             originalHttpGet = null;
         }
+        // Restore undici global dispatcher
+        if (undici && originalUndiciDispatcher) {
+            undici.setGlobalDispatcher(originalUndiciDispatcher);
+            originalUndiciDispatcher = null;
+        }
         if (egressReporter) {
             egressReporter.stop();
             egressReporter = null;
         }
         chatgptCodexPassthroughWarned = false;
+        loggedInterceptHosts.clear();
+        if (selfTestTimer) {
+            clearInterval(selfTestTimer);
+            selfTestTimer = null;
+        }
+        _shared.installed = false;
+        _shared.guardrailPort = null;
         console.log("[defenseclaw] LLM fetch interceptor stopped");
     }
-    return { start, stop };
+    return { start, stop, describeLayers, verifyInterception };
 }

--- a/extensions/defenseclaw/dist/fetch-interceptor.js
+++ b/extensions/defenseclaw/dist/fetch-interceptor.js
@@ -1721,5 +1721,5 @@ export function createFetchInterceptor(portOrOpts) {
         _shared.guardrailPort = null;
         console.log("[defenseclaw] LLM fetch interceptor stopped");
     }
-    return { start, stop, describeLayers, verifyInterception };
+    return { start, stop, describeLayers, verifyInterception, runSelfTest };
 }

--- a/extensions/defenseclaw/dist/fetch-interceptor.js
+++ b/extensions/defenseclaw/dist/fetch-interceptor.js
@@ -1113,6 +1113,12 @@ export function createFetchInterceptor(portOrOpts) {
             // Rewrite: keep path + query, replace scheme://host with proxy.
             const proxied = `${proxyBase}${original.pathname}${original.search}`;
             noteInterceptLayer("fetch", urlStr);
+            if (new Headers(effective.headers).get(INTERCEPTION_PROBE_HEADER) === "1") {
+                return new Response(JSON.stringify({ id: "dc-intercept-probe" }), {
+                    status: 200,
+                    headers: { "content-type": "application/json", [INTERCEPTION_PROBE_HEADER]: "1" },
+                });
+            }
             // Merge effective headers (Request + init overrides) and add
             // proxy-hop headers. init wins, matching native Fetch (#742).
             const headers = new Headers(effective.headers);
@@ -1530,17 +1536,9 @@ export function createFetchInterceptor(portOrOpts) {
                 reason: "interceptor-not-started",
             };
         }
-        const captured = [];
-        const prev = originalFetch;
-        originalFetch = (async (input) => {
-            captured.push(String(input instanceof Request ? input.url : input));
-            return new Response(JSON.stringify({ id: "dc-intercept-probe" }), {
-                status: 200,
-                headers: { "content-type": "application/json", [INTERCEPTION_PROBE_HEADER]: "1" },
-            });
-        });
+        let destination = "";
         try {
-            await globalThis.fetch(INTERCEPTION_SELF_TEST_URL, {
+            const response = await globalThis.fetch(INTERCEPTION_SELF_TEST_URL, {
                 method: "POST",
                 headers: {
                     "content-type": "application/json",
@@ -1551,14 +1549,16 @@ export function createFetchInterceptor(portOrOpts) {
                     messages: [{ role: "user", content: "defenseclaw-intercept-probe" }],
                 }),
             });
+            // Probe hops short-circuit inside the wrapper after rewrite. A
+            // 200 with the probe header means the rewrite happened and the
+            // original fetch was never used for a provider host.
+            if (response.headers.get(INTERCEPTION_PROBE_HEADER) === "1") {
+                destination = expectedDest;
+            }
         }
         catch {
-            // The stub never throws; keep the miss path for a broken wrapper.
+            // Keep the miss path for a broken wrapper.
         }
-        finally {
-            originalFetch = prev;
-        }
-        const destination = captured[0] ?? "";
         const ok = destination === expectedDest && layers.fetch;
         return {
             ok,
@@ -1605,7 +1605,6 @@ export function createFetchInterceptor(portOrOpts) {
         return result;
     }
     function scheduleSelfTest() {
-        void runSelfTest();
         if (selfTestTimer)
             return;
         selfTestTimer = setInterval(() => {

--- a/extensions/defenseclaw/src/__tests__/fetch-interceptor-selftest.test.ts
+++ b/extensions/defenseclaw/src/__tests__/fetch-interceptor-selftest.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2026 Cisco Systems, Inc. and its affiliates
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #473: OpenClaw 2026.6.x can emit LLM traffic that never increments
+ * gateway.log "INCOMING REQUEST" while :4000 still answers liveliness.
+ * The interceptor must rewrite a sentinel OpenAI chat URL onto the
+ * local proxy without leaving the box.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createFetchInterceptor,
+  INTERCEPTION_PROBE_HEADER,
+} from "../fetch-interceptor.js";
+
+const guardrailPort = 14173;
+
+describe("OpenClaw interception self-test", () => {
+  const realFetch = globalThis.fetch;
+  const forwarded: string[] = [];
+  let interceptor: ReturnType<typeof createFetchInterceptor>;
+
+  beforeEach(() => {
+    forwarded.length = 0;
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      forwarded.push(String(input instanceof Request ? input.url : input));
+      return new Response("ok");
+    }) as typeof fetch;
+    interceptor = createFetchInterceptor(guardrailPort);
+    interceptor.start();
+  });
+
+  afterEach(() => {
+    interceptor.stop();
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("rewrites a sentinel OpenAI chat URL onto the local guardrail proxy", async () => {
+    const result = await interceptor.verifyInterception();
+    expect(result.ok).toBe(true);
+    expect(result.destination).toBe(`http://127.0.0.1:${guardrailPort}/v1/chat/completions`);
+    expect(result.layers.fetch).toBe(true);
+    expect(result.reason).toBe("interception-self-test");
+    expect(forwarded.some((url) => url.includes("api.openai.com"))).toBe(false);
+  });
+
+  it("records fetch, http, https, and undici layers on the startup banner", () => {
+    const layers = interceptor.describeLayers();
+    expect(layers.fetch).toBe(true);
+    expect(layers.httpsRequest).toBe(true);
+    expect(layers.httpRequest).toBe(true);
+    expect(layers.httpGet).toBe(true);
+    const banner = vi.mocked(console.log).mock.calls.map((call) => String(call[0]));
+    expect(banner.some((line) => line.includes("interceptor layers") && line.includes("fetch=true"))).toBe(true);
+  });
+
+  it("does not emit the probe header toward a real provider host", async () => {
+    await interceptor.verifyInterception();
+    expect(forwarded.filter((url) => url.includes("api.openai.com"))).toEqual([]);
+    expect(INTERCEPTION_PROBE_HEADER).toBe("X-DC-Interception-Probe");
+  });
+});

--- a/extensions/defenseclaw/src/__tests__/fetch-interceptor-selftest.test.ts
+++ b/extensions/defenseclaw/src/__tests__/fetch-interceptor-selftest.test.ts
@@ -48,6 +48,10 @@ describe("OpenClaw interception self-test", () => {
     expect(result.ok).toBe(true);
     expect(result.destination).toBe(`http://127.0.0.1:${guardrailPort}/v1/chat/completions`);
     expect(result.layers.fetch).toBe(true);
+    expect(result.layers.httpsRequest).toBe(true);
+    expect(result.layers.httpRequest).toBe(true);
+    expect(result.layers.httpGet).toBe(true);
+    expect(result.layers.undiciDispatcher).toBe(true);
     expect(result.reason).toBe("interception-self-test");
     expect(forwarded.some((url) => url.includes("api.openai.com"))).toBe(false);
   });
@@ -58,8 +62,9 @@ describe("OpenClaw interception self-test", () => {
     expect(layers.httpsRequest).toBe(true);
     expect(layers.httpRequest).toBe(true);
     expect(layers.httpGet).toBe(true);
+    expect(layers.undiciDispatcher).toBe(true);
     const banner = vi.mocked(console.log).mock.calls.map((call) => String(call[0]));
-    expect(banner.some((line) => line.includes("interceptor layers") && line.includes("fetch=true"))).toBe(true);
+    expect(banner.some((line) => line.includes("interceptor layers") && line.includes("undici=true"))).toBe(true);
   });
 
   it("does not emit the probe header toward a real provider host", async () => {

--- a/extensions/defenseclaw/src/egress-telemetry.ts
+++ b/extensions/defenseclaw/src/egress-telemetry.ts
@@ -35,7 +35,7 @@ import { loadSidecarConfig } from "./sidecar-config.js";
 const DC_AUTH_HEADER = "X-DC-Auth";
 
 /** Branch labels mirror the Go-side emitter in internal/gateway/events.go. */
-export type EgressBranch = "known" | "shape" | "passthrough" | "undici";
+export type EgressBranch = "known" | "shape" | "passthrough" | "undici" | "selftest";
 
 /** Allow/block decision at the guardrail edge. */
 export type EgressDecision = "allow" | "block" | "intercept";

--- a/extensions/defenseclaw/src/fetch-interceptor.ts
+++ b/extensions/defenseclaw/src/fetch-interceptor.ts
@@ -2021,5 +2021,5 @@ export function createFetchInterceptor(
     console.log("[defenseclaw] LLM fetch interceptor stopped");
   }
 
-  return { start, stop, describeLayers, verifyInterception };
+  return { start, stop, describeLayers, verifyInterception, runSelfTest };
 }

--- a/extensions/defenseclaw/src/fetch-interceptor.ts
+++ b/extensions/defenseclaw/src/fetch-interceptor.ts
@@ -58,6 +58,13 @@ let undici: {
   getGlobalDispatcher: () => unknown;
   setGlobalDispatcher: (d: unknown) => void;
   Dispatcher: new () => unknown;
+  request?: (
+    url: string,
+    opts?: Record<string, unknown>,
+  ) => Promise<{
+    headers?: Record<string, string | string[] | undefined>;
+    body?: { text?: () => Promise<string> };
+  }>;
 } | null = null;
 try {
   undici = _require("undici") as typeof undici;
@@ -1059,6 +1066,64 @@ const INTERCEPTION_SELF_TEST_URL = "https://api.openai.com/v1/chat/completions";
 const INTERCEPTION_SELF_TEST_INTERVAL_MS = 60_000;
 export const INTERCEPTION_PROBE_HEADER = "X-DC-Interception-Probe";
 
+function readUndiciHeader(headers: unknown, name: string): string {
+  if (headers == null) {
+    return "";
+  }
+  const wanted = name.toLowerCase();
+  if (Array.isArray(headers)) {
+    for (let i = 0; i < headers.length - 1; i += 2) {
+      if (String(headers[i]).toLowerCase() === wanted) {
+        return String(headers[i + 1]);
+      }
+    }
+    return "";
+  }
+  if (typeof headers === "object") {
+    for (const [key, value] of Object.entries(headers as Record<string, unknown>)) {
+      if (key.toLowerCase() === wanted) {
+        return Array.isArray(value) ? String(value[0] ?? "") : String(value ?? "");
+      }
+    }
+  }
+  return "";
+}
+
+function completeUndiciProbe(handler: unknown): boolean {
+  const sink = handler as {
+    onConnect?: (abort: () => void) => void;
+    onHeaders?: (
+      status: number,
+      headers: Buffer[],
+      resume: () => void,
+      statusText?: string,
+    ) => boolean | void;
+    onData?: (chunk: Buffer) => boolean | void;
+    onComplete?: (trailers: Buffer[]) => void;
+    onError?: (err: Error) => void;
+  };
+  try {
+    sink.onConnect?.(() => undefined);
+    sink.onHeaders?.(
+      200,
+      [
+        Buffer.from(INTERCEPTION_PROBE_HEADER.toLowerCase()),
+        Buffer.from("1"),
+        Buffer.from("content-type"),
+        Buffer.from("application/json"),
+      ],
+      () => undefined,
+      "OK",
+    );
+    sink.onData?.(Buffer.from('{"id":"dc-intercept-probe"}'));
+    sink.onComplete?.([]);
+    return true;
+  } catch (err) {
+    sink.onError?.(err instanceof Error ? err : new Error(String(err)));
+    return false;
+  }
+}
+
 export interface CreateFetchInterceptorOptions {
   guardrailPort: number;
   /**
@@ -1099,6 +1164,7 @@ export function createFetchInterceptor(
   let chatgptCodexPassthroughWarned = false;
   let selfTestTimer: ReturnType<typeof setInterval> | null = null;
   const loggedInterceptHosts = new Set<string>();
+  let lastUndiciProbeDestination = "";
 
   function describeLayers(): InterceptorLayers {
     return {
@@ -1775,6 +1841,10 @@ export function createFetchInterceptor(
             decision: "intercept",
             reason: "undici-dispatcher",
           });
+          if (readUndiciHeader(opts.headers, INTERCEPTION_PROBE_HEADER) === "1") {
+            lastUndiciProbeDestination = `${proxyBase}${pathStr || "/v1/chat/completions"}`;
+            return completeUndiciProbe(handler);
+          }
         }
 
         return (parentDispatcher as unknown as { dispatch: UndiciDispatchFn }).dispatch(opts, handler);
@@ -1809,18 +1879,19 @@ export function createFetchInterceptor(
     }
 
     let destination = "";
+    const probeInit = {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        [INTERCEPTION_PROBE_HEADER]: "1",
+      },
+      body: JSON.stringify({
+        model: "defenseclaw-intercept-probe",
+        messages: [{ role: "user", content: "defenseclaw-intercept-probe" }],
+      }),
+    };
     try {
-      const response = await globalThis.fetch(INTERCEPTION_SELF_TEST_URL, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          [INTERCEPTION_PROBE_HEADER]: "1",
-        },
-        body: JSON.stringify({
-          model: "defenseclaw-intercept-probe",
-          messages: [{ role: "user", content: "defenseclaw-intercept-probe" }],
-        }),
-      });
+      const response = await globalThis.fetch(INTERCEPTION_SELF_TEST_URL, probeInit);
       // Probe hops short-circuit inside the wrapper after rewrite. A
       // 200 with the probe header means the rewrite happened and the
       // original fetch was never used for a provider host.
@@ -1831,12 +1902,34 @@ export function createFetchInterceptor(
       // Keep the miss path for a broken wrapper.
     }
 
-    const ok = destination === expectedDest && layers.fetch;
+    lastUndiciProbeDestination = "";
+    if (undici && typeof undici.request === "function" && layers.undiciDispatcher) {
+      try {
+        const response = await undici.request(INTERCEPTION_SELF_TEST_URL, probeInit);
+        await response.body?.text?.();
+      } catch {
+        // Rewrite is recorded on the dispatcher even if the sink is stubbed.
+      }
+    }
+
+    const requiredLayers =
+      layers.fetch && layers.httpsRequest && layers.httpRequest && layers.httpGet;
+    const undiciRequired = Boolean(undici);
+    const undiciOk =
+      !undiciRequired ||
+      (layers.undiciDispatcher && lastUndiciProbeDestination === expectedDest);
+    const ok = destination === expectedDest && requiredLayers && undiciOk;
+    let reason = "interception-self-test-miss";
+    if (ok) {
+      reason = "interception-self-test";
+    } else if (destination === expectedDest && requiredLayers && !undiciOk) {
+      reason = "interception-self-test-undici-miss";
+    }
     return {
       ok,
       destination,
       layers,
-      reason: ok ? "interception-self-test" : "interception-self-test-miss",
+      reason,
     };
   }
 

--- a/extensions/defenseclaw/src/fetch-interceptor.ts
+++ b/extensions/defenseclaw/src/fetch-interceptor.ts
@@ -1263,6 +1263,12 @@ export function createFetchInterceptor(
       // Rewrite: keep path + query, replace scheme://host with proxy.
       const proxied = `${proxyBase}${original.pathname}${original.search}`;
       noteInterceptLayer("fetch", urlStr);
+      if (new Headers(effective.headers).get(INTERCEPTION_PROBE_HEADER) === "1") {
+        return new Response(JSON.stringify({ id: "dc-intercept-probe" }), {
+          status: 200,
+          headers: { "content-type": "application/json", [INTERCEPTION_PROBE_HEADER]: "1" },
+        });
+      }
 
       // Merge effective headers (Request + init overrides) and add
       // proxy-hop headers. init wins, matching native Fetch (#742).
@@ -1802,18 +1808,9 @@ export function createFetchInterceptor(
       };
     }
 
-    const captured: string[] = [];
-    const prev = originalFetch;
-    originalFetch = (async (input: RequestInfo | URL) => {
-      captured.push(String(input instanceof Request ? input.url : input));
-      return new Response(JSON.stringify({ id: "dc-intercept-probe" }), {
-        status: 200,
-        headers: { "content-type": "application/json", [INTERCEPTION_PROBE_HEADER]: "1" },
-      });
-    }) as typeof fetch;
-
+    let destination = "";
     try {
-      await globalThis.fetch(INTERCEPTION_SELF_TEST_URL, {
+      const response = await globalThis.fetch(INTERCEPTION_SELF_TEST_URL, {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -1824,13 +1821,16 @@ export function createFetchInterceptor(
           messages: [{ role: "user", content: "defenseclaw-intercept-probe" }],
         }),
       });
+      // Probe hops short-circuit inside the wrapper after rewrite. A
+      // 200 with the probe header means the rewrite happened and the
+      // original fetch was never used for a provider host.
+      if (response.headers.get(INTERCEPTION_PROBE_HEADER) === "1") {
+        destination = expectedDest;
+      }
     } catch {
-      // The stub never throws; keep the miss path for a broken wrapper.
-    } finally {
-      originalFetch = prev;
+      // Keep the miss path for a broken wrapper.
     }
 
-    const destination = captured[0] ?? "";
     const ok = destination === expectedDest && layers.fetch;
     return {
       ok,
@@ -1879,7 +1879,6 @@ export function createFetchInterceptor(
   }
 
   function scheduleSelfTest(): void {
-    void runSelfTest();
     if (selfTestTimer) return;
     selfTestTimer = setInterval(() => {
       void runSelfTest();

--- a/extensions/defenseclaw/src/fetch-interceptor.ts
+++ b/extensions/defenseclaw/src/fetch-interceptor.ts
@@ -1040,6 +1040,25 @@ export const DEFENSECLAW_CORRELATION_HEADER_NAMES = [
   HEADER_DEFENSECLAW_TRACE_ID,
 ] as const;
 
+export interface InterceptorLayers {
+  fetch: boolean;
+  httpRequest: boolean;
+  httpsRequest: boolean;
+  httpGet: boolean;
+  undiciDispatcher: boolean;
+}
+
+export interface InterceptionSelfTest {
+  ok: boolean;
+  destination: string;
+  layers: InterceptorLayers;
+  reason: string;
+}
+
+const INTERCEPTION_SELF_TEST_URL = "https://api.openai.com/v1/chat/completions";
+const INTERCEPTION_SELF_TEST_INTERVAL_MS = 60_000;
+export const INTERCEPTION_PROBE_HEADER = "X-DC-Interception-Probe";
+
 export interface CreateFetchInterceptorOptions {
   guardrailPort: number;
   /**
@@ -1078,6 +1097,43 @@ export function createFetchInterceptor(
   let originalUndiciDispatcher: UndiciDispatcher | null = null;
   let egressReporter: EgressReporter | null = null;
   let chatgptCodexPassthroughWarned = false;
+  let selfTestTimer: ReturnType<typeof setInterval> | null = null;
+  const loggedInterceptHosts = new Set<string>();
+
+  function describeLayers(): InterceptorLayers {
+    return {
+      fetch: originalFetch !== null && globalThis.fetch !== originalFetch,
+      httpRequest: originalHttpRequest !== null && http.request !== originalHttpRequest,
+      httpsRequest: originalHttpsRequest !== null && https.request !== originalHttpsRequest,
+      httpGet: originalHttpGet !== null && http.get !== originalHttpGet,
+      undiciDispatcher: Boolean(
+        undici &&
+          originalUndiciDispatcher &&
+          undici.getGlobalDispatcher() !== originalUndiciDispatcher,
+      ),
+    };
+  }
+
+  function logStartupBanner(layers: InterceptorLayers): void {
+    console.log(
+      `[defenseclaw] interceptor layers fetch=${layers.fetch} https.request=${layers.httpsRequest} ` +
+        `http.request=${layers.httpRequest} http.get=${layers.httpGet} undici=${layers.undiciDispatcher} ` +
+        `fetch_resolvable=${typeof globalThis.fetch === "function"} undici_resolvable=${Boolean(undici)}`,
+    );
+  }
+
+  function noteInterceptLayer(layer: string, urlStr: string): void {
+    let host = urlStr;
+    try {
+      host = new URL(urlStr).hostname;
+    } catch {
+      // keep the raw string when URL parsing fails
+    }
+    const key = `${layer}:${host}`;
+    if (loggedInterceptHosts.has(key)) return;
+    loggedInterceptHosts.add(key);
+    console.log(`[defenseclaw] intercept via=${layer} host=${host}`);
+  }
 
   // Extract { host, path } from a URL string without throwing. Missing
   // pieces are tolerated so the caller's downstream fetch is never
@@ -1206,6 +1262,7 @@ export function createFetchInterceptor(
 
       // Rewrite: keep path + query, replace scheme://host with proxy.
       const proxied = `${proxyBase}${original.pathname}${original.search}`;
+      noteInterceptLayer("fetch", urlStr);
 
       // Merge effective headers (Request + init overrides) and add
       // proxy-hop headers. init wins, matching native Fetch (#742).
@@ -1456,6 +1513,7 @@ export function createFetchInterceptor(
       );
 
       if (urlStr && (knownForHTTPS || shapedForHTTPS)) {
+        noteInterceptLayer("https.request", urlStr);
         let opts: NodeRequestOptions = {};
         let cb = callback;
 
@@ -1701,6 +1759,7 @@ export function createFetchInterceptor(
           );
           opts.headers = { ...existingHeaders, ...proxyHdrs };
 
+          noteInterceptLayer("undici", urlStr);
           egressReporter?.report({
             targetHost: new URL(origin).hostname,
             targetPath: pathStr,
@@ -1726,6 +1785,108 @@ export function createFetchInterceptor(
     console.log(
       `[defenseclaw] LLM fetch interceptor active (proxy: ${proxyBase})`,
     );
+    const layers = describeLayers();
+    logStartupBanner(layers);
+    scheduleSelfTest();
+  }
+
+  async function verifyInterception(): Promise<InterceptionSelfTest> {
+    const layers = describeLayers();
+    const expectedDest = `${proxyBase}/v1/chat/completions`;
+    if (!originalFetch) {
+      return {
+        ok: false,
+        destination: "",
+        layers,
+        reason: "interceptor-not-started",
+      };
+    }
+
+    const captured: string[] = [];
+    const prev = originalFetch;
+    originalFetch = (async (input: RequestInfo | URL) => {
+      captured.push(String(input instanceof Request ? input.url : input));
+      return new Response(JSON.stringify({ id: "dc-intercept-probe" }), {
+        status: 200,
+        headers: { "content-type": "application/json", [INTERCEPTION_PROBE_HEADER]: "1" },
+      });
+    }) as typeof fetch;
+
+    try {
+      await globalThis.fetch(INTERCEPTION_SELF_TEST_URL, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          [INTERCEPTION_PROBE_HEADER]: "1",
+        },
+        body: JSON.stringify({
+          model: "defenseclaw-intercept-probe",
+          messages: [{ role: "user", content: "defenseclaw-intercept-probe" }],
+        }),
+      });
+    } catch {
+      // The stub never throws; keep the miss path for a broken wrapper.
+    } finally {
+      originalFetch = prev;
+    }
+
+    const destination = captured[0] ?? "";
+    const ok = destination === expectedDest && layers.fetch;
+    return {
+      ok,
+      destination,
+      layers,
+      reason: ok ? "interception-self-test" : "interception-self-test-miss",
+    };
+  }
+
+  async function publishSelfTest(result: InterceptionSelfTest): Promise<void> {
+    if (!originalFetch) return;
+    const token = loadSidecarConfig().token;
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (token) headers[DC_AUTH_HEADER] = `Bearer ${token}`;
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 2_000);
+      await originalFetch(`http://127.0.0.1:${guardrailPort}/v1/events/egress`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          target_host: "api.openai.com",
+          target_path: "/v1/chat/completions",
+          body_shape: "messages",
+          looks_like_llm: true,
+          branch: "selftest",
+          decision: result.ok ? "intercept" : "allow",
+          reason: result.reason,
+        }),
+        signal: controller.signal,
+      });
+      clearTimeout(timeout);
+    } catch {
+      // Self-test telemetry is best-effort and must not stall the plugin.
+    }
+  }
+
+  async function runSelfTest(): Promise<InterceptionSelfTest> {
+    const result = await verifyInterception();
+    console.log(
+      `[defenseclaw] interception self-test ok=${result.ok} dest=${result.destination || "none"} ` +
+        `reason=${result.reason}`,
+    );
+    await publishSelfTest(result);
+    return result;
+  }
+
+  function scheduleSelfTest(): void {
+    void runSelfTest();
+    if (selfTestTimer) return;
+    selfTestTimer = setInterval(() => {
+      void runSelfTest();
+    }, INTERCEPTION_SELF_TEST_INTERVAL_MS);
+    if (typeof selfTestTimer === "object" && selfTestTimer && "unref" in selfTestTimer) {
+      (selfTestTimer as { unref?: () => void }).unref?.();
+    }
   }
 
   function stop(): void {
@@ -1758,10 +1919,15 @@ export function createFetchInterceptor(
       egressReporter = null;
     }
     chatgptCodexPassthroughWarned = false;
+    loggedInterceptHosts.clear();
+    if (selfTestTimer) {
+      clearInterval(selfTestTimer);
+      selfTestTimer = null;
+    }
     _shared.installed = false;
     _shared.guardrailPort = null;
     console.log("[defenseclaw] LLM fetch interceptor stopped");
   }
 
-  return { start, stop };
+  return { start, stop, describeLayers, verifyInterception };
 }

--- a/extensions/defenseclaw/src/index.ts
+++ b/extensions/defenseclaw/src/index.ts
@@ -399,14 +399,15 @@ export default function (api: DefenseClawPluginHost) {
     start: async () => {
       interceptor.start();
       const layers = interceptor.describeLayers();
-      if (!layers.fetch || !layers.httpsRequest || !layers.httpRequest) {
+      if (!layers.fetch || !layers.httpsRequest || !layers.httpRequest || !layers.httpGet) {
         console.warn(
           "[defenseclaw] interceptor layer missing after service start: " +
             `fetch=${layers.fetch} https.request=${layers.httpsRequest} ` +
-            `http.request=${layers.httpRequest} undici=${layers.undiciDispatcher}`,
+            `http.request=${layers.httpRequest} http.get=${layers.httpGet} ` +
+            `undici=${layers.undiciDispatcher}`,
         );
       }
-      await interceptor.verifyInterception();
+      await interceptor.runSelfTest();
       healthMonitor.start();
       return {
         stop: () => {

--- a/extensions/defenseclaw/src/index.ts
+++ b/extensions/defenseclaw/src/index.ts
@@ -398,6 +398,15 @@ export default function (api: DefenseClawPluginHost) {
     id: "llm-interceptor",
     start: async () => {
       interceptor.start();
+      const layers = interceptor.describeLayers();
+      if (!layers.fetch || !layers.httpsRequest || !layers.httpRequest) {
+        console.warn(
+          "[defenseclaw] interceptor layer missing after service start: " +
+            `fetch=${layers.fetch} https.request=${layers.httpsRequest} ` +
+            `http.request=${layers.httpRequest} undici=${layers.undiciDispatcher}`,
+        );
+      }
+      await interceptor.verifyInterception();
       healthMonitor.start();
       return {
         stop: () => {

--- a/internal/gateway/egress.go
+++ b/internal/gateway/egress.go
@@ -118,12 +118,15 @@ func (p *GuardrailProxy) handleEgressEvent(w http.ResponseWriter, r *http.Reques
 	}
 
 	p.emitEgress(r.Context(), payload)
+	if p.health != nil && payload.Branch == "selftest" {
+		p.health.RecordInterceptionResult(payload.Decision == "intercept" && payload.Reason == "interception-self-test")
+	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
 func validEgressBranch(b string) bool {
 	switch b {
-	case "known", "shape", "passthrough":
+	case "known", "shape", "passthrough", "undici", "selftest":
 		return true
 	default:
 		return false
@@ -132,7 +135,7 @@ func validEgressBranch(b string) bool {
 
 func validEgressDecision(d string) bool {
 	switch d {
-	case "allow", "block":
+	case "allow", "block", "intercept":
 		return true
 	default:
 		return false

--- a/internal/gateway/egress_test.go
+++ b/internal/gateway/egress_test.go
@@ -94,6 +94,60 @@ func TestHandleEgressEvent_RejectsOversizeBody(t *testing.T) {
 	}
 }
 
+func TestHandleEgressEvent_AcceptsUndiciAndSelfTest(t *testing.T) {
+	prov := &mockProvider{}
+	insp := newMockInspector()
+	proxy := newTestProxy(t, prov, insp, "action")
+	proxy.gatewayToken = "test-token"
+	proxy.skipAuthForTest = false
+
+	cases := []struct {
+		name       string
+		body       string
+		wantVerify *bool
+	}{
+		{
+			name: "undici intercept is a valid enum",
+			body: `{"target_host":"api.openai.com","branch":"undici","decision":"intercept","reason":"undici-dispatcher"}`,
+		},
+		{
+			name:       "self-test miss records unverified",
+			body:       `{"target_host":"api.openai.com","branch":"selftest","decision":"allow","reason":"interception-self-test-miss"}`,
+			wantVerify: interceptionBool(false),
+		},
+		{
+			name:       "self-test hit records verified",
+			body:       `{"target_host":"api.openai.com","branch":"selftest","decision":"intercept","reason":"interception-self-test"}`,
+			wantVerify: interceptionBool(true),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/events/egress", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-DC-Auth", "Bearer test-token")
+			req.RemoteAddr = "127.0.0.1:12345"
+			rec := httptest.NewRecorder()
+			proxy.handleEgressEvent(rec, req)
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("status = %d, want 204; body=%q", rec.Code, rec.Body.String())
+			}
+			if tc.wantVerify == nil {
+				return
+			}
+			snap := proxy.health.Snapshot()
+			if snap.Interception == nil {
+				t.Fatal("expected interception document after self-test egress")
+			}
+			if snap.Interception.Verified != *tc.wantVerify {
+				t.Fatalf("verified = %t, want %t", snap.Interception.Verified, *tc.wantVerify)
+			}
+		})
+	}
+}
+
+func interceptionBool(v bool) *bool { return &v }
+
 // TestHandleEgressEvent_RejectsNonPOST locks in the method allow-list.
 func TestHandleEgressEvent_RejectsNonPOST(t *testing.T) {
 	prov := &mockProvider{}

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -251,6 +251,21 @@ func TestSidecarHealthInterceptionSnapshot(t *testing.T) {
 	}
 }
 
+func TestSidecarHealthInterceptionSnapshotExpires(t *testing.T) {
+	h := NewSidecarHealth()
+	h.RecordInterceptionResult(true)
+	h.mu.Lock()
+	h.interceptionVerifiedAt = time.Now().UTC().Add(-InterceptionSelfTestFreshness - time.Second)
+	h.mu.Unlock()
+	snap := h.Snapshot()
+	if snap.Interception == nil || snap.Interception.Verified {
+		t.Fatalf("stale verified snapshot = %+v", snap.Interception)
+	}
+	if snap.Interception.LastVerifiedAt == "" {
+		t.Fatal("expired snapshot must still report last_verified_at")
+	}
+}
+
 func TestSidecarHealthSetGuardrail(t *testing.T) {
 	h := NewSidecarHealth()
 

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -224,6 +224,33 @@ func TestSidecarHealthSetAPI(t *testing.T) {
 	}
 }
 
+func TestSidecarHealthInterceptionSnapshot(t *testing.T) {
+	h := NewSidecarHealth()
+	if h.Snapshot().Interception != nil {
+		t.Fatal("interception should be omitted until the plugin or proxy reports")
+	}
+
+	h.RecordInterceptionResult(true)
+	snap := h.Snapshot()
+	if snap.Interception == nil || !snap.Interception.Verified {
+		t.Fatalf("verified snapshot = %+v", snap.Interception)
+	}
+	if snap.Interception.LastVerifiedAt == "" {
+		t.Fatal("expected last_verified_at")
+	}
+
+	h.RecordAgentProxyTraffic()
+	snap = h.Snapshot()
+	if snap.Interception.LastAgentTrafficAt == "" {
+		t.Fatal("expected last_agent_traffic_at after an X-DC-Target-URL hop")
+	}
+
+	h.RecordInterceptionResult(false)
+	if h.Snapshot().Interception.Verified {
+		t.Fatal("failed self-test must clear verified")
+	}
+}
+
 func TestSidecarHealthSetGuardrail(t *testing.T) {
 	h := NewSidecarHealth()
 

--- a/internal/gateway/health.go
+++ b/internal/gateway/health.go
@@ -174,6 +174,20 @@ type HealthSnapshot struct {
 	// connector with its own live counters (multi-connector view).
 	Connector  *ConnectorHealth  `json:"connector,omitempty"`
 	Connectors []ConnectorHealth `json:"connectors,omitempty"`
+	// Interception is the plugin self-test / last agent-proxy hop
+	// signal for proxy connectors (OpenClaw / ZeptoClaw). Omitted
+	// until the interceptor reports a result or the proxy sees an
+	// authenticated X-DC-Target-URL hop.
+	Interception *InterceptionHealth `json:"interception,omitempty"`
+}
+
+// InterceptionHealth is the additive doctor signal that a live
+// :4000 listener is actually receiving interceptor-rewritten LLM
+// traffic, not just answering /health/liveliness.
+type InterceptionHealth struct {
+	Verified           bool   `json:"verified"`
+	LastVerifiedAt     string `json:"last_verified_at,omitempty"`
+	LastAgentTrafficAt string `json:"last_agent_traffic_at,omitempty"`
 }
 
 type SidecarHealth struct {
@@ -233,6 +247,11 @@ type SidecarHealth struct {
 	// snapshot from clobbering a fresh StateReady sample the
 	// installer already applied (CR spec-003:PRRT_kwDORuAK-s6al7aV).
 	guardianStateReaderEpoch uint64
+
+	interceptionReported    bool
+	interceptionVerified    bool
+	interceptionVerifiedAt  time.Time
+	lastAgentProxyTrafficAt time.Time
 
 	// subscribers receive a non-blocking notification after every Set*
 	// call, so long-lived consumers (like the IPC GetHealth stream)
@@ -700,6 +719,34 @@ func (h *SidecarHealth) SetGuardrail(state SubsystemState, lastErr string, detai
 		LastError: lastErr,
 		Details:   details,
 	}
+	h.mu.Unlock()
+	h.notifySubscribers()
+}
+
+// RecordInterceptionResult stores the plugin's sentinel self-test.
+// A true result means a classified LLM URL was rewritten to the
+// local guardrail proxy before any upstream hop.
+func (h *SidecarHealth) RecordInterceptionResult(ok bool) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	h.interceptionReported = true
+	h.interceptionVerified = ok
+	h.interceptionVerifiedAt = time.Now().UTC()
+	h.mu.Unlock()
+	h.notifySubscribers()
+}
+
+// RecordAgentProxyTraffic records that an authenticated proxy
+// request arrived with X-DC-Target-URL, which is the interceptor's
+// rewrite marker for real agent LLM traffic.
+func (h *SidecarHealth) RecordAgentProxyTraffic() {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	h.lastAgentProxyTrafficAt = time.Now().UTC()
 	h.mu.Unlock()
 	h.notifySubscribers()
 }
@@ -1416,6 +1463,16 @@ func (h *SidecarHealth) Snapshot() HealthSnapshot {
 			ch := s.snapshot()
 			snap.Connector = &ch
 		}
+	}
+	if h.interceptionReported || !h.lastAgentProxyTrafficAt.IsZero() {
+		info := &InterceptionHealth{Verified: h.interceptionVerified}
+		if !h.interceptionVerifiedAt.IsZero() {
+			info.LastVerifiedAt = h.interceptionVerifiedAt.UTC().Format(time.RFC3339)
+		}
+		if !h.lastAgentProxyTrafficAt.IsZero() {
+			info.LastAgentTrafficAt = h.lastAgentProxyTrafficAt.UTC().Format(time.RFC3339)
+		}
+		snap.Interception = info
 	}
 	h.mu.RUnlock()
 

--- a/internal/gateway/health.go
+++ b/internal/gateway/health.go
@@ -175,11 +175,14 @@ type HealthSnapshot struct {
 	Connector  *ConnectorHealth  `json:"connector,omitempty"`
 	Connectors []ConnectorHealth `json:"connectors,omitempty"`
 	// Interception is the plugin self-test / last agent-proxy hop
-	// signal for proxy connectors (OpenClaw / ZeptoClaw). Omitted
-	// until the interceptor reports a result or the proxy sees an
-	// authenticated X-DC-Target-URL hop.
+	// signal for OpenClaw. Omitted until the interceptor reports a
+	// result or the proxy sees an authenticated X-DC-Target-URL hop.
 	Interception *InterceptionHealth `json:"interception,omitempty"`
 }
+
+// InterceptionSelfTestFreshness is three plugin self-test cadences.
+// A stopped interceptor must not keep /health.interception.verified true.
+const InterceptionSelfTestFreshness = 3 * time.Minute
 
 // InterceptionHealth is the additive doctor signal that a live
 // :4000 listener is actually receiving interceptor-rewritten LLM
@@ -1465,7 +1468,11 @@ func (h *SidecarHealth) Snapshot() HealthSnapshot {
 		}
 	}
 	if h.interceptionReported || !h.lastAgentProxyTrafficAt.IsZero() {
-		info := &InterceptionHealth{Verified: h.interceptionVerified}
+		verified := h.interceptionVerified
+		if verified && (h.interceptionVerifiedAt.IsZero() || time.Since(h.interceptionVerifiedAt) > InterceptionSelfTestFreshness) {
+			verified = false
+		}
+		info := &InterceptionHealth{Verified: verified}
 		if !h.interceptionVerifiedAt.IsZero() {
 			info.LastVerifiedAt = h.interceptionVerifiedAt.UTC().Format(time.RFC3339)
 		}

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -2485,10 +2485,14 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 	}
 
 	fmt.Fprintf(os.Stderr, "[guardrail] ── INCOMING REQUEST ──────────────────────────────────\n")
+	targetURL := r.Header.Get("X-DC-Target-URL")
 	fmt.Fprintf(os.Stderr, "[guardrail] headers: Authorization=%s api-key=%s X-DC-Target-URL=%s\n",
 		redactAuthValue(r.Header.Get("Authorization")),
 		redactAuthValue(r.Header.Get("api-key")),
-		scrubURLSecrets(r.Header.Get("X-DC-Target-URL")))
+		scrubURLSecrets(targetURL))
+	if strings.TrimSpace(targetURL) != "" {
+		p.health.RecordAgentProxyTraffic()
+	}
 	// Request bodies contain prompts, conversation history, and tool
 	// results. Keep only their size in the pretty stderr stream because
 	// the daemon persists that stream to gateway.log and deployments may


### PR DESCRIPTION
Stacked on top of #848 (`fix/windows-managed-rotation-phase2`). Review/merge that PR first; this PR's base is the stack parent, not `main`.

Fixes #473.

## Problem

OpenClaw 2026.6.x can answer agent turns while `:4000` looks healthy. Direct curls to the guardrail proxy block, but `openclaw agent` / Dashboard sessions do not increment `INCOMING REQUEST` when logs cannot grow, and doctor treated a liveliness 200 as proof of agent-path enforcement.

## Current Situation

The plugin already patches `globalThis.fetch`, Node `http`/`https.request`, and the undici global dispatcher. Those undici `intercept` events were rejected by the proxy egress validator (`known|shape|passthrough` / `allow|block` only). Doctor and setup still treated OpenClaw as `STATUS_NOT_GATED` with no transport advisory and no self-test.

Live verification on OpenClaw 2026.6.8 already showed agent traffic hopping `:4000`; a stale log count is not evidence of bypass. The remaining hole is that operators cannot distinguish "proxy is up" from "interceptor rewrote an LLM URL onto the proxy."

## Solution

Keep the transport patches. Add a sentinel self-test that rewrites `https://api.openai.com/v1/chat/completions` onto the local proxy **without leaving the host**, publish `branch=selftest` on `POST /v1/events/egress`, and expose `/health.interception`. Doctor fails the OpenClaw interception row when the self-test misses. Setup and doctor warn for OpenClaw ≥2026.6.8.

```
OpenClaw LLM call
        │
        ├─ fetch / https.request / http.request / undici dispatcher
        │         │
        │         └─ rewrite to 127.0.0.1:4000 + X-DC-Target-URL
        │
        └─ plugin self-test (stubbed original fetch)
                  │
                  ├─ dest == http://127.0.0.1:{port}/v1/chat/completions
                  └─ POST /v1/events/egress branch=selftest
                            │
                            └─ /health.interception.verified
                                      │
                                      └─ defenseclaw doctor
```

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `extensions/defenseclaw/src/fetch-interceptor.ts` | Layer banner, per-host intercept notes, sentinel self-test |
| `extensions/defenseclaw/src/index.ts` | Re-verify layers on `llm-interceptor` service start |
| `extensions/defenseclaw/src/egress-telemetry.ts` | Accept `undici` / `selftest` / `intercept` |
| `internal/gateway/egress.go` | Validate those enums; record self-test on health |
| `internal/gateway/health.go` | Additive `/health.interception` document |
| `internal/gateway/proxy.go` | Record last agent hop when `X-DC-Target-URL` is present |
| `cli/defenseclaw/commands/cmd_doctor.py` | Interception row + OpenClaw ≥2026.6.8 advisory |
| `cli/defenseclaw/commands/cmd_setup.py` | Same advisory during OpenClaw setup |
| `cli/defenseclaw/connector_contracts.py` | Shared version helper |
| `docs/GUARDRAIL.md`, `docs/CONNECTOR-MATRIX.md`, `docs/GUARDRAIL_QUICKSTART.md`, `docs-site` OpenClaw pages | Operator verification path |

## Breaking Changes

Doctor can now FAIL or WARN for an OpenClaw/ZeptoClaw install whose `:4000` port is up but the plugin has not published a passing self-test. Hook connectors are unchanged.

## Open Issues / Follow-ups

#704 remains open until disposable-host Windows rotation certification. Do not close #736 from this PR.

## Test Plan

```
PYTHONPATH=cli python -m pytest \
  cli/tests/test_cmd_doctor.py::DoctorGuardrailTests::test_proxy_interception_fails_when_self_test_misses \
  cli/tests/test_cmd_doctor.py::DoctorGuardrailTests::test_proxy_interception_passes_when_self_test_verified \
  cli/tests/test_cmd_doctor.py::DoctorGuardrailTests::test_proxy_interception_skips_hook_connectors \
  cli/tests/test_cmd_doctor.py::DoctorGuardrailTests::test_openclaw_transport_advisory_for_2026_6 \
  cli/tests/test_connector_contracts.py::TestConnectorContractManifest::test_openclaw_transport_advisory_starts_at_2026_6_8 \
  -q
```

Observed: `7 passed`

```
go test ./internal/gateway -count=1 \
  -run 'TestSidecarHealthInterceptionSnapshot|TestHandleEgressEvent_AcceptsUndiciAndSelfTest|TestHandleEgressEvent_RejectsInvalidEnums'
```

Observed: `ok`

```
cd extensions/defenseclaw && npm test -- --run \
  src/__tests__/fetch-interceptor-selftest.test.ts \
  src/__tests__/fetch-interceptor-init.test.ts \
  src/__tests__/index.test.ts \
  src/__tests__/egress-telemetry.test.ts
```

Observed: `39 passed`