### PR TITLE
fix(deps): bump js-yaml to 4.3.2 for GHSA-2883-xcg3-v3hh

### DIFF
--- a/extensions/defenseclaw/package-lock.json
+++ b/extensions/defenseclaw/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "js-yaml": "^4.3.1",
+        "js-yaml": "^4.3.2",
         "undici": "^7.10.0"
       },
       "devDependencies": {
@@ -864,6 +864,7 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1174,9 +1175,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -1268,6 +1269,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1490,6 +1492,7 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/extensions/defenseclaw/package.json
+++ b/extensions/defenseclaw/package.json
@@ -16,7 +16,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "js-yaml": "^4.3.1",
+    "js-yaml": "^4.3.2",
     "undici": "^7.10.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Problem

`npm audit --omit=dev --audit-level=high` (`.github/workflows/ci.yml:1034`) fails on **every** open PR, including ones that only touch documentation. Advisory [GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh) was published against `js-yaml < 4.3.2` — *maxTotalMergeKeys does not limit CPU use for empty merge sources* — and the OpenClaw extension pins `js-yaml` as a direct production dependency.

## Current Situation

`extensions/defenseclaw/package.json` declared `^4.3.1` and the lockfile pinned exactly `4.3.1`. The advisory's affected range is `>= 4.0.0, < 4.3.2`; first patched version is `4.3.2`.

This is unrelated to any in-flight change — it started failing when the advisory published, so it blocks the whole queue rather than one branch.

## Solution

Bump to `4.3.2`. The declared range already permitted it, so this is a lockfile bump plus raising the floor so a fresh `npm install` cannot resolve back into the affected range.

Alternative considered: `npm audit fix --force`. Rejected — it pulls unrelated major bumps for no benefit here.

## What Changed

| File | Summary |
| --- | --- |
| `extensions/defenseclaw/package.json` | `js-yaml` `^4.3.1` -> `^4.3.2` (one line) |
| `extensions/defenseclaw/package-lock.json` | locked `js-yaml` 4.3.1 -> 4.3.2 |

No code change.

## Open Issues

None.

## Test Plan

- `npm audit --omit=dev --audit-level=high` now reports **found 0 vulnerabilities** (was `1 high severity vulnerability`).
- Extension suite unchanged: 257 tests pass, 14 skipped. The 3 unrunnable suites (`codeguard-scan`, `correlation.integration`, `inspect-hook`) bind local HTTP servers and fail identically before and after; they pass on a host where socket binding is permitted.
