### PR TITLE
docs(spec-077): hook-based LLM guardrail — replace fetch interception…

### DIFF
--- a/docs/specs/077-hook-based-llm-guardrail/design.md
+++ b/docs/specs/077-hook-based-llm-guardrail/design.md
@@ -1,0 +1,380 @@
+# Spec 077 — Hook-Based LLM Guardrail
+
+| Field         | Value |
+|---------------|-------|
+| Status        | Draft |
+| Author        | nghodki |
+| Created       | 2026-09-08 |
+| Minimum OC    | 2026.6.8 |
+| Replaces      | fetch-interceptor (undici dispatcher patch) as primary LLM scanning path |
+
+## Problem
+
+The current DefenseClaw LLM interception relies on patching Node's `globalThis.fetch`
+via an undici `setGlobalDispatcher` call to redirect outbound LLM API requests through
+a guardrail proxy running at `127.0.0.1:4000`.  This approach has two production-blocking
+defects (documented in `defenseclaw-interception-findings-2026-09-08.md`):
+
+1. **Worker-thread isolation** — `setGlobalDispatcher` is per-thread.  OpenClaw 2026.6.8
+   executes model calls inside `worker_threads` (`dist/agents/*.worker.js`), so the
+   patched dispatcher on the main thread never sees those fetches.
+   `network_egress_events = 0` for every agent turn.
+
+2. **Proxy header forwarding** — When the guardrail proxy *does* intercept a call
+   (main-thread test), it cannot forward custom upstream auth headers
+   (e.g. AMD's `Ocp-Apim-Subscription-Key`).  The customer gets HTTP 401 from their
+   LLM gateway.
+
+Both defects are inherent to the proxy architecture.  A fundamentally different
+interception point is needed.
+
+## Solution
+
+Replace fetch-level interception with **OpenClaw's native plugin hook lifecycle**.
+OpenClaw 2026.6.8 exposes `llm_input`, `llm_output`, `model_call_started`,
+`model_call_ended`, and the modifying hook `before_model_resolve`.  These fire from
+the main agent harness — not the worker thread that issues the HTTP call — and carry
+the full prompt and response payloads.  No proxy, no undici, no thread isolation
+problems.
+
+The guardrail proxy at `:4000` is no longer required for LLM traffic.  A single
+sidecar REST endpoint (`POST /api/v1/scan`) handles all content scanning: tool calls,
+LLM input, and LLM output.
+
+## Hook Inventory (OpenClaw 2026.6.8)
+
+| Hook                  | Type              | Payload summary | Can block? |
+|-----------------------|-------------------|-----------------|------------|
+| `llm_input`           | void (fire-and-forget) | provider, model, systemPrompt, prompt, historyMessages, tools | No (observe) |
+| `llm_output`          | void (fire-and-forget) | provider, model, assistantTexts, lastAssistant, usage | No (observe) |
+| `model_call_started`  | void (fire-and-forget) | sanitized model-call metadata | No |
+| `model_call_ended`    | void (fire-and-forget) | metadata + durationMs + outcome | No |
+| `before_model_resolve`| modifying         | (receives model context) | Yes — can return `{ modelOverride }` |
+| `before_agent_reply`  | claiming          | user message | Yes — can return `{ handled: true, text }` |
+| `before_tool_call`    | claiming          | tool name, params | Yes — existing |
+
+The `allowConversationAccess` plugin permission gate must be `true` for
+`llm_input`, `llm_output`, `before_model_resolve`, and `before_agent_reply`.
+
+## Architecture
+
+### Request flow — observe mode
+
+```
+User message
+  → [before_agent_reply] — no-op (pass-through)
+  → prompt built (system + history + user + tools)
+  → [llm_input] → async POST /api/v1/scan {direction:"input"}
+                   sidecar logs finding, returns verdict
+                   plugin logs verdict, fire-and-forget
+  → LLM HTTP call (direct to provider — no proxy)
+  → LLM response received
+  → [llm_output] → async POST /api/v1/scan {direction:"output"}
+                    sidecar logs finding, fire-and-forget
+  → reply delivered to user
+```
+
+Zero added latency.  Scan results land in the sidecar audit DB asynchronously.
+
+### Request flow — action (block) mode
+
+```
+User message
+  → [before_agent_reply] — no-op
+  → prompt built
+  → [llm_input] → await POST /api/v1/scan {direction:"input"}
+                   sidecar returns {action:"block", reason:"..."}
+                   plugin stores ScanDecision in shared turn state
+  → [before_model_resolve] → reads ScanDecision
+       if blocked → return {modelOverride: "__defenseclaw_blocked__"}
+       else       → pass-through (no override)
+  → OpenClaw tries to resolve "__defenseclaw_blocked__"
+       → model resolution fails → agent turn ends
+       → error includes the guardrail block reason
+  → (no LLM call made — no wasted tokens)
+  → [llm_output] — does not fire (no model call completed)
+```
+
+For output blocking (response scanning in action mode):
+
+```
+  → LLM response received
+  → [llm_output] → await POST /api/v1/scan {direction:"output"}
+       if blocked → log violation + emit audit event
+                    (response already streamed — cannot retract)
+       else       → pass-through
+  → reply delivered
+```
+
+Output blocking is **best-effort**: the response is streamed to the user before the
+scan completes.  The audit trail records the violation for downstream enforcement
+(supervisor alerts, session termination).  True inline output blocking requires an
+OpenClaw change to make `llm_output` a claiming hook — tracked as a future enhancement.
+
+### Shared turn state for input blocking
+
+`llm_input` and `before_model_resolve` fire sequentially in the same agent turn.
+However, `llm_input` is void (fire-and-forget) — OpenClaw does not `await` it before
+calling `before_model_resolve`.  To bridge this gap:
+
+```typescript
+// Shared state between hooks within a single agent turn
+let pendingScan: {
+  promise: Promise<ScanVerdict>;
+  runId: string;
+} | null = null;
+
+// llm_input handler: starts the scan, stores the promise
+api.on("llm_input", (event, ctx) => {
+  pendingScan = {
+    promise: scanClient.scan({ direction: "input", ...event }),
+    runId: ctx.runId,
+  };
+});
+
+// before_model_resolve handler: awaits the scan result
+api.on("before_model_resolve", async (event, ctx) => {
+  if (!pendingScan || pendingScan.runId !== ctx.runId) return {};
+  const verdict = await pendingScan.promise;
+  pendingScan = null;
+  if (verdict.action === "block" && verdict.mode === "action") {
+    return { modelOverride: "__defenseclaw_blocked__" };
+  }
+  return {};
+});
+```
+
+`before_model_resolve` is a modifying hook — OpenClaw **does** await it.  The sidecar
+scan typically completes in 50-200 ms.  The `before_model_resolve` handler awaits
+the scan promise, so even if `llm_input` fired fire-and-forget the scan always
+completes before the model call proceeds.
+
+### Sidecar API
+
+#### `POST /api/v1/scan`
+
+Unified content scan endpoint.  Replaces the guardrail proxy for LLM traffic and
+extends the existing `/api/v1/inspect/tool` pattern.
+
+**Request:**
+
+```json
+{
+  "direction": "input" | "output",
+  "provider": "anthropic",
+  "model": "claude-opus-4.6",
+  "content": {
+    "system_prompt": "...",
+    "messages": [
+      {"role": "user", "content": "..."},
+      {"role": "assistant", "content": "..."}
+    ],
+    "tools": [{"name": "bash", "description": "..."}],
+    "assistant_text": "..."
+  },
+  "session_id": "...",
+  "run_id": "...",
+  "agent_id": "...",
+  "trace_id": "..."
+}
+```
+
+- `direction: "input"`: `content.messages`, `content.system_prompt`, and
+  `content.tools` are populated from the `llm_input` hook event.
+- `direction: "output"`: `content.assistant_text` is populated from the
+  `llm_output` hook event's `assistantTexts` / `lastAssistant`.
+
+**Response:**
+
+```json
+{
+  "action": "allow" | "block" | "flag",
+  "severity": "NONE" | "LOW" | "MEDIUM" | "HIGH" | "CRITICAL",
+  "reason": "prompt injection detected in user message",
+  "mode": "observe" | "action",
+  "findings": [
+    {
+      "type": "prompt_injection",
+      "severity": "HIGH",
+      "evidence": "...",
+      "scanner": "llm_judge"
+    }
+  ],
+  "scan_duration_ms": 142
+}
+```
+
+**Internal routing:**
+
+The Go handler delegates to the same guardrail evaluator pipeline that the proxy
+currently uses (LiteLLM judge, PII scanner, content classifier).  The handler:
+
+1. Builds a `ScanRequest` from the JSON body.
+2. Calls `evaluator.Evaluate(ctx, req)` — the same evaluator wired into the
+   existing proxy `handleChat` path.
+3. Writes the result to the audit DB (`scan_results` table).
+4. Returns the verdict.
+
+No new evaluator code.  The only new code is the HTTP handler and the
+request/response serialization.
+
+### Fetch interceptor fallback
+
+On plugin boot:
+
+```typescript
+const hasHookSupport = typeof api.on === "function"
+  && hookRunnerAvailable("llm_input");
+
+if (hasHookSupport) {
+  registerLlmHooks(api);
+  console.log("[defenseclaw] LLM guardrail: hook mode (llm_input/llm_output)");
+} else {
+  interceptor.start();
+  console.log("[defenseclaw] LLM guardrail: fetch interceptor mode (legacy)");
+}
+```
+
+`hookRunnerAvailable` probes whether the hook runner accepts `llm_input`
+registrations.  On OpenClaw < 2026.6.8 this returns false and the existing
+undici-based fetch interceptor activates.
+
+### Proxy deprecation
+
+With hooks as the primary path, the guardrail proxy at `:4000` becomes optional:
+
+- **New deployments** (OpenClaw >= 2026.6.8): proxy can be disabled.  The sidecar
+  runs only the REST API on `:18970`.
+- **Existing deployments** (mixed versions): proxy stays active as fallback.
+  Config flag `DEFENSECLAW_DISABLE_GUARDRAIL_PROXY=1` turns it off.
+- **Full removal**: targeted for the next major release once all customers are on
+  2026.6.8+.
+
+### Plugin config changes
+
+```jsonc
+// openclaw.plugin.json — add to configSchema
+{
+  "guardrail": {
+    "mode": {
+      "type": "string",
+      "enum": ["observe", "action"],
+      "default": "observe",
+      "description": "observe: scan and log, no blocking. action: scan and block violating prompts."
+    }
+  }
+}
+```
+
+```jsonc
+// Customer openclaw.json — plugin permissions
+{
+  "plugins": {
+    "entries": {
+      "defenseclaw": {
+        "hooks": {
+          "allowConversationAccess": true
+        }
+      }
+    }
+  }
+}
+```
+
+## Files changed
+
+### Plugin (TypeScript — `extensions/defenseclaw/`)
+
+| File | Change |
+|------|--------|
+| `src/index.ts` | Register `llm_input`, `llm_output`, `before_model_resolve` hooks; hook-vs-interceptor detection; shared `pendingScan` state |
+| `src/llm-scan.ts` **(new)** | `LlmScanClient` class — formats hook payloads → sidecar `POST /api/v1/scan`, parses verdict |
+| `src/llm-scan-types.ts` **(new)** | TypeScript types for scan request/response/verdict |
+| `src/fetch-interceptor.ts` | Add `isHookModeActive()` guard — skip interceptor start when hooks are registered |
+| `src/health-monitor.ts` | No change (continues polling `/status`) |
+| `typings/@openclaw/plugin-sdk.d.ts` | Add `llm_input`, `llm_output`, `before_model_resolve`, `model_call_started`, `model_call_ended` event type declarations |
+| `openclaw.plugin.json` | Add `guardrail.mode` to `configSchema` |
+| `package.json` | No new dependencies (uses native `fetch`) |
+
+### Sidecar (Go — `internal/gateway/`)
+
+| File | Change |
+|------|--------|
+| `scan_llm.go` **(new)** | `POST /api/v1/scan` HTTP handler: deserialize request, call evaluator, write audit row, return verdict |
+| `scan_llm_test.go` **(new)** | Table-driven tests: input/output scan, block/allow/flag, malformed request, evaluator timeout |
+| `sidecar.go` | Register `/api/v1/scan` route on the REST mux |
+| `audit.go` | Add `ScanTypeEnum = "LLM_CONTENT"` constant for audit rows |
+
+### Helm
+
+| File | Change |
+|------|--------|
+| `helm/dataplane/values.yaml` | Add `defenseclaw.guardrailProxy.enabled: true` toggle (default true for backward compat) |
+
+### Docs
+
+| File | Change |
+|------|--------|
+| `docs/specs/077-hook-based-llm-guardrail/design.md` | This document |
+
+## Testing
+
+### Unit tests (plugin)
+
+- `llm-scan.test.ts` — payload formatting for input/output directions; verdict parsing;
+  timeout handling; correlation header injection.
+- `index.test.ts` — hook registration: verify `llm_input` + `before_model_resolve` +
+  `llm_output` registered when hook support detected; verify fetch interceptor skipped.
+- `index.test.ts` — action-mode blocking: mock sidecar returns `block` → verify
+  `before_model_resolve` returns `{ modelOverride: "__defenseclaw_blocked__" }`.
+- `index.test.ts` — observe-mode pass-through: mock sidecar returns `allow` → verify
+  `before_model_resolve` returns `{}`.
+- `index.test.ts` — fallback: simulate missing `llm_input` support → verify fetch
+  interceptor activates.
+
+### Unit tests (sidecar)
+
+- `scan_llm_test.go` — table-driven: input scan → allow; input scan → block;
+  output scan → flag; malformed body → 400; evaluator timeout → fail-closed;
+  audit row written.
+
+### Integration tests
+
+- Mock sidecar + real plugin: trigger agent turn → verify `llm_input` fires →
+  scan request reaches sidecar → verdict returned → `before_model_resolve` blocks
+  or passes through.
+- Mock sidecar + real plugin: verify `llm_output` fires after LLM response → scan
+  request includes assistant text → audit row written.
+
+### E2E validation
+
+- Deploy to preview sandbox with OpenClaw 2026.6.8 image.
+- Trigger agent turn with known prompt-injection payload.
+- Verify `scan_results` table in sidecar audit DB has `direction=input` row.
+- Verify `network_egress_events > 0` (from the scan call, not fetch interception).
+- Verify agent reply delivered (observe mode) or blocked (action mode).
+
+## Migration
+
+1. **Phase 1 (this spec):** Ship hook-based scanning.  Fetch interceptor remains as
+   fallback.  Proxy remains enabled.  Default mode: `observe`.
+2. **Phase 2:** Customer validation on staging.  Switch AMD worker to `action` mode.
+   Verify blocking works on known-bad prompts.
+3. **Phase 3:** Disable proxy via `DEFENSECLAW_DISABLE_GUARDRAIL_PROXY=1` on new
+   deployments.  Monitor for regressions.
+4. **Phase 4:** Remove fetch interceptor and proxy code.  Hooks-only.
+
+## Open questions
+
+1. **Output blocking latency:** If OpenClaw makes `llm_output` a claiming hook in a
+   future release, we can block responses inline.  Until then, output blocking is
+   audit-only.  Is this acceptable for the AMD deployment?
+
+2. **Streaming responses:** `llm_output` fires after the full response is assembled.
+   For streaming-enabled models, the user sees tokens before the scan runs.  Do we
+   need a streaming-aware scan path?
+
+3. **`before_model_resolve` timeout:** If the sidecar scan takes > 600ms, the
+   `before_model_resolve` hook may hit OpenClaw's per-hook timeout (default 5s,
+   configurable via `hooks.timeouts.before_model_resolve`).  Should we set an
+   explicit timeout in the plugin config?

--- a/docs/specs/077-hook-based-llm-guardrail/techspec.md
+++ b/docs/specs/077-hook-based-llm-guardrail/techspec.md
@@ -1,0 +1,595 @@
+# Spec 077 — Technical Specification
+
+## 1. Plugin TypeScript changes
+
+### 1.1 New file: `src/llm-scan-types.ts`
+
+```typescript
+export type ScanDirection = "input" | "output";
+
+export interface ScanRequest {
+  direction: ScanDirection;
+  provider: string;
+  model: string;
+  content: ScanContent;
+  session_id?: string;
+  run_id?: string;
+  agent_id?: string;
+  trace_id?: string;
+}
+
+export interface ScanContent {
+  system_prompt?: string;
+  messages?: Array<{ role: string; content: string }>;
+  tools?: Array<{ name: string; description?: string }>;
+  assistant_text?: string;
+}
+
+export interface ScanFinding {
+  type: string;
+  severity: string;
+  evidence?: string;
+  scanner: string;
+}
+
+export interface ScanVerdict {
+  action: "allow" | "block" | "flag";
+  severity: "NONE" | "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+  reason: string;
+  mode: "observe" | "action";
+  findings: ScanFinding[];
+  scan_duration_ms: number;
+}
+```
+
+### 1.2 New file: `src/llm-scan.ts`
+
+```typescript
+import { randomUUID } from "node:crypto";
+import type { ScanDirection, ScanRequest, ScanVerdict } from "./llm-scan-types.js";
+
+export interface LlmScanClientOptions {
+  sidecarBaseUrl: string;
+  sidecarToken: string;
+  timeoutMs?: number;
+  getCorrelationHeaders: () => Record<string, string>;
+  logOutboundRequest: (entry: Record<string, unknown>) => void;
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+function failClosedVerdict(reason: string): ScanVerdict {
+  const failOpen =
+    (process.env.DEFENSECLAW_LLM_SCAN_FAIL_OPEN || "").trim() === "1";
+  if (failOpen) {
+    return {
+      action: "allow",
+      severity: "NONE",
+      reason: `${reason} (fail-open opt-in)`,
+      mode: "observe",
+      findings: [],
+      scan_duration_ms: 0,
+    };
+  }
+  return {
+    action: "block",
+    severity: "HIGH",
+    reason: `defenseclaw failing closed: ${reason}`,
+    mode: "action",
+    findings: [],
+    scan_duration_ms: 0,
+  };
+}
+
+export class LlmScanClient {
+  private readonly baseUrl: string;
+  private readonly token: string;
+  private readonly timeoutMs: number;
+  private readonly getHeaders: () => Record<string, string>;
+  private readonly log: (entry: Record<string, unknown>) => void;
+
+  constructor(opts: LlmScanClientOptions) {
+    this.baseUrl = opts.sidecarBaseUrl;
+    this.token = opts.sidecarToken;
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.getHeaders = opts.getCorrelationHeaders;
+    this.log = opts.logOutboundRequest;
+  }
+
+  async scan(req: ScanRequest): Promise<ScanVerdict> {
+    const started = performance.now();
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const headers: Record<string, string> = {
+        ...this.getHeaders(),
+        "Content-Type": "application/json",
+      };
+      if (this.token) {
+        headers["Authorization"] = `Bearer ${this.token}`;
+      }
+
+      const res = await fetch(`${this.baseUrl}/api/v1/scan`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(req),
+        signal: controller.signal,
+      });
+
+      const durationMs = Math.round(performance.now() - started);
+      this.log({
+        message: "defenseclaw.plugin.llm_scan",
+        direction: req.direction,
+        status_code: res.status,
+        duration_ms: durationMs,
+      });
+
+      if (!res.ok) {
+        return failClosedVerdict(`sidecar returned ${res.status}`);
+      }
+
+      return (await res.json()) as ScanVerdict;
+    } catch (err) {
+      const durationMs = Math.round(performance.now() - started);
+      this.log({
+        message: "defenseclaw.plugin.llm_scan",
+        direction: req.direction,
+        status_code: 0,
+        duration_ms: durationMs,
+      });
+      const msg = err instanceof Error ? err.message : String(err);
+      return failClosedVerdict(`sidecar unreachable: ${msg}`);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+```
+
+### 1.3 Hook registration in `src/index.ts`
+
+Add after the existing `createFetchInterceptor` block:
+
+```typescript
+import { LlmScanClient } from "./llm-scan.js";
+import type { ScanVerdict } from "./llm-scan-types.js";
+
+// ─── Hook-based LLM guardrail ───
+
+// Detect whether the host supports typed hooks.
+// OpenClaw 2026.6.8+ exposes llm_input/llm_output via the plugin API.
+function hasLlmHookSupport(api: PluginApi): boolean {
+  // api.on("llm_input", ...) succeeds silently on supported versions.
+  // On unsupported versions the hook is never dispatched.
+  // We rely on the hook-runner advertising via hasHooks, but since we
+  // register eagerly we can only detect at first dispatch.  The
+  // VERSION_MIN check is the reliable gate.
+  try {
+    // OpenClaw sets api._hostVersion or we parse from package.json
+    const ver = (api as any)._hostVersion ?? process.env.OPENCLAW_VERSION ?? "";
+    const match = ver.match(/^(\d{4})\.(\d+)\.(\d+)/);
+    if (!match) return false;
+    const [, year, major, minor] = match.map(Number);
+    // 2026.6.8 is the minimum
+    return year > 2026 || (year === 2026 && (major > 6 || (major === 6 && minor >= 8)));
+  } catch {
+    return false;
+  }
+}
+
+// Shared per-turn state: llm_input stores the scan promise,
+// before_model_resolve awaits it.
+interface PendingScan {
+  promise: Promise<ScanVerdict>;
+  runId: string;
+}
+
+function registerLlmHooks(
+  api: PluginApi,
+  scanClient: LlmScanClient,
+  guardrailMode: "observe" | "action",
+  getCorrelationHeaders: () => Record<string, string>,
+) {
+  let pendingScan: PendingScan | null = null;
+
+  // ── llm_input: scan the full prompt ──
+  api.on("llm_input", (event: any, ctx: any) => {
+    const req = {
+      direction: "input" as const,
+      provider: event.provider ?? "",
+      model: event.model ?? "",
+      content: {
+        system_prompt: event.systemPrompt,
+        messages: (event.historyMessages ?? []).concat(
+          event.prompt ? [{ role: "user", content: event.prompt }] : []
+        ),
+        tools: event.tools,
+      },
+      session_id: ctx?.sessionId ?? ctx?.sessionKey,
+      run_id: ctx?.runId,
+      trace_id: getCorrelationHeaders()["X-DefenseClaw-Trace-Id"],
+    };
+
+    const promise = scanClient.scan(req);
+    pendingScan = { promise, runId: ctx?.runId ?? "" };
+
+    if (guardrailMode === "observe") {
+      // Fire-and-forget: log verdict, don't block
+      promise.then((v) => {
+        console.log(
+          `[defenseclaw] llm_input scan: action=${v.action} severity=${v.severity}`
+        );
+      }).catch(() => {});
+    }
+  });
+
+  // ── before_model_resolve: block if input scan flagged ──
+  api.on("before_model_resolve", async (_event: any, ctx: any) => {
+    if (guardrailMode !== "action") return {};
+    if (!pendingScan || pendingScan.runId !== (ctx?.runId ?? "")) return {};
+
+    const scan = pendingScan;
+    pendingScan = null;
+
+    try {
+      const verdict = await scan.promise;
+      if (verdict.action === "block" && verdict.mode === "action") {
+        console.log(
+          `[defenseclaw] BLOCKED llm_input: ${verdict.reason} (severity=${verdict.severity})`
+        );
+        return { modelOverride: "__defenseclaw_blocked__" };
+      }
+    } catch {
+      // Fail-closed: if scan errored, block
+      return { modelOverride: "__defenseclaw_blocked__" };
+    }
+
+    return {};
+  });
+
+  // ── llm_output: scan the LLM response ──
+  api.on("llm_output", (event: any, ctx: any) => {
+    const assistantText =
+      event.lastAssistant ?? (event.assistantTexts ?? []).join("\n");
+    if (!assistantText) return;
+
+    const req = {
+      direction: "output" as const,
+      provider: event.provider ?? "",
+      model: event.model ?? "",
+      content: {
+        assistant_text: assistantText,
+      },
+      session_id: ctx?.sessionId ?? ctx?.sessionKey,
+      run_id: ctx?.runId,
+      trace_id: getCorrelationHeaders()["X-DefenseClaw-Trace-Id"],
+    };
+
+    // Always fire-and-forget: output scan cannot block inline
+    // (llm_output is a void hook — response is already assembled)
+    scanClient.scan(req).then((v) => {
+      console.log(
+        `[defenseclaw] llm_output scan: action=${v.action} severity=${v.severity}`
+      );
+      if (v.action === "block") {
+        console.warn(
+          `[defenseclaw] OUTPUT VIOLATION (post-delivery): ${v.reason}`
+        );
+      }
+    }).catch(() => {});
+  });
+}
+```
+
+### 1.4 Boot-time detection in `src/index.ts`
+
+Replace the unconditional `interceptor.start()` with:
+
+```typescript
+const llmScanClient = new LlmScanClient({
+  sidecarBaseUrl: SIDECAR_API,
+  sidecarToken: SIDECAR_TOKEN,
+  getCorrelationHeaders: getFetchCorrelationHeaders,
+  logOutboundRequest: (e) => logOutboundRequest(e as any),
+});
+
+const guardrailMode: "observe" | "action" =
+  ((api.pluginConfig as any)?.guardrail?.mode ?? "observe") === "action"
+    ? "action"
+    : "observe";
+
+let hookModeActive = false;
+
+if (hasLlmHookSupport(api)) {
+  registerLlmHooks(api, llmScanClient, guardrailMode, getFetchCorrelationHeaders);
+  hookModeActive = true;
+  console.log(
+    `[defenseclaw] LLM guardrail: hook mode (llm_input/llm_output) [${guardrailMode}]`
+  );
+} else {
+  interceptor.start();
+  console.log("[defenseclaw] LLM guardrail: fetch interceptor mode (legacy)");
+}
+```
+
+Update the `registerService` block to skip the interceptor in hook mode:
+
+```typescript
+api.registerService({
+  id: "llm-interceptor",
+  start: async () => {
+    if (!hookModeActive) interceptor.start();
+    healthMonitor.start();
+    return {
+      stop: () => {
+        if (!hookModeActive) interceptor.stop();
+        healthMonitor.stop();
+      },
+    };
+  },
+});
+```
+
+### 1.5 Updated type declarations: `typings/@openclaw/plugin-sdk.d.ts`
+
+Add to the existing `PluginApi` interface:
+
+```typescript
+interface LlmInputEvent {
+  runId?: string;
+  sessionId?: string;
+  provider: string;
+  model: string;
+  systemPrompt?: string;
+  prompt?: string;
+  historyMessages?: Array<{ role: string; content: string }>;
+  imagesCount?: number;
+  tools?: Array<{ name: string; description?: string }>;
+}
+
+interface LlmOutputEvent {
+  runId?: string;
+  sessionId?: string;
+  provider: string;
+  model: string;
+  assistantTexts?: string[];
+  lastAssistant?: string;
+  usage?: Record<string, unknown>;
+}
+
+interface BeforeModelResolveEvent {
+  [key: string]: unknown;
+}
+
+interface BeforeModelResolveResult {
+  modelOverride?: string;
+  providerOverride?: string;
+}
+
+interface ModelCallEvent {
+  [key: string]: unknown;
+  durationMs?: number;
+  outcome?: string;
+}
+
+// Add to PluginApi.on() overloads:
+export interface PluginApi {
+  // ... existing overloads ...
+  on(event: "llm_input", handler: (event: LlmInputEvent, ctx?: ToolContext) => void | Promise<void>): void;
+  on(event: "llm_output", handler: (event: LlmOutputEvent, ctx?: ToolContext) => void | Promise<void>): void;
+  on(event: "before_model_resolve", handler: (event: BeforeModelResolveEvent, ctx?: ToolContext) => BeforeModelResolveResult | void | Promise<BeforeModelResolveResult | void>): void;
+  on(event: "model_call_started", handler: (event: ModelCallEvent, ctx?: ToolContext) => void | Promise<void>): void;
+  on(event: "model_call_ended", handler: (event: ModelCallEvent, ctx?: ToolContext) => void | Promise<void>): void;
+}
+```
+
+## 2. Sidecar Go changes
+
+### 2.1 New file: `internal/gateway/scan_llm.go`
+
+```go
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+type ScanDirection string
+
+const (
+	ScanDirectionInput  ScanDirection = "input"
+	ScanDirectionOutput ScanDirection = "output"
+)
+
+type ScanContent struct {
+	SystemPrompt  string                   `json:"system_prompt,omitempty"`
+	Messages      []map[string]interface{} `json:"messages,omitempty"`
+	Tools         []map[string]interface{} `json:"tools,omitempty"`
+	AssistantText string                   `json:"assistant_text,omitempty"`
+}
+
+type ScanRequest struct {
+	Direction ScanDirection `json:"direction"`
+	Provider  string        `json:"provider"`
+	Model     string        `json:"model"`
+	Content   ScanContent   `json:"content"`
+	SessionID string        `json:"session_id,omitempty"`
+	RunID     string        `json:"run_id,omitempty"`
+	AgentID   string        `json:"agent_id,omitempty"`
+	TraceID   string        `json:"trace_id,omitempty"`
+}
+
+type ScanFinding struct {
+	Type     string `json:"type"`
+	Severity string `json:"severity"`
+	Evidence string `json:"evidence,omitempty"`
+	Scanner  string `json:"scanner"`
+}
+
+type ScanResponse struct {
+	Action         string        `json:"action"`
+	Severity       string        `json:"severity"`
+	Reason         string        `json:"reason"`
+	Mode           string        `json:"mode"`
+	Findings       []ScanFinding `json:"findings"`
+	ScanDurationMs int64         `json:"scan_duration_ms"`
+}
+
+// HandleScan processes POST /api/v1/scan requests from the plugin's
+// llm_input / llm_output hooks.  It delegates to the same evaluator
+// pipeline used by the guardrail proxy.
+func (s *Sidecar) HandleScan(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req ScanRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.Direction != ScanDirectionInput && req.Direction != ScanDirectionOutput {
+		http.Error(w, "direction must be 'input' or 'output'", http.StatusBadRequest)
+		return
+	}
+
+	started := time.Now()
+
+	// Delegate to the guardrail evaluator.  The evaluator is the same
+	// pipeline that the proxy uses — we just build the evaluator request
+	// from the hook payload instead of from an intercepted HTTP request.
+	verdict := s.evaluateLlmContent(r.Context(), req)
+
+	durationMs := time.Since(started).Milliseconds()
+
+	// Write audit row
+	s.writeScanAudit(r.Context(), req, verdict, durationMs)
+
+	resp := ScanResponse{
+		Action:         verdict.Action,
+		Severity:       verdict.Severity,
+		Reason:         verdict.Reason,
+		Mode:           s.guardrailMode(),
+		Findings:       verdict.Findings,
+		ScanDurationMs: durationMs,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+```
+
+### 2.2 Route registration in `sidecar.go`
+
+Add to the REST mux setup (alongside existing `/api/v1/inspect/tool`):
+
+```go
+mux.HandleFunc("/api/v1/scan", s.HandleScan)
+```
+
+### 2.3 Audit integration
+
+Add `ScanTypeLLMContent = "LLM_CONTENT"` to the audit type constants.
+The `writeScanAudit` method writes to the existing `scan_results` table with
+`scan_type = "LLM_CONTENT"` and `direction = req.Direction`.
+
+## 3. Plugin config (`openclaw.plugin.json`)
+
+Add to the existing `configSchema`:
+
+```json
+{
+  "guardrail": {
+    "type": "object",
+    "properties": {
+      "mode": {
+        "type": "string",
+        "enum": ["observe", "action"],
+        "default": "observe",
+        "description": "observe: scan and log. action: scan and block violating prompts."
+      }
+    }
+  }
+}
+```
+
+## 4. Helm values
+
+Add to `helm/dataplane/values.yaml` under the `defenseclaw` section:
+
+```yaml
+defenseclaw:
+  guardrailProxy:
+    enabled: true  # set false to disable proxy on 2026.6.8+ deployments
+```
+
+## 5. Sequence diagrams
+
+### Input scan — action mode (block)
+
+```
+Plugin                    Sidecar              Evaluator
+  │                         │                     │
+  │──[llm_input]────────────│                     │
+  │  POST /api/v1/scan      │                     │
+  │  {direction:"input"...} │                     │
+  │                         │──evaluate()────────>│
+  │                         │<───{block,HIGH}─────│
+  │                         │──writeAudit()       │
+  │<────{action:"block"}────│                     │
+  │                         │                     │
+  │──[before_model_resolve] │                     │
+  │  await pendingScan      │                     │
+  │  verdict = block        │                     │
+  │  return {modelOverride: │                     │
+  │    "__defenseclaw_blocked__"}                  │
+  │                         │                     │
+  │──(model resolution fails)                     │
+  │  agent turn ends with                         │
+  │  guardrail block reason                       │
+```
+
+### Output scan — observe mode
+
+```
+Plugin                    Sidecar              Evaluator
+  │                         │                     │
+  │──(LLM call completes)   │                     │
+  │──[llm_output]───────────│                     │
+  │  POST /api/v1/scan      │                     │
+  │  {direction:"output"..} │                     │
+  │                         │──evaluate()────────>│
+  │  (reply delivered to     │<───{allow,NONE}────│
+  │   user immediately)     │──writeAudit()       │
+  │                         │                     │
+  │<────{action:"allow"}────│                     │
+  │  (logged, no action)    │                     │
+```
+
+## 6. Error handling
+
+| Failure | Behavior |
+|---------|----------|
+| Sidecar unreachable | Fail-closed by default (block). Opt-in fail-open via `DEFENSECLAW_LLM_SCAN_FAIL_OPEN=1` |
+| Sidecar returns non-200 | Fail-closed |
+| Sidecar returns malformed JSON | Fail-closed |
+| Scan timeout (> 5s default) | AbortController fires, fail-closed |
+| `before_model_resolve` timeout | OpenClaw enforces per-hook timeout (default 5s). If scan hasn't returned, the hook returns empty (pass-through). Mitigated by setting `hooks.timeouts.before_model_resolve: 10000` in plugin config |
+| `llm_input` handler throws | OpenClaw catches and logs warning. `before_model_resolve` sees no `pendingScan`, passes through |
+
+## 7. Observability
+
+| Signal | Where |
+|--------|-------|
+| `defenseclaw.plugin.llm_scan` structured log | Plugin — every scan call with direction, status, duration |
+| `[defenseclaw] llm_input scan: action=X severity=Y` | Plugin — console log per input scan |
+| `[defenseclaw] llm_output scan: action=X severity=Y` | Plugin — console log per output scan |
+| `[defenseclaw] BLOCKED llm_input: reason` | Plugin — console warn on block |
+| `[defenseclaw] OUTPUT VIOLATION (post-delivery): reason` | Plugin — console warn on output violation |
+| `scan_results` table row | Sidecar audit DB — `scan_type=LLM_CONTENT`, `direction=input|output` |
+| `defenseclaw.guardrail.llm_scan` OTel span | Sidecar — if OTel is wired |


### PR DESCRIPTION
… with OpenClaw hooks

Replace undici fetch-interceptor-based LLM scanning with OpenClaw 2026.6.8 native plugin hooks (llm_input, llm_output, before_model_resolve). Hooks fire from the main agent harness — not worker threads — solving the thread-isolation bypass and eliminating the need for the guardrail proxy. Adds unified POST /api/v1/scan sidecar endpoint for both observe and action (block) modes.

<!--
Every future action item must have a GitHub issue before it appears in this PR
body. List linked issues under "Open Issues / Follow-ups". If there are no
follow-ups, write "None".
-->

## Problem

<!-- What user, operator, security, reliability, or maintenance problem does this PR solve? -->

## Current Situation

<!-- What exists today? Include relevant constraints, failing behavior, prior work, or base-branch context. -->

## Solution

<!-- Describe the implementation. For complex work, add focused subsections. -->

## Architecture Diagram

<!-- Include a diagram when it clarifies security posture, data flow, policy behavior, or reviewer risk. Write "N/A" if not useful. -->

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| <!-- path --> | <!-- change summary --> |

## Breaking Changes

<!-- Describe behavior/default/config/API/operator workflow changes. Write "None" if not applicable. -->

## Open Issues / Follow-ups

<!-- Every future action item here must link to a GitHub issue, e.g. "- #123 - follow-up summary". Write "None" if not applicable. -->

## Test Plan

<!-- Include exact commands and observed results. -->
