### PR TITLE
fix(docs): reject unsafe credential environment names

### DIFF
--- a/docs-site/components/command-generator.tsx
+++ b/docs-site/components/command-generator.tsx
@@ -218,23 +218,24 @@ function appendEnvironmentPlaceholder(
   name: string,
   placeholder: string,
   shell: ShellFlavor,
-): void {
+): boolean {
   if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
     warnings.push(
-      `Environment variable name ${JSON.stringify(name)} is not portable. Use letters, digits, and underscores, starting with a letter or underscore. The placeholder assignment was omitted.`,
+      `Environment variable name ${JSON.stringify(name)} is not portable. Use letters, digits, and underscores, starting with a letter or underscore. The placeholder assignment and matching environment-name flag were omitted.`,
     );
-    return;
+    return false;
   }
   const controlsCommandLookup = shell === 'powershell'
     ? /^(?:path|pathext)$/i.test(name)
     : name === 'PATH' || name === 'path';
   if (controlsCommandLookup) {
     warnings.push(
-      `Environment variable name ${JSON.stringify(name)} controls executable lookup in ${shell === 'powershell' ? 'PowerShell' : 'Bash/zsh'}. The placeholder assignment was omitted so the defenseclaw command remains resolvable.`,
+      `Environment variable name ${JSON.stringify(name)} controls executable lookup in ${shell === 'powershell' ? 'PowerShell' : 'Bash/zsh'}. The placeholder assignment and matching environment-name flag were omitted so the defenseclaw command remains resolvable.`,
     );
-    return;
+    return false;
   }
   preExports.push(environmentAssignment(name, placeholder, shell));
+  return true;
 }
 
 // Emit the advanced judge-provider + provider-typed auth flags. Only the
@@ -286,16 +287,22 @@ function appendJudgeProviderFlags(
       lines.push(`--judge-bedrock-auth-mode ${s.judgeBedrockAuthMode}`);
     }
     if (s.judgeBedrockAccessKeyEnv.trim()) {
-      lines.push(`--judge-bedrock-access-key-env ${quote(s.judgeBedrockAccessKeyEnv.trim())}`);
-      appendEnvironmentPlaceholder(preExports, warnings, s.judgeBedrockAccessKeyEnv.trim(), '<aws-access-key-id>', shell);
+      const name = s.judgeBedrockAccessKeyEnv.trim();
+      if (appendEnvironmentPlaceholder(preExports, warnings, name, '<aws-access-key-id>', shell)) {
+        lines.push(`--judge-bedrock-access-key-env ${quote(name)}`);
+      }
     }
     if (s.judgeBedrockSecretKeyEnv.trim()) {
-      lines.push(`--judge-bedrock-secret-key-env ${quote(s.judgeBedrockSecretKeyEnv.trim())}`);
-      appendEnvironmentPlaceholder(preExports, warnings, s.judgeBedrockSecretKeyEnv.trim(), '<aws-secret-access-key>', shell);
+      const name = s.judgeBedrockSecretKeyEnv.trim();
+      if (appendEnvironmentPlaceholder(preExports, warnings, name, '<aws-secret-access-key>', shell)) {
+        lines.push(`--judge-bedrock-secret-key-env ${quote(name)}`);
+      }
     }
     if (s.judgeBedrockSessionTokenEnv.trim()) {
-      lines.push(`--judge-bedrock-session-token-env ${quote(s.judgeBedrockSessionTokenEnv.trim())}`);
-      appendEnvironmentPlaceholder(preExports, warnings, s.judgeBedrockSessionTokenEnv.trim(), '<aws-session-token>', shell);
+      const name = s.judgeBedrockSessionTokenEnv.trim();
+      if (appendEnvironmentPlaceholder(preExports, warnings, name, '<aws-session-token>', shell)) {
+        lines.push(`--judge-bedrock-session-token-env ${quote(name)}`);
+      }
     }
     if (s.judgeBedrockProfileName.trim()) {
       lines.push(`--judge-bedrock-profile-name ${quote(s.judgeBedrockProfileName.trim())}`);
@@ -317,16 +324,16 @@ function appendJudgeProviderFlags(
       lines.push(`--judge-vertex-auth-mode ${s.judgeVertexAuthMode}`);
     }
     if (s.judgeVertexServiceAccountJsonEnv.trim()) {
-      lines.push(
-        `--judge-vertex-service-account-json-env ${quote(s.judgeVertexServiceAccountJsonEnv.trim())}`,
-      );
-      appendEnvironmentPlaceholder(
+      const name = s.judgeVertexServiceAccountJsonEnv.trim();
+      if (appendEnvironmentPlaceholder(
         preExports,
         warnings,
-        s.judgeVertexServiceAccountJsonEnv.trim(),
+        name,
         '<path-to-service-account-json>',
         shell,
-      );
+      )) {
+        lines.push(`--judge-vertex-service-account-json-env ${quote(name)}`);
+      }
     }
   } else if (azure) {
     if (s.judgeAzureEndpoint.trim()) {
@@ -419,17 +426,28 @@ export function buildCommand(
           : 'Remote scanner is enabled but no Cisco endpoint is set. The CLI will reject the run unless an endpoint is already in ~/.defenseclaw/config.yaml.',
       );
     }
-    if (s.ciscoApiKeyEnv.trim() && s.ciscoApiKeyEnv !== 'CISCO_AI_DEFENSE_API_KEY') {
-      lines.push(`--cisco-api-key-env ${quote(s.ciscoApiKeyEnv.trim())}`);
-    }
     if (s.ciscoTimeoutMs.trim()) {
       const n = Number(s.ciscoTimeoutMs.trim());
       if (Number.isFinite(n) && n > 0) {
         lines.push(`--cisco-timeout-ms ${n}`);
       }
     }
-    const apiKeyEnv = s.ciscoApiKeyEnv.trim() || 'CISCO_AI_DEFENSE_API_KEY';
-    appendEnvironmentPlaceholder(preExports, warnings, apiKeyEnv, '<your-cisco-ai-defense-api-key>', shell);
+    const requestedApiKeyEnv = s.ciscoApiKeyEnv.trim();
+    const apiKeyEnv = requestedApiKeyEnv || 'CISCO_AI_DEFENSE_API_KEY';
+    if (appendEnvironmentPlaceholder(preExports, warnings, apiKeyEnv, '<your-cisco-ai-defense-api-key>', shell)) {
+      if (requestedApiKeyEnv && requestedApiKeyEnv !== 'CISCO_AI_DEFENSE_API_KEY') {
+        lines.push(`--cisco-api-key-env ${quote(requestedApiKeyEnv)}`);
+      }
+    } else if (apiKeyEnv !== 'CISCO_AI_DEFENSE_API_KEY') {
+      appendEnvironmentPlaceholder(
+        preExports,
+        warnings,
+        'CISCO_AI_DEFENSE_API_KEY',
+        '<your-cisco-ai-defense-api-key>',
+        shell,
+      );
+      warnings.push('Falling back to the default CISCO_AI_DEFENSE_API_KEY credential variable.');
+    }
   }
 
   // Action-mode-only enforcement knobs.
@@ -472,11 +490,22 @@ export function buildCommand(
     if (s.judgeApiBase.trim()) {
       lines.push(`--judge-api-base ${quote(s.judgeApiBase.trim())}`);
     }
-    if (s.judgeApiKeyEnv.trim()) {
-      lines.push(`--judge-api-key-env ${quote(s.judgeApiKeyEnv.trim())}`);
+    const requestedApiKeyEnv = s.judgeApiKeyEnv.trim();
+    const apiKeyEnv = requestedApiKeyEnv || 'DEFENSECLAW_LLM_KEY';
+    if (appendEnvironmentPlaceholder(preExports, warnings, apiKeyEnv, '<your-llm-api-key>', shell)) {
+      if (requestedApiKeyEnv) {
+        lines.push(`--judge-api-key-env ${quote(requestedApiKeyEnv)}`);
+      }
+    } else if (apiKeyEnv !== 'DEFENSECLAW_LLM_KEY') {
+      appendEnvironmentPlaceholder(
+        preExports,
+        warnings,
+        'DEFENSECLAW_LLM_KEY',
+        '<your-llm-api-key>',
+        shell,
+      );
+      warnings.push('Falling back to the default DEFENSECLAW_LLM_KEY credential variable.');
     }
-    const apiKeyEnv = s.judgeApiKeyEnv.trim() || 'DEFENSECLAW_LLM_KEY';
-    appendEnvironmentPlaceholder(preExports, warnings, apiKeyEnv, '<your-llm-api-key>', shell);
 
     // Advanced judge provider + provider-typed auth.
     appendJudgeProviderFlags(s, shell, lines, preExports, warnings);

--- a/docs-site/content/docs/setup/enterprise-deployment.mdx
+++ b/docs-site/content/docs/setup/enterprise-deployment.mdx
@@ -1704,7 +1704,7 @@ Treat this evidence as a release gate for the managed endpoint image. Run destru
 - [ ] Managed config, policy, units/plists/SCM definitions, manifest, and authorization directory have trusted path chains.
 - [ ] Gateway service runs as the dedicated service identity (or the documented root identity on macOS), not the AI user.
 - [ ] Linux gateway sandbox properties match the packaged unit or a reviewed stricter override.
-- [ ] Guardian targets are current and authorized: Linux/macOS manifests contain only explicit approved pairs; Windows enumerator output contains only expected interactive SIDs, configured connector families that pass the Windows managed-hook filter, and discovered supported versions.
+- [ ] Guardian targets are current and authorized: Linux/macOS manifests contain only explicit approved pairs; Windows enumerator output contains only expected interactive SIDs, connector families explicitly qualified by the managed-enterprise acceptance guidance that pass the Windows managed-hook filter, and discovered supported versions.
 - [ ] First reconcile succeeds for every enabled target before action mode is enabled.
 - [ ] Watcher and periodic backstop are enabled according to OS capabilities.
 - [ ] Scoped token files are connector-specific; no automation copies a shared gateway token into user hooks.

--- a/docs-site/scripts/test-feature-demos.ts
+++ b/docs-site/scripts/test-feature-demos.ts
@@ -80,9 +80,12 @@ describe('command generator shell safety', () => {
   it('omits placeholder assignments that can hide the CLI from Bash or zsh', () => {
     for (const name of ['PATH', 'path']) {
       const result = buildRemoteCommand(name, 'bash');
-      assert.deepStrictEqual(result.preExports, []);
+      assert.deepStrictEqual(result.preExports, [
+        "export CISCO_AI_DEFENSE_API_KEY='<your-cisco-ai-defense-api-key>'",
+      ]);
       assert.match(result.warnings.join(' '), /controls executable lookup in Bash\/zsh/i);
-      assert.ok(result.lines.includes(`--cisco-api-key-env ${name}`));
+      assert.match(result.warnings.join(' '), /falling back.*CISCO_AI_DEFENSE_API_KEY/i);
+      assert.ok(!result.lines.some((line) => line.startsWith('--cisco-api-key-env')));
     }
 
     for (const name of ['Path', 'PATHEXT', 'PATH_API_KEY']) {
@@ -93,17 +96,23 @@ describe('command generator shell safety', () => {
     }
 
     const invalid = buildRemoteCommand('BAD-NAME', 'bash');
-    assert.deepStrictEqual(invalid.preExports, []);
+    assert.deepStrictEqual(invalid.preExports, [
+      "export CISCO_AI_DEFENSE_API_KEY='<your-cisco-ai-defense-api-key>'",
+    ]);
     assert.match(invalid.warnings.join(' '), /is not portable/i);
     assert.doesNotMatch(invalid.warnings.join(' '), /controls executable lookup/i);
+    assert.ok(!invalid.lines.some((line) => line.startsWith('--cisco-api-key-env')));
   });
 
   it('omits case-insensitive Windows command-search placeholder assignments', () => {
     for (const name of ['PATH', 'Path', 'path', 'pAtH', 'PATHEXT', 'PathExt', 'pathext']) {
       const result = buildRemoteCommand(name, 'powershell');
-      assert.deepStrictEqual(result.preExports, []);
+      assert.deepStrictEqual(result.preExports, [
+        "$env:CISCO_AI_DEFENSE_API_KEY = '<your-cisco-ai-defense-api-key>'",
+      ]);
       assert.match(result.warnings.join(' '), /controls executable lookup in PowerShell/i);
-      assert.ok(result.lines.includes(`--cisco-api-key-env '${name}'`));
+      assert.match(result.warnings.join(' '), /falling back.*CISCO_AI_DEFENSE_API_KEY/i);
+      assert.ok(!result.lines.some((line) => line.startsWith('--cisco-api-key-env')));
     }
 
     for (const name of ['MY_PATH_TOKEN', 'PATH_API_KEY']) {
@@ -111,6 +120,25 @@ describe('command generator shell safety', () => {
       assert.deepStrictEqual(valid.preExports, [
         `$env:${name} = '<your-cisco-ai-defense-api-key>'`,
       ]);
+    }
+  });
+
+  it('falls back from command-search names for the judge API key', () => {
+    for (const [shell, name, expectedAssignment] of [
+      ['bash', 'PATH', "export DEFENSECLAW_LLM_KEY='<your-llm-api-key>'"],
+      ['powershell', 'Path', "$env:DEFENSECLAW_LLM_KEY = '<your-llm-api-key>'"],
+    ] as const) {
+      const result = buildCommand(
+        {
+          ...DEFAULT_STATE,
+          detectionStrategy: 'regex_judge',
+          judgeApiKeyEnv: name,
+        },
+        shell,
+      );
+      assert.deepStrictEqual(result.preExports, [expectedAssignment]);
+      assert.ok(!result.lines.some((line) => line.startsWith('--judge-api-key-env')));
+      assert.match(result.warnings.join(' '), /falling back.*DEFENSECLAW_LLM_KEY/i);
     }
   });
 });


### PR DESCRIPTION
## Problem

The documentation command generator omitted unsafe credential placeholder assignments for names such as `PATH`, but still emitted the matching CLI option. A copied command could therefore ask DefenseClaw to treat the shell's executable-search path as credential material instead of producing a usable placeholder.

## Current Situation

This follow-up preserves the valid tracked edits found while cleaning the local worktrees after #864 merged. Generated build, presentation, benchmark-cache, and test-result residue is not included.

## Solution

Make environment-placeholder validation return an explicit result. Emit a credential environment-name option only when its placeholder name is portable and does not control executable lookup. For configurable generic API-key names, fall back to the documented default credential variable and warn the operator.

The enterprise deployment checklist also clarifies that Windows connector families must be explicitly qualified by the managed-enterprise acceptance guidance.

## What Changed (Where & How)

| Path | Change |
| --- | --- |
| `docs-site/components/command-generator.tsx` | Reject unsafe credential environment-name flags and use safe default-variable fallbacks where supported. |
| `docs-site/scripts/test-feature-demos.ts` | Cover invalid names plus Bash/zsh and case-insensitive PowerShell command-search variables. |
| `docs-site/content/docs/setup/enterprise-deployment.mdx` | Clarify the production enrollment acceptance requirement. |

## Breaking Changes

None. This changes only generated example commands for invalid or command-search environment-variable names.

## Open Issues / Follow-ups

None.

## Test Plan

| Command | Observed result |
| --- | --- |
| `cd docs-site && npm run test:feature-demos` | Passed: 19 tests. |
| `cd docs-site && npm run lint` | Passed with 0 errors; 35 pre-existing warnings. |
| `cd docs-site && npm run validate-links` | Passed with 0 errors. |
| `git diff --check origin/main...HEAD` | Passed. |
